### PR TITLE
feat: Add pre-connect loading screen with error handling

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/ConnectionState.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/ConnectionState.kt
@@ -1,0 +1,44 @@
+package org.jetbrains.jediterm.compose
+
+import org.jetbrains.jediterm.compose.PlatformServices
+
+/**
+ * Represents the connection state of the terminal during PTY initialization.
+ *
+ * States:
+ * - [Initializing]: Initial state before connection attempt
+ * - [Connecting]: Active connection attempt in progress
+ * - [Connected]: Successfully connected with processHandle
+ * - [Error]: Connection failed with error message
+ */
+sealed class ConnectionState {
+    /**
+     * Initial state before any connection attempt.
+     */
+    object Initializing : ConnectionState()
+
+    /**
+     * Connection attempt in progress (spawning PTY).
+     */
+    object Connecting : ConnectionState()
+
+    /**
+     * Successfully connected to shell.
+     * @param handle The process handle for the connected PTY
+     */
+    data class Connected(
+        val handle: PlatformServices.ProcessService.ProcessHandle
+    ) : ConnectionState()
+
+    /**
+     * Connection failed with error.
+     * @param message Human-readable error message
+     * @param cause Optional underlying exception
+     */
+    data class Error(
+        val message: String,
+        val cause: Throwable? = null
+    ) : ConnectionState() {
+        override fun toString(): String = "ConnectionState.Error(message='$message', cause=${cause?.javaClass?.simpleName})"
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/PreConnectScreen.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/PreConnectScreen.kt
@@ -1,0 +1,72 @@
+package org.jetbrains.jediterm.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Pre-connection loading screen displayed while terminal is initializing.
+ *
+ * Displays:
+ * - Loading spinner during [ConnectionState.Initializing] and [ConnectionState.Connecting]
+ * - Error message with retry button for [ConnectionState.Error]
+ * - Nothing when [ConnectionState.Connected] (parent handles terminal rendering)
+ *
+ * @param state Current connection state
+ * @param onRetry Callback invoked when user clicks retry button after error
+ */
+@Composable
+fun PreConnectScreen(
+    state: ConnectionState,
+    onRetry: () -> Unit = {}
+) {
+    Box(
+        modifier = Modifier.fillMaxSize().background(Color(0xFF1E1E1E)),
+        contentAlignment = Alignment.Center
+    ) {
+        when (state) {
+            is ConnectionState.Initializing,
+            is ConnectionState.Connecting -> {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    CircularProgressIndicator(color = Color.White)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Connecting to shell...",
+                        color = Color.White,
+                        fontSize = 14.sp
+                    )
+                }
+            }
+            is ConnectionState.Error -> {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "⚠️ Connection Failed",
+                        color = Color.Red,
+                        fontSize = 18.sp
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = state.message,
+                        color = Color.White,
+                        fontSize = 14.sp
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Button(onClick = onRetry) {
+                        Text("Retry")
+                    }
+                }
+            }
+            is ConnectionState.Connected -> {
+                // Connected state handled by parent - show nothing here
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements a pre-connect handler/loading screen for the terminal during PTY initialization.

## Changes
- **ConnectionState.kt**: Sealed class for managing connection lifecycle states (Initializing, Connecting, Connected, Error)
- **PreConnectScreen.kt**: Composable loading screen with spinner and error display
- **ProperTerminal.kt**: Updated with connection state management, conditional rendering, and error handling

## Features
- Loading spinner displayed during the 50-200ms connection window
- Error screen with descriptive messages and retry button
- Type-safe state machine for connection lifecycle
- Graceful error handling with try-catch around PTY initialization
- Retry functionality that resets state and triggers reconnection

## Testing
- Normal connection flow works (brief loading screen, then terminal)
- Error handling can be tested by modifying command to invalid path
- Build succeeded and application runs without errors

Closes #12

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)