### PR TITLE
feat: Add search match visualization in scrollbar (issue #25)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/scrollbar/SearchMatchPositions.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/scrollbar/SearchMatchPositions.kt
@@ -1,0 +1,34 @@
+package org.jetbrains.jediterm.compose.scrollbar
+
+/**
+ * Utility for converting search match coordinates to normalized scrollbar positions.
+ */
+
+/**
+ * Convert search match row coordinates to normalized scrollbar positions [0, 1].
+ *
+ * @param matches List of (column, row) pairs where row is buffer-relative
+ *                (negative = history, 0+ = screen)
+ * @param historyLinesCount Number of lines in history buffer
+ * @param screenHeight Number of visible lines on screen
+ * @return List of normalized positions [0, 1] corresponding to each match
+ */
+fun computeMatchPositions(
+    matches: List<Pair<Int, Int>>,
+    historyLinesCount: Int,
+    screenHeight: Int
+): List<Float> {
+    if (matches.isEmpty()) return emptyList()
+
+    val totalLines = historyLinesCount + screenHeight
+    if (totalLines <= 0) return emptyList()
+
+    return matches.map { (_, row) ->
+        // Buffer-relative row: negative = history, 0+ = screen
+        // Convert to absolute position from top of buffer
+        // For row -N (history): absoluteRow = historyLinesCount + (-N) = historyLinesCount - N
+        // For row +N (screen): absoluteRow = historyLinesCount + N
+        val absoluteRow = historyLinesCount + row
+        (absoluteRow.toFloat() / totalLines).coerceIn(0f, 1f)
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/settings/TerminalSettings.kt
@@ -135,6 +135,21 @@ data class TerminalSettings(
      */
     val scrollbarThumbColor: String = "0xFFAAAAAA",
 
+    /**
+     * Show search match markers in scrollbar
+     */
+    val showSearchMarkersInScrollbar: Boolean = true,
+
+    /**
+     * Search marker color for regular matches (serialized as ARGB hex)
+     */
+    val searchMarkerColor: String = "0xFFFFFF00",
+
+    /**
+     * Search marker color for current match (serialized as ARGB hex)
+     */
+    val currentSearchMarkerColor: String = "0xFFFF6600",
+
     // ===== Performance Settings =====
 
     /**
@@ -292,6 +307,12 @@ data class TerminalSettings(
 
     @Transient
     val scrollbarThumbColorValue: Color = Color(scrollbarThumbColor.removePrefix("0x").toULong(16).toLong())
+
+    @Transient
+    val searchMarkerColorValue: Color = Color(searchMarkerColor.removePrefix("0x").toULong(16).toLong())
+
+    @Transient
+    val currentSearchMarkerColorValue: Color = Color(currentSearchMarkerColor.removePrefix("0x").toULong(16).toLong())
 
     companion object {
         /**


### PR DESCRIPTION
## Summary

Implements GitHub Issue #25: Add search match visualization in scrollbar

### New Features
- **Scrollbar markers**: Visual indicators showing all search match positions
  - Yellow markers for regular matches
  - Orange marker for current match
  - Click markers to jump to that match
- **Compact search bar**: VS Code-style search UI in top-right corner
  - Smaller footprint (max 320dp width)
  - Material 3 design matching terminal theme
  - Case-sensitive toggle with "Aa" indicator
- **All-match highlighting**: Shows all search results in terminal simultaneously
  - Yellow highlight for regular matches (40% opacity)
  - Orange highlight for current match (60% opacity)
- **Smart scroll behavior**: Only scrolls when match not visible (2-line margin)

### Bug Fixes
- Fixed rapid click pass-through from SearchBar to terminal
  - Added `isConsumed` checks in all Canvas pointer event handlers
  - Dual-layer event consumption in SearchBar (Main + Final pass)
  - Prevents multi-click detection interference

### Technical Details
- New `SearchMatchPositions.kt`: Buffer-to-scrollbar position mapping utility
- New settings in `TerminalSettings.kt`:
  - `searchMarkerColor` (default: yellow)
  - `currentSearchMarkerColor` (default: orange)
  - `showSearchMarkersInScrollbar` (default: true)
- Enhanced `AlwaysVisibleScrollbar.kt` with marker rendering and click-to-jump
- Complete SearchBar.kt rewrite for compact layout
- Added overlay event consumption guards in ProperTerminal.kt

### Files Changed
- `SearchBar.kt`: Complete rewrite (150 → 227 lines)
- `ProperTerminal.kt`: Search UI improvements, event guards (+100 lines)
- `AlwaysVisibleScrollbar.kt`: Marker rendering (+70 lines)
- `TerminalSettings.kt`: New marker color settings (+9 lines)
- `SearchMatchPositions.kt`: New utility (35 lines)

## Test Plan
- [x] Search for text and verify all matches highlighted
- [x] Verify scrollbar markers appear at correct positions
- [x] Click markers to jump to matches
- [x] Rapid click search buttons without terminal selection
- [x] Cmd/Ctrl+F toggle works correctly
- [x] Focus returns to terminal after search closes
- [x] Search scrolls only when match not visible
- [x] Current match highlighted differently

🤖 Generated with [Claude Code](https://claude.com/claude-code)