### PR TITLE
fix: Monochrome symbol rendering and vertical alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,9 +403,10 @@ gh pr create --base master --head dev --title "Your PR title" --body "Descriptio
 ## Development Guidelines
 
 ### Testing
-1. Build and run: `./gradlew :compose-ui:run`
-2. Capture screenshot: `python3 capture_jediterm_only.py`
-3. Verify rendering and functionality
+**IMPORTANT**: Do NOT run the application or capture screenshots. The user will handle running and testing.
+1. Make code changes
+2. Wait for user to run and provide feedback/screenshots
+3. Iterate based on user feedback
 
 ### Performance
 - Use `remember {}` for expensive computations
@@ -442,8 +443,8 @@ gh pr create --base master --head dev --title "Your PR title" --body "Descriptio
 ### Continuous Improvement Cycle
 1. Identify issue or improvement opportunity
 2. Implement fix or enhancement
-3. Test with screenshot capture
-4. Commit to dev branch
+3. Wait for user to test and provide feedback
+4. Commit to dev branch (when user approves)
 5. Push to GitHub
 6. Create PR when feature complete
 7. Merge to master when stable

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/tabs/TabBar.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -111,11 +112,12 @@ private fun TabItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            // Tab title
+            // Tab title - use Monospace font (Menlo on macOS) for monochrome symbols
             Text(
                 text = title,
                 color = if (isActive) Color.White else Color(0xFFB0B0B0),
                 fontSize = 13.sp,
+                fontFamily = FontFamily.Monospace,  // Menlo has monochrome Dingbats (✳, ❯, etc.)
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f)


### PR DESCRIPTION
## Summary

- **Monochrome technical symbols**: Symbols like ⏸⏵⏹ (U+23E9-U+23FF) now render as monochrome using STIX Two Math font instead of Apple Color Emoji
- **Monochrome Dingbats**: Symbols like ✳❯ (U+2700-U+27BF) now use Nerd Font's monochrome glyphs instead of emoji fallback
- **Vertical alignment fix**: Technical/prompt symbols (⏵⏵) now align to text baseline instead of being off-center
- **Tab bar font**: Tab titles use FontFamily.Monospace (Menlo) for consistent monochrome symbol rendering

## Test plan

- [ ] Verify ⏸ ⏵ ⏹ render as monochrome (not colorful emoji)
- [ ] Verify ✳ ❯ render as monochrome in terminal
- [ ] Verify ⏵⏵ prompt symbols align vertically with text
- [ ] Verify tab titles with symbols render monochrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)