### PR TITLE
fix: Add CSI s/u cursor save/restore for zsh-autosuggestions compatibility

### DIFF
--- a/jediterm-core-mpp/src/jvmMain/kotlin/com/jediterm/terminal/emulator/JediEmulator1.kt
+++ b/jediterm-core-mpp/src/jvmMain/kotlin/com/jediterm/terminal/emulator/JediEmulator1.kt
@@ -494,6 +494,18 @@ class JediEmulator(dataStream: TerminalDataStream, terminal: Terminal?) :
             }
 
             't' -> return windowManipulation(args)
+            's' -> {
+                // CSI s - Save Cursor Position (ANSI.SYS / SCO style)
+                // Used by zsh-autosuggestions and other shell plugins
+                myTerminal?.saveCursor()
+                return true
+            }
+            'u' -> {
+                // CSI u - Restore Cursor Position (ANSI.SYS / SCO style)
+                // Used by zsh-autosuggestions and other shell plugins
+                myTerminal?.restoreCursor()
+                return true
+            }
             else -> return false
         }
     }


### PR DESCRIPTION
## Summary
- Implements ANSI.SYS-style cursor save (`CSI s`) and restore (`CSI u`) escape sequences
- Fixes rendering bug when typing commands starting with 'e' (like "echo") with zsh-autosuggestions enabled
- Characters were appearing to be "erased in opposite direction" due to cursor position corruption

## Root Cause
zsh-autosuggestions uses `CSI s` to save cursor position before rendering the gray suggestion text, then `CSI u` to restore cursor position so the user continues typing at the correct location. Without these sequences implemented, the cursor position was lost.

## Test plan
- [x] Build compiles successfully
- [ ] Type "echo" at zsh prompt with autosuggestions enabled
- [ ] Verify no character erasure/corruption occurs
- [ ] Verify autosuggestions appear correctly in gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)