### PR TITLE
feat: Add hyperlink context menu actions (#37)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/features/ContextMenuController.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/features/ContextMenuController.kt
@@ -177,6 +177,73 @@ fun showTerminalContextMenu(
 }
 
 /**
+ * Create hyperlink-specific context menu items
+ */
+fun createHyperlinkContextMenuItems(
+    url: String,
+    onOpenLink: () -> Unit,
+    onCopyLinkAddress: () -> Unit
+): List<ContextMenuController.MenuItem> {
+    return listOf(
+        ContextMenuController.MenuItem(
+            id = "open_link",
+            label = "Open Link",
+            enabled = true,
+            action = onOpenLink
+        ),
+        ContextMenuController.MenuItem(
+            id = "copy_link",
+            label = "Copy Link Address",
+            enabled = true,
+            action = onCopyLinkAddress
+        ),
+        ContextMenuController.MenuItem(
+            id = "separator_hyperlink",
+            label = "",
+            enabled = false,
+            action = {}
+        )
+    )
+}
+
+/**
+ * Show context menu with hyperlink actions followed by standard terminal items
+ */
+fun showHyperlinkContextMenu(
+    controller: ContextMenuController,
+    x: Float,
+    y: Float,
+    url: String,
+    onOpenLink: () -> Unit,
+    onCopyLinkAddress: () -> Unit,
+    hasSelection: Boolean,
+    onCopy: () -> Unit,
+    onPaste: () -> Unit,
+    onSelectAll: () -> Unit,
+    onClearScreen: () -> Unit,
+    onClearScrollback: () -> Unit,
+    onFind: () -> Unit,
+    onShowDebug: (() -> Unit)? = null
+) {
+    val hyperlinkItems = createHyperlinkContextMenuItems(
+        url = url,
+        onOpenLink = onOpenLink,
+        onCopyLinkAddress = onCopyLinkAddress
+    )
+    val terminalItems = createTerminalContextMenuItems(
+        hasSelection = hasSelection,
+        onCopy = onCopy,
+        onPaste = onPaste,
+        onSelectAll = onSelectAll,
+        onClearScreen = onClearScreen,
+        onClearScrollback = onClearScrollback,
+        onFind = onFind,
+        onShowDebug = onShowDebug
+    )
+    controller.showMenu(x, y, hyperlinkItems + terminalItems)
+}
+
+/**
  * Context menu popup composable
  */
 @Composable


### PR DESCRIPTION
## Summary

Adds hyperlink-specific context menu actions when right-clicking on a detected URL in the terminal.

## Changes

- **ContextMenuController.kt**: Added `createHyperlinkContextMenuItems()` and `showHyperlinkContextMenu()` functions
- **ProperTerminal.kt**: Modified right-click handler to detect `hoveredHyperlink` and show appropriate context menu

## New Menu Items (when clicking on a hyperlink)

1. **Open Link** - Opens the URL in the default browser
2. **Copy Link Address** - Copies the URL to clipboard
3. *(separator)*
4. Standard terminal menu items (Copy, Paste, Select All, etc.)

## Test Plan

- [ ] Run terminal, type `echo "https://github.com"` to display a URL
- [ ] Hover over the URL (cursor should change to pointer)
- [ ] Right-click on the URL
- [ ] Verify "Open Link" and "Copy Link Address" appear at the top of the menu
- [ ] Click "Open Link" - should open URL in browser
- [ ] Click "Copy Link Address" - should copy URL to clipboard
- [ ] Right-click on non-hyperlink area - should show standard menu only

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)