### PR TITLE
fix: Use configurable blink timers from settings (#38)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/demo/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/demo/ProperTerminal.kt
@@ -469,26 +469,26 @@ fun ProperTerminal(
   val cellWidth = cellMetrics.first
   val cellHeight = cellMetrics.second
 
-  // SLOW_BLINK animation timer (500ms intervals)
-  LaunchedEffect(Unit) {
+  // SLOW_BLINK animation timer (configurable via settings.slowTextBlinkMs)
+  LaunchedEffect(settings.slowTextBlinkMs) {
     while (true) {
-      delay(500)
+      delay(settings.slowTextBlinkMs.toLong())
       slowBlinkVisible = !slowBlinkVisible
     }
   }
 
-  // RAPID_BLINK animation timer (250ms intervals)
-  LaunchedEffect(Unit) {
+  // RAPID_BLINK animation timer (configurable via settings.rapidTextBlinkMs)
+  LaunchedEffect(settings.rapidTextBlinkMs) {
     while (true) {
-      delay(250)
+      delay(settings.rapidTextBlinkMs.toLong())
       rapidBlinkVisible = !rapidBlinkVisible
     }
   }
 
-  // Cursor blink animation timer (500ms intervals)
-  LaunchedEffect(Unit) {
+  // Cursor blink animation timer (configurable via settings.caretBlinkMs)
+  LaunchedEffect(settings.caretBlinkMs) {
     while (true) {
-      delay(500)
+      delay(settings.caretBlinkMs.toLong())
       cursorBlinkVisible = !cursorBlinkVisible
     }
   }


### PR DESCRIPTION
## Summary

Replaces hardcoded blink timer values with configurable settings from `TerminalSettings`.

## Changes

**ProperTerminal.kt** (lines 472-494):
- `delay(500)` → `delay(settings.slowTextBlinkMs.toLong())` for SLOW_BLINK text
- `delay(250)` → `delay(settings.rapidTextBlinkMs.toLong())` for RAPID_BLINK text  
- `delay(500)` → `delay(settings.caretBlinkMs.toLong())` for cursor blink
- Added settings values as `LaunchedEffect` keys for timer restart on settings change

## Settings Used

| Setting | Default | Purpose |
|---------|---------|---------|
| `slowTextBlinkMs` | 1000ms | SLOW_BLINK text attribute timing |
| `rapidTextBlinkMs` | 500ms | RAPID_BLINK text attribute timing |
| `caretBlinkMs` | 500ms | Cursor blink timing |

## Test Plan

- [ ] Verify cursor blinks at configured rate
- [ ] Test SLOW_BLINK text (if application supports SGR 5)
- [ ] Test RAPID_BLINK text (if application supports SGR 6)
- [ ] Modify settings values and verify timer updates

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)