### PR TITLE
feat: Add interactive pre-connection handler with dropdown selection (#43)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/ComposeQuestioner.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/ComposeQuestioner.kt
@@ -1,0 +1,130 @@
+package org.jetbrains.jediterm.compose
+
+import com.jediterm.terminal.Questioner
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * Compose-compatible implementation of the Questioner interface.
+ *
+ * Bridges the synchronous Questioner API with Compose's callback-based approach
+ * using Kotlin coroutines. When input is required, sets ConnectionState.RequiresInput
+ * and suspends until user provides input.
+ *
+ * Usage:
+ * ```kotlin
+ * val questioner = ComposeQuestioner { newState ->
+ *     connectionState = newState
+ * }
+ *
+ * // In coroutine scope:
+ * val password = questioner.questionHidden("Enter password:")
+ * ```
+ *
+ * @param onStateChange Callback to update connection state for UI rendering
+ */
+@Suppress("DEPRECATION")
+class ComposeQuestioner(
+    private val onStateChange: (ConnectionState) -> Unit
+) : Questioner {
+
+    /**
+     * Request visible (non-masked) input from user.
+     *
+     * @param question The prompt to display
+     * @param defValue Optional default value to pre-populate
+     * @return User input, or null if cancelled
+     */
+    override fun questionVisible(question: String?, defValue: String?): String? {
+        if (question == null) return null
+
+        return kotlinx.coroutines.runBlocking {
+            suspendCancellableCoroutine { continuation ->
+                onStateChange(
+                    ConnectionState.RequiresInput(
+                        prompt = question,
+                        isPassword = false,
+                        defaultValue = defValue,
+                        onSubmit = { input ->
+                            continuation.resume(input)
+                        },
+                        onCancel = {
+                            continuation.resume(null)
+                        }
+                    )
+                )
+            }
+        }
+    }
+
+    /**
+     * Request hidden (password) input from user.
+     *
+     * @param string The prompt to display
+     * @return User input, or null if cancelled
+     */
+    override fun questionHidden(string: String?): String? {
+        if (string == null) return null
+
+        return kotlinx.coroutines.runBlocking {
+            suspendCancellableCoroutine { continuation ->
+                onStateChange(
+                    ConnectionState.RequiresInput(
+                        prompt = string,
+                        isPassword = true,
+                        defaultValue = null,
+                        onSubmit = { input ->
+                            continuation.resume(input)
+                        },
+                        onCancel = {
+                            continuation.resume(null)
+                        }
+                    )
+                )
+            }
+        }
+    }
+
+    /**
+     * Display an informational message to the user.
+     *
+     * @param message The message to display
+     */
+    override fun showMessage(message: String?) {
+        if (message != null) {
+            onStateChange(ConnectionState.ShowMessage(message))
+        }
+    }
+
+    /**
+     * Request user to select from a list of options.
+     *
+     * @param prompt The prompt to display
+     * @param options List of options (value to label pairs)
+     * @param defaultIndex Index of default selection (0-based)
+     * @return Selected value, or null if cancelled
+     */
+    fun questionSelection(
+        prompt: String,
+        options: List<ConnectionState.SelectOption>,
+        defaultIndex: Int = 0
+    ): String? {
+        return kotlinx.coroutines.runBlocking {
+            suspendCancellableCoroutine { continuation ->
+                onStateChange(
+                    ConnectionState.RequiresSelection(
+                        prompt = prompt,
+                        options = options,
+                        defaultIndex = defaultIndex,
+                        onSelect = { selected ->
+                            continuation.resume(selected)
+                        },
+                        onCancel = {
+                            continuation.resume(null)
+                        }
+                    )
+                )
+            }
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/ConnectionState.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/ConnectionState.kt
@@ -41,4 +41,58 @@ sealed class ConnectionState {
     ) : ConnectionState() {
         override fun toString(): String = "ConnectionState.Error(message='$message', cause=${cause?.javaClass?.simpleName})"
     }
+
+    /**
+     * Connection requires user input before proceeding.
+     * Used for interactive authentication (passwords, 2FA codes) or custom TtyConnector setup.
+     *
+     * @param prompt The question or prompt to display to the user
+     * @param isPassword If true, input should be masked (not displayed)
+     * @param defaultValue Optional default value to pre-populate
+     * @param onSubmit Callback invoked when user submits input
+     * @param onCancel Optional callback invoked when user cancels input
+     */
+    data class RequiresInput(
+        val prompt: String,
+        val isPassword: Boolean = false,
+        val defaultValue: String? = null,
+        val onSubmit: (String) -> Unit,
+        val onCancel: (() -> Unit)? = null
+    ) : ConnectionState()
+
+    /**
+     * Displaying an informational message during pre-connection phase.
+     * @param message The message to display
+     */
+    data class ShowMessage(
+        val message: String
+    ) : ConnectionState()
+
+    /**
+     * Connection requires user to select from a list of options.
+     * Used for connection type selection, database type, etc.
+     *
+     * @param prompt The question or prompt to display
+     * @param options List of selectable options (value to display label)
+     * @param defaultIndex Index of default selected option (0-based)
+     * @param onSelect Callback invoked when user selects an option (receives the value)
+     * @param onCancel Optional callback invoked when user cancels
+     */
+    data class RequiresSelection(
+        val prompt: String,
+        val options: List<SelectOption>,
+        val defaultIndex: Int = 0,
+        val onSelect: (String) -> Unit,
+        val onCancel: (() -> Unit)? = null
+    ) : ConnectionState()
+
+    /**
+     * Represents a selectable option in RequiresSelection.
+     * @param value The value returned when selected
+     * @param label The display label shown to user
+     */
+    data class SelectOption(
+        val value: String,
+        val label: String
+    )
 }

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/PreConnectScreen.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/PreConnectScreen.kt
@@ -1,14 +1,33 @@
 package org.jetbrains.jediterm.compose
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.*
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -18,6 +37,8 @@ import androidx.compose.ui.unit.sp
  * Displays:
  * - Loading spinner during [ConnectionState.Initializing] and [ConnectionState.Connecting]
  * - Error message with retry button for [ConnectionState.Error]
+ * - Input field for [ConnectionState.RequiresInput] (password prompts, 2FA codes)
+ * - Informational message for [ConnectionState.ShowMessage]
  * - Nothing when [ConnectionState.Connected] (parent handles terminal rendering)
  *
  * @param state Current connection state
@@ -48,7 +69,7 @@ fun PreConnectScreen(
             is ConnectionState.Error -> {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
-                        text = "⚠️ Connection Failed",
+                        text = "Connection Failed",
                         color = Color.Red,
                         fontSize = 18.sp
                     )
@@ -64,8 +85,265 @@ fun PreConnectScreen(
                     }
                 }
             }
+            is ConnectionState.RequiresInput -> {
+                PreConnectInputForm(
+                    prompt = state.prompt,
+                    isPassword = state.isPassword,
+                    defaultValue = state.defaultValue,
+                    onSubmit = state.onSubmit,
+                    onCancel = state.onCancel
+                )
+            }
+            is ConnectionState.ShowMessage -> {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = state.message,
+                        color = Color.White,
+                        fontSize = 14.sp
+                    )
+                }
+            }
+            is ConnectionState.RequiresSelection -> {
+                PreConnectSelectionForm(
+                    prompt = state.prompt,
+                    options = state.options,
+                    defaultIndex = state.defaultIndex,
+                    onSelect = state.onSelect,
+                    onCancel = state.onCancel
+                )
+            }
             is ConnectionState.Connected -> {
                 // Connected state handled by parent - show nothing here
+            }
+        }
+    }
+}
+
+/**
+ * Input form for pre-connection user input (passwords, authentication codes, etc.)
+ */
+@Composable
+private fun PreConnectInputForm(
+    prompt: String,
+    isPassword: Boolean,
+    defaultValue: String?,
+    onSubmit: (String) -> Unit,
+    onCancel: (() -> Unit)?
+) {
+    var inputValue by remember { mutableStateOf(defaultValue ?: "") }
+    val focusRequester = remember { FocusRequester() }
+
+    // Auto-focus the input field
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(32.dp).widthIn(max = 400.dp)
+    ) {
+        // Prompt text
+        Text(
+            text = prompt,
+            color = Color.White,
+            fontSize = 14.sp,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        // Input field
+        OutlinedTextField(
+            value = inputValue,
+            onValueChange = { inputValue = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester)
+                .onKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyDown) {
+                        when (event.key) {
+                            Key.Enter -> {
+                                onSubmit(inputValue)
+                                true
+                            }
+                            Key.Escape -> {
+                                onCancel?.invoke()
+                                true
+                            }
+                            else -> false
+                        }
+                    } else {
+                        false
+                    }
+                },
+            visualTransformation = if (isPassword) {
+                PasswordVisualTransformation()
+            } else {
+                VisualTransformation.None
+            },
+            singleLine = true,
+            placeholder = {
+                Text(
+                    text = if (isPassword) "Enter password..." else "Enter value...",
+                    color = Color.Gray
+                )
+            },
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                textColor = Color.White,
+                cursorColor = Color.White,
+                focusedBorderColor = Color(0xFF5C9FFF),
+                unfocusedBorderColor = Color.Gray,
+                backgroundColor = Color(0xFF2B2B2B)
+            ),
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = { onSubmit(inputValue) }
+            )
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Action buttons
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            if (onCancel != null) {
+                OutlinedButton(
+                    onClick = { onCancel() },
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        backgroundColor = Color.Transparent,
+                        contentColor = Color.White
+                    ),
+                    border = BorderStroke(1.dp, Color.Gray)
+                ) {
+                    Text("Cancel")
+                }
+            }
+            Button(
+                onClick = { onSubmit(inputValue) },
+                modifier = if (onCancel != null) Modifier.weight(1f) else Modifier.fillMaxWidth()
+            ) {
+                Text("Submit")
+            }
+        }
+
+        // Help text
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Press Enter to submit" + if (onCancel != null) ", Escape to cancel" else "",
+            color = Color.Gray,
+            fontSize = 12.sp
+        )
+    }
+}
+
+/**
+ * Dropdown selection form for choosing from predefined options.
+ */
+@Composable
+private fun PreConnectSelectionForm(
+    prompt: String,
+    options: List<ConnectionState.SelectOption>,
+    defaultIndex: Int,
+    onSelect: (String) -> Unit,
+    onCancel: (() -> Unit)?
+) {
+    var selectedIndex by remember { mutableStateOf(defaultIndex.coerceIn(0, options.lastIndex)) }
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(32.dp).widthIn(max = 400.dp)
+    ) {
+        // Prompt text
+        Text(
+            text = prompt,
+            color = Color.White,
+            fontSize = 14.sp,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        // Dropdown selector
+        Box(modifier = Modifier.fillMaxWidth()) {
+            OutlinedButton(
+                onClick = { expanded = true },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    backgroundColor = Color(0xFF2B2B2B),
+                    contentColor = Color.White
+                ),
+                border = BorderStroke(1.dp, Color.Gray)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = options.getOrNull(selectedIndex)?.label ?: "Select...",
+                        color = Color.White
+                    )
+                    Icon(
+                        imageVector = Icons.Default.ArrowDropDown,
+                        contentDescription = "Dropdown",
+                        tint = Color.White
+                    )
+                }
+            }
+
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+                modifier = Modifier
+                    .background(Color(0xFF2B2B2B))
+                    .widthIn(min = 300.dp)
+            ) {
+                options.forEachIndexed { index, option ->
+                    DropdownMenuItem(
+                        onClick = {
+                            selectedIndex = index
+                            expanded = false
+                        },
+                        modifier = Modifier.background(
+                            if (index == selectedIndex) Color(0xFF3C3C3C) else Color.Transparent
+                        )
+                    ) {
+                        Text(
+                            text = option.label,
+                            color = Color.White
+                        )
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Action buttons
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            if (onCancel != null) {
+                OutlinedButton(
+                    onClick = { onCancel() },
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        backgroundColor = Color.Transparent,
+                        contentColor = Color.White
+                    ),
+                    border = BorderStroke(1.dp, Color.Gray)
+                ) {
+                    Text("Cancel")
+                }
+            }
+            Button(
+                onClick = {
+                    options.getOrNull(selectedIndex)?.let { onSelect(it.value) }
+                },
+                modifier = if (onCancel != null) Modifier.weight(1f) else Modifier.fillMaxWidth()
+            ) {
+                Text("Continue")
             }
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/TtyConnectorFactory.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/TtyConnectorFactory.kt
@@ -1,0 +1,64 @@
+package org.jetbrains.jediterm.compose
+
+import com.jediterm.terminal.Questioner
+import com.jediterm.terminal.TtyConnector
+
+/**
+ * Factory interface for creating TtyConnector instances with optional pre-connection prompts.
+ *
+ * This enables interactive setup flows like:
+ * - SSH password authentication
+ * - Two-factor authentication (2FA/MFA)
+ * - Custom host/port selection
+ * - Certificate passphrases
+ *
+ * Usage:
+ * ```kotlin
+ * val sshConnectorFactory = object : TtyConnectorFactory {
+ *     override suspend fun createConnector(questioner: Questioner): TtyConnector? {
+ *         val host = questioner.questionVisible("Enter SSH host:", "localhost")
+ *         val password = questioner.questionHidden("Enter password:")
+ *         if (password == null) return null  // User cancelled
+ *
+ *         questioner.showMessage("Connecting to $host...")
+ *         return SshTtyConnector(host, password)
+ *     }
+ * }
+ *
+ * tabController.createTabWithConnector(sshConnectorFactory)
+ * ```
+ */
+interface TtyConnectorFactory {
+    /**
+     * Create a TtyConnector, optionally prompting user for input.
+     *
+     * The questioner parameter provides methods to:
+     * - `questionVisible()`: Ask for visible input (hostname, username)
+     * - `questionHidden()`: Ask for hidden input (passwords, secrets)
+     * - `showMessage()`: Display informational messages
+     *
+     * @param questioner Interface for prompting user input
+     * @return The created TtyConnector, or null if user cancelled
+     */
+    suspend fun createConnector(questioner: Questioner): TtyConnector?
+}
+
+/**
+ * Simple result wrapper for connector factory operations.
+ */
+sealed class ConnectorResult {
+    /**
+     * Successfully created a connector.
+     */
+    data class Success(val connector: TtyConnector) : ConnectorResult()
+
+    /**
+     * User cancelled the connection setup.
+     */
+    object Cancelled : ConnectorResult()
+
+    /**
+     * Connection setup failed with an error.
+     */
+    data class Error(val message: String, val cause: Throwable? = null) : ConnectorResult()
+}

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/actions/BuiltinActions.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/actions/BuiltinActions.kt
@@ -273,6 +273,7 @@ private fun extractSelectedText(
 fun addTabManagementActions(
     registry: ActionRegistry,
     onNewTab: () -> Unit,
+    onNewPreConnectTab: () -> Unit = {},  // Test pre-connection input
     onCloseTab: () -> Unit,
     onNextTab: () -> Unit,
     onPreviousTab: () -> Unit,
@@ -289,6 +290,21 @@ fun addTabManagementActions(
         ),
         handler = { event ->
             onNewTab()
+            true  // Consume event
+        }
+    ))
+
+    // NEW PRE-CONNECT TAB - Cmd/Ctrl+Shift+T
+    // Opens a new tab with pre-connection input prompts (for testing)
+    registry.register(TerminalAction(
+        id = "new_preconnect_tab",
+        name = "New Pre-Connect Tab",
+        keyStrokes = listOf(
+            KeyStroke(key = Key.T, ctrl = true, shift = true),  // Windows/Linux
+            KeyStroke(key = Key.T, meta = true, shift = true)   // macOS
+        ),
+        handler = { event ->
+            onNewPreConnectTab()
             true  // Consume event
         }
     ))

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/demo/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/demo/ProperTerminal.kt
@@ -138,6 +138,7 @@ fun ProperTerminal(
   sharedFont: FontFamily,
   onTabTitleChange: (String) -> Unit,
   onNewTab: () -> Unit = {},
+  onNewPreConnectTab: () -> Unit = {},  // Ctrl+Shift+T: Test pre-connection input
   onCloseTab: () -> Unit = {},
   onNextTab: () -> Unit = {},
   onPreviousTab: () -> Unit = {},
@@ -433,6 +434,7 @@ fun ProperTerminal(
     addTabManagementActions(
       registry = registry,
       onNewTab = onNewTab,
+      onNewPreConnectTab = onNewPreConnectTab,
       onCloseTab = onCloseTab,
       onNextTab = onNextTab,
       onPreviousTab = onPreviousTab,


### PR DESCRIPTION
## Summary
- Add interactive pre-connection handler for user input during terminal setup
- Implement dropdown selection UI for connection type (SSH, Database, K8s, Local Shell)
- Use native CLI commands for real connections (ssh, psql, mysql, mongosh, kubectl)

## Changes
- **ConnectionState.kt**: Added `RequiresSelection` state and `SelectOption` data class
- **PreConnectScreen.kt**: Added `PreConnectSelectionForm` with Material DropdownMenu
- **ComposeQuestioner.kt**: New class implementing `Questioner` with `questionSelection()` method
- **TtyConnectorFactory.kt**: Factory for PTY connector creation
- **TabController.kt**: Updated `createTabWithPreConnect` to use `ComposeQuestioner`
- **Main.kt**: Realistic connection flows for SSH, Database, Kubernetes, Local Shell
- **BuiltinActions.kt**: Cmd/Ctrl+Shift+T shortcut for pre-connect tab

## Test plan
- [ ] Press Cmd+Shift+T to open pre-connect dialog
- [ ] Verify dropdown appears with 4 connection options
- [ ] Test SSH connection flow (requires ssh CLI)
- [ ] Test Database connection flow (requires mysql/psql/mongosh)
- [ ] Test Kubernetes flow (requires kubectl)
- [ ] Test Local Shell flow
- [ ] Verify Cancel button styling (transparent with gray border)

🤖 Generated with [Claude Code](https://claude.com/claude-code)