### PR TITLE
feat: Add enableTextBlinking master toggle setting (#42)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/demo/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/demo/ProperTerminal.kt
@@ -472,18 +472,21 @@ fun ProperTerminal(
   val cellHeight = cellMetrics.second
 
   // SLOW_BLINK animation timer (configurable via settings.slowTextBlinkMs)
-  LaunchedEffect(settings.slowTextBlinkMs) {
-    while (true) {
-      delay(settings.slowTextBlinkMs.toLong())
-      slowBlinkVisible = !slowBlinkVisible
+  // Wrapped with enableTextBlinking master toggle for accessibility
+  if (settings.enableTextBlinking) {
+    LaunchedEffect(settings.slowTextBlinkMs) {
+      while (true) {
+        delay(settings.slowTextBlinkMs.toLong())
+        slowBlinkVisible = !slowBlinkVisible
+      }
     }
-  }
 
-  // RAPID_BLINK animation timer (configurable via settings.rapidTextBlinkMs)
-  LaunchedEffect(settings.rapidTextBlinkMs) {
-    while (true) {
-      delay(settings.rapidTextBlinkMs.toLong())
-      rapidBlinkVisible = !rapidBlinkVisible
+    // RAPID_BLINK animation timer (configurable via settings.rapidTextBlinkMs)
+    LaunchedEffect(settings.rapidTextBlinkMs) {
+      while (true) {
+        delay(settings.rapidTextBlinkMs.toLong())
+        rapidBlinkVisible = !rapidBlinkVisible
+      }
     }
   }
 

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/settings/TerminalSettings.kt
@@ -168,6 +168,11 @@ data class TerminalSettings(
     val caretBlinkMs: Int = 500,
 
     /**
+     * Master toggle to enable/disable all text blinking (accessibility feature)
+     */
+    val enableTextBlinking: Boolean = true,
+
+    /**
      * Slow text blink rate in milliseconds
      */
     val slowTextBlinkMs: Int = 1000,


### PR DESCRIPTION
## Summary
- Add master toggle to enable/disable all text blinking (SLOW_BLINK and RAPID_BLINK)
- Accessibility feature for users who find blinking text distracting
- Low-power mode benefit: disabling saves CPU cycles

## Changes
- **TerminalSettings.kt**: Added `enableTextBlinking: Boolean = true` setting
- **ProperTerminal.kt**: Wrapped blink animation timers with setting check

## Test plan
- [ ] Set `enableTextBlinking: false` in `~/.jediterm/settings.json`
- [ ] Verify blinking text (SGR 5/6) renders as static text
- [ ] Set `enableTextBlinking: true` (default)
- [ ] Verify blinking animations work normally

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)