### PR TITLE
Add line spacing options for alternate buffer (#46)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/demo/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/demo/ProperTerminal.kt
@@ -469,7 +469,21 @@ fun ProperTerminal(
     Triple(width, height, baseline)
   }
   val cellWidth = cellMetrics.first
-  val cellHeight = cellMetrics.second
+  val baseCellHeight = cellMetrics.second  // Raw height without line spacing
+
+  // Calculate effective line spacing based on settings and alternate buffer state
+  val isUsingAlternateBuffer = textBuffer.isUsingAlternateBuffer
+  val effectiveLineSpacing = if (settings.disableLineSpacingInAlternateBuffer && isUsingAlternateBuffer) {
+    1.0f  // No line spacing in alternate buffer
+  } else {
+    settings.lineSpacing
+  }
+
+  // Apply line spacing to cell height
+  val cellHeight = baseCellHeight * effectiveLineSpacing
+
+  // Calculate line spacing gap (extra space added by line spacing)
+  val lineSpacingGap = cellHeight - baseCellHeight
 
   // SLOW_BLINK animation timer (configurable via settings.slowTextBlinkMs)
   // Wrapped with enableTextBlinking master toggle for accessibility
@@ -1262,11 +1276,13 @@ fun ProperTerminal(
                 }
 
                 // Draw background (single or double width)
+                // When fillBackgroundInLineSpacing is false, only fill baseCellHeight
                 val bgWidth = if (isWcwidthDoubleWidth) cellWidth * 2 else cellWidth
+                val bgHeight = if (settings.fillBackgroundInLineSpacing) cellHeight else baseCellHeight
                 drawRect(
                   color = bgColor,
                   topLeft = Offset(x, y),
-                  size = Size(bgWidth, cellHeight)
+                  size = Size(bgWidth, bgHeight)
                 )
 
                 // Skip next column if double-width

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/settings/TerminalSettings.kt
@@ -24,6 +24,19 @@ data class TerminalSettings(
     val lineSpacing: Float = 1.0f,
 
     /**
+     * Disable line spacing when in alternate screen buffer.
+     * Full-screen apps (vim, htop, less) may look better without extra spacing.
+     */
+    val disableLineSpacingInAlternateBuffer: Boolean = false,
+
+    /**
+     * Fill character background color through line spacing area.
+     * When true, background colors extend into line spacing.
+     * When false, line spacing shows terminal background only.
+     */
+    val fillBackgroundInLineSpacing: Boolean = true,
+
+    /**
      * Use antialiasing for text rendering
      */
     val useAntialiasing: Boolean = true,


### PR DESCRIPTION
## Summary
- Add `disableLineSpacingInAlternateBuffer` setting (default: false) - when enabled, line spacing resets to 1.0 in alternate buffer for full-screen apps (vim, htop, less)
- Add `fillBackgroundInLineSpacing` setting (default: true) - controls whether character background colors extend into line spacing area
- Update ProperTerminal.kt rendering to calculate effective line spacing based on alternate buffer state

## Test plan
- [ ] Verify line spacing works normally in primary buffer
- [ ] Enable `disableLineSpacingInAlternateBuffer`, run vim/htop/less, verify line spacing is 1.0
- [ ] Test `fillBackgroundInLineSpacing=false` to verify background colors don't extend into line spacing
- [ ] Verify settings persist after restart

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)