### PR TITLE
feat: Add LoggingTtyConnector interface and file logging (#52)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/debug/DebugDataCollector.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/debug/DebugDataCollector.kt
@@ -1,6 +1,12 @@
 package org.jetbrains.jediterm.compose.debug
 
+import com.jediterm.terminal.LoggingTtyConnector
 import org.jetbrains.jediterm.compose.tabs.TerminalTab
+import java.io.File
+import java.io.FileWriter
+import java.io.PrintWriter
+import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -10,6 +16,8 @@ import java.util.concurrent.atomic.AtomicInteger
  * This class maintains a circular buffer of data chunks and periodic snapshots of
  * terminal state (screen content, cursor position, styles, etc.) for time-travel
  * debugging and analysis.
+ *
+ * Implements [LoggingTtyConnector] for compatibility with legacy debugging tools.
  *
  * Thread-safety: All public methods are thread-safe and can be called from any coroutine.
  *
@@ -21,7 +29,12 @@ class DebugDataCollector(
     private var tab: TerminalTab?,
     private val maxChunks: Int = 1000,
     private val maxSnapshots: Int = 100
-) {
+) : LoggingTtyConnector {
+
+    // File logging state
+    private var fileLogWriter: PrintWriter? = null
+    private var fileLogPath: String? = null
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
     private val chunks = ConcurrentLinkedQueue<DebugChunk>()
     private val snapshots = ConcurrentLinkedQueue<TerminalSnapshot>()
     private val chunkIndex = AtomicInteger(0)
@@ -58,6 +71,9 @@ class DebugDataCollector(
         while (chunks.size > maxChunks) {
             chunks.poll()
         }
+
+        // Write to file log if active
+        writeChunkToFile(chunk)
     }
 
     /**
@@ -146,11 +162,11 @@ class DebugDataCollector(
     }
 
     /**
-     * Get all currently stored chunks.
+     * Get all currently stored chunks with full debug metadata.
      *
      * @return Immutable list of chunks in chronological order
      */
-    fun getChunks(): List<DebugChunk> {
+    fun getDebugChunks(): List<DebugChunk> {
         return chunks.toList()
     }
 
@@ -282,6 +298,186 @@ class DebugDataCollector(
         }
 
         return total
+    }
+
+    // === LoggingTtyConnector Interface Implementation ===
+
+    /**
+     * Get all captured data chunks as CharArrays.
+     * Implements [LoggingTtyConnector.getChunks].
+     */
+    override fun getChunks(): List<CharArray> {
+        return chunks.map { it.data }
+    }
+
+    /**
+     * Get all captured terminal states.
+     * Implements [LoggingTtyConnector.getStates].
+     */
+    override fun getStates(): List<LoggingTtyConnector.TerminalState> {
+        return snapshots.map { snapshot ->
+            LoggingTtyConnector.TerminalState(
+                screenLines = snapshot.screenLines,
+                styleLines = snapshot.styleLines,
+                historyLines = snapshot.historyLines,
+                timestamp = snapshot.timestamp,
+                cursorX = snapshot.cursorX,
+                cursorY = snapshot.cursorY,
+                alternateBufferActive = snapshot.alternateBufferActive
+            )
+        }
+    }
+
+    /**
+     * Get the starting index of the log buffer.
+     * Implements [LoggingTtyConnector.getLogStart].
+     */
+    override fun getLogStart(): Int {
+        return chunks.firstOrNull()?.index ?: 0
+    }
+
+    // === File Logging Methods ===
+
+    /**
+     * Start logging to a file.
+     *
+     * Creates or overwrites the specified file and writes all I/O data to it.
+     * Each chunk is written with a timestamp and source indicator.
+     *
+     * @param filePath Path to the log file
+     * @throws java.io.IOException If the file cannot be created or written to
+     */
+    fun startFileLogging(filePath: String) {
+        synchronized(this) {
+            stopFileLogging()
+            val file = File(filePath)
+            file.parentFile?.mkdirs()
+            fileLogWriter = PrintWriter(FileWriter(file, false), true)
+            fileLogPath = filePath
+            fileLogWriter?.println("=== JediTerm Debug Log Started: ${dateFormat.format(Date())} ===")
+            fileLogWriter?.println()
+        }
+    }
+
+    /**
+     * Stop logging to file and close the writer.
+     */
+    fun stopFileLogging() {
+        synchronized(this) {
+            fileLogWriter?.let { writer ->
+                writer.println()
+                writer.println("=== JediTerm Debug Log Ended: ${dateFormat.format(Date())} ===")
+                writer.close()
+            }
+            fileLogWriter = null
+            fileLogPath = null
+        }
+    }
+
+    /**
+     * Check if file logging is currently active.
+     */
+    fun isFileLoggingActive(): Boolean {
+        return fileLogWriter != null
+    }
+
+    /**
+     * Get the current log file path, or null if not logging.
+     */
+    fun getLogFilePath(): String? = fileLogPath
+
+    /**
+     * Write a chunk to the log file (called internally from recordChunk).
+     */
+    private fun writeChunkToFile(chunk: DebugChunk) {
+        fileLogWriter?.let { writer ->
+            synchronized(this) {
+                val timestamp = dateFormat.format(Date(chunk.timestamp))
+                val sourceTag = when (chunk.source) {
+                    ChunkSource.PTY_OUTPUT -> "PTY>"
+                    ChunkSource.USER_INPUT -> "USR<"
+                    ChunkSource.EMULATOR_GENERATED -> "EMU!"
+                }
+                writer.print("[$timestamp] $sourceTag ")
+                // Escape non-printable characters for readability
+                val escaped = chunk.data.joinToString("") { c ->
+                    when {
+                        c == '\u001b' -> "\\e"
+                        c == '\n' -> "\\n"
+                        c == '\r' -> "\\r"
+                        c == '\t' -> "\\t"
+                        c.code < 32 -> "\\x${c.code.toString(16).padStart(2, '0')}"
+                        else -> c.toString()
+                    }
+                }
+                writer.println(escaped)
+            }
+        }
+    }
+
+    // === Export Methods ===
+
+    /**
+     * Export all collected data to a file in human-readable format.
+     *
+     * @param filePath Path to the export file
+     * @param includeSnapshots Whether to include state snapshots
+     */
+    fun exportToFile(filePath: String, includeSnapshots: Boolean = true) {
+        val file = File(filePath)
+        file.parentFile?.mkdirs()
+
+        PrintWriter(FileWriter(file)).use { writer ->
+            val stats = getStats()
+            writer.println("=== JediTerm Debug Export ===")
+            writer.println("Exported: ${dateFormat.format(Date())}")
+            writer.println()
+            writer.println("=== Statistics ===")
+            writer.println(stats.toDisplayString())
+            writer.println()
+
+            writer.println("=== Data Chunks (${chunks.size}) ===")
+            chunks.forEach { chunk ->
+                val timestamp = dateFormat.format(Date(chunk.timestamp))
+                val sourceTag = chunk.source.name
+                writer.println("--- Chunk #${chunk.index} [$timestamp] $sourceTag ---")
+                writer.println(String(chunk.data))
+                writer.println()
+            }
+
+            if (includeSnapshots) {
+                writer.println("=== State Snapshots (${snapshots.size}) ===")
+                snapshots.forEach { snapshot ->
+                    val timestamp = dateFormat.format(Date(snapshot.timestamp))
+                    writer.println("--- Snapshot @${snapshot.chunkIndex} [$timestamp] ---")
+                    writer.println("Cursor: (${snapshot.cursorX}, ${snapshot.cursorY})")
+                    writer.println("Alternate Buffer: ${snapshot.alternateBufferActive}")
+                    writer.println("Screen:")
+                    writer.println(snapshot.screenLines)
+                    writer.println("History:")
+                    writer.println(snapshot.historyLines)
+                    writer.println()
+                }
+            }
+
+            writer.println("=== End Export ===")
+        }
+    }
+
+    /**
+     * Export raw chunks to a binary-compatible format for replay.
+     *
+     * @param filePath Path to the export file
+     */
+    fun exportRawChunks(filePath: String) {
+        val file = File(filePath)
+        file.parentFile?.mkdirs()
+
+        file.writeText(buildString {
+            chunks.forEach { chunk ->
+                append(String(chunk.data))
+            }
+        })
     }
 }
 

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/debug/DebugPanel.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/debug/DebugPanel.kt
@@ -51,14 +51,14 @@ fun DebugPanel(
 
     // Auto-refresh: Update snapshot list periodically
     val snapshots = remember { mutableStateOf(collector.getSnapshots()) }
-    val chunks = remember { mutableStateOf(collector.getChunks()) }
+    val chunks = remember { mutableStateOf(collector.getDebugChunks()) }
     val stats = remember { mutableStateOf(collector.getStats()) }
 
     LaunchedEffect(Unit) {
         while (true) {
             delay(1000)  // Refresh every second
             snapshots.value = collector.getSnapshots()
-            chunks.value = collector.getChunks()
+            chunks.value = collector.getDebugChunks()
             stats.value = collector.getStats()
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/org/jetbrains/jediterm/compose/settings/TerminalSettings.kt
@@ -301,7 +301,28 @@ data class TerminalSettings(
     /**
      * Color-code escape sequences in debug view
      */
-    val debugColorCodeSequences: Boolean = true
+    val debugColorCodeSequences: Boolean = true,
+
+    // ===== File Logging Settings =====
+
+    /**
+     * Enable automatic file logging on terminal start.
+     * When enabled, all terminal I/O is written to a log file.
+     */
+    val fileLoggingEnabled: Boolean = false,
+
+    /**
+     * Directory for log files. If empty, uses ~/.jediterm/logs/
+     */
+    val fileLoggingDirectory: String = "",
+
+    /**
+     * Log file name pattern. Supports placeholders:
+     * {timestamp} - ISO 8601 timestamp
+     * {tab} - Tab ID (first 8 chars)
+     * {pid} - Process ID
+     */
+    val fileLoggingPattern: String = "jediterm_{timestamp}_{tab}.log"
 ) {
     // Non-serialized computed properties
 

--- a/jediterm-core-mpp/src/jvmMain/kotlin/com/jediterm/terminal/LoggingTtyConnector.kt
+++ b/jediterm-core-mpp/src/jvmMain/kotlin/com/jediterm/terminal/LoggingTtyConnector.kt
@@ -1,0 +1,89 @@
+package com.jediterm.terminal
+
+/**
+ * Interface for terminal connectors that support logging of I/O data.
+ *
+ * This interface allows querying captured chunks of terminal data and
+ * periodic state snapshots, useful for debugging terminal issues.
+ *
+ * Implementations typically wrap another TtyConnector and intercept
+ * all read/write operations to record them.
+ *
+ * @see TtyConnector
+ */
+interface LoggingTtyConnector {
+    /**
+     * Get all captured data chunks.
+     *
+     * Each chunk represents a single read operation from the PTY,
+     * preserving the exact byte boundaries as received.
+     *
+     * @return List of character arrays in chronological order
+     */
+    fun getChunks(): List<CharArray>
+
+    /**
+     * Get all captured terminal state snapshots.
+     *
+     * Snapshots are taken periodically (e.g., every 100ms) and capture
+     * the complete terminal state at that moment for time-travel debugging.
+     *
+     * @return List of terminal states in chronological order
+     */
+    fun getStates(): List<TerminalState>
+
+    /**
+     * Get the starting index of the log buffer.
+     *
+     * When the buffer wraps (circular buffer), this indicates which
+     * chunk index was the earliest still available.
+     *
+     * @return The index of the first chunk in the buffer
+     */
+    fun getLogStart(): Int
+
+    /**
+     * Represents a snapshot of terminal state at a specific point in time.
+     *
+     * This class captures the complete visual state of the terminal,
+     * allowing reconstruction of what was displayed at any moment.
+     */
+    data class TerminalState(
+        /**
+         * Content of the visible screen buffer (newline-separated lines).
+         */
+        val screenLines: String,
+
+        /**
+         * Style attributes for each character position (encoded format).
+         * Format varies by implementation but typically includes color,
+         * bold, italic, underline, etc.
+         */
+        val styleLines: String,
+
+        /**
+         * Content of the scrollback history buffer (newline-separated lines).
+         */
+        val historyLines: String,
+
+        /**
+         * Timestamp when this snapshot was captured (milliseconds since epoch).
+         */
+        val timestamp: Long = System.currentTimeMillis(),
+
+        /**
+         * Cursor X position (column, 0-based).
+         */
+        val cursorX: Int = 0,
+
+        /**
+         * Cursor Y position (row, 0-based).
+         */
+        val cursorY: Int = 0,
+
+        /**
+         * Whether the alternate screen buffer was active.
+         */
+        val alternateBufferActive: Boolean = false
+    )
+}


### PR DESCRIPTION
## Summary
- Add `LoggingTtyConnector` interface to jediterm-core-mpp for debug logging compatibility
- `DebugDataCollector` now implements `LoggingTtyConnector` for legacy tool compatibility
- Add file logging capability with timestamped entries and source indicators
- Add export methods for debug data (`exportToFile()`, `exportRawChunks()`)
- Add file logging settings to `TerminalSettings`

## Changes
| File | Changes |
|------|---------|
| `LoggingTtyConnector.kt` | NEW - Interface with `getChunks()`, `getStates()`, `getLogStart()`, `TerminalState` data class |
| `DebugDataCollector.kt` | Implements interface, adds file logging methods |
| `TerminalSettings.kt` | Adds `fileLoggingEnabled`, `fileLoggingDirectory`, `fileLoggingPattern` |
| `DebugPanel.kt` | Uses renamed `getDebugChunks()` method |

## Test plan
- [ ] Verify debug panel still works (Cmd+Shift+D)
- [ ] Test `startFileLogging()` / `stopFileLogging()` API
- [ ] Test `exportToFile()` produces readable output
- [ ] Verify file logging settings in TerminalSettings

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)