### PR TITLE
Scrollbar improvements, multi-window support, and bug fixes

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ime/IMEHandler.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ime/IMEHandler.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.sp
+import kotlin.math.roundToInt
 
 /**
  * IME (Input Method Editor) handler for CJK (Chinese, Japanese, Korean) input.
@@ -49,9 +50,9 @@ fun IMEHandler(
     var textFieldValue by remember { mutableStateOf("") }
     val focusRequester = remember { FocusRequester() }
 
-    // Position TextField at cursor location
-    val offsetX = (cursorX * charWidth).toInt()
-    val offsetY = (cursorY * charHeight).toInt()
+    // Position TextField at cursor location (use roundToInt to prevent cumulative drift)
+    val offsetX = (cursorX * charWidth).roundToInt()
+    val offsetY = (cursorY * charHeight).roundToInt()
 
     Box(modifier = modifier) {
         BasicTextField(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -425,12 +425,16 @@ fun ProperTerminal(
   }
 
   // Cache cell dimensions and baseline offset (calculated once, reused for all rendering)
+  // Measure a string of 100 characters to get accurate average advance width
+  // This prevents cumulative rounding errors when rendering long lines
   val cellMetrics = remember(measurementStyle) {
-    val measurement = textMeasurer.measure("W", measurementStyle)
-    val width = measurement.size.width.toFloat()
-    val height = measurement.size.height.toFloat()
+    val sampleString = "W".repeat(100)  // 100 characters for precise averaging
+    val measurement = textMeasurer.measure(sampleString, measurementStyle)
+    val width = measurement.size.width.toFloat() / sampleString.length
+    val singleMeasurement = textMeasurer.measure("W", measurementStyle)
+    val height = singleMeasurement.size.height.toFloat()
     // Get baseline offset from top of text bounds
-    val baseline = measurement.firstBaseline
+    val baseline = singleMeasurement.firstBaseline
     Triple(width, height, baseline)
   }
   val cellWidth = cellMetrics.first


### PR DESCRIPTION
## Summary
- **Auto-hide scrollbar**: Smooth fade animation after 1.5s inactivity
- **Scrollbar drag**: Fixed thumb dragging with proper event handling
- **Multi-window support**: Cmd/Ctrl+N opens new windows
- **Memory leak fix**: Proper cleanup when closing windows
- **Cursor drift fix**: Accurate cell width measurement for long input lines
- **Flickering fix**: Batch operations prevent intermediate state rendering

## Changes
- feat: Add smooth auto-hide scrollbar with inactivity timeout
- fix: Fix scrollbar thumb dragging with accumulated drag tracking
- fix: Prevent terminal selection when dragging scrollbar
- feat: Add multi-window support with Cmd/Ctrl+N shortcut
- fix: Prevent memory leak when closing windows (TabController.disposeAll)
- fix: Reduce cursor position drift in long input lines
- fix: Eliminate terminal flickering during rapid clear/write sequences
- style: Add consistent padding at start of terminal

## Test plan
- [ ] Open terminal, scroll to generate history, verify scrollbar auto-hides after 1.5s
- [ ] Drag scrollbar thumb, verify smooth scrolling without terminal selection
- [ ] Press Cmd/Ctrl+N to open new window
- [ ] Close windows and verify no zombie processes remain
- [ ] Type long input lines (100+ chars) and verify cursor stays aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)