### PR TITLE
fix: Tab focus and paste improvements

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -495,9 +495,12 @@ fun ProperTerminal(
 
   // Request focus when tab becomes active or changes
   // Use tab.id as key so effect re-triggers when switching between tabs
-  LaunchedEffect(tab.id) {
-    delay(100)
-    focusRequester.requestFocus()
+  // Also trigger on isActiveTab to handle focus after tab close
+  LaunchedEffect(tab.id, isActiveTab) {
+    if (isActiveTab) {
+      delay(50)
+      focusRequester.requestFocus()
+    }
   }
 
   // Resize PTY when it becomes available


### PR DESCRIPTION
## Summary
- **Paste targets active tab**: Fixed Cmd+V always pasting to first tab instead of current tab
- **Focus restoration**: Terminal now regains focus after closing a tab

## Changes
1. Added `tab` as key to `remember()` for actionRegistry so paste operations reference current tab
2. Added `isActiveTab` as key to focus `LaunchedEffect` to restore focus after tab close

## Test plan
- [ ] Open multiple tabs, switch to tab 2, Cmd+V paste → text appears in tab 2
- [ ] Open 2 tabs, close tab 1 → focus automatically on tab 2 (can type immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)