### PR TITLE
fix: Remove architecture constraints from snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,12 +16,6 @@ description: |
 grade: stable
 confinement: classic
 
-architectures:
-  - build-on: [amd64]
-    build-for: [amd64]
-  - build-on: [arm64]
-    build-for: [arm64]
-
 apps:
   bossterm:
     command: bin/bossterm


### PR DESCRIPTION
## Summary
Remove architecture constraints from snapcraft.yaml to allow building for all supported architectures.

## Changes
- Removed `architectures` section that limited builds to amd64/arm64 only

## Test plan
- [ ] Snap builds successfully for all architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)