### PR TITLE
fix: Make snap publish step non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,6 +426,7 @@ jobs:
       # To get credentials: snapcraft export-login --snaps=bossterm --acls package_access,package_push,package_update,package_release credentials.txt
       - name: Publish to Snap Store
         if: env.SNAPCRAFT_STORE_CREDENTIALS != ''
+        continue-on-error: true  # Don't fail build if snap publish fails (e.g., review queue)
         uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}


### PR DESCRIPTION
## Summary
Add `continue-on-error: true` to snap publish step so builds don't fail when snap store has pending reviews in queue.

## Changes
- `.github/workflows/release.yml`: Added `continue-on-error: true` to Publish to Snap Store step

## Test plan
- [ ] Release workflow completes even if snap publish fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)