### PR TITLE
fix: Respect soft-wrapped lines when copying selected text

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/selection/SelectionEngine.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/selection/SelectionEngine.kt
@@ -152,8 +152,10 @@ object SelectionEngine {
                 }
             }
 
-            // Add newline between rows (except after last row)
-            if (row < lastRow) {
+            // Add newline only for hard line breaks (non-wrapped lines)
+            // isWrapped=true means content continues on next line (soft wrap, no newline)
+            // isWrapped=false means hard line break (actual newline in content)
+            if (!line.isWrapped && row < lastRow) {
                 result.append('\n')
             }
         }


### PR DESCRIPTION
## Summary
- Fixed copy behavior for soft-wrapped lines in terminal
- Previously, all visual line breaks added newlines when copying
- Now only hard line breaks (actual newlines) add `\n` to copied text

## Changes
- Modified `SelectionEngine.extractSelectedText()` to check `line.isWrapped` before adding newlines
- Soft-wrapped lines (content that continues due to terminal width) no longer get unwanted newlines

## Test plan
- [ ] Generate long line that wraps: `echo "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"`
- [ ] Select the wrapped text and copy
- [ ] Paste - should be single line without internal newlines
- [ ] Test multi-line selection with actual newlines still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)