### PR TITLE
fix: Update CI/CD workflows for bossterm-app module refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Build macOS App Bundle
         run: |
           chmod +x ./gradlew
-          ./gradlew :compose-ui:createDistributable
+          ./gradlew :bossterm-app:createDistributable
         env:
           RELEASE_BUILD: true
           APP_VERSION: ${{ needs.prepare-version.outputs.version }}
@@ -144,7 +144,7 @@ jobs:
         if: env.DISABLE_MACOS_SIGNING != 'true'
         run: |
           # Convert to absolute path to avoid issues when changing directories
-          APP_PATH=$(find "$(pwd)/.gradleBuild/compose-ui/compose/binaries/main/app" -name "*.app" -type d | head -1)
+          APP_PATH=$(find "$(pwd)/.gradleBuild/bossterm-app/compose/binaries/main/app" -name "*.app" -type d | head -1)
           echo "App bundle: $APP_PATH"
 
           if [[ -n "$APP_PATH" && -d "$APP_PATH" ]]; then
@@ -199,7 +199,7 @@ jobs:
 
       - name: Package macOS DMG
         run: |
-          ./gradlew :compose-ui:packageDmg
+          ./gradlew :bossterm-app:packageDmg
         env:
           RELEASE_BUILD: true
           APP_VERSION: ${{ needs.prepare-version.outputs.version }}
@@ -207,7 +207,7 @@ jobs:
       - name: Notarize macOS DMG
         if: env.DISABLE_MACOS_SIGNING != 'true'
         run: |
-          DMG_PATH=$(find .gradleBuild/compose-ui/compose/binaries/main/dmg -name "*.dmg" | head -1)
+          DMG_PATH=$(find .gradleBuild/bossterm-app/compose/binaries/main/dmg -name "*.dmg" | head -1)
 
           if [[ -n "$DMG_PATH" && -f "$DMG_PATH" ]]; then
             echo "Notarizing: $DMG_PATH"
@@ -252,7 +252,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bossterm-macos-${{ needs.prepare-version.outputs.version }}
-          path: .gradleBuild/compose-ui/compose/binaries/main/dmg/*.dmg
+          path: .gradleBuild/bossterm-app/compose/binaries/main/dmg/*.dmg
           retention-days: 30
 
   build-linux-amd64:
@@ -294,14 +294,14 @@ jobs:
       - name: Build Linux Packages (Deb & RPM)
         run: |
           chmod +x ./gradlew
-          ./gradlew :compose-ui:packageDeb :compose-ui:packageRpm
+          ./gradlew :bossterm-app:packageDeb :bossterm-app:packageRpm
         env:
           RELEASE_BUILD: true
           APP_VERSION: ${{ needs.prepare-version.outputs.version }}
 
       - name: Build Uber JAR
         run: |
-          ./gradlew :compose-ui:packageUberJarForCurrentOS
+          ./gradlew :bossterm-app:packageUberJarForCurrentOS
         env:
           RELEASE_BUILD: true
           APP_VERSION: ${{ needs.prepare-version.outputs.version }}
@@ -310,21 +310,21 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bossterm-linux-amd64-deb-${{ needs.prepare-version.outputs.version }}
-          path: .gradleBuild/compose-ui/compose/binaries/main/deb/*.deb
+          path: .gradleBuild/bossterm-app/compose/binaries/main/deb/*.deb
           retention-days: 30
 
       - name: Upload RPM Package
         uses: actions/upload-artifact@v4
         with:
           name: bossterm-linux-amd64-rpm-${{ needs.prepare-version.outputs.version }}
-          path: .gradleBuild/compose-ui/compose/binaries/main/rpm/*.rpm
+          path: .gradleBuild/bossterm-app/compose/binaries/main/rpm/*.rpm
           retention-days: 30
 
       - name: Upload Uber JAR
         uses: actions/upload-artifact@v4
         with:
           name: bossterm-jar-${{ needs.prepare-version.outputs.version }}
-          path: .gradleBuild/compose-ui/compose/jars/*.jar
+          path: .gradleBuild/bossterm-app/compose/jars/*.jar
           retention-days: 30
 
   build-linux-arm64:
@@ -367,7 +367,7 @@ jobs:
       - name: Build Linux Packages (Deb & RPM)
         run: |
           chmod +x ./gradlew
-          ./gradlew :compose-ui:packageDeb :compose-ui:packageRpm
+          ./gradlew :bossterm-app:packageDeb :bossterm-app:packageRpm
         env:
           RELEASE_BUILD: true
           APP_VERSION: ${{ needs.prepare-version.outputs.version }}
@@ -376,14 +376,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bossterm-linux-arm64-deb-${{ needs.prepare-version.outputs.version }}
-          path: .gradleBuild/compose-ui/compose/binaries/main/deb/*.deb
+          path: .gradleBuild/bossterm-app/compose/binaries/main/deb/*.deb
           retention-days: 30
 
       - name: Upload RPM Package (ARM64)
         uses: actions/upload-artifact@v4
         with:
           name: bossterm-linux-arm64-rpm-${{ needs.prepare-version.outputs.version }}
-          path: .gradleBuild/compose-ui/compose/binaries/main/rpm/*.rpm
+          path: .gradleBuild/bossterm-app/compose/binaries/main/rpm/*.rpm
           retention-days: 30
 
   build-snap:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -45,7 +45,7 @@ parts:
       - libx11-6
     override-build: |
       # Build the uber JAR using Gradle (from build-snap, no network download)
-      gradle :compose-ui:packageUberJarForCurrentOS --no-daemon
+      gradle :bossterm-app:packageUberJarForCurrentOS --no-daemon
 
       # Find and copy the JAR (path varies based on build location)
       mkdir -p $CRAFT_PART_INSTALL/lib


### PR DESCRIPTION
## Summary
- Fix CI/CD workflow failure caused by module refactoring
- Update all `:compose-ui:` task references to `:bossterm-app:`
- Update all artifact paths from `compose-ui` to `bossterm-app`

## Changes

### `.github/workflows/release.yml`
| Task/Path | Before | After |
|-----------|--------|-------|
| packageDmg | `:compose-ui:` | `:bossterm-app:` |
| packageDeb/Rpm (AMD64) | `:compose-ui:` | `:bossterm-app:` |
| packageDeb/Rpm (ARM64) | `:compose-ui:` | `:bossterm-app:` |
| packageUberJar | `:compose-ui:` | `:bossterm-app:` |
| DMG artifact path | `.gradleBuild/compose-ui/...` | `.gradleBuild/bossterm-app/...` |
| DEB/RPM artifact paths | `.gradleBuild/compose-ui/...` | `.gradleBuild/bossterm-app/...` |
| JAR artifact path | `.gradleBuild/compose-ui/...` | `.gradleBuild/bossterm-app/...` |

### `snapcraft.yaml`
- Updated gradle task from `:compose-ui:packageUberJarForCurrentOS` to `:bossterm-app:packageUberJarForCurrentOS`

## Test plan
- [ ] Verify release workflow can find and run `:bossterm-app:packageDmg`
- [ ] Verify Linux build can find and run `:bossterm-app:packageDeb`
- [ ] Verify artifact paths correctly locate built packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)