### PR TITLE
fix: Add PTY4J signing task for macOS notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,73 +132,11 @@ jobs:
             echo "DISABLE_MACOS_SIGNING=true" >> $GITHUB_ENV
           fi
 
-      - name: Build macOS App Bundle
+      - name: Build and Package macOS DMG
         run: |
           chmod +x ./gradlew
-          ./gradlew :bossterm-app:createDistributable
-        env:
-          RELEASE_BUILD: true
-          APP_VERSION: ${{ needs.prepare-version.outputs.version }}
-
-      - name: Sign Native Executables in JARs
-        if: env.DISABLE_MACOS_SIGNING != 'true'
-        run: |
-          # Convert to absolute path to avoid issues when changing directories
-          APP_PATH=$(find "$(pwd)/.gradleBuild/bossterm-app/compose/binaries/main/app" -name "*.app" -type d | head -1)
-          echo "App bundle: $APP_PATH"
-
-          if [[ -n "$APP_PATH" && -d "$APP_PATH" ]]; then
-            # Find all JARs that might contain native executables
-            find "$APP_PATH/Contents/app" -name "*.jar" | while read JAR_PATH; do
-              # Convert JAR_PATH to absolute path
-              JAR_PATH=$(cd "$(dirname "$JAR_PATH")" && pwd)/$(basename "$JAR_PATH")
-
-              # Check if JAR contains native darwin executables
-              if unzip -l "$JAR_PATH" 2>/dev/null | grep -q "darwin"; then
-                echo "Processing: $JAR_PATH"
-
-                # Create temp directory
-                TEMP_DIR=$(mktemp -d)
-                JAR_NAME=$(basename "$JAR_PATH")
-
-                # Extract JAR
-                unzip -q "$JAR_PATH" -d "$TEMP_DIR"
-
-                # Find and sign native executables (not just dylibs)
-                SIGNED_COUNT=0
-                while IFS= read -r -d '' NATIVE_FILE; do
-                  # Check if it's a Mach-O executable or dylib
-                  if file "$NATIVE_FILE" | grep -q "Mach-O"; then
-                    echo "  Signing: $NATIVE_FILE"
-                    codesign --force --options runtime --timestamp \
-                      --sign "${{ secrets.MACOS_DEVELOPER_ID }}" \
-                      --entitlements compose-ui/src/desktopMain/resources/runtime-entitlements.plist \
-                      "$NATIVE_FILE" || echo "  Warning: Failed to sign $NATIVE_FILE"
-                    SIGNED_COUNT=$((SIGNED_COUNT + 1))
-                  fi
-                done < <(find "$TEMP_DIR" -type f \( -name "*darwin*" -o -path "*/native/*" \) -print0)
-
-                # Repackage JAR if we signed anything or found darwin files
-                if [[ "$SIGNED_COUNT" -gt 0 ]] || find "$TEMP_DIR" -name "*darwin*" | grep -q .; then
-                  echo "  Repackaging: $JAR_NAME (signed $SIGNED_COUNT files)"
-                  rm "$JAR_PATH"
-                  (cd "$TEMP_DIR" && zip -qr "$JAR_PATH" .)
-                fi
-
-                rm -rf "$TEMP_DIR"
-              fi
-            done
-
-            # Re-sign the entire app bundle after modifying JARs
-            echo "Re-signing app bundle..."
-            codesign --force --deep --options runtime --timestamp \
-              --sign "${{ secrets.MACOS_DEVELOPER_ID }}" \
-              --entitlements compose-ui/src/desktopMain/resources/entitlements.plist \
-              "$APP_PATH"
-          fi
-
-      - name: Package macOS DMG
-        run: |
+          # packageDmg triggers: createDistributable -> signPty4jBinaries (finalizer) -> packageDmg
+          # The signPty4jBinaries gradle task signs PTY4J natives with hardened runtime
           ./gradlew :bossterm-app:packageDmg
         env:
           RELEASE_BUILD: true

--- a/bossterm-app/build.gradle.kts
+++ b/bossterm-app/build.gradle.kts
@@ -1,6 +1,14 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import java.util.Properties
+import javax.inject.Inject
+import org.gradle.process.ExecOperations
+
+// Interface for injecting ExecOperations into tasks
+// Replaces deprecated project.exec() calls for Gradle 9.0 compatibility
+interface InjectedExecOps {
+    @get:Inject val execOps: ExecOperations
+}
 
 // Load local.properties for signing configuration (gitignored)
 val localProperties = Properties().apply {
@@ -154,6 +162,185 @@ compose.desktop {
                 version.set("7.7.0")
                 configurationFiles.from(project.file("../compose-ui/proguard-rules.pro"))
             }
+        }
+    }
+}
+
+// Sign PTY4J native binaries with hardened runtime for macOS notarization
+tasks.register("signPty4jBinaries") {
+    description = "Signs PTY4J native binaries with hardened runtime for Apple notarization"
+    group = "build"
+
+    // Only run on macOS and when signing is enabled
+    onlyIf {
+        val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
+        val signingDisabled = System.getenv("DISABLE_MACOS_SIGNING") == "true"
+        isMacOS && !signingDisabled
+    }
+
+    // Inject ExecOperations for exec calls (replaces deprecated project.exec)
+    val injected = project.objects.newInstance<InjectedExecOps>()
+
+    doLast {
+        println("🔧 Signing PTY4J native binaries with hardened runtime for notarization...")
+
+        // Get developer identity from environment or use default
+        val developerId = System.getenv("MACOS_DEVELOPER_ID")
+            ?: localProperties.getProperty("macos.signing.identity")
+            ?: "-"
+
+        if (developerId == "-") {
+            println("⚠️ No signing identity found, skipping PTY4J signing")
+            return@doLast
+        }
+
+        // Find the built app in the standard Compose Desktop location
+        val appDir = project.layout.buildDirectory.dir("compose/binaries/main/app").get().asFile
+        val appFile = appDir.listFiles()?.find { it.name.endsWith(".app") }
+
+        if (appFile?.exists() == true) {
+            println("Found app: ${appFile.name}")
+
+            // Find PTY4J jar inside the app
+            val appContents = File(appFile, "Contents/app")
+            val pty4jJar = appContents.listFiles()?.find {
+                it.name.startsWith("pty4j-") && it.name.endsWith(".jar")
+            }
+
+            if (pty4jJar?.exists() == true) {
+                println("Processing PTY4J jar: ${pty4jJar.name}")
+
+                // Create temporary directory for jar manipulation
+                val tempDir = File(System.getProperty("java.io.tmpdir"), "pty4j-sign-${System.currentTimeMillis()}")
+                tempDir.mkdirs()
+
+                try {
+                    // Extract the entire jar
+                    injected.execOps.exec {
+                        workingDir = tempDir
+                        commandLine("jar", "xf", pty4jJar.absolutePath)
+                    }
+
+                    // Sign PTY4J native libraries with hardened runtime
+                    val nativeFiles = tempDir.walkTopDown().filter {
+                        it.isFile && (it.name.endsWith(".dylib") || it.name.contains("spawn-helper"))
+                    }.toList()
+
+                    if (nativeFiles.isNotEmpty()) {
+                        println("Found ${nativeFiles.size} PTY4J native binary(ies) to sign:")
+
+                        for (nativeFile in nativeFiles) {
+                            println("  Signing: ${nativeFile.relativeTo(tempDir)}")
+
+                            // Make executable
+                            nativeFile.setExecutable(true)
+
+                            // Sign with hardened runtime
+                            try {
+                                injected.execOps.exec {
+                                    commandLine(
+                                        "codesign",
+                                        "--force",
+                                        "--options", "runtime",
+                                        "--sign", developerId,
+                                        "--timestamp",
+                                        nativeFile.absolutePath
+                                    )
+                                }
+
+                                // Verify signature
+                                injected.execOps.exec {
+                                    commandLine("codesign", "-vv", nativeFile.absolutePath)
+                                }
+
+                                println("    ✅ Successfully signed ${nativeFile.name}")
+                            } catch (e: Exception) {
+                                println("    ⚠️ Warning: Failed to sign ${nativeFile.name}: ${e.message}")
+                            }
+                        }
+
+                        // Recreate the jar with signed native libraries
+                        val signedJar = File(pty4jJar.parentFile, "${pty4jJar.nameWithoutExtension}-signed.jar")
+                        injected.execOps.exec {
+                            workingDir = tempDir
+                            commandLine("jar", "cf", signedJar.absolutePath, ".")
+                        }
+
+                        // Replace original jar with signed version
+                        pty4jJar.delete()
+                        signedJar.renameTo(pty4jJar)
+
+                        println("✅ PTY4J jar updated with signed native libraries")
+
+                    } else {
+                        println("⚠️ Warning: No PTY4J native binaries found in jar")
+                    }
+
+                } finally {
+                    // Clean up temp directory
+                    tempDir.deleteRecursively()
+                }
+
+                // CRITICAL: Re-sign the entire app bundle after modifying the JAR
+                println("🔒 Re-signing app bundle after PTY4J modifications...")
+                try {
+                    injected.execOps.exec {
+                        commandLine(
+                            "codesign",
+                            "--force",
+                            "--deep",
+                            "--options", "runtime",
+                            "--sign", developerId,
+                            "--timestamp",
+                            "--entitlements", project.file("../compose-ui/src/desktopMain/resources/entitlements.plist").absolutePath,
+                            appFile.absolutePath
+                        )
+                    }
+
+                    // Verify the re-signed app
+                    injected.execOps.exec {
+                        commandLine("codesign", "-vvv", "--deep", "--strict", appFile.absolutePath)
+                    }
+
+                    println("✅ App bundle re-signed successfully")
+                } catch (e: Exception) {
+                    println("❌ Failed to re-sign app bundle: ${e.message}")
+                    throw e
+                }
+
+            } else {
+                println("⚠️ Warning: PTY4J jar not found in app bundle")
+            }
+        } else {
+            println("⚠️ Warning: Built app not found at expected location")
+        }
+    }
+}
+
+// Configure task dependencies for PTY4J signing
+afterEvaluate {
+    val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
+    val signingDisabled = System.getenv("DISABLE_MACOS_SIGNING") == "true"
+
+    // Make signPty4jBinaries run AFTER createDistributable
+    tasks.findByName("signPty4jBinaries")?.apply {
+        mustRunAfter("createDistributable")
+    }
+
+    // CRITICAL: Make createDistributable finalize with signPty4jBinaries
+    // This ensures PTY4J natives are signed before Compose Desktop signs the whole app
+    tasks.findByName("createDistributable")?.apply {
+        if (isMacOS && !signingDisabled) {
+            finalizedBy("signPty4jBinaries")
+            println("📝 createDistributable will be finalized by signPty4jBinaries")
+        }
+    }
+
+    // Make sure signing happens before packaging
+    tasks.findByName("packageDmg")?.apply {
+        if (isMacOS && !signingDisabled) {
+            mustRunAfter("signPty4jBinaries")
+            println("📝 packageDmg will run after PTY4J signing")
         }
     }
 }


### PR DESCRIPTION
## Summary
Fix macOS notarization failure caused by `pty4j-unix-spawn-helper` not having hardened runtime enabled.

## Root Cause
After the module refactoring (PR #128), the `signPty4jBinaries` task existed in `compose-ui/build.gradle.kts` but looked for the app in the wrong location. The app is now built in `bossterm-app`, not `compose-ui`.

## Solution
Added `signPty4jBinaries` task to `bossterm-app/build.gradle.kts`:
- Runs as a finalizer after `createDistributable`
- Signs all PTY4J native binaries (`.dylib` + `spawn-helper`) with hardened runtime
- Re-signs entire app bundle after JAR modification
- Simplified `release.yml` to use gradle task instead of shell script

## Changes

### `bossterm-app/build.gradle.kts`
- Added `InjectedExecOps` interface for Gradle 9.0 compatibility
- Added `signPty4jBinaries` task (lines 169-317)
- Added `afterEvaluate` block to configure task dependencies (lines 320-346)

### `.github/workflows/release.yml`
- Removed redundant "Sign Native Executables in JARs" shell script step
- Combined build steps into single "Build and Package macOS DMG" step
- The gradle task handles signing automatically via `finalizedBy`

## Test plan
- [ ] Verify `signPty4jBinaries` task runs during `packageDmg`
- [ ] Verify PTY4J natives are signed with hardened runtime
- [ ] Verify notarization succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)