### PR TITLE
feat: Add initialCommand parameter to EmbeddableTerminal

### DIFF
--- a/embedded-example/src/desktopMain/kotlin/ai/rever/bossterm/embedded/Main.kt
+++ b/embedded-example/src/desktopMain/kotlin/ai/rever/bossterm/embedded/Main.kt
@@ -80,6 +80,9 @@ fun EmbeddedExampleApp() {
                     ) {
                         EmbeddableTerminal(
                             state = terminalState,
+                            // Run a command automatically when terminal is ready
+                            // Uses OSC 133 shell integration for proper timing if available
+                            initialCommand = "echo 'Welcome to BossTerm Embedded Example!'",
                             onExit = { exitCode ->
                                 statusMessage = "Terminal exited with code: $exitCode"
                             },


### PR DESCRIPTION
## Summary

- Add `initialCommand` parameter to `EmbeddableTerminal` composable for running a command after the terminal is ready
- Uses OSC 133 shell integration for proper timing when shell has it configured
- Falls back to configurable delay (`settings.initialCommandDelayMs`, default 500ms) for shells without OSC 133
- Consistent API with `TabbedTerminal` which already has this feature

## Changes

### EmbeddableTerminal.kt
- Add `initialCommand: String?` parameter to composable
- Pass through to `initializeSession` and `initializeProcess`
- Implement OSC 133 prompt detection with `CommandStateListener`
- Use `CompletableDeferred` + `withTimeoutOrNull` for async waiting

### embedded-example/Main.kt
- Add demonstration of `initialCommand` showing a welcome message

### docs/embedding.md
- Update API signature and parameter table
- Add new "Initial Command" section with:
  - Usage examples
  - Explanation of timing/shell integration
  - Comparison with `onReady` callback alternative

## Test plan

- [ ] Run embedded-example and verify welcome message appears after prompt
- [ ] Test with shell that has OSC 133 configured (should be instant)
- [ ] Test with shell without OSC 133 (should wait ~500ms)
- [ ] Verify `initialCommand = null` (default) doesn't send anything

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)