### PR TITLE
fix: Add StartupWMClass to .desktop file for Ubuntu icon grouping

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateScriptGenerator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateScriptGenerator.kt
@@ -291,6 +291,11 @@ object UpdateScriptGenerator {
                 echo "Added StartupWMClass to desktop file"
             fi
 
+            # Refresh desktop database to pick up changes immediately
+            if command -v update-desktop-database &> /dev/null; then
+                update-desktop-database /usr/share/applications 2>/dev/null || true
+            fi
+
             # Launch the updated app
             echo "Launching BossTerm..."
             if [ -x /opt/bossterm/bin/BossTerm ]; then
@@ -369,6 +374,22 @@ object UpdateScriptGenerator {
                 echo "RPM installation failed with exit code ${'$'}INSTALL_RESULT"
             else
                 echo "Installation complete!"
+            fi
+
+            # Fix StartupWMClass in .desktop file for proper icon/taskbar integration
+            DESKTOP_FILE="/usr/share/applications/bossterm-BossTerm.desktop"
+            if [ -f "${'$'}DESKTOP_FILE" ] && ! grep -q "StartupWMClass" "${'$'}DESKTOP_FILE"; then
+                if command -v pkexec &> /dev/null; then
+                    echo "StartupWMClass=bossterm" | pkexec tee -a "${'$'}DESKTOP_FILE" > /dev/null
+                elif command -v sudo &> /dev/null; then
+                    echo "StartupWMClass=bossterm" | sudo tee -a "${'$'}DESKTOP_FILE" > /dev/null
+                fi
+                echo "Added StartupWMClass to desktop file"
+            fi
+
+            # Refresh desktop database to pick up changes immediately
+            if command -v update-desktop-database &> /dev/null; then
+                update-desktop-database /usr/share/applications 2>/dev/null || true
             fi
 
             # Launch the updated app


### PR DESCRIPTION
## Summary

Fixes #153 - After updating BossTerm via UpdateScript on Ubuntu, windows showed a generic gear icon instead of being grouped under the BossTerm icon.

**Root cause**: The `.deb` package didn't include `StartupWMClass=bossterm` in the `.desktop` file, which GNOME uses to associate windows with their application entry.

## Changes

- Add `fixLinuxDesktopFile` task to `bossterm-app/build.gradle.kts` that post-processes `.deb` packages to inject `StartupWMClass`
- Wire task to run automatically after `packageDeb` via `finalizedBy()`
- Add `.desktop` fix to RPM update script (was completely missing)
- Add `update-desktop-database` call to both Deb and RPM update scripts to refresh desktop environment cache immediately

## How it works

1. **Build-time (Primary)**: When building `.deb` packages, the `fixLinuxDesktopFile` task extracts the package, adds `StartupWMClass=bossterm` to the `.desktop` file, and repacks it

2. **Update-time (Fallback)**: When users update via UpdateScript, the script adds `StartupWMClass=bossterm` if missing and calls `update-desktop-database` to refresh immediately

## Test plan

- [x] Build `.deb` package: `./gradlew :bossterm-app:packageDeb`
- [x] Verify `.desktop` file contains `StartupWMClass=bossterm`
- [ ] Install and verify windows group under BossTerm icon in Ubuntu dock

🤖 Generated with [Claude Code](https://claude.com/claude-code)