### PR TITLE
fix: Add fakeroot dependency for ARM64 deb packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,8 +300,8 @@ jobs:
         with:
           cache-read-only: false
 
-      - name: Install RPM Tools
-        run: sudo apt-get update && sudo apt-get install -y rpm
+      - name: Install Package Build Dependencies
+        run: sudo apt-get update && sudo apt-get install -y rpm fakeroot
 
       - name: Generate Linux Icons
         run: |


### PR DESCRIPTION
## Summary
- Add `fakeroot` to apt-get install in the ARM64 Linux build job
- The ARM64 runner (`ubuntu-24.04-arm`) does not have `fakeroot` pre-installed unlike `ubuntu-latest`
- `jpackage` requires `fakeroot` to create `.deb` packages, causing `packageDeb` to fail with exit code 1

## Test plan
- [ ] Trigger a release workflow run on ARM64
- [ ] Verify `packageDeb` task completes successfully
- [ ] Confirm `.deb` artifact is uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)