### PR TITLE
fix: Read version from JAR manifest when used as Maven dependency

### DIFF
--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -114,6 +114,18 @@ kotlin {
     }
 }
 
+// Configure JAR manifest with version information for library consumers
+// This enables Version.CURRENT to read the version when used as a Maven dependency
+tasks.withType<Jar> {
+    manifest {
+        attributes(
+            "Implementation-Title" to "BossTerm Compose",
+            "Implementation-Version" to version.toString(),
+            "Implementation-Vendor" to "risalabs.ai"
+        )
+    }
+}
+
 // Note: Android configuration removed - compose-ui is Desktop-only
 // See bossterm-core-mpp for Android support
 


### PR DESCRIPTION
## Summary
- Fixes version showing `1.0.0` instead of actual version when BossTerm is used as a Maven/Gradle dependency
- Adds `Implementation-Version` attribute to JAR manifest during build
- Adds `tryGetJarManifestVersion()` fallback in `Version.kt` to read from manifest at runtime

## Test plan
- [x] Build and verify JAR manifest contains `Implementation-Version`
- [ ] Publish to Maven Central and verify dependent projects show correct version

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)