### PR TITLE
feat: Add onLinkClick API for custom link handling

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -130,6 +130,8 @@ data class ContextMenuSubmenu(
  * @param onExit Callback invoked when shell process exits with exit code
  * @param onReady Callback invoked when terminal is ready (process started)
  * @param contextMenuItems Custom context menu elements (items, sections, submenus) to add after the default items
+ * @param onLinkClick Optional callback for custom link handling. When provided, intercepts Ctrl/Cmd+Click
+ *                    on links and context menu "Open Link" action. When null, links open in system browser.
  * @param modifier Compose modifier for the terminal container
  */
 @Composable
@@ -147,6 +149,7 @@ fun EmbeddableTerminal(
     onReady: (() -> Unit)? = null,
     onNewWindow: (() -> Unit)? = null,
     contextMenuItems: List<ContextMenuElement> = emptyList(),
+    onLinkClick: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     // Use provided state or create auto-disposing one
@@ -212,6 +215,7 @@ fun EmbeddableTerminal(
             onNewWindow = onNewWindow,
             enableDebugPanel = false,  // Hide debug panel in embedded mode
             customContextMenuItems = contextMenuItems,
+            onLinkClick = onLinkClick,
             modifier = modifier
         )
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -65,6 +65,8 @@ import ai.rever.bossterm.compose.ui.ProperTerminal
  * @param menuActions Optional menu action callbacks for wiring up menu bar
  * @param isWindowFocused Lambda returning whether this window is currently focused (for notifications)
  * @param initialCommand Optional command to run in the first terminal tab after startup
+ * @param onLinkClick Optional callback for custom link handling. When provided, intercepts Ctrl/Cmd+Click
+ *                    on links and context menu "Open Link" action. When null, links open in system browser.
  * @param modifier Compose modifier for the terminal container
  */
 @Composable
@@ -77,6 +79,7 @@ fun TabbedTerminal(
     menuActions: MenuActions? = null,
     isWindowFocused: () -> Boolean = { true },
     initialCommand: String? = null,
+    onLinkClick: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     // Settings integration
@@ -399,6 +402,7 @@ fun TabbedTerminal(
                 splitFocusBorderEnabled = settings.splitFocusBorderEnabled,
                 splitFocusBorderColor = settings.splitFocusBorderColorValue,
                 splitMinimumSize = settings.splitMinimumSize,
+                onLinkClick = onLinkClick,
                 modifier = Modifier.fillMaxSize()
             )
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
@@ -57,6 +57,7 @@ fun SplitContainer(
     splitFocusBorderEnabled: Boolean = true,
     splitFocusBorderColor: Color = Color(0xFF4A90E2),
     splitMinimumSize: Float = 0.1f,
+    onLinkClick: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -84,6 +85,7 @@ fun SplitContainer(
             splitFocusBorderEnabled = splitFocusBorderEnabled,
             splitFocusBorderColor = splitFocusBorderColor,
             splitMinimumSize = splitMinimumSize,
+            onLinkClick = onLinkClick,
             modifier = Modifier.fillMaxSize()
         )
     }
@@ -117,6 +119,7 @@ private fun RenderSplitNode(
     splitFocusBorderEnabled: Boolean,
     splitFocusBorderColor: Color,
     splitMinimumSize: Float,
+    onLinkClick: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     when (node) {
@@ -145,6 +148,7 @@ private fun RenderSplitNode(
                 menuActions = menuActions,
                 splitFocusBorderEnabled = splitFocusBorderEnabled,
                 splitFocusBorderColor = splitFocusBorderColor,
+                onLinkClick = onLinkClick,
                 modifier = modifier
             )
         }
@@ -174,6 +178,7 @@ private fun RenderSplitNode(
                 splitFocusBorderEnabled = splitFocusBorderEnabled,
                 splitFocusBorderColor = splitFocusBorderColor,
                 splitMinimumSize = splitMinimumSize,
+                onLinkClick = onLinkClick,
                 modifier = modifier
             )
         }
@@ -203,6 +208,7 @@ private fun RenderSplitNode(
                 splitFocusBorderEnabled = splitFocusBorderEnabled,
                 splitFocusBorderColor = splitFocusBorderColor,
                 splitMinimumSize = splitMinimumSize,
+                onLinkClick = onLinkClick,
                 modifier = modifier
             )
         }
@@ -237,6 +243,7 @@ private fun RenderPane(
     menuActions: MenuActions?,
     splitFocusBorderEnabled: Boolean,
     splitFocusBorderColor: Color,
+    onLinkClick: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     // Focus border for active pane (only show when there are multiple panes and enabled)
@@ -290,6 +297,7 @@ private fun RenderPane(
             onMoveToNewTab = onMoveToNewTab,
             onPaneFocus = { splitState.setFocusedPane(pane.id) },
             menuActions = menuActions,
+            onLinkClick = onLinkClick,
             modifier = Modifier.fillMaxSize()
         )
     }
@@ -323,6 +331,7 @@ private fun RenderVerticalSplit(
     splitFocusBorderEnabled: Boolean,
     splitFocusBorderColor: Color,
     splitMinimumSize: Float,
+    onLinkClick: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     BoxWithConstraints(modifier = modifier) {
@@ -361,6 +370,7 @@ private fun RenderVerticalSplit(
                     splitFocusBorderEnabled = splitFocusBorderEnabled,
                     splitFocusBorderColor = splitFocusBorderColor,
                     splitMinimumSize = splitMinimumSize,
+                    onLinkClick = onLinkClick,
                     modifier = Modifier.fillMaxSize()
                 )
             }
@@ -394,6 +404,7 @@ private fun RenderVerticalSplit(
                     splitFocusBorderEnabled = splitFocusBorderEnabled,
                     splitFocusBorderColor = splitFocusBorderColor,
                     splitMinimumSize = splitMinimumSize,
+                    onLinkClick = onLinkClick,
                     modifier = Modifier.fillMaxSize()
                 )
             }
@@ -443,6 +454,7 @@ private fun RenderHorizontalSplit(
     splitFocusBorderEnabled: Boolean,
     splitFocusBorderColor: Color,
     splitMinimumSize: Float,
+    onLinkClick: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     BoxWithConstraints(modifier = modifier) {
@@ -481,6 +493,7 @@ private fun RenderHorizontalSplit(
                     splitFocusBorderEnabled = splitFocusBorderEnabled,
                     splitFocusBorderColor = splitFocusBorderColor,
                     splitMinimumSize = splitMinimumSize,
+                    onLinkClick = onLinkClick,
                     modifier = Modifier.fillMaxSize()
                 )
             }
@@ -514,6 +527,7 @@ private fun RenderHorizontalSplit(
                     splitFocusBorderEnabled = splitFocusBorderEnabled,
                     splitFocusBorderColor = splitFocusBorderColor,
                     splitMinimumSize = splitMinimumSize,
+                    onLinkClick = onLinkClick,
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -134,6 +134,7 @@ fun ProperTerminal(
   menuActions: MenuActions? = null,
   enableDebugPanel: Boolean = true,  // Whether to show debug panel option in context menu
   customContextMenuItems: List<ai.rever.bossterm.compose.ContextMenuElement> = emptyList(),
+  onLinkClick: ((String) -> Unit)? = null,  // Custom link handler (null = open in system browser)
   modifier: Modifier = Modifier
 ) {
   // Extract session state (no more remember {} blocks - state lives in TerminalSession)
@@ -804,7 +805,13 @@ fun ProperTerminal(
                   x = pos.x,
                   y = pos.y,
                   url = link.url,
-                  onOpenLink = { HyperlinkDetector.openUrl(link.url) },
+                  onOpenLink = {
+                    if (onLinkClick != null) {
+                      onLinkClick(link.url)
+                    } else {
+                      HyperlinkDetector.openUrl(link.url)
+                    }
+                  },
                   onCopyLinkAddress = { clipboardManager.setText(AnnotatedString(link.url)) },
                   hasSelection = selectionStart != null && selectionEnd != null,
                   onCopy = {
@@ -904,7 +911,12 @@ fun ProperTerminal(
             // Check for hyperlink click with Ctrl/Cmd modifier
             // Standard terminal behavior: Ctrl+Click (Windows/Linux) or Cmd+Click (macOS)
             if (hoveredHyperlink != null && isModifierPressed) {
-              HyperlinkDetector.openUrl(hoveredHyperlink!!.url)
+              val url = hoveredHyperlink!!.url
+              if (onLinkClick != null) {
+                onLinkClick(url)
+              } else {
+                HyperlinkDetector.openUrl(url)
+              }
               change.consume()
               return@onPointerEvent
             }

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -56,6 +56,7 @@ fun EmbeddableTerminal(
     onExit: ((Int) -> Unit)? = null,
     onReady: (() -> Unit)? = null,
     contextMenuItems: List<ContextMenuElement> = emptyList(),
+    onLinkClick: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier
 )
 ```
@@ -74,6 +75,7 @@ fun EmbeddableTerminal(
 | `onExit` | `(Int) -> Unit` | Callback when shell process exits |
 | `onReady` | `() -> Unit` | Callback when terminal is ready |
 | `contextMenuItems` | `List<ContextMenuElement>` | Custom context menu items |
+| `onLinkClick` | `(String) -> Unit` | Custom link click handler (see [Custom Link Handling](#custom-link-handling)) |
 | `modifier` | `Modifier` | Compose modifier |
 
 ### EmbeddableTerminalState
@@ -337,3 +339,58 @@ EmbeddableTerminal(
 ```
 
 See the main [README](../README.md#configuration) for available settings.
+
+## Custom Link Handling
+
+By default, clicking links in the terminal (with Ctrl/Cmd+Click or via the context menu "Open Link") opens them in the system's default browser. You can intercept these clicks with the `onLinkClick` callback:
+
+```kotlin
+EmbeddableTerminal(
+    onLinkClick = { url ->
+        // Custom handling - e.g., open in an in-app browser
+        myInAppBrowser.openUrl(url)
+    }
+)
+```
+
+### Use Cases
+
+- **In-app browser**: Open URLs in a browser tab within your application
+- **URL filtering**: Validate or sanitize URLs before opening
+- **Custom protocols**: Handle custom URL schemes (e.g., `myapp://...`)
+- **Logging**: Track which links users click
+
+### Behavior
+
+| `onLinkClick` | Ctrl/Cmd+Click | Context Menu "Open Link" |
+|---------------|----------------|--------------------------|
+| `null` (default) | Opens in system browser | Opens in system browser |
+| Provided | Calls your callback | Calls your callback |
+
+### Example: In-App Browser Integration
+
+```kotlin
+@Composable
+fun TerminalWithInAppBrowser() {
+    var browserUrl by remember { mutableStateOf<String?>(null) }
+
+    Column {
+        // Terminal with custom link handling
+        EmbeddableTerminal(
+            onLinkClick = { url ->
+                browserUrl = url  // Open in our browser component
+            },
+            modifier = Modifier.weight(1f)
+        )
+
+        // In-app browser (shown when URL is set)
+        browserUrl?.let { url ->
+            InAppBrowser(
+                url = url,
+                onClose = { browserUrl = null },
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+```

--- a/docs/tabbed-terminal.md
+++ b/docs/tabbed-terminal.md
@@ -56,6 +56,7 @@ fun TabbedTerminal(
     menuActions: MenuActions? = null,
     isWindowFocused: () -> Boolean = { true },
     initialCommand: String? = null,
+    onLinkClick: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier
 )
 ```
@@ -70,6 +71,7 @@ fun TabbedTerminal(
 | `menuActions` | `MenuActions?` | Callbacks for menu bar integration |
 | `isWindowFocused` | `() -> Boolean` | Returns window focus state (for notifications) |
 | `initialCommand` | `String?` | Command to run in first tab after startup |
+| `onLinkClick` | `(String) -> Unit` | Custom link click handler (see [Custom Link Handling](#custom-link-handling)) |
 | `modifier` | `Modifier` | Compose modifier |
 
 ### MenuActions
@@ -357,6 +359,36 @@ Run the example:
 ./gradlew :tabbed-example:run
 ```
 
+## Custom Link Handling
+
+By default, clicking links in the terminal (with Ctrl/Cmd+Click or via the context menu "Open Link") opens them in the system's default browser. You can intercept these clicks with the `onLinkClick` callback:
+
+```kotlin
+TabbedTerminal(
+    onExit = { exitApplication() },
+    onLinkClick = { url ->
+        // Custom handling - e.g., open in an in-app browser
+        myInAppBrowser.openUrl(url)
+    }
+)
+```
+
+### Use Cases
+
+- **In-app browser**: Open URLs in a browser tab within your application
+- **URL filtering**: Validate or sanitize URLs before opening
+- **Custom protocols**: Handle custom URL schemes (e.g., `myapp://...`)
+- **Logging**: Track which links users click
+
+### Behavior
+
+| `onLinkClick` | Ctrl/Cmd+Click | Context Menu "Open Link" |
+|---------------|----------------|--------------------------|
+| `null` (default) | Opens in system browser | Opens in system browser |
+| Provided | Calls your callback | Calls your callback |
+
+The callback is invoked for all tabs and split panes within the terminal.
+
 ## Comparison: EmbeddableTerminal vs TabbedTerminal
 
 | Feature | EmbeddableTerminal | TabbedTerminal |
@@ -368,6 +400,7 @@ Run the example:
 | External state holder | `EmbeddableTerminalState` | `TabbedTerminalState` |
 | State persistence | Yes | Yes |
 | Custom context menu | Yes | Built-in |
+| Custom link handling | Yes | Yes |
 | Menu bar integration | No | Yes |
 | Window management | No | Yes |
 | Command notifications | No | Yes |


### PR DESCRIPTION
## Summary
- Adds `onLinkClick: ((String) -> Unit)? = null` parameter to `EmbeddableTerminal` and `TabbedTerminal`
- When provided, intercepts Ctrl/Cmd+Click and context menu "Open Link" actions
- When null (default), preserves existing behavior (opens system browser)

## Changes
- `ProperTerminal.kt`: Add parameter, modify click handlers
- `SplitContainer.kt`: Pass through to all panes
- `TabbedTerminal.kt`: Public API with KDoc
- `EmbeddableTerminal.kt`: Public API with KDoc
- `docs/embedding.md`: Add documentation section
- `docs/tabbed-terminal.md`: Add documentation section

## Usage
```kotlin
TabbedTerminal(
    onExit = { exitApplication() },
    onLinkClick = { url ->
        // Custom handling - e.g., open in in-app browser
        myBrowser.openUrl(url)
    }
)
```

## Test plan
- [ ] Without `onLinkClick`: Verify Ctrl/Cmd+Click opens system browser
- [ ] With `onLinkClick`: Verify callback invoked, browser NOT opened
- [ ] Context menu "Open Link": Same behavior as above

Fixes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)