### PR TITLE
fix: Focus terminal pane on middle-click paste in split view

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -903,6 +903,8 @@ fun ProperTerminal(
                     e.printStackTrace()
                   }
                 }
+                // Ensure focus is on terminal canvas after middle-click paste (for split view)
+                focusRequester.requestFocus()
                 change.consume()
                 return@onPointerEvent
               }


### PR DESCRIPTION
## Summary
- Adds `focusRequester.requestFocus()` to the middle-click paste handler
- Ensures terminal pane receives focus after middle-click paste in split view
- Follows the same pattern used for regular clicks (single, double, triple-click)

## Test plan
- [ ] Open BossTerm with split view (vertical or horizontal split)
- [ ] Click in one pane to focus it
- [ ] Middle-click in the other pane to paste
- [ ] Verify the pasted-to pane now has focus (cursor should be blinking there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)