### PR TITLE
fix: Respect scrollToBottomOnTyping setting (#183)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -1362,7 +1362,9 @@ fun ProperTerminal(
               if (text.isNotEmpty()) {
                 // Auto-scroll to cursor when user types (standard terminal behavior)
                 // If scrolled into history, snap back to current screen so user sees their input
-                scrollOffset = 0
+                if (settings.scrollToBottomOnTyping) {
+                  scrollOffset = 0
+                }
 
                 // Feed keyboard event to type-ahead manager BEFORE sending to PTY
                 // This creates predictions that reduce perceived latency on SSH


### PR DESCRIPTION
## Summary

- Fixed bug where `scrollToBottomOnTyping` setting was defined but never checked
- The setting had a UI toggle in Behavior Settings but was ignored in the code

## Bug Details

| File | Issue |
|------|-------|
| `TerminalSettings.kt:192` | Setting defined: `scrollToBottomOnTyping: Boolean = true` |
| `BehaviorSettingsSection.kt:125-130` | UI toggle exists and works |
| `ProperTerminal.kt:1365` | **Bug**: Unconditionally set `scrollOffset = 0` |

## Fix

Added conditional check before resetting scroll position:

```kotlin
// Before (bug)
scrollOffset = 0

// After (fixed)
if (settings.scrollToBottomOnTyping) {
  scrollOffset = 0
}
```

## Behavior Change

| Setting Value | Before | After |
|---------------|--------|-------|
| `true` (default) | Scroll to bottom | Scroll to bottom |
| `false` | Scroll to bottom (bug) | **Stay at position** |

## Test plan

- [ ] Enable setting (default) → Type while scrolled up → Should snap to bottom
- [ ] Disable setting → Type while scrolled up → Should stay at current position

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)