### PR TITLE
feat: Add Close Pane option to context menu

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/features/ContextMenuController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/features/ContextMenuController.kt
@@ -261,6 +261,7 @@ fun createTerminalContextMenuItems(
     onSplitVertical: (() -> Unit)? = null,
     onSplitHorizontal: (() -> Unit)? = null,
     onMoveToNewTab: (() -> Unit)? = null,
+    onClosePane: (() -> Unit)? = null,
     onShowDebug: (() -> Unit)? = null,
     onShowSettings: (() -> Unit)? = null,
     customItems: List<ai.rever.bossterm.compose.ContextMenuElement> = emptyList()
@@ -346,6 +347,17 @@ fun createTerminalContextMenuItems(
                     label = "Move Pane to New Tab",
                     enabled = true,
                     action = onMoveToNewTab
+                )
+            )
+        }
+
+        if (onClosePane != null) {
+            splitItems.add(
+                ContextMenuController.MenuItem(
+                    id = "close_pane",
+                    label = "Close Pane",
+                    enabled = true,
+                    action = onClosePane
                 )
             )
         }
@@ -469,6 +481,7 @@ fun showTerminalContextMenu(
     onSplitVertical: (() -> Unit)? = null,
     onSplitHorizontal: (() -> Unit)? = null,
     onMoveToNewTab: (() -> Unit)? = null,
+    onClosePane: (() -> Unit)? = null,
     onShowDebug: (() -> Unit)? = null,
     onShowSettings: (() -> Unit)? = null,
     customItems: List<ai.rever.bossterm.compose.ContextMenuElement> = emptyList(),
@@ -486,6 +499,7 @@ fun showTerminalContextMenu(
         onSplitVertical = onSplitVertical,
         onSplitHorizontal = onSplitHorizontal,
         onMoveToNewTab = onMoveToNewTab,
+        onClosePane = onClosePane,
         onShowDebug = onShowDebug,
         onShowSettings = onShowSettings,
         customItems = customItems
@@ -557,6 +571,7 @@ fun showHyperlinkContextMenu(
     onSplitVertical: (() -> Unit)? = null,
     onSplitHorizontal: (() -> Unit)? = null,
     onMoveToNewTab: (() -> Unit)? = null,
+    onClosePane: (() -> Unit)? = null,
     onShowDebug: (() -> Unit)? = null,
     onShowSettings: (() -> Unit)? = null,
     customItems: List<ai.rever.bossterm.compose.ContextMenuElement> = emptyList(),
@@ -579,6 +594,7 @@ fun showHyperlinkContextMenu(
         onSplitVertical = onSplitVertical,
         onSplitHorizontal = onSplitHorizontal,
         onMoveToNewTab = onMoveToNewTab,
+        onClosePane = onClosePane,
         onShowDebug = onShowDebug,
         onShowSettings = onShowSettings,
         customItems = customItems

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -846,6 +846,7 @@ fun ProperTerminal(
                   onSplitVertical = onSplitVertical,
                   onSplitHorizontal = onSplitHorizontal,
                   onMoveToNewTab = onMoveToNewTab,
+                  onClosePane = if (onMoveToNewTab != null) onClosePane else null,
                   onShowDebug = if (enableDebugPanel && settings.debugModeEnabled) {
                     { debugPanelVisible = !debugPanelVisible }
                   } else null,
@@ -890,6 +891,7 @@ fun ProperTerminal(
                   onSplitVertical = onSplitVertical,
                   onSplitHorizontal = onSplitHorizontal,
                   onMoveToNewTab = onMoveToNewTab,
+                  onClosePane = if (onMoveToNewTab != null) onClosePane else null,
                   onShowDebug = if (enableDebugPanel && settings.debugModeEnabled) {
                     { debugPanelVisible = !debugPanelVisible }
                   } else null,


### PR DESCRIPTION
## Summary
- Add "Close Pane" menu item to the terminal context menu
- Positioned below "Move Pane to New Tab" in the split pane section
- Only appears when terminal is in a split pane context (same visibility condition as Move Pane to New Tab)

## Test plan
- [ ] Open terminal and split pane (Cmd+D or context menu)
- [ ] Right-click in a split pane - verify "Close Pane" appears below "Move Pane to New Tab"
- [ ] Right-click in a non-split terminal - verify "Close Pane" does NOT appear
- [ ] Click "Close Pane" - verify the pane closes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)