### PR TITLE
feat: Add settings override parameter to TabbedTerminal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,6 +617,24 @@ None - feature complete for current phase
 December 28, 2025
 
 ### Recent Changes
+- **December 28, 2025**: Settings Override Parameter (#187)
+  - **Feature**: Per-instance settings customization for `TabbedTerminal` and `EmbeddableTerminal`
+  - **Purpose**: Allows different terminal instances to have different configurations (e.g., sidebar terminals with persistent tab bars)
+  - **New Class**: `TerminalSettingsOverride` - Data class with all nullable fields for selective overrides
+  - **New Extension**: `TerminalSettings.withOverrides()` - Merges override with base settings
+  - **New Parameters**:
+    - `TabbedTerminal(settingsOverride: TerminalSettingsOverride? = null)`
+    - `EmbeddableTerminal(settingsOverride: TerminalSettingsOverride? = null)`
+  - **Usage**:
+    ```kotlin
+    TabbedTerminal(
+        settingsOverride = TerminalSettingsOverride(alwaysShowTabBar = true),
+        onExit = { ... }
+    )
+    ```
+  - **New Files**: `compose-ui/.../settings/TerminalSettingsOverride.kt` (270 lines)
+  - **Modified Files**: `TabbedTerminal.kt`, `EmbeddableTerminal.kt`
+  - **Status**: Complete, PR #188
 - **December 28, 2025**: Programmatic Input API (#182)
   - **Feature**: Added API to send raw bytes and control characters to terminal processes
   - **Purpose**: Allows parent applications to send Ctrl+C (interrupt), Ctrl+D (EOF), Ctrl+Z (suspend), and arbitrary bytes

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettingsOverride.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettingsOverride.kt
@@ -1,0 +1,286 @@
+package ai.rever.bossterm.compose.settings
+
+/**
+ * Settings override container with nullable fields for selective customization.
+ *
+ * Use this to override specific settings per terminal instance while
+ * respecting global defaults for unspecified fields.
+ *
+ * Example usage:
+ * ```kotlin
+ * TabbedTerminal(
+ *     settingsOverride = TerminalSettingsOverride(
+ *         alwaysShowTabBar = true,
+ *         fontSize = 16f
+ *     ),
+ *     onExit = { ... }
+ * )
+ * ```
+ *
+ * Only non-null fields will override the global settings.
+ */
+data class TerminalSettingsOverride(
+    // ===== Visual Settings =====
+    val fontSize: Float? = null,
+    val fontName: String? = null,
+    val lineSpacing: Float? = null,
+    val disableLineSpacingInAlternateBuffer: Boolean? = null,
+    val fillBackgroundInLineSpacing: Boolean? = null,
+    val useAntialiasing: Boolean? = null,
+    val preferTerminalFontForSymbols: Boolean? = null,
+    val defaultForeground: String? = null,
+    val defaultBackground: String? = null,
+    val selectionColor: String? = null,
+    val foundPatternColor: String? = null,
+    val hyperlinkColor: String? = null,
+    val activeThemeId: String? = null,
+    val colorPaletteId: String? = null,
+    val backgroundOpacity: Float? = null,
+    val windowBlur: Boolean? = null,
+    val blurRadius: Float? = null,
+    val backgroundImagePath: String? = null,
+    val backgroundImageOpacity: Float? = null,
+    val useNativeTitleBar: Boolean? = null,
+    val showUnfocusedOverlay: Boolean? = null,
+
+    // ===== Behavior Settings =====
+    val useLoginSession: Boolean? = null,
+    val initialCommand: String? = null,
+    val initialCommandDelayMs: Int? = null,
+    val copyOnSelect: Boolean? = null,
+    val pasteOnMiddleClick: Boolean? = null,
+    val emulateX11CopyPaste: Boolean? = null,
+    val scrollToBottomOnTyping: Boolean? = null,
+    val altSendsEscape: Boolean? = null,
+    val enableMouseReporting: Boolean? = null,
+    val forceActionOnMouseReporting: Boolean? = null,
+    val mouseScrollThreshold: Float? = null,
+    val audibleBell: Boolean? = null,
+    val visualBell: Boolean? = null,
+
+    // ===== Progress Bar Settings =====
+    val progressBarEnabled: Boolean? = null,
+    val progressBarPosition: String? = null,
+    val progressBarHeight: Float? = null,
+
+    // ===== Clipboard Settings (OSC 52) =====
+    val clipboardOsc52Enabled: Boolean? = null,
+    val clipboardOsc52AllowRead: Boolean? = null,
+    val clipboardOsc52AllowWrite: Boolean? = null,
+    val useInverseSelectionColor: Boolean? = null,
+
+    // ===== Scrollbar Settings =====
+    val showScrollbar: Boolean? = null,
+    val scrollbarAlwaysVisible: Boolean? = null,
+    val scrollbarWidth: Float? = null,
+    val scrollbarColor: String? = null,
+    val scrollbarThumbColor: String? = null,
+    val showSearchMarkersInScrollbar: Boolean? = null,
+    val searchMarkerColor: String? = null,
+    val currentSearchMarkerColor: String? = null,
+
+    // ===== GPU Rendering Settings =====
+    val gpuAcceleration: Boolean? = null,
+    val gpuRenderApi: String? = null,
+    val gpuPriority: String? = null,
+    val gpuVsyncEnabled: Boolean? = null,
+    val gpuCacheSizeMb: Int? = null,
+    val gpuCacheMaxPercent: Int? = null,
+
+    // ===== Performance Settings =====
+    val performanceMode: String? = null,
+    val maxRefreshRate: Int? = null,
+    val bufferMaxLines: Int? = null,
+    val caretBlinkMs: Int? = null,
+    val enableTextBlinking: Boolean? = null,
+    val slowTextBlinkMs: Int? = null,
+    val rapidTextBlinkMs: Int? = null,
+
+    // ===== Terminal Emulation Settings =====
+    val decCompatibilityMode: Boolean? = null,
+    val ambiguousCharsAreDoubleWidth: Boolean? = null,
+    val characterEncoding: String? = null,
+    val simulateMouseScrollInAlternateScreen: Boolean? = null,
+
+    // ===== Search Settings =====
+    val searchCaseSensitive: Boolean? = null,
+    val searchUseRegex: Boolean? = null,
+
+    // ===== Hyperlink Settings =====
+    val hyperlinkUnderlineOnHover: Boolean? = null,
+    val hyperlinkRequireModifier: Boolean? = null,
+
+    // ===== Type-Ahead Settings =====
+    val typeAheadEnabled: Boolean? = null,
+    val typeAheadLatencyThresholdNanos: Long? = null,
+
+    // ===== Debug Settings =====
+    val debugModeEnabled: Boolean? = null,
+    val debugMaxChunks: Int? = null,
+    val debugMaxSnapshots: Int? = null,
+    val debugCaptureInterval: Long? = null,
+    val debugShowChunkIds: Boolean? = null,
+    val debugShowInvisibleChars: Boolean? = null,
+    val debugWrapLines: Boolean? = null,
+    val debugColorCodeSequences: Boolean? = null,
+
+    // ===== File Logging Settings =====
+    val fileLoggingEnabled: Boolean? = null,
+    val fileLoggingDirectory: String? = null,
+    val fileLoggingPattern: String? = null,
+
+    // ===== Notification Settings =====
+    val notifyOnCommandComplete: Boolean? = null,
+    val notifyMinDurationSeconds: Int? = null,
+    val notifyShowExitCode: Boolean? = null,
+    val notifyWithSound: Boolean? = null,
+    val notificationPermissionRequested: Boolean? = null,
+
+    // ===== Split Pane Settings =====
+    val splitDefaultRatio: Float? = null,
+    val splitMinimumSize: Float? = null,
+    val splitFocusBorderEnabled: Boolean? = null,
+    val splitFocusBorderColor: String? = null,
+    val splitInheritWorkingDirectory: Boolean? = null,
+
+    // ===== Tab Bar Settings =====
+    val alwaysShowTabBar: Boolean? = null
+)
+
+/**
+ * Merge this settings with an override, using override values where non-null.
+ *
+ * @param override The override settings (null fields use base settings)
+ * @return A new TerminalSettings with overrides applied
+ */
+fun TerminalSettings.withOverrides(override: TerminalSettingsOverride?): TerminalSettings {
+    if (override == null) return this
+
+    return copy(
+        // Visual Settings
+        fontSize = override.fontSize ?: fontSize,
+        fontName = override.fontName ?: fontName,
+        lineSpacing = override.lineSpacing ?: lineSpacing,
+        disableLineSpacingInAlternateBuffer = override.disableLineSpacingInAlternateBuffer ?: disableLineSpacingInAlternateBuffer,
+        fillBackgroundInLineSpacing = override.fillBackgroundInLineSpacing ?: fillBackgroundInLineSpacing,
+        useAntialiasing = override.useAntialiasing ?: useAntialiasing,
+        preferTerminalFontForSymbols = override.preferTerminalFontForSymbols ?: preferTerminalFontForSymbols,
+        defaultForeground = override.defaultForeground ?: defaultForeground,
+        defaultBackground = override.defaultBackground ?: defaultBackground,
+        selectionColor = override.selectionColor ?: selectionColor,
+        foundPatternColor = override.foundPatternColor ?: foundPatternColor,
+        hyperlinkColor = override.hyperlinkColor ?: hyperlinkColor,
+        activeThemeId = override.activeThemeId ?: activeThemeId,
+        colorPaletteId = override.colorPaletteId ?: colorPaletteId,
+        backgroundOpacity = override.backgroundOpacity ?: backgroundOpacity,
+        windowBlur = override.windowBlur ?: windowBlur,
+        blurRadius = override.blurRadius ?: blurRadius,
+        backgroundImagePath = override.backgroundImagePath ?: backgroundImagePath,
+        backgroundImageOpacity = override.backgroundImageOpacity ?: backgroundImageOpacity,
+        useNativeTitleBar = override.useNativeTitleBar ?: useNativeTitleBar,
+        showUnfocusedOverlay = override.showUnfocusedOverlay ?: showUnfocusedOverlay,
+
+        // Behavior Settings
+        useLoginSession = override.useLoginSession ?: useLoginSession,
+        initialCommand = override.initialCommand ?: initialCommand,
+        initialCommandDelayMs = override.initialCommandDelayMs ?: initialCommandDelayMs,
+        copyOnSelect = override.copyOnSelect ?: copyOnSelect,
+        pasteOnMiddleClick = override.pasteOnMiddleClick ?: pasteOnMiddleClick,
+        emulateX11CopyPaste = override.emulateX11CopyPaste ?: emulateX11CopyPaste,
+        scrollToBottomOnTyping = override.scrollToBottomOnTyping ?: scrollToBottomOnTyping,
+        altSendsEscape = override.altSendsEscape ?: altSendsEscape,
+        enableMouseReporting = override.enableMouseReporting ?: enableMouseReporting,
+        forceActionOnMouseReporting = override.forceActionOnMouseReporting ?: forceActionOnMouseReporting,
+        mouseScrollThreshold = override.mouseScrollThreshold ?: mouseScrollThreshold,
+        audibleBell = override.audibleBell ?: audibleBell,
+        visualBell = override.visualBell ?: visualBell,
+
+        // Progress Bar Settings
+        progressBarEnabled = override.progressBarEnabled ?: progressBarEnabled,
+        progressBarPosition = override.progressBarPosition ?: progressBarPosition,
+        progressBarHeight = override.progressBarHeight ?: progressBarHeight,
+
+        // Clipboard Settings
+        clipboardOsc52Enabled = override.clipboardOsc52Enabled ?: clipboardOsc52Enabled,
+        clipboardOsc52AllowRead = override.clipboardOsc52AllowRead ?: clipboardOsc52AllowRead,
+        clipboardOsc52AllowWrite = override.clipboardOsc52AllowWrite ?: clipboardOsc52AllowWrite,
+        useInverseSelectionColor = override.useInverseSelectionColor ?: useInverseSelectionColor,
+
+        // Scrollbar Settings
+        showScrollbar = override.showScrollbar ?: showScrollbar,
+        scrollbarAlwaysVisible = override.scrollbarAlwaysVisible ?: scrollbarAlwaysVisible,
+        scrollbarWidth = override.scrollbarWidth ?: scrollbarWidth,
+        scrollbarColor = override.scrollbarColor ?: scrollbarColor,
+        scrollbarThumbColor = override.scrollbarThumbColor ?: scrollbarThumbColor,
+        showSearchMarkersInScrollbar = override.showSearchMarkersInScrollbar ?: showSearchMarkersInScrollbar,
+        searchMarkerColor = override.searchMarkerColor ?: searchMarkerColor,
+        currentSearchMarkerColor = override.currentSearchMarkerColor ?: currentSearchMarkerColor,
+
+        // GPU Rendering Settings
+        gpuAcceleration = override.gpuAcceleration ?: gpuAcceleration,
+        gpuRenderApi = override.gpuRenderApi ?: gpuRenderApi,
+        gpuPriority = override.gpuPriority ?: gpuPriority,
+        gpuVsyncEnabled = override.gpuVsyncEnabled ?: gpuVsyncEnabled,
+        gpuCacheSizeMb = override.gpuCacheSizeMb ?: gpuCacheSizeMb,
+        gpuCacheMaxPercent = override.gpuCacheMaxPercent ?: gpuCacheMaxPercent,
+
+        // Performance Settings
+        performanceMode = override.performanceMode ?: performanceMode,
+        maxRefreshRate = override.maxRefreshRate ?: maxRefreshRate,
+        bufferMaxLines = override.bufferMaxLines ?: bufferMaxLines,
+        caretBlinkMs = override.caretBlinkMs ?: caretBlinkMs,
+        enableTextBlinking = override.enableTextBlinking ?: enableTextBlinking,
+        slowTextBlinkMs = override.slowTextBlinkMs ?: slowTextBlinkMs,
+        rapidTextBlinkMs = override.rapidTextBlinkMs ?: rapidTextBlinkMs,
+
+        // Terminal Emulation Settings
+        decCompatibilityMode = override.decCompatibilityMode ?: decCompatibilityMode,
+        ambiguousCharsAreDoubleWidth = override.ambiguousCharsAreDoubleWidth ?: ambiguousCharsAreDoubleWidth,
+        characterEncoding = override.characterEncoding ?: characterEncoding,
+        simulateMouseScrollInAlternateScreen = override.simulateMouseScrollInAlternateScreen ?: simulateMouseScrollInAlternateScreen,
+
+        // Search Settings
+        searchCaseSensitive = override.searchCaseSensitive ?: searchCaseSensitive,
+        searchUseRegex = override.searchUseRegex ?: searchUseRegex,
+
+        // Hyperlink Settings
+        hyperlinkUnderlineOnHover = override.hyperlinkUnderlineOnHover ?: hyperlinkUnderlineOnHover,
+        hyperlinkRequireModifier = override.hyperlinkRequireModifier ?: hyperlinkRequireModifier,
+
+        // Type-Ahead Settings
+        typeAheadEnabled = override.typeAheadEnabled ?: typeAheadEnabled,
+        typeAheadLatencyThresholdNanos = override.typeAheadLatencyThresholdNanos ?: typeAheadLatencyThresholdNanos,
+
+        // Debug Settings
+        debugModeEnabled = override.debugModeEnabled ?: debugModeEnabled,
+        debugMaxChunks = override.debugMaxChunks ?: debugMaxChunks,
+        debugMaxSnapshots = override.debugMaxSnapshots ?: debugMaxSnapshots,
+        debugCaptureInterval = override.debugCaptureInterval ?: debugCaptureInterval,
+        debugShowChunkIds = override.debugShowChunkIds ?: debugShowChunkIds,
+        debugShowInvisibleChars = override.debugShowInvisibleChars ?: debugShowInvisibleChars,
+        debugWrapLines = override.debugWrapLines ?: debugWrapLines,
+        debugColorCodeSequences = override.debugColorCodeSequences ?: debugColorCodeSequences,
+
+        // File Logging Settings
+        fileLoggingEnabled = override.fileLoggingEnabled ?: fileLoggingEnabled,
+        fileLoggingDirectory = override.fileLoggingDirectory ?: fileLoggingDirectory,
+        fileLoggingPattern = override.fileLoggingPattern ?: fileLoggingPattern,
+
+        // Notification Settings
+        notifyOnCommandComplete = override.notifyOnCommandComplete ?: notifyOnCommandComplete,
+        notifyMinDurationSeconds = override.notifyMinDurationSeconds ?: notifyMinDurationSeconds,
+        notifyShowExitCode = override.notifyShowExitCode ?: notifyShowExitCode,
+        notifyWithSound = override.notifyWithSound ?: notifyWithSound,
+        notificationPermissionRequested = override.notificationPermissionRequested ?: notificationPermissionRequested,
+
+        // Split Pane Settings
+        splitDefaultRatio = override.splitDefaultRatio ?: splitDefaultRatio,
+        splitMinimumSize = override.splitMinimumSize ?: splitMinimumSize,
+        splitFocusBorderEnabled = override.splitFocusBorderEnabled ?: splitFocusBorderEnabled,
+        splitFocusBorderColor = override.splitFocusBorderColor ?: splitFocusBorderColor,
+        splitInheritWorkingDirectory = override.splitInheritWorkingDirectory ?: splitInheritWorkingDirectory,
+
+        // Tab Bar Settings
+        alwaysShowTabBar = override.alwaysShowTabBar ?: alwaysShowTabBar
+    )
+}

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -57,6 +57,7 @@ fun EmbeddableTerminal(
     onReady: (() -> Unit)? = null,
     contextMenuItems: List<ContextMenuElement> = emptyList(),
     onLinkClick: ((String) -> Unit)? = null,
+    settingsOverride: TerminalSettingsOverride? = null,
     modifier: Modifier = Modifier
 )
 ```
@@ -76,6 +77,7 @@ fun EmbeddableTerminal(
 | `onReady` | `() -> Unit` | Callback when terminal is ready |
 | `contextMenuItems` | `List<ContextMenuElement>` | Custom context menu items |
 | `onLinkClick` | `(String) -> Unit` | Custom link click handler (see [Custom Link Handling](#custom-link-handling)) |
+| `settingsOverride` | `TerminalSettingsOverride?` | Per-instance settings overrides (see [Settings Override](#settings-override)) |
 | `modifier` | `Modifier` | Compose modifier |
 
 ### EmbeddableTerminalState
@@ -347,6 +349,68 @@ EmbeddableTerminal(
 ```
 
 See the main [README](../README.md#configuration) for available settings.
+
+## Settings Override
+
+For per-instance customization without replacing all settings, use `settingsOverride`. This allows you to override specific settings while inheriting others from the resolved settings (via `settings`, `settingsPath`, or defaults).
+
+```kotlin
+import ai.rever.bossterm.compose.settings.TerminalSettingsOverride
+
+EmbeddableTerminal(
+    settingsOverride = TerminalSettingsOverride(
+        fontSize = 12f,           // Override font size
+        showScrollbar = false     // Hide scrollbar
+    )
+    // All other settings come from defaults or settingsPath
+)
+```
+
+### When to Use
+
+| Approach | Use Case |
+|----------|----------|
+| `settings` | Full control over all settings |
+| `settingsPath` | Load settings from a config file |
+| `settingsOverride` | Override specific settings per-instance |
+
+### Combining with Other Settings
+
+`settingsOverride` is applied last, after resolving from `settings`/`settingsPath`/defaults:
+
+```kotlin
+EmbeddableTerminal(
+    // Load base settings from file
+    settingsPath = "~/.myapp/terminal-settings.json",
+    // Override specific settings for this instance
+    settingsOverride = TerminalSettingsOverride(
+        fontSize = 10f  // Smaller font for sidebar terminal
+    )
+)
+```
+
+### Common Override Examples
+
+```kotlin
+// Compact sidebar terminal
+TerminalSettingsOverride(
+    fontSize = 11f,
+    showScrollbar = false,
+    lineSpacing = 1.0f
+)
+
+// High-contrast terminal
+TerminalSettingsOverride(
+    defaultForeground = "0xFFFFFFFF",
+    defaultBackground = "0xFF000000"
+)
+
+// Performance-optimized terminal
+TerminalSettingsOverride(
+    maxRefreshRate = 30,
+    bufferMaxLines = 5000
+)
+```
 
 ## Custom Link Handling
 

--- a/docs/tabbed-terminal.md
+++ b/docs/tabbed-terminal.md
@@ -57,6 +57,8 @@ fun TabbedTerminal(
     isWindowFocused: () -> Boolean = { true },
     initialCommand: String? = null,
     onLinkClick: ((String) -> Unit)? = null,
+    contextMenuItems: List<ContextMenuElement> = emptyList(),
+    settingsOverride: TerminalSettingsOverride? = null,
     modifier: Modifier = Modifier
 )
 ```
@@ -73,6 +75,7 @@ fun TabbedTerminal(
 | `initialCommand` | `String?` | Command to run in first tab after startup |
 | `onLinkClick` | `(String) -> Unit` | Custom link click handler (see [Custom Link Handling](#custom-link-handling)) |
 | `contextMenuItems` | `List<ContextMenuElement>` | Custom context menu items (see [Custom Context Menu](#custom-context-menu)) |
+| `settingsOverride` | `TerminalSettingsOverride?` | Per-instance settings overrides (see [Settings Override](#settings-override)) |
 | `modifier` | `Modifier` | Compose modifier |
 
 ### MenuActions
@@ -307,6 +310,67 @@ Run a command when the terminal starts:
 TabbedTerminal(
     onExit = { /* ... */ },
     initialCommand = "echo 'Welcome!' && ls -la"
+)
+```
+
+## Settings Override
+
+Override specific global settings for a particular `TabbedTerminal` instance without affecting other instances or the global settings file.
+
+```kotlin
+import ai.rever.bossterm.compose.settings.TerminalSettingsOverride
+
+TabbedTerminal(
+    onExit = { /* ... */ },
+    settingsOverride = TerminalSettingsOverride(
+        alwaysShowTabBar = true,  // Always show tab bar (useful for sidebars)
+        fontSize = 12f            // Smaller font for compact view
+    )
+)
+```
+
+### Use Cases
+
+- **Sidebar terminals**: Force `alwaysShowTabBar = true` so users always see tabs
+- **Compact views**: Reduce `fontSize` for space-constrained layouts
+- **Different themes per instance**: Override colors for specific terminals
+- **Performance tuning**: Different `bufferMaxLines` for different use cases
+
+### How It Works
+
+`settingsOverride` merges with global settings from `~/.bossterm/settings.json`:
+
+1. Global settings are loaded from `SettingsManager`
+2. Non-null fields in `settingsOverride` replace corresponding global values
+3. Null fields in `settingsOverride` inherit from global settings
+
+```kotlin
+// Example: Only override alwaysShowTabBar, inherit everything else
+TabbedTerminal(
+    settingsOverride = TerminalSettingsOverride(
+        alwaysShowTabBar = true
+    ),
+    onExit = { /* ... */ }
+)
+```
+
+### Common Override Examples
+
+```kotlin
+// Always show tab bar (for sidebar integration)
+TerminalSettingsOverride(alwaysShowTabBar = true)
+
+// Compact terminal
+TerminalSettingsOverride(
+    fontSize = 11f,
+    lineSpacing = 1.0f,
+    showScrollbar = false
+)
+
+// Different split behavior
+TerminalSettingsOverride(
+    splitDefaultRatio = 0.3f,  // 30/70 splits
+    splitFocusBorderEnabled = false
 )
 ```
 


### PR DESCRIPTION
## Summary
- Add `TerminalSettingsOverride` class with all nullable fields for selective property customization
- Add `withOverrides()` extension function to merge overrides with base `TerminalSettings`
- Add `settingsOverride` parameter to `TabbedTerminal` composable

This enables per-instance configuration overrides while respecting global settings for unspecified fields.

## Usage Example
```kotlin
TabbedTerminal(
    settingsOverride = TerminalSettingsOverride(
        alwaysShowTabBar = true,
        fontSize = 16f
    ),
    onExit = { ... }
)
```

## Test plan
- [ ] Create `TabbedTerminal` without override - verify global settings apply
- [ ] Create `TabbedTerminal` with `TerminalSettingsOverride(alwaysShowTabBar = true)` - verify tab bar always shows
- [ ] Verify non-overridden settings still use global values
- [ ] Test with multiple overridden fields simultaneously

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)