### PR TITLE
fix: Split pane exit closes only that pane, not entire tab

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -135,7 +135,27 @@ fun TabbedTerminal(
     // Helper function to get or create SplitViewState for a tab
     fun getOrCreateSplitState(tab: TerminalTab): SplitViewState {
         return splitStates.getOrPut(tab.id) {
-            SplitViewState(initialSession = tab)
+            val state = SplitViewState(initialSession = tab)
+
+            // Set up split-aware process exit for the original tab
+            // This ensures exiting the original pane closes just that pane,
+            // not the entire tab (unless it's the last pane)
+            tab.onProcessExit = {
+                if (state.isSinglePane) {
+                    // Last pane - close the tab
+                    val tabIndex = tabController.tabs.indexOfFirst { it.id == tab.id }
+                    if (tabIndex != -1) {
+                        tabController.closeTab(tabIndex)
+                    }
+                } else {
+                    // Close just this pane
+                    state.getAllPanes()
+                        .find { it.session === tab }
+                        ?.let { pane -> state.closePane(pane.id) }
+                }
+            }
+
+            state
         }
     }
 
@@ -175,7 +195,7 @@ fun TabbedTerminal(
     LaunchedEffect(menuActions, tabController.activeTabIndex, tabController.tabs.size) {
         if (tabController.tabs.isEmpty()) return@LaunchedEffect
         val activeTab = tabController.tabs.getOrNull(tabController.activeTabIndex) ?: return@LaunchedEffect
-        val splitState = splitStates.getOrPut(activeTab.id) { SplitViewState(initialSession = activeTab) }
+        val splitState = getOrCreateSplitState(activeTab)
 
         menuActions?.apply {
             onSplitVertical = {
@@ -184,10 +204,20 @@ fun TabbedTerminal(
                 val newSession = tabController.createSessionForSplit(
                     workingDir = workingDir,
                     onProcessExit = {
-                        newSessionRef?.let { session ->
-                            splitState.getAllPanes()
-                                .find { it.session === session }
-                                ?.let { pane -> splitState.closePane(pane.id) }
+                        // Auto-close the pane when process exits
+                        if (splitState.isSinglePane) {
+                            // Last pane - close the tab
+                            val tabIndex = tabController.tabs.indexOfFirst { it.id == activeTab.id }
+                            if (tabIndex != -1) {
+                                tabController.closeTab(tabIndex)
+                            }
+                        } else {
+                            // Close just this pane
+                            newSessionRef?.let { session ->
+                                splitState.getAllPanes()
+                                    .find { it.session === session }
+                                    ?.let { pane -> splitState.closePane(pane.id) }
+                            }
                         }
                     }
                 )
@@ -200,10 +230,20 @@ fun TabbedTerminal(
                 val newSession = tabController.createSessionForSplit(
                     workingDir = workingDir,
                     onProcessExit = {
-                        newSessionRef?.let { session ->
-                            splitState.getAllPanes()
-                                .find { it.session === session }
-                                ?.let { pane -> splitState.closePane(pane.id) }
+                        // Auto-close the pane when process exits
+                        if (splitState.isSinglePane) {
+                            // Last pane - close the tab
+                            val tabIndex = tabController.tabs.indexOfFirst { it.id == activeTab.id }
+                            if (tabIndex != -1) {
+                                tabController.closeTab(tabIndex)
+                            }
+                        } else {
+                            // Close just this pane
+                            newSessionRef?.let { session ->
+                                splitState.getAllPanes()
+                                    .find { it.session === session }
+                                    ?.let { pane -> splitState.closePane(pane.id) }
+                            }
                         }
                     }
                 )
@@ -342,10 +382,19 @@ fun TabbedTerminal(
                     workingDir = workingDir,
                     onProcessExit = {
                         // Auto-close the pane when process exits
-                        newSessionRef?.let { session ->
-                            splitState.getAllPanes()
-                                .find { it.session === session }
-                                ?.let { pane -> splitState.closePane(pane.id) }
+                        if (splitState.isSinglePane) {
+                            // Last pane - close the tab
+                            val tabIndex = tabController.tabs.indexOfFirst { it.id == activeTab.id }
+                            if (tabIndex != -1) {
+                                tabController.closeTab(tabIndex)
+                            }
+                        } else {
+                            // Close just this pane
+                            newSessionRef?.let { session ->
+                                splitState.getAllPanes()
+                                    .find { it.session === session }
+                                    ?.let { pane -> splitState.closePane(pane.id) }
+                            }
                         }
                     }
                 )
@@ -366,10 +415,19 @@ fun TabbedTerminal(
                     workingDir = workingDir,
                     onProcessExit = {
                         // Auto-close the pane when process exits
-                        newSessionRef?.let { session ->
-                            splitState.getAllPanes()
-                                .find { it.session === session }
-                                ?.let { pane -> splitState.closePane(pane.id) }
+                        if (splitState.isSinglePane) {
+                            // Last pane - close the tab
+                            val tabIndex = tabController.tabs.indexOfFirst { it.id == activeTab.id }
+                            if (tabIndex != -1) {
+                                tabController.closeTab(tabIndex)
+                            }
+                        } else {
+                            // Close just this pane
+                            newSessionRef?.let { session ->
+                                splitState.getAllPanes()
+                                    .find { it.session === session }
+                                    ?.let { pane -> splitState.closePane(pane.id) }
+                            }
                         }
                     }
                 )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -899,14 +899,21 @@ class TabController(
             handle.waitFor()
             println("INFO: Shell process exited for tab: ${tab.title.value}")
 
+            // Call onProcessExit callback - this handles split pane closure
+            // If callback exists, it handles the exit (e.g., closing just the pane in a split)
+            val hasCallback = tab.onProcessExit != null
             withContext(Dispatchers.Main) {
                 tab.onProcessExit?.invoke()
             }
 
-            withContext(Dispatchers.Main) {
-                val tabIndex = tabs.indexOf(tab)
-                if (tabIndex != -1) {
-                    closeTab(tabIndex)
+            // Auto-close tab only if no callback is set
+            // (tabs in splits have callbacks that handle pane closure)
+            if (!hasCallback) {
+                withContext(Dispatchers.Main) {
+                    val tabIndex = tabs.indexOf(tab)
+                    if (tabIndex != -1) {
+                        closeTab(tabIndex)
+                    }
                 }
             }
 
@@ -1086,16 +1093,21 @@ class TabController(
                 handle.waitFor()  // Blocks until process exits
                 println("INFO: Shell process exited for tab: ${tab.title.value}")
 
-                // Call onProcessExit callback for custom cleanup/logging (if provided)
+                // Call onProcessExit callback - this handles split pane closure
+                // If callback exists, it handles the exit (e.g., closing just the pane in a split)
+                val hasCallback = tab.onProcessExit != null
                 withContext(Dispatchers.Main) {
                     tab.onProcessExit?.invoke()
                 }
 
-                // Auto-close tab when shell exits (as per user requirements)
-                withContext(Dispatchers.Main) {
-                    val tabIndex = tabs.indexOf(tab)
-                    if (tabIndex != -1) {
-                        closeTab(tabIndex)
+                // Auto-close tab only if no callback is set
+                // (tabs in splits have callbacks that handle pane closure)
+                if (!hasCallback) {
+                    withContext(Dispatchers.Main) {
+                        val tabIndex = tabs.indexOf(tab)
+                        if (tabIndex != -1) {
+                            closeTab(tabIndex)
+                        }
                     }
                 }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -103,8 +103,11 @@ data class TerminalTab(
      * Callback invoked when the shell process exits.
      * Called by TabController before auto-closing the tab.
      * Can be used for cleanup, logging, or custom exit handling.
+     *
+     * Note: This can be reassigned after creation (e.g., when the tab becomes
+     * part of a split pane and needs split-aware exit behavior).
      */
-    val onProcessExit: (() -> Unit)? = null,
+    var onProcessExit: (() -> Unit)? = null,
 
     // === Coroutine Management ===
 


### PR DESCRIPTION
## Summary
- Fixes issue where exiting the original pane in a split would close the entire tab
- Now exiting any pane (including the original/first pane) only closes that pane
- Last remaining pane exit still closes the tab automatically

## Changes
- **TabController.kt**: Modified `initializeTerminalSession()` and `initializeTerminalSessionWithConfig()` to skip auto-close if `onProcessExit` callback is set
- **TabbedTerminal.kt**: Updated `getOrCreateSplitState()` to set up split-aware exit handler for original tab; updated all split pane callbacks to handle last pane case
- **TerminalTab.kt**: Changed `onProcessExit` from `val` to `var` to allow reassignment when tab becomes part of a split

## Test plan
- [ ] Single tab with no splits: Exit closes tab (unchanged behavior)
- [ ] Tab with 2 panes, exit original pane: Only that pane closes, other pane remains
- [ ] Tab with 2 panes, exit split pane: Only that pane closes
- [ ] Tab with 2 panes, both exit sequentially: First exit closes pane, second exit closes tab
- [ ] Tab with 3+ panes: Each exit closes just that pane until last one closes tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)