### PR TITLE
fix: Increase default scrollbar width to 14px

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -281,7 +281,7 @@ data class TerminalSettings(
     /**
      * Scrollbar width in pixels
      */
-    val scrollbarWidth: Float = 10f,
+    val scrollbarWidth: Float = 14f,
 
     /**
      * Scrollbar track color (serialized as ARGB hex)


### PR DESCRIPTION
## Summary
- Increase default scrollbar width from 10px to 14px for better visibility and usability

## Test plan
- [ ] Verify scrollbar appears at 14px width on new installations
- [ ] Verify existing user settings override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)