### PR TITLE
feat: Add onTabClose callback to TabbedTerminal

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -63,6 +63,8 @@ import ai.rever.bossterm.compose.ui.ProperTerminal
  *              recomposition (e.g., when embedded in a tab system). When null, state is
  *              managed internally and lost when composable unmounts.
  * @param onExit Called when the last tab is closed
+ * @param onTabClose Called when a tab is about to close (before removal). Receives the stable tab ID.
+ *                   Use this to clean up resources associated with specific tabs.
  * @param onWindowTitleChange Called when active tab's title changes (for window title bar)
  * @param onNewWindow Called when user requests a new window (Cmd/Ctrl+N)
  * @param menuActions Optional menu action callbacks for wiring up menu bar
@@ -81,6 +83,7 @@ import ai.rever.bossterm.compose.ui.ProperTerminal
 fun TabbedTerminal(
     state: TabbedTerminalState? = null,
     onExit: () -> Unit,
+    onTabClose: ((tabId: String) -> Unit)? = null,
     onWindowTitleChange: (String) -> Unit = {},
     onNewWindow: () -> Unit = {},
     onShowSettings: () -> Unit = {},
@@ -112,7 +115,8 @@ fun TabbedTerminal(
         state.initialize(
             settings = settings,
             onLastTabClosed = onExit,
-            isWindowFocused = isWindowFocused
+            isWindowFocused = isWindowFocused,
+            onTabClose = onTabClose
         )
     }
 
@@ -121,7 +125,8 @@ fun TabbedTerminal(
         TabController(
             settings = settings,
             onLastTabClosed = onExit,
-            isWindowFocused = isWindowFocused
+            isWindowFocused = isWindowFocused,
+            onTabClose = onTabClose
         )
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -129,7 +129,8 @@ class TabbedTerminalState {
     internal fun initialize(
         settings: TerminalSettings,
         onLastTabClosed: () -> Unit,
-        isWindowFocused: () -> Boolean
+        isWindowFocused: () -> Boolean,
+        onTabClose: ((tabId: String) -> Unit)? = null
     ) {
         if (initialized) return
         initialized = true
@@ -137,7 +138,8 @@ class TabbedTerminalState {
         tabController = TabController(
             settings = settings,
             onLastTabClosed = onLastTabClosed,
-            isWindowFocused = isWindowFocused
+            isWindowFocused = isWindowFocused,
+            onTabClose = onTabClose
         )
     }
 


### PR DESCRIPTION
## Summary

- Add `onTabClose` callback parameter to `TabbedTerminal` that fires **before** a tab is removed
- Allows parent applications to clean up resources associated with specific tabs (e.g., runner states)
- Receives stable tab ID for reliable resource association

Closes #194

## Changes

- `TabbedTerminal.kt`: Add `onTabClose` parameter, wire through to TabController
- `TabbedTerminalState.kt`: Add `onTabClose` to `initialize()` method
- `TabController.kt`: Add constructor parameter, invoke callback in `closeTab()` before disposal
- `docs/tabbed-terminal.md`: Document new callback with runner system example

## Usage

```kotlin
TabbedTerminal(
    onExit = { exitApplication() },
    onTabClose = { tabId ->
        // Clean up runner state when tab closes
        myRunnerStates.remove(tabId)?.cleanup()
    }
)
```

## Test plan

- [ ] Create tabs with stable IDs
- [ ] Close tabs and verify callback fires with correct tab ID
- [ ] Verify callback fires before tab is removed from state
- [ ] Verify exception in callback doesn't crash the application

🤖 Generated with [Claude Code](https://claude.com/claude-code)