### PR TITLE
feat: Add configurable Shift+Enter behavior (#196)

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/Terminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/Terminal.kt
@@ -183,6 +183,8 @@ interface Terminal {
 
     fun setAltSendsEscape(enabled: Boolean)
 
+    fun setShiftEnterSendsNewline(enabled: Boolean)
+
     fun deviceStatusReport(str: String?)
 
     fun deviceAttributes(response: ByteArray?)

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/TerminalKeyEncoder.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/TerminalKeyEncoder.kt
@@ -48,6 +48,11 @@ class TerminalKeyEncoder @JvmOverloads constructor(private val myPlatform: Platf
 
         putCode(KeyCodeAndModifier(VK_TAB, InputEvent.SHIFT_MASK), ESC, '['.code, 'Z'.code)
 
+        // Default: Shift+Enter sends LF (newline) - matches iTerm2 behavior
+        // IMPORTANT: This default must match TerminalSettings.shiftEnterBehavior default ("newline")
+        // Can be changed via setShiftEnterSendsNewline()
+        putCode(KeyCodeAndModifier(VK_ENTER, InputEvent.SHIFT_MASK), Ascii.LF.code)
+
         putCode(KeyCodeAndModifier(VK_BACK_SPACE, InputEvent.CTRL_MASK), VK_BACK_SPACE)
         if (isMacOS) {
             putCode(KeyCodeAndModifier(VK_LEFT, InputEvent.META_MASK), Ascii.SOH.code)
@@ -209,6 +214,19 @@ class TerminalKeyEncoder @JvmOverloads constructor(private val myPlatform: Platf
 
     fun setMetaSendsEscape(metaSendsEscape: Boolean) {
         myMetaSendsEscape = metaSendsEscape
+    }
+
+    /**
+     * Configure Shift+Enter behavior.
+     * @param sendsNewline true = send LF (0x0A, newline) for multi-line input (iTerm2 style)
+     *                     false = send CR (0x0D, same as Enter)
+     */
+    fun setShiftEnterSendsNewline(sendsNewline: Boolean) {
+        if (sendsNewline) {
+            putCode(KeyCodeAndModifier(VK_ENTER, InputEvent.SHIFT_MASK), Ascii.LF.code)
+        } else {
+            putCode(KeyCodeAndModifier(VK_ENTER, InputEvent.SHIFT_MASK), Ascii.CR.code)
+        }
     }
 
     private class KeyCodeAndModifier(private val myCode: Int, private val myModifier: Int) {

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -1509,6 +1509,10 @@ class BossTerminal(
         myTerminalKeyEncoder.setAltSendsEscape(enabled)
     }
 
+    override fun setShiftEnterSendsNewline(enabled: Boolean) {
+        myTerminalKeyEncoder.setShiftEnterSendsNewline(enabled)
+    }
+
     override fun deviceStatusReport(str: String?) {
         str?.let {
             myTerminalOutput?.sendString(it, false)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -224,6 +224,16 @@ data class TerminalSettings(
      */
     val visualBell: Boolean = true,
 
+    /**
+     * Shift+Enter key behavior.
+     * Valid values:
+     * - "newline": Send LF (0x0A) - inserts literal newline for multi-line input (iTerm2 style)
+     * - "same-as-enter": Send CR (0x0D) - same as regular Enter key
+     * Default: "newline" to match iTerm2 behavior
+     * IMPORTANT: Default must match TerminalKeyEncoder init block default
+     */
+    val shiftEnterBehavior: String = "newline",
+
     // ===== Progress Bar Settings =====
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettingsOverride.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettingsOverride.kt
@@ -57,6 +57,7 @@ data class TerminalSettingsOverride(
     val mouseScrollThreshold: Float? = null,
     val audibleBell: Boolean? = null,
     val visualBell: Boolean? = null,
+    val shiftEnterBehavior: String? = null,
 
     // ===== Progress Bar Settings =====
     val progressBarEnabled: Boolean? = null,
@@ -194,6 +195,7 @@ fun TerminalSettings.withOverrides(override: TerminalSettingsOverride?): Termina
         mouseScrollThreshold = override.mouseScrollThreshold ?: mouseScrollThreshold,
         audibleBell = override.audibleBell ?: audibleBell,
         visualBell = override.visualBell ?: visualBell,
+        shiftEnterBehavior = override.shiftEnterBehavior ?: shiftEnterBehavior,
 
         // Progress Bar Settings
         progressBarEnabled = override.progressBarEnabled ?: progressBarEnabled,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/BehaviorSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/BehaviorSettingsSection.kt
@@ -115,6 +115,25 @@ fun BehaviorSettingsSection(
 
         // Keyboard Settings
         SettingsSection(title = "Keyboard") {
+            // Valid values: "newline", "same-as-enter" (see TerminalSettings.shiftEnterBehavior)
+            SettingsDropdown(
+                label = "Shift+Enter Behavior",
+                options = listOf("Newline (iTerm2 style)", "Same as Enter"),
+                selectedOption = when (settings.shiftEnterBehavior) {
+                    "newline" -> "Newline (iTerm2 style)"
+                    "same-as-enter" -> "Same as Enter"
+                    else -> "Newline (iTerm2 style)" // Invalid value defaults to newline
+                },
+                onOptionSelected = {
+                    val value = when (it) {
+                        "Newline (iTerm2 style)" -> "newline"
+                        else -> "same-as-enter"
+                    }
+                    onSettingsChange(settings.copy(shiftEnterBehavior = value))
+                },
+                description = "Newline inserts line break without executing command"
+            )
+
             SettingsToggle(
                 label = "Alt Sends Escape",
                 checked = settings.altSendsEscape,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -262,6 +262,23 @@ fun ProperTerminal(
   // Terminal key encoder for proper escape sequence generation (function keys, modifiers, etc.)
   val keyEncoder = remember { TerminalKeyEncoder() }
 
+  // Configure key encoder based on settings
+  // We configure BOTH encoders because:
+  // - keyEncoder (local): Used at line ~1358 for keyboard input processing (getCode)
+  // - terminal's encoder: Configured via Terminal interface for architectural consistency
+  //   and potential future use by terminal emulation code
+  // Note: Defaults in TerminalKeyEncoder.init() match TerminalSettings defaults,
+  // so there's no incorrect state before this effect runs on first render.
+  LaunchedEffect(settings.shiftEnterBehavior, settings.altSendsEscape) {
+    val shiftEnterNewline = settings.shiftEnterBehavior == "newline"
+    // Configure local key encoder (used for keyboard input at line ~1358)
+    keyEncoder.setShiftEnterSendsNewline(shiftEnterNewline)
+    keyEncoder.setAltSendsEscape(settings.altSendsEscape)
+    // Configure terminal's internal encoder (via Terminal interface)
+    terminal.setShiftEnterSendsNewline(shiftEnterNewline)
+    terminal.setAltSendsEscape(settings.altSendsEscape)
+  }
+
   // ProcessTerminalOutput is now defined in TabController
   // No longer needed here since terminal output routing is set up during tab initialization
 


### PR DESCRIPTION
## Summary

- Add `shiftEnterBehavior` setting with two options:
  - **"newline"** (default): Send LF (0x0A) for multi-line input (iTerm2 style)
  - **"same-as-enter"**: Send CR (0x0D) like regular Enter
- Add dropdown in Settings UI under **Behavior → Keyboard**
- Configurable via `~/.bossterm/settings.json`

## Changes

| File | Change |
|------|--------|
| `TerminalKeyEncoder.kt` | Add `setShiftEnterSendsNewline()` method |
| `TerminalSettings.kt` | Add `shiftEnterBehavior` setting |
| `TerminalSettingsOverride.kt` | Add override support |
| `BehaviorSettingsSection.kt` | Add UI dropdown |
| `ProperTerminal.kt` | Configure encoder from settings |

## Test Plan

- [ ] Run app and press Shift+Enter - should insert newline (not execute)
- [ ] Change setting to "Same as Enter" - Shift+Enter should execute like Enter
- [ ] Verify setting persists in `~/.bossterm/settings.json`

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)