### PR TITLE
fix: Detect wrapped hyperlinks across multiple terminal lines

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/pool/IncrementalSnapshotBuilder.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/pool/IncrementalSnapshotBuilder.kt
@@ -268,6 +268,31 @@ class VersionedBufferSnapshot(
             historyLines.getOrNull(historyIndex)?.version
         }
     }
+
+    /**
+     * Compute a hash of all line versions in this snapshot.
+     * Used for detecting content changes across frames to enable caching.
+     *
+     * @return A hash combining all screen and recent history line versions
+     */
+    fun computeVersionHash(): Long {
+        var hash = 17L
+        // Hash all screen lines
+        for (i in 0 until height) {
+            val version = screenLines.getOrNull(i)?.version ?: 0L
+            hash = hash * 31 + version
+        }
+        // Include recent history lines (limit to avoid excessive computation)
+        val historyToInclude = minOf(historyLinesCount, 100)
+        for (i in 0 until historyToInclude) {
+            val version = historyLines.getOrNull(historyLinesCount - 1 - i)?.version ?: 0L
+            hash = hash * 31 + version
+        }
+        // Include structural info
+        hash = hash * 31 + width
+        hash = hash * 31 + height
+        return hash
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #199 - When a URL wraps across multiple terminal lines, clicking the link now opens the entire URL instead of just the first line portion.

- Extended `Hyperlink` data class with `startRow`, `endRow`, `rowSpans` for multi-row support
- Added `collectWrappedLines()` to walk wrapped line sequences using `isWrapped` property
- Added `detectHyperlinksWithWrapping()` to join lines, detect URLs, and map back to rows
- Updated renderer to populate hyperlink cache for ALL rows a hyperlink spans
- Updated hover detection to use `containsPosition(col, row)` method
- Updated underline rendering to draw across all spanned rows

## Test plan

- [ ] Echo a long URL that wraps to multiple lines
- [ ] Hold Cmd/Ctrl and hover over any part of the wrapped URL
- [ ] Verify all portions underline
- [ ] Click to open - verify full URL opens (not truncated)
- [ ] Test URLs spanning 2, 3, and 4+ lines
- [ ] Test scrolling with wrapped URLs in/out of view

🤖 Generated with [Claude Code](https://claude.com/claude-code)