### PR TITLE
fix: Set PWD env var to match workingDirectory for Starship compatibility

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -571,12 +571,15 @@ private suspend fun initializeProcess(
             emptyList()
         }
 
-        // Build environment
+        // Build environment (filter out PWD/OLDPWD to avoid inheriting stale values)
+        val effectiveWorkingDir = workingDirectory ?: System.getProperty("user.home")
         val terminalEnvironment = buildMap {
-            putAll(System.getenv())
+            putAll(System.getenv().filterKeys { it != "PWD" && it != "OLDPWD" })
             put("TERM", "xterm-256color")
             put("COLORTERM", "truecolor")
             put("TERM_PROGRAM", "BossTerm")
+            // Set PWD to match actual working directory (required for Starship and other prompts)
+            put("PWD", effectiveWorkingDir)
             environment?.let { putAll(it) }
         }
 
@@ -585,7 +588,7 @@ private suspend fun initializeProcess(
             command = command,
             arguments = args,
             environment = terminalEnvironment,
-            workingDirectory = workingDirectory ?: System.getProperty("user.home")
+            workingDirectory = effectiveWorkingDir
         )
 
         // Spawn PTY process

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -904,6 +904,8 @@ class TabController(
                 put("COLORTERM", "truecolor")
                 put("TERM_PROGRAM", "BossTerm")
                 put("TERM_FEATURES", "T2:M:H:Ts0:Ts1:Ts2:Sc0:Sc1:Sc2:B:U:Aw")
+                // Set PWD to match actual working directory (required for Starship and other prompts)
+                put("PWD", config.workingDir ?: System.getProperty("user.home"))
                 putAll(config.environment)
             }
 
@@ -1066,6 +1068,8 @@ class TabController(
                     put("COLORTERM", "truecolor")
                     put("TERM_PROGRAM", "BossTerm")
                     put("TERM_FEATURES", "T2:M:H:Ts0:Ts1:Ts2:Sc0:Sc1:Sc2:B:U:Aw")
+                    // Set PWD to match actual working directory (required for Starship and other prompts)
+                    put("PWD", workingDir ?: System.getProperty("user.home"))
                 }
 
                 val config = PlatformServices.ProcessService.ProcessConfig(
@@ -1548,13 +1552,17 @@ class TabController(
 
     /**
      * Filter environment variables to remove potentially problematic ones.
-     * (e.g., parent terminal's TERM variables that shouldn't be inherited)
+     * (e.g., parent terminal's TERM variables that shouldn't be inherited,
+     * and PWD/OLDPWD which would reflect the parent's directory instead of
+     * the requested working directory)
      */
     private fun filterEnvironmentVariables(env: Map<String, String>): Map<String, String> {
         return env.filterKeys { key ->
             !key.startsWith("ITERM_") &&
             !key.startsWith("KITTY_") &&
-            key != "TERM_SESSION_ID"
+            key != "TERM_SESSION_ID" &&
+            key != "PWD" &&
+            key != "OLDPWD"
         }
     }
 

--- a/embedded-example/src/desktopMain/kotlin/ai/rever/bossterm/embedded/Main.kt
+++ b/embedded-example/src/desktopMain/kotlin/ai/rever/bossterm/embedded/Main.kt
@@ -100,9 +100,11 @@ fun EmbeddedExampleApp() {
                     ) {
                         EmbeddableTerminal(
                             state = terminalState,
+                            // Test workingDirectory fix for Starship prompt
+                            workingDirectory = "/tmp",
                             // Run a command automatically when terminal is ready
                             // Uses OSC 133 shell integration for proper timing if available
-                            initialCommand = "echo 'Welcome to BossTerm Embedded Example!'",
+                            initialCommand = "echo 'Welcome to BossTerm Embedded Example!' && pwd",
                             onExit = { exitCode ->
                                 statusMessage = "Terminal exited with code: $exitCode"
                             },


### PR DESCRIPTION
## Summary
- Fix `workingDirectory` API not working with Starship prompt
- Filter out inherited `PWD` and `OLDPWD` from parent process environment
- Explicitly set `PWD` to match the requested working directory

## Problem
When using `workingDirectory` parameter with `TabbedTerminal` or `EmbeddableTerminal`, Starship prompt showed the wrong directory. This was because Starship reads `PWD` from environment rather than calling `getcwd()`.

## Root Cause
The `PWD` environment variable from BossTerm's parent process was inherited and passed to the shell, creating a mismatch between:
- **PTY working directory**: Set correctly via `PtyProcessBuilder.setDirectory()`
- **`PWD` env var**: Stale value from wherever BossTerm was launched

## Solution
1. Filter out `PWD` and `OLDPWD` from inherited environment in `filterEnvironmentVariables()`
2. Explicitly set `PWD` to match the `workingDirectory` parameter
3. Applied fix to both `TabController.kt` and `EmbeddableTerminal.kt`

## Test plan
- [ ] Run `./gradlew :embedded-example:run` - terminal should open in `/tmp`
- [ ] Verify Starship prompt shows `/tmp` (not home directory)
- [ ] Verify `pwd` command output matches Starship prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)