### PR TITLE
feat: Auto-inject shell integration for command notifications (#202)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/notification/CommandNotificationHandler.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/notification/CommandNotificationHandler.kt
@@ -54,7 +54,7 @@ class CommandNotificationHandler(
 
         // Check for incomplete shell integration (D without B)
         if (startTime == 0L) {
-            LOG.warn("Command finished without corresponding start event - shell integration may be incomplete")
+            // This is normal for the initial prompt before any command is run
             isCommandRunning.set(false)
             return
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -600,6 +600,15 @@ data class TerminalSettings(
      */
     val notificationPermissionRequested: Boolean = false,
 
+    /**
+     * Automatically inject shell integration (OSC 133) into new terminal sessions.
+     * When enabled, BossTerm hijacks shell environment variables (ZDOTDIR for zsh,
+     * ENV for bash, XDG_DATA_DIRS for fish) to auto-load shell integration scripts.
+     * This enables command completion notifications without manual shell configuration.
+     * Set to false if this causes issues with your shell setup.
+     */
+    val autoInjectShellIntegration: Boolean = true,
+
     // ===== Split Pane Settings =====
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/NotificationSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/NotificationSettingsSection.kt
@@ -20,12 +20,24 @@ fun NotificationSettingsSection(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
+        SettingsSection(title = "Shell Integration") {
+            SettingsToggle(
+                label = "Auto-inject Shell Integration",
+                checked = settings.autoInjectShellIntegration,
+                onCheckedChange = { onSettingsChange(settings.copy(autoInjectShellIntegration = it)) },
+                description = "Automatically enable OSC 133 command tracking (required for notifications)"
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
         SettingsSection(title = "Command Notifications") {
             SettingsToggle(
                 label = "Enable Notifications",
                 checked = settings.notifyOnCommandComplete,
                 onCheckedChange = { onSettingsChange(settings.copy(notifyOnCommandComplete = it)) },
-                description = "Show notification when commands complete while unfocused"
+                description = "Show notification when commands complete while unfocused",
+                enabled = settings.autoInjectShellIntegration
             )
 
             SettingsSlider(
@@ -37,7 +49,7 @@ fun NotificationSettingsSection(
                 steps = 58,
                 valueDisplay = { "${it.toInt()} sec" },
                 description = "Only notify for commands longer than this",
-                enabled = settings.notifyOnCommandComplete
+                enabled = settings.autoInjectShellIntegration && settings.notifyOnCommandComplete
             )
         }
 
@@ -49,7 +61,7 @@ fun NotificationSettingsSection(
                 checked = settings.notifyShowExitCode,
                 onCheckedChange = { onSettingsChange(settings.copy(notifyShowExitCode = it)) },
                 description = "Include exit code in notification message",
-                enabled = settings.notifyOnCommandComplete
+                enabled = settings.autoInjectShellIntegration && settings.notifyOnCommandComplete
             )
 
             SettingsToggle(
@@ -57,7 +69,7 @@ fun NotificationSettingsSection(
                 checked = settings.notifyWithSound,
                 onCheckedChange = { onSettingsChange(settings.copy(notifyWithSound = it)) },
                 description = "Play system notification sound",
-                enabled = settings.notifyOnCommandComplete
+                enabled = settings.autoInjectShellIntegration && settings.notifyOnCommandComplete
             )
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/ShellIntegrationInjector.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/ShellIntegrationInjector.kt
@@ -1,0 +1,175 @@
+package ai.rever.bossterm.compose.tabs
+
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * Injects BossTerm shell integration into shell processes.
+ *
+ * This uses the same approach as iTerm2:
+ * - For Zsh: Hijack ZDOTDIR to point to our integration directory
+ * - For Bash: Set ENV to point to our loader script
+ * - For Fish: Prepend our vendor_conf.d to XDG_DATA_DIRS
+ *
+ * The integration scripts send OSC 133 sequences to track command execution,
+ * enabling features like command completion notifications.
+ */
+object ShellIntegrationInjector {
+
+    private val LOG = LoggerFactory.getLogger(ShellIntegrationInjector::class.java)
+
+    // Resource paths for shell integration scripts
+    private val SHELL_INTEGRATION_RESOURCES = listOf(
+        ".zshenv",
+        "bossterm_shell_integration.zsh",
+        "bash-loader",
+        "bossterm_shell_integration.bash",
+        "fish/vendor_conf.d/bossterm_shell_integration.fish"
+    )
+
+    // Lazy-initialized integration directory
+    private val integrationDir: File by lazy {
+        File(System.getProperty("user.home"), ".bossterm/shell-integration").also { dir ->
+            extractAllResources(dir)
+        }
+    }
+
+    /**
+     * Inject shell integration environment variables for the given shell.
+     *
+     * @param shell The shell command/path (e.g., "/bin/zsh", "bash", etc.)
+     * @param env The environment map to modify
+     * @param enabled Whether shell integration is enabled (from settings)
+     */
+    fun injectForShell(shell: String, env: MutableMap<String, String>, enabled: Boolean = true) {
+        if (!enabled) {
+            LOG.debug("Shell integration disabled, skipping injection")
+            return
+        }
+
+        val shellName = File(shell).name
+
+        // If the command is 'login' (macOS uses /usr/bin/login as wrapper),
+        // detect the actual shell from SHELL environment variable
+        val effectiveShellName = if (shellName == "login") {
+            val userShell = env["SHELL"] ?: System.getenv("SHELL") ?: ""
+            File(userShell).name
+        } else {
+            shellName
+        }
+
+        LOG.debug("Injecting shell integration for: $effectiveShellName")
+
+        when {
+            effectiveShellName == "zsh" || effectiveShellName.endsWith("zsh") -> injectZsh(env)
+            effectiveShellName == "bash" || effectiveShellName.endsWith("bash") -> injectBash(env)
+            effectiveShellName == "fish" || effectiveShellName.endsWith("fish") -> injectFish(env)
+            else -> LOG.debug("Unknown shell '$effectiveShellName', shell integration not injected")
+        }
+    }
+
+    /**
+     * Inject for Zsh using ZDOTDIR hijacking.
+     *
+     * How it works:
+     * 1. Save original ZDOTDIR (if any) to BOSSTERM_ORIG_ZDOTDIR
+     * 2. Set ZDOTDIR to our integration directory
+     * 3. Zsh reads .zshenv from our directory first
+     * 4. Our .zshenv restores original ZDOTDIR and sources user's config
+     * 5. Then loads shell integration for interactive shells
+     */
+    private fun injectZsh(env: MutableMap<String, String>) {
+        // Save original ZDOTDIR if it exists
+        env["ZDOTDIR"]?.let { original ->
+            env["BOSSTERM_ORIG_ZDOTDIR"] = original
+        }
+
+        // Point ZDOTDIR to our integration directory
+        env["ZDOTDIR"] = integrationDir.absolutePath
+        env["BOSSTERM_INJECT_INTEGRATION"] = "1"
+
+        LOG.debug("Injected Zsh integration via ZDOTDIR=${integrationDir.absolutePath}")
+    }
+
+    /**
+     * Inject for Bash using ENV variable.
+     *
+     * How it works:
+     * 1. Set ENV to point to our bash-loader script
+     * 2. Bash sources ENV for interactive shells
+     * 3. Our loader sources normal startup files first
+     * 4. Then loads shell integration
+     */
+    private fun injectBash(env: MutableMap<String, String>) {
+        val loaderPath = File(integrationDir, "bash-loader").absolutePath
+
+        // Set ENV to our loader script
+        env["ENV"] = loaderPath
+        env["BOSSTERM_INJECT_INTEGRATION"] = "1"
+
+        LOG.debug("Injected Bash integration via ENV=$loaderPath")
+    }
+
+    /**
+     * Inject for Fish using XDG_DATA_DIRS.
+     *
+     * How it works:
+     * 1. Prepend our fish directory to XDG_DATA_DIRS
+     * 2. Fish discovers vendor_conf.d/bossterm_shell_integration.fish
+     * 3. Fish autoloads it during initialization
+     */
+    private fun injectFish(env: MutableMap<String, String>) {
+        val fishDir = File(integrationDir, "fish").absolutePath
+        val existingDirs = env["XDG_DATA_DIRS"] ?: "/usr/local/share:/usr/share"
+
+        // Prepend our fish directory
+        env["XDG_DATA_DIRS"] = "$fishDir:$existingDirs"
+        env["BOSSTERM_INJECT_INTEGRATION"] = "1"
+
+        LOG.debug("Injected Fish integration via XDG_DATA_DIRS")
+    }
+
+    /**
+     * Extract all shell integration resources to the integration directory.
+     */
+    private fun extractAllResources(targetDir: File) {
+        // Create target directory
+        if (!targetDir.exists()) {
+            targetDir.mkdirs()
+        }
+
+        for (resource in SHELL_INTEGRATION_RESOURCES) {
+            val targetFile = File(targetDir, resource)
+
+            // Create parent directories if needed
+            targetFile.parentFile?.mkdirs()
+
+            // Extract resource (always overwrite to ensure latest version)
+            try {
+                val resourcePath = "shell-integration/$resource"
+                // Use anonymous object pattern for more reliable classloader access (same as FontUtils)
+                val inputStream = object {}.javaClass.classLoader?.getResourceAsStream(resourcePath)
+                    ?: Thread.currentThread().contextClassLoader?.getResourceAsStream(resourcePath)
+                    ?: ShellIntegrationInjector::class.java.classLoader?.getResourceAsStream(resourcePath)
+
+                if (inputStream != null) {
+                    inputStream.use { input ->
+                        targetFile.outputStream().use { output ->
+                            input.copyTo(output)
+                        }
+                    }
+                    // Make scripts executable
+                    if (resource.endsWith(".bash") || resource.endsWith(".zsh") ||
+                        resource.endsWith(".fish") || resource == "bash-loader" ||
+                        resource == ".zshenv") {
+                        targetFile.setExecutable(true)
+                    }
+                } else {
+                    System.err.println("[ShellIntegration] Resource not found: $resourcePath")
+                }
+            } catch (e: Exception) {
+                System.err.println("[ShellIntegration] Error extracting $resource: ${e.message}")
+            }
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -907,7 +907,14 @@ class TabController(
                 // Set PWD to match actual working directory (required for Starship and other prompts)
                 put("PWD", config.workingDir ?: System.getProperty("user.home"))
                 putAll(config.environment)
-            }
+            }.toMutableMap()
+
+            // Inject shell integration for command completion notifications (OSC 133)
+            ShellIntegrationInjector.injectForShell(
+                shell = config.command,
+                env = terminalEnvironment,
+                enabled = settings.autoInjectShellIntegration
+            )
 
             val processConfig = PlatformServices.ProcessService.ProcessConfig(
                 command = config.command,
@@ -1070,7 +1077,14 @@ class TabController(
                     put("TERM_FEATURES", "T2:M:H:Ts0:Ts1:Ts2:Sc0:Sc1:Sc2:B:U:Aw")
                     // Set PWD to match actual working directory (required for Starship and other prompts)
                     put("PWD", workingDir ?: System.getProperty("user.home"))
-                }
+                }.toMutableMap()
+
+                // Inject shell integration for command completion notifications (OSC 133)
+                ShellIntegrationInjector.injectForShell(
+                    shell = command,
+                    env = terminalEnvironment,
+                    enabled = settings.autoInjectShellIntegration
+                )
 
                 val config = PlatformServices.ProcessService.ProcessConfig(
                     command = command,

--- a/compose-ui/src/desktopMain/resources/shell-integration/.zshenv
+++ b/compose-ui/src/desktopMain/resources/shell-integration/.zshenv
@@ -1,0 +1,23 @@
+# BossTerm Shell Integration Loader for Zsh
+# This file is sourced when ZDOTDIR is hijacked by BossTerm
+
+# Store integration directory path (this is where BossTerm extracts scripts)
+typeset -g __bossterm_integration_dir="$HOME/.bossterm/shell-integration"
+
+# Restore original ZDOTDIR immediately
+if [[ -n "${BOSSTERM_ORIG_ZDOTDIR+x}" ]]; then
+    ZDOTDIR="$BOSSTERM_ORIG_ZDOTDIR"
+    unset BOSSTERM_ORIG_ZDOTDIR
+else
+    ZDOTDIR="$HOME"
+fi
+
+# Source user's original .zshenv if it exists
+[[ -f "$ZDOTDIR/.zshenv" ]] && source "$ZDOTDIR/.zshenv"
+
+# Load BossTerm shell integration for interactive shells only
+if [[ -o interactive && -n "${BOSSTERM_INJECT_INTEGRATION-}" ]]; then
+    source "$__bossterm_integration_dir/bossterm_shell_integration.zsh"
+fi
+
+unset __bossterm_integration_dir

--- a/compose-ui/src/desktopMain/resources/shell-integration/bash-loader
+++ b/compose-ui/src/desktopMain/resources/shell-integration/bash-loader
@@ -1,0 +1,32 @@
+#!/bin/bash
+# BossTerm Shell Integration Loader for Bash
+# This file is sourced via the ENV variable
+
+# Get the directory containing this script
+_bossterm_integration_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source normal startup files first (respecting bash conventions)
+# For login shells: /etc/profile, then first of ~/.bash_profile, ~/.bash_login, ~/.profile
+# For non-login interactive: ~/.bashrc
+
+if shopt -q login_shell; then
+    # Login shell
+    [[ -f /etc/profile ]] && . /etc/profile
+    if [[ -f ~/.bash_profile ]]; then
+        . ~/.bash_profile
+    elif [[ -f ~/.bash_login ]]; then
+        . ~/.bash_login
+    elif [[ -f ~/.profile ]]; then
+        . ~/.profile
+    fi
+else
+    # Non-login interactive shell
+    [[ -f ~/.bashrc ]] && . ~/.bashrc
+fi
+
+# Load BossTerm shell integration if injection is enabled
+if [[ -n "$BOSSTERM_INJECT_INTEGRATION" ]]; then
+    source "$_bossterm_integration_dir/bossterm_shell_integration.bash"
+fi
+
+unset _bossterm_integration_dir

--- a/compose-ui/src/desktopMain/resources/shell-integration/bossterm_shell_integration.bash
+++ b/compose-ui/src/desktopMain/resources/shell-integration/bossterm_shell_integration.bash
@@ -1,0 +1,69 @@
+#!/bin/bash
+# BossTerm Shell Integration for Bash
+# Provides OSC 133 command tracking for notifications
+
+# Avoid loading twice
+[[ -n "$BOSSTERM_SHELL_INTEGRATION_LOADED" ]] && return
+
+# Skip inside tmux/screen unless explicitly enabled
+if [[ -z "${BOSSTERM_ENABLE_INTEGRATION_WITH_TMUX-}" ]]; then
+    [[ "$TERM" == "tmux-256color" ]] && return
+    [[ "$TERM" == screen* ]] && return
+fi
+
+# Skip in dumb terminals
+[[ "$TERM" == "dumb" ]] && return
+
+BOSSTERM_SHELL_INTEGRATION_LOADED=1
+
+# Track if we're in a command (to avoid duplicate B markers)
+__bossterm_in_command=0
+
+# Called via PROMPT_COMMAND before each prompt
+__bossterm_prompt_command() {
+    local exit_code=$?
+
+    # Only emit D if we were in a command
+    if [[ $__bossterm_in_command -eq 1 ]]; then
+        # D - Command finished with exit code
+        printf '\e]133;D;%s\a' "$exit_code"
+        __bossterm_in_command=0
+    fi
+
+    # A - Prompt starting
+    printf '\e]133;A\a'
+}
+
+# Called via DEBUG trap before each command
+__bossterm_preexec() {
+    # Skip if this is the PROMPT_COMMAND itself
+    [[ "$BASH_COMMAND" == "__bossterm_prompt_command" ]] && return
+    [[ "$BASH_COMMAND" == "$PROMPT_COMMAND" ]] && return
+
+    # Skip if we're already in a command (avoid duplicates)
+    [[ $__bossterm_in_command -eq 1 ]] && return
+
+    __bossterm_in_command=1
+    # B - Command starting
+    printf '\e]133;B\a'
+}
+
+# Preserve existing PROMPT_COMMAND
+if [[ -n "$PROMPT_COMMAND" ]]; then
+    PROMPT_COMMAND="__bossterm_prompt_command; $PROMPT_COMMAND"
+else
+    PROMPT_COMMAND="__bossterm_prompt_command"
+fi
+
+# Set DEBUG trap for preexec functionality
+# Preserve existing DEBUG trap if any
+__bossterm_old_debug_trap=$(trap -p DEBUG | sed "s/trap -- '\\(.*\\)' DEBUG/\\1/")
+if [[ -n "$__bossterm_old_debug_trap" ]]; then
+    trap "__bossterm_preexec; $__bossterm_old_debug_trap" DEBUG
+else
+    trap '__bossterm_preexec' DEBUG
+fi
+unset __bossterm_old_debug_trap
+
+# Emit initial prompt marker
+printf '\e]133;A\a'

--- a/compose-ui/src/desktopMain/resources/shell-integration/bossterm_shell_integration.zsh
+++ b/compose-ui/src/desktopMain/resources/shell-integration/bossterm_shell_integration.zsh
@@ -1,0 +1,46 @@
+# BossTerm Shell Integration for Zsh
+# Provides OSC 133 command tracking for notifications
+
+# Avoid loading twice
+[[ -n "$BOSSTERM_SHELL_INTEGRATION_LOADED" ]] && return
+
+# Skip inside tmux/screen unless explicitly enabled
+# (OSC sequences may not pass through correctly)
+if [[ -z "${BOSSTERM_ENABLE_INTEGRATION_WITH_TMUX-}" ]]; then
+    [[ "$TERM" == "tmux-256color" ]] && return
+    [[ "$TERM" == "screen"* ]] && return
+fi
+
+# Skip in dumb terminals
+[[ "$TERM" == "dumb" ]] && return
+
+BOSSTERM_SHELL_INTEGRATION_LOADED=1
+
+# OSC 133 sequences:
+# A - Prompt started (shell ready for input)
+# B - Command started (user entered command)
+# C - Command output ended (not commonly used)
+# D;exitcode - Command finished with exit code
+
+# Called before each prompt is displayed
+_bossterm_precmd() {
+    local exit_code=$?
+    # D - Command finished with exit code (from previous command)
+    printf '\e]133;D;%s\a' "$exit_code"
+    # A - Prompt starting
+    printf '\e]133;A\a'
+}
+
+# Called just before a command is executed
+_bossterm_preexec() {
+    # B - Command starting
+    printf '\e]133;B\a'
+}
+
+# Register hooks using zsh's add-zsh-hook
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _bossterm_precmd
+add-zsh-hook preexec _bossterm_preexec
+
+# Emit initial prompt marker
+printf '\e]133;A\a'

--- a/compose-ui/src/desktopMain/resources/shell-integration/fish/vendor_conf.d/bossterm_shell_integration.fish
+++ b/compose-ui/src/desktopMain/resources/shell-integration/fish/vendor_conf.d/bossterm_shell_integration.fish
@@ -1,0 +1,49 @@
+# BossTerm Shell Integration for Fish
+# Provides OSC 133 command tracking for notifications
+
+# Avoid loading twice
+if set -q BOSSTERM_SHELL_INTEGRATION_LOADED
+    exit 0
+end
+
+# Skip inside tmux/screen unless explicitly enabled
+if not set -q BOSSTERM_ENABLE_INTEGRATION_WITH_TMUX
+    if string match -q "tmux-256color" "$TERM"
+        exit 0
+    end
+    if string match -q "screen*" "$TERM"
+        exit 0
+    end
+end
+
+# Skip in dumb terminals
+if test "$TERM" = "dumb"
+    exit 0
+end
+
+set -g BOSSTERM_SHELL_INTEGRATION_LOADED 1
+
+# Track exit code from last command
+set -g __bossterm_last_status 0
+
+# Called before each prompt
+function __bossterm_fish_prompt --on-event fish_prompt
+    # D - Command finished with exit code (from previous command)
+    printf '\e]133;D;%s\a' $__bossterm_last_status
+    # A - Prompt starting
+    printf '\e]133;A\a'
+end
+
+# Called just before a command is executed
+function __bossterm_fish_preexec --on-event fish_preexec
+    # B - Command starting
+    printf '\e]133;B\a'
+end
+
+# Called after a command completes to capture exit status
+function __bossterm_fish_postexec --on-event fish_postexec
+    set -g __bossterm_last_status $status
+end
+
+# Emit initial prompt marker
+printf '\e]133;A\a'


### PR DESCRIPTION
## Summary

Fixes #202 - Notifications not appearing when BossTerm window is unfocused.

**Root Cause**: OSC 133 shell integration was required but not automatically enabled, requiring manual shell configuration.

**Solution**: Implements iTerm2-style automatic shell integration injection so notifications work out of the box.

### Changes
- Add `ShellIntegrationInjector` that extracts and injects shell integration scripts at runtime
- Support for **Zsh** (ZDOTDIR hijacking), **Bash** (ENV variable), and **Fish** (XDG_DATA_DIRS)
- Handle macOS `/usr/bin/login` wrapper by detecting actual shell from `$SHELL`
- Add shell integration scripts with OSC 133 command tracking (A=prompt, B=command start, D=exit code)
- Add `autoInjectShellIntegration` setting (default: `true`)
- Add shell integration toggle to Settings UI under Notifications section

### How It Works
1. When a new terminal tab is created, `ShellIntegrationInjector` is called
2. Scripts are extracted to `~/.bossterm/shell-integration/`
3. Environment variables are set to inject our scripts before user's shell config
4. Shell integration sends OSC 133 sequences for command tracking
5. User's existing shell config (`.zshrc`, `.bashrc`, etc.) is preserved

### Files Added
- `ShellIntegrationInjector.kt` - Core injection logic
- `shell-integration/.zshenv` - Zsh loader
- `shell-integration/bossterm_shell_integration.zsh` - Zsh OSC 133 hooks
- `shell-integration/bash-loader` - Bash loader  
- `shell-integration/bossterm_shell_integration.bash` - Bash OSC 133 hooks
- `shell-integration/fish/vendor_conf.d/bossterm_shell_integration.fish` - Fish integration

## Test plan
- [ ] Start BossTerm, open new tab
- [ ] Verify shell integration loaded: `echo $BOSSTERM_SHELL_INTEGRATION_LOADED` should show `1`
- [ ] Run `sleep 10`, Cmd+Tab away from BossTerm
- [ ] Confirm notification appears when command completes
- [ ] Test with Bash: run `bash`, then `sleep 10`
- [ ] Verify Settings > Notifications shows "Auto-inject Shell Integration" toggle
- [ ] Verify disabling the toggle prevents shell integration injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)