### PR TITLE
fix: Respect workingDirectory parameter when useLoginSession is enabled

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -253,8 +253,9 @@ class TabController(
         val isMacOS = System.getProperty("os.name")?.lowercase()?.contains("mac") == true
         val username = System.getProperty("user.name")
 
-        val (effectiveCommand, effectiveArguments) = if (command == null && arguments.isEmpty() && isMacOS && username != null && settings.useLoginSession) {
+        val (effectiveCommand, effectiveArguments) = if (command == null && arguments.isEmpty() && isMacOS && username != null && settings.useLoginSession && workingDir == null) {
             // Use login command on macOS for proper session registration
+            // NOTE: Only when workingDir is null - login command ignores workingDirectory parameter
             "/usr/bin/login" to listOf("-fp", username)
         } else {
             // Use provided command or fall back to shell
@@ -493,8 +494,9 @@ class TabController(
         val isMacOS = System.getProperty("os.name")?.lowercase()?.contains("mac") == true
         val username = System.getProperty("user.name")
 
-        val (effectiveCommand, effectiveArguments) = if (command == null && arguments.isEmpty() && isMacOS && username != null && settings.useLoginSession) {
+        val (effectiveCommand, effectiveArguments) = if (command == null && arguments.isEmpty() && isMacOS && username != null && settings.useLoginSession && workingDir == null) {
             // Use login command on macOS for proper session registration
+            // NOTE: Only when workingDir is null - login command ignores workingDirectory parameter
             "/usr/bin/login" to listOf("-fp", username)
         } else {
             // Use provided command or fall back to shell

--- a/tabbed-example/src/desktopMain/kotlin/ai/rever/bossterm/tabbed/Main.kt
+++ b/tabbed-example/src/desktopMain/kotlin/ai/rever/bossterm/tabbed/Main.kt
@@ -264,6 +264,7 @@ private fun ApplicationScope.TabbedTerminalWindow(
                                     menuActions = menuActions,
                                     isWindowFocused = { isWindowFocused },
                                     contextMenuItems = customContextMenuItems,
+                                    workingDirectory = "/tmp",
                                     modifier = Modifier.fillMaxSize()
                                 )
                             }


### PR DESCRIPTION
## Summary

- Fix TabbedTerminal ignoring `workingDirectory` parameter when `useLoginSession` is enabled on macOS
- The `/usr/bin/login` command always starts in user's home directory, ignoring the ProcessConfig workingDirectory
- Now bypasses login session when `workingDir` is explicitly provided

## Root Cause

`TabController.createTab()` uses `/usr/bin/login -fp $USER` on macOS when `settings.useLoginSession` is true. The `login` command ignores the `workingDirectory` parameter and always starts in the user's home directory, causing Starship and other prompts to show incorrect PWD.

## Trade-off

When `workingDirectory` is specified:
- **Lost**: "Last login" message, utmp/wtmp session registration
- **Gained**: Correct working directory, correct PWD for Starship/prompts

When `workingDirectory` is NOT specified (null), behavior is unchanged.

## Test plan

- [ ] Run `./gradlew :tabbed-example:run` and verify terminal starts in `/tmp`
- [ ] Verify Starship shows `/tmp` as current directory
- [ ] Verify new tabs without explicit workingDirectory still show "Last login" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)