### PR TITLE
fix: Arrow key navigation not working in htop/less (#213)

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -887,10 +887,17 @@ class BossTerminal(
     }
 
     override fun setApplicationKeypad(enabled: Boolean) {
+        // DECKPAM (ESC =) enables keypad application sequences.
+        // We also synchronize arrow keys to application mode here, matching practical xterm
+        // behavior where smkx typically sends both DECKPAM and DECCKM sequences.
+        // Note: VT100 spec separates DECKPAM (keypad) from DECCKM (cursor keys), but
+        // synchronizing them provides better compatibility with ncurses apps like htop/less.
         if (enabled) {
             myTerminalKeyEncoder.keypadApplicationSequences()
+            myTerminalKeyEncoder.arrowKeysApplicationSequences()
         } else {
             myTerminalKeyEncoder.keypadAnsiSequences()
+            myTerminalKeyEncoder.arrowKeysAnsiCursorSequences()
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix arrow key navigation in htop, less, and other ncurses applications
- Root cause: ProperTerminal used a disconnected local key encoder that ignored terminal mode changes
- Additional fix: DECKPAM mode (ESC =) now synchronizes arrow keys with keypad mode

## Changes
- **ProperTerminal.kt**: Use `terminal.getCodeForKey()` instead of local encoder
- **BossTerminal.kt**: `setApplicationKeypad()` now also switches arrow key mode

## Test plan
- [x] `htop` - arrow keys navigate process list
- [x] `less /etc/passwd` - arrows scroll content  
- [x] `vim` - cursor movement works
- [x] Plain shell - command history with arrows works

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)