### PR TITLE
fix: Replace deprecated loadImageBitmap with Skia Image API

### DIFF
--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -37,6 +37,8 @@ import kotlinx.coroutines.launch
 import java.awt.GraphicsEnvironment
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import org.jetbrains.skia.Image
+import androidx.compose.ui.graphics.toComposeImageBitmap
 
 /**
  * BossTerm - Modern terminal emulator built with Kotlin and Compose Desktop.
@@ -499,7 +501,7 @@ fun main() {
                             try {
                                 val file = java.io.File(windowSettings.backgroundImagePath)
                                 if (file.exists()) {
-                                    androidx.compose.ui.res.loadImageBitmap(file.inputStream())
+                                    Image.makeFromEncoded(file.readBytes()).toComposeImageBitmap()
                                 } else null
                             } catch (e: Exception) {
                                 null


### PR DESCRIPTION
## Summary
- Fixed deprecation warning by replacing `androidx.compose.ui.res.loadImageBitmap()` with the recommended Skia-based API
- Changed to `Image.makeFromEncoded().toComposeImageBitmap()` pattern used elsewhere in the codebase (ImageRenderer.kt)

## Changes
- Updated `Main.kt:504` to use Skia's `Image.makeFromEncoded()` for loading background images
- Added necessary imports for Skia Image API

## Test plan
- [x] Built all desktop modules with `--warning-mode=all`
- [x] Verified no deprecation warnings remain
- [x] Follows existing pattern from ImageRenderer.kt

🤖 Generated with [Claude Code](https://claude.com/claude-code)