### PR TITLE
✨ Expose isActive parameter on TabbedTerminal

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -155,6 +155,23 @@ fun TabbedTerminal(
     onContextMenuOpenAsync: (suspend () -> Unit)? = null,
     settingsOverride: TerminalSettingsOverride? = null,
     hyperlinkRegistry: HyperlinkRegistry = HyperlinkDetector.registry,
+    /**
+     * Whether the terminal is currently "active" from the host's
+     * perspective — i.e. the surrounding panel/tab is the one the user
+     * is interacting with. Defaults to `true` for callers that don't
+     * differentiate (single-window, single-panel embedding).
+     *
+     * Toggling this to `false` when the host loses external focus and
+     * back to `true` on regain causes [ai.rever.bossterm.compose.ui.ProperTerminal]'s
+     * internal `LaunchedEffect(tab.id, isActiveTab)` to re-issue the
+     * focus requester for the focused pane — restoring keyboard input
+     * routing to the embedded terminal widget. Without this signal,
+     * external focus round-trips (clicking another panel and back) can
+     * leave the terminal visually present but unable to receive
+     * keystrokes until the user manually clicks a split or switches
+     * tabs.
+     */
+    isActive: Boolean = true,
     modifier: Modifier = Modifier,
     platformServices: PlatformServices = getPlatformServices()
 ) {
@@ -804,7 +821,7 @@ fun TabbedTerminal(
             SplitContainer(
                 splitState = splitState,
                 sharedFont = sharedFont,
-                isActiveTab = true,
+                isActiveTab = isActive,
                 onTabTitleChange = { newTitle ->
                     activeTab.title.value = newTitle
                 },


### PR DESCRIPTION
## Summary
Adds an `isActive: Boolean = true` parameter to the top-level `TabbedTerminal()` composable. Hardcoded `isActiveTab = true` at the `SplitContainer` call site is now replaced with the new parameter.

## Motivation
`ProperTerminal.kt:597-602` already has the refocus mechanism we need:

```kotlin
LaunchedEffect(tab.id, isActiveTab) {
    if (isActiveTab) {
        delay(50)
        focusRequester.requestFocus()
    }
}
```

— it re-issues the focus requester whenever `isActiveTab` toggles. But callers of `TabbedTerminal()` could not drive that toggle: the parameter was always `true`. As a result, hosts that move external Compose focus to/from the terminal (e.g. BossConsole's main panel system) can leave the embedded terminal visually present but unable to receive keystrokes until the user manually clicks a split-pane or switches tabs.

This change lets embedding hosts pass a real `isActive` signal. When the host transitions `true → false → true`, BossTerm's existing internal effect re-fires and restores keyboard focus.

## Backward compatibility
- New parameter has a default of `true`.
- All existing callers (single-window apps, embedded-example, tests, any external integrators) compile unchanged and behave identically.

## Test plan
- [x] Source compiles (added param + call-site update only).
- [ ] BossConsole's main-panel terminal-tab plugin pinned against this build no longer loses focus after click-out/click-in to other panels (separate PR in the BossConsole + terminal-tab repos to consume the new parameter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)