### PR TITLE
feat(mcp): in-process Model Context Protocol server with embedder configuration

### DIFF
--- a/bossterm-app/build.gradle.kts
+++ b/bossterm-app/build.gradle.kts
@@ -57,6 +57,11 @@ kotlin {
                 implementation(compose.foundation)
                 implementation(compose.material)
                 implementation(compose.ui)
+
+                // SLF4J binding so logs from compose-ui (e.g. BossTermMcpManager,
+                // Ktor server) actually reach stderr instead of being dropped by
+                // the NOP logger.
+                runtimeOnly("org.slf4j:slf4j-simple:2.0.17")
             }
         }
     }

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -20,6 +20,7 @@ import ai.rever.bossterm.compose.rememberTabbedTerminalState
 import ai.rever.bossterm.compose.cli.CLIInstallDialog
 import ai.rever.bossterm.compose.cli.CLIInstaller
 import ai.rever.bossterm.compose.mcp.BossTermMcpManager
+import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.notification.NotificationService
 import ai.rever.bossterm.compose.onboarding.OnboardingWizard
 import ai.rever.bossterm.compose.settings.SettingsManager
@@ -42,6 +43,10 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowPlacement
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.awt.GraphicsEnvironment
 import java.awt.event.WindowAdapter
@@ -60,6 +65,22 @@ fun main() {
 
     // Set WM_CLASS for Linux desktop integration (must be before any AWT init)
     setLinuxWMClass()
+
+    // App-singleton MCP server. Constructed once before composition starts so
+    // its lifetime spans every Window. Windows register their TabbedTerminalState
+    // with McpTerminalRegistry; the manager exposes all tabs through a single
+    // endpoint. JVM shutdown hook tears it down on exit.
+    val mcpScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val mcpManager = BossTermMcpManager(
+        registry = McpTerminalRegistry,
+        settingsManager = SettingsManager.instance,
+        parentScope = mcpScope
+    )
+    mcpManager.start()
+    Runtime.getRuntime().addShutdownHook(Thread {
+        mcpManager.stop()
+        mcpScope.cancel()
+    })
 
     application {
         // Create initial window if none exist
@@ -168,14 +189,12 @@ fun main() {
                     // are released when this Window composition leaves).
                     val tabbedState = rememberTabbedTerminalState(autoDispose = true)
 
-                    // MCP server lifecycle: manager reads mcpEnabled from settings itself,
-                    // so we unconditionally start() and let it decide. stop() runs on dispose.
-                    val mcpManager = remember(tabbedState) {
-                        BossTermMcpManager(tabbedState, SettingsManager.instance, scope)
-                    }
-                    DisposableEffect(mcpManager) {
-                        mcpManager.start()
-                        onDispose { mcpManager.stop() }
+                    // Expose this Window's tabs to the app-singleton MCP server.
+                    // The manager itself is constructed in fun main(); here we
+                    // only join/leave the registry.
+                    DisposableEffect(tabbedState) {
+                        McpTerminalRegistry.register(tabbedState)
+                        onDispose { McpTerminalRegistry.unregister(tabbedState) }
                     }
 
                     // Track window focus for command completion notifications

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -19,7 +19,9 @@ import ai.rever.bossterm.compose.TabbedTerminal
 import ai.rever.bossterm.compose.rememberTabbedTerminalState
 import ai.rever.bossterm.compose.cli.CLIInstallDialog
 import ai.rever.bossterm.compose.cli.CLIInstaller
+import ai.rever.bossterm.compose.mcp.BossTermMcpConfig
 import ai.rever.bossterm.compose.mcp.BossTermMcpManager
+import ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
 import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.notification.NotificationService
 import ai.rever.bossterm.compose.onboarding.OnboardingWizard
@@ -70,11 +72,21 @@ fun main() {
     // its lifetime spans every Window. Windows register their TabbedTerminalState
     // with McpTerminalRegistry; the manager exposes all tabs through a single
     // endpoint. JVM shutdown hook tears it down on exit.
+    //
+    // The explicit BossTermMcpConfig here brands the server as "bossterm";
+    // other applications that embed compose-ui as a library pass their own
+    // BossTermMcpConfig with their app name, version, and any additional
+    // tools they want to expose. See BossTermMcpConfig kdoc for the contract.
+    val mcpConfig = BossTermMcpConfig(
+        serverName = "bossterm",
+        serverVersion = "1.0"
+    )
     val mcpScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     val mcpManager = BossTermMcpManager(
         registry = McpTerminalRegistry,
         settingsManager = SettingsManager.instance,
-        parentScope = mcpScope
+        parentScope = mcpScope,
+        config = mcpConfig
     )
     mcpManager.start()
     Runtime.getRuntime().addShutdownHook(Thread {
@@ -83,6 +95,10 @@ fun main() {
     })
 
     application {
+        // Expose the embedder's MCP config to the in-app settings UI so it
+        // can adapt its labels and visibility. bossterm-app provides the
+        // default; other host applications would provide their own.
+        CompositionLocalProvider(LocalBossTermMcpConfig provides mcpConfig) {
         // Create initial window if none exist
         if (WindowManager.windows.isEmpty()) {
             WindowManager.createWindow()
@@ -435,20 +451,27 @@ fun main() {
                                 )
                             }
                             // MCP server submenu — quick toggle plus deep-link into settings.
-                            Menu("MCP Server") {
-                                CheckboxItem(
-                                    "Enable MCP Server",
-                                    checked = windowSettings.mcpEnabled,
-                                    onCheckedChange = { enabled ->
-                                        settingsManagerForWindow.updateSetting {
-                                            copy(mcpEnabled = enabled)
+                            // Embedders that set showInSettingsUi=false hide it entirely.
+                            if (mcpConfig.showInSettingsUi) {
+                                Menu("MCP Server") {
+                                    CheckboxItem(
+                                        "Enable MCP Server",
+                                        checked = windowSettings.mcpEnabled,
+                                        onCheckedChange = { enabled ->
+                                            settingsManagerForWindow.updateSetting {
+                                                copy(mcpEnabled = enabled)
+                                            }
                                         }
-                                    }
-                                )
-                                Item(
-                                    "Settings…",
-                                    onClick = { showSettingsDialog = true }
-                                )
+                                    )
+                                    Item(
+                                        "Settings…",
+                                        onClick = {
+                                            initialSettingsCategory =
+                                                ai.rever.bossterm.compose.settings.SettingsCategory.MCP
+                                            showSettingsDialog = true
+                                        }
+                                    )
+                                }
                             }
                             Separator()
                             // Git submenu - conditional based on repo status
@@ -803,6 +826,7 @@ fun main() {
                 }
             }
         }
+        } // end CompositionLocalProvider(LocalBossTermMcpConfig)
     }
 }
 

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -617,16 +617,20 @@ fun main() {
                         shape = RoundedCornerShape(cornerRadius)
                     ) {
                         Box(modifier = Modifier.fillMaxSize()) {
-                            // Compute global hotkey hint (used for both title bar modes)
+                            // Compute global hotkey hint (used for both title bar modes).
+                            // Returns null when the user has hidden the hint via
+                            // showGlobalHotkeyHint, so the render sites' null-check
+                            // skips both the overlay and the title-bar slot.
                             val globalHotkeyHint = remember(
                                 windowSettings.globalHotkeyEnabled,
+                                windowSettings.showGlobalHotkeyHint,
                                 windowSettings.globalHotkeyCtrl,
                                 windowSettings.globalHotkeyAlt,
                                 windowSettings.globalHotkeyShift,
                                 windowSettings.globalHotkeyWin,
                                 window.windowNumber
                             ) {
-                                if (windowSettings.globalHotkeyEnabled && window.windowNumber in 1..9) {
+                                if (windowSettings.globalHotkeyEnabled && windowSettings.showGlobalHotkeyHint && window.windowNumber in 1..9) {
                                     val config = HotKeyConfig.fromSettings(windowSettings)
                                     config.toWindowDisplayString(window.windowNumber, useMacSymbols = isMacOS)
                                 } else {

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -16,8 +16,10 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import ai.rever.bossterm.compose.TabbedTerminal
+import ai.rever.bossterm.compose.rememberTabbedTerminalState
 import ai.rever.bossterm.compose.cli.CLIInstallDialog
 import ai.rever.bossterm.compose.cli.CLIInstaller
+import ai.rever.bossterm.compose.mcp.BossTermMcpManager
 import ai.rever.bossterm.compose.notification.NotificationService
 import ai.rever.bossterm.compose.onboarding.OnboardingWizard
 import ai.rever.bossterm.compose.settings.SettingsManager
@@ -160,6 +162,21 @@ fun main() {
                     val updateManager = remember { UpdateManager.instance }
                     val updateState by updateManager.updateState.collectAsState()
                     val scope = rememberCoroutineScope()
+
+                    // Hoist TabbedTerminalState so external integrations (MCP) can observe it.
+                    // autoDispose=true mirrors the prior internal-state lifecycle (sessions
+                    // are released when this Window composition leaves).
+                    val tabbedState = rememberTabbedTerminalState(autoDispose = true)
+
+                    // MCP server lifecycle: manager reads mcpEnabled from settings itself,
+                    // so we unconditionally start() and let it decide. stop() runs on dispose.
+                    val mcpManager = remember(tabbedState) {
+                        BossTermMcpManager(tabbedState, SettingsManager.instance, scope)
+                    }
+                    DisposableEffect(mcpManager) {
+                        mcpManager.start()
+                        onDispose { mcpManager.stop() }
+                    }
 
                     // Track window focus for command completion notifications
                     val awtWindow = this.window
@@ -649,6 +666,7 @@ fun main() {
 
                                 // Terminal content
                                 TabbedTerminal(
+                                    state = tabbedState,
                                     onExit = {
                                         WindowManager.closeWindow(window.id)
                                         if (!WindowManager.hasWindows()) {

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -103,6 +103,11 @@ fun main() {
                 val windowState = rememberWindowState()
                 // Settings dialog state (declared before Window for onPreviewKeyEvent access)
                 var showSettingsDialog by remember { mutableStateOf(false) }
+                // Optional initial category — set by deep links (e.g. MCP status indicator).
+                // Cleared on dismiss so the next open falls back to the default category.
+                var initialSettingsCategory by remember {
+                    mutableStateOf<ai.rever.bossterm.compose.settings.SettingsCategory?>(null)
+                }
                 // CLI install dialog state
                 var showCLIInstallDialog by remember { mutableStateOf(false) }
                 var isFirstRun by remember { mutableStateOf(false) }
@@ -715,6 +720,11 @@ fun main() {
                                         WindowManager.createWindow()
                                     },
                                     onShowSettings = { showSettingsDialog = true },
+                                    onShowMcpSettings = {
+                                        initialSettingsCategory =
+                                            ai.rever.bossterm.compose.settings.SettingsCategory.MCP
+                                        showSettingsDialog = true
+                                    },
                                     onShowWelcomeWizard = { showOnboardingWizard = true },
                                     menuActions = window.menuActions,
                                     isWindowFocused = { window.isWindowFocused.value },
@@ -744,13 +754,18 @@ fun main() {
                     // Settings dialog
                     SettingsWindow(
                         visible = showSettingsDialog,
-                        onDismiss = { showSettingsDialog = false },
+                        onDismiss = {
+                            showSettingsDialog = false
+                            initialSettingsCategory = null
+                        },
                         onRestartApp = {
                             // Close this window and create a new one with updated settings
                             showSettingsDialog = false
+                            initialSettingsCategory = null
                             WindowManager.closeWindow(window.id)
                             WindowManager.createWindow()
-                        }
+                        },
+                        initialCategory = initialSettingsCategory
                     )
 
                     // CLI install dialog

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -429,6 +429,22 @@ fun main() {
                                     onClick = { window.menuActions.onLaunchOpenCode?.invoke() }
                                 )
                             }
+                            // MCP server submenu — quick toggle plus deep-link into settings.
+                            Menu("MCP Server") {
+                                CheckboxItem(
+                                    "Enable MCP Server",
+                                    checked = windowSettings.mcpEnabled,
+                                    onCheckedChange = { enabled ->
+                                        settingsManagerForWindow.updateSetting {
+                                            copy(mcpEnabled = enabled)
+                                        }
+                                    }
+                                )
+                                Item(
+                                    "Settings…",
+                                    onClick = { showSettingsDialog = true }
+                                )
+                            }
                             Separator()
                             // Git submenu - conditional based on repo status
                             Menu("Git") {

--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -108,8 +108,11 @@ kotlin {
                 implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
                 implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
 
-                // MCP (Model Context Protocol) server + Ktor CIO server backend
-                implementation("io.modelcontextprotocol:kotlin-sdk-server:0.8.3")
+                // MCP (Model Context Protocol) server + Ktor CIO server backend.
+                // `api` for the SDK because BossTermMcpConfig's additionalTools
+                // hook exposes the SDK's Server type to embedders, which would
+                // otherwise be inaccessible from a downstream module.
+                api("io.modelcontextprotocol:kotlin-sdk-server:0.8.3")
                 implementation("io.ktor:ktor-server-cio:3.2.3")
             }
         }

--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -107,6 +107,10 @@ kotlin {
                 implementation("io.ktor:ktor-client-cio:$ktorVersion")
                 implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
                 implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+
+                // MCP (Model Context Protocol) server + Ktor CIO server backend
+                implementation("io.modelcontextprotocol:kotlin-sdk-server:0.8.3")
+                implementation("io.ktor:ktor-server-cio:3.2.3")
             }
         }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import ai.rever.bossterm.compose.ContextMenuElement
 import ai.rever.bossterm.compose.ContextMenuItem
-import ai.rever.bossterm.compose.ContextMenuSection
 import ai.rever.bossterm.compose.ContextMenuSubmenu
 import ai.rever.bossterm.compose.mcp.AttachStatus
 import ai.rever.bossterm.compose.mcp.AttachToast
@@ -987,6 +986,28 @@ fun TabbedTerminal(
                         items = items + aiItems
                     }
 
+                    // MCP attach submenu — sits directly under the AI Assistants
+                    // group so users find it near related tooling. Only rendered
+                    // when the Ktor server is actually bound. Each entry fires
+                    // the shared fireMcpAttach so the AttachToast surfaces the
+                    // result in the same place the indicator's right-click does.
+                    if (McpTerminalRegistry.runningPort.value != null) {
+                        val mcpAttachItems: List<ContextMenuElement> = listOf(
+                            ContextMenuSubmenu(
+                                id = "mcp_attach_submenu",
+                                label = "Attach MCP to…",
+                                items = McpAttachTarget.entries.map { target ->
+                                    ContextMenuItem(
+                                        id = "mcp_attach_${target.name}",
+                                        label = target.displayName,
+                                        action = { fireMcpAttach(target) }
+                                    )
+                                }
+                            )
+                        )
+                        items = items + mcpAttachItems
+                    }
+
                     // Add Version Control menu items
                     val terminalWriter: (String) -> Unit = { text ->
                         splitState.getFocusedSession()?.writeUserInput(text)
@@ -1024,28 +1045,6 @@ fun TabbedTerminal(
                         }
                     )
                     items = items + shellItems
-
-                    // MCP attach submenu — only shown when the Ktor server
-                    // is actually bound. Each entry fires the shared
-                    // fireMcpAttach so the AttachToast surfaces the result
-                    // in the same place the indicator's right-click does.
-                    if (McpTerminalRegistry.runningPort.value != null) {
-                        val mcpAttachItems: List<ContextMenuElement> = listOf(
-                            ContextMenuSection(id = "mcp_section", label = "MCP"),
-                            ContextMenuSubmenu(
-                                id = "mcp_attach_submenu",
-                                label = "Attach MCP to…",
-                                items = McpAttachTarget.entries.map { target ->
-                                    ContextMenuItem(
-                                        id = "mcp_attach_${target.name}",
-                                        label = target.displayName,
-                                        action = { fireMcpAttach(target) }
-                                    )
-                                }
-                            )
-                        )
-                        items = items + mcpAttachItems
-                    }
 
                     items
                 },

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -28,6 +28,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import ai.rever.bossterm.compose.ContextMenuElement
+import ai.rever.bossterm.compose.ContextMenuItem
+import ai.rever.bossterm.compose.ContextMenuSection
+import ai.rever.bossterm.compose.ContextMenuSubmenu
 import ai.rever.bossterm.compose.ai.AIAssistantDefinition
 import ai.rever.bossterm.compose.ai.AIAssistants
 import ai.rever.bossterm.compose.ai.AICommandInterceptor
@@ -696,6 +699,37 @@ fun TabbedTerminal(
         }
     }
 
+    // Shared MCP attach plumbing — used by both the indicator's right-click
+    // context menu and the terminal canvas's right-click menu. Hoisted to
+    // TabbedTerminal scope so the in-flight Pending → Done toast state is
+    // a single source of truth across both entry points.
+    val mcpRunningPort by ai.rever.bossterm.compose.mcp.McpTerminalRegistry
+        .runningPort.collectAsState()
+    val mcpScope = rememberCoroutineScope()
+    var attachStatus by remember {
+        mutableStateOf<ai.rever.bossterm.compose.mcp.AttachStatus?>(null)
+    }
+    LaunchedEffect(attachStatus) {
+        val s = attachStatus
+        if (s is ai.rever.bossterm.compose.mcp.AttachStatus.Done) {
+            kotlinx.coroutines.delay(5000)
+            if (attachStatus === s) attachStatus = null
+        }
+    }
+    val mcpServerName = ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
+        .current?.serverName ?: "bossterm"
+    val fireMcpAttach: (ai.rever.bossterm.compose.mcp.McpAttachTarget) -> Unit = { target ->
+        val port = ai.rever.bossterm.compose.mcp.McpTerminalRegistry.runningPort.value
+        if (port != null) {
+            attachStatus = ai.rever.bossterm.compose.mcp.AttachStatus.Pending(target)
+            mcpScope.launch {
+                val result = ai.rever.bossterm.compose.mcp
+                    .McpCliAttacher.attach(target, mcpServerName, port)
+                attachStatus = ai.rever.bossterm.compose.mcp.AttachStatus.Done(result)
+            }
+        }
+    }
+
     // Tab UI layout with focus overlay support
     Box(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -971,6 +1005,28 @@ fun TabbedTerminal(
                     )
                     items = items + shellItems
 
+                    // MCP attach submenu — only shown when the Ktor server
+                    // is actually bound. Each entry fires the shared
+                    // fireMcpAttach so the AttachToast surfaces the result
+                    // in the same place the indicator's right-click does.
+                    if (ai.rever.bossterm.compose.mcp.McpTerminalRegistry.runningPort.value != null) {
+                        val mcpAttachItems: List<ContextMenuElement> = listOf(
+                            ContextMenuSection(id = "mcp_section", label = "MCP"),
+                            ContextMenuSubmenu(
+                                id = "mcp_attach_submenu",
+                                label = "Attach MCP to…",
+                                items = ai.rever.bossterm.compose.mcp.McpAttachTarget.entries.map { target ->
+                                    ContextMenuItem(
+                                        id = "mcp_attach_${target.name}",
+                                        label = target.displayName,
+                                        action = { fireMcpAttach(target) }
+                                    )
+                                }
+                            )
+                        )
+                        items = items + mcpAttachItems
+                    }
+
                     items
                 },
                 onContextMenuOpen = onContextMenuOpen,
@@ -1017,30 +1073,14 @@ fun TabbedTerminal(
             )
         }
 
-        // MCP status indicator — floats over the top-right of the content
-        // area (same slot the global-hotkey hint uses), so it's visible
+        // MCP status indicator + toast — floats over the top-right of the
+        // content area (same slot the global-hotkey hint uses), visible
         // regardless of whether the tab bar is shown. Only renders when the
         // Ktor server has actually bound the port (registry.runningPort != null),
         // not just when the user toggled mcpEnabled. The dot reflects reality.
-        val mcpRunningPort by ai.rever.bossterm.compose.mcp.McpTerminalRegistry
-            .runningPort.collectAsState()
-        // Hoisted state so an in-flight attach survives a brief unmount of
-        // the indicator (e.g. settings toggling mcpShowStatusIndicator off).
-        val mcpScope = rememberCoroutineScope()
-        var attachStatus by remember {
-            mutableStateOf<ai.rever.bossterm.compose.mcp.AttachStatus?>(null)
-        }
-        // Auto-dismiss the toast a few seconds after completion.
-        LaunchedEffect(attachStatus) {
-            val s = attachStatus
-            if (s is ai.rever.bossterm.compose.mcp.AttachStatus.Done) {
-                kotlinx.coroutines.delay(5000)
-                if (attachStatus === s) attachStatus = null
-            }
-        }
+        // Both right-click paths (indicator's own menu + the terminal canvas's
+        // menu) drive attachStatus, which the AttachToast surfaces here.
         if (mcpRunningPort != null && settings.mcpShowStatusIndicator) {
-            val mcpServerName = ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
-                .current?.serverName ?: "bossterm"
             Column(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
@@ -1056,15 +1096,7 @@ fun TabbedTerminal(
                             copy(mcpShowStatusIndicator = false)
                         }
                     },
-                    onAttachRequest = { target ->
-                        val port = mcpRunningPort ?: return@McpStatusIndicator
-                        attachStatus = ai.rever.bossterm.compose.mcp.AttachStatus.Pending(target)
-                        mcpScope.launch {
-                            val result = ai.rever.bossterm.compose.mcp
-                                .McpCliAttacher.attach(target, mcpServerName, port)
-                            attachStatus = ai.rever.bossterm.compose.mcp.AttachStatus.Done(result)
-                        }
-                    }
+                    onAttachRequest = fireMcpAttach
                 )
                 attachStatus?.let { status ->
                     ai.rever.bossterm.compose.mcp.AttachToast(status = status)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -699,18 +699,8 @@ fun TabbedTerminal(
     // Tab UI layout with focus overlay support
     Box(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
-            // Tab bar at top (show when multiple tabs, alwaysShowTabBar is set,
-            // or the MCP indicator is on — the bar hosts the MCP status indicator).
-            //
-            // The MCP indicator only shows when the manager has *actually* bound
-            // the port (runningPort != null) — not just when the user toggled
-            // mcpEnabled. Prevents a false-positive dot in embedder builds that
-            // forgot to construct BossTermMcpManager, and in cases where the
-            // bind failed (e.g. port already in use).
-            val mcpRunningPort by ai.rever.bossterm.compose.mcp.McpTerminalRegistry
-                .runningPort.collectAsState()
-            val showMcpIndicator = mcpRunningPort != null && settings.mcpShowStatusIndicator
-            if (tabController.tabs.size > 1 || settings.alwaysShowTabBar || showMcpIndicator) {
+            // Tab bar at top (show when multiple tabs or alwaysShowTabBar is set).
+            if (tabController.tabs.size > 1 || settings.alwaysShowTabBar) {
             TabBar(
                 tabs = tabController.tabs,
                 activeTabIndex = tabController.activeTabIndex,
@@ -730,9 +720,7 @@ fun TabbedTerminal(
                     val extractedTab = tabController.extractTab(index) ?: return@TabBar
                     // Create new window and transfer both tab and split state
                     WindowManager.createWindowWithTab(extractedTab, splitState)
-                },
-                mcpEnabled = showMcpIndicator,
-                onMcpIndicatorClick = onShowMcpSettings
+                }
             )
         }
 
@@ -1027,6 +1015,26 @@ fun TabbedTerminal(
                     .fillMaxSize()
                     .background(Color.White.copy(alpha = 0.15f))
             )
+        }
+
+        // MCP status indicator — floats over the top-right of the content
+        // area (same slot the global-hotkey hint uses), so it's visible
+        // regardless of whether the tab bar is shown. Only renders when the
+        // Ktor server has actually bound the port (registry.runningPort != null),
+        // not just when the user toggled mcpEnabled. The dot reflects reality.
+        val mcpRunningPort by ai.rever.bossterm.compose.mcp.McpTerminalRegistry
+            .runningPort.collectAsState()
+        if (mcpRunningPort != null && settings.mcpShowStatusIndicator) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 4.dp, end = 8.dp)
+            ) {
+                ai.rever.bossterm.compose.mcp.McpStatusIndicator(
+                    enabled = true,
+                    onClick = onShowMcpSettings
+                )
+            }
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1025,6 +1025,7 @@ fun TabbedTerminal(
         val mcpRunningPort by ai.rever.bossterm.compose.mcp.McpTerminalRegistry
             .runningPort.collectAsState()
         if (mcpRunningPort != null && settings.mcpShowStatusIndicator) {
+            val mcpScope = rememberCoroutineScope()
             Box(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
@@ -1036,6 +1037,25 @@ fun TabbedTerminal(
                     onHideRequest = {
                         SettingsManager.instance.updateSetting {
                             copy(mcpShowStatusIndicator = false)
+                        }
+                    },
+                    onAttachRequest = { target ->
+                        // Same shell-out + clipboard fallback path the
+                        // Settings panel's buttons use. Surface result via
+                        // a system notification so the user gets feedback
+                        // even though they're not looking at Settings.
+                        val port = mcpRunningPort ?: return@McpStatusIndicator
+                        mcpScope.launch {
+                            val result = ai.rever.bossterm.compose.mcp
+                                .McpCliAttacher.attach(target, port)
+                            val (title, message) = when (result) {
+                                is ai.rever.bossterm.compose.mcp.McpAttachResult.Success ->
+                                    "MCP attached" to "${result.target.displayName}: ${result.detail.ifEmpty { "ok" }}"
+                                is ai.rever.bossterm.compose.mcp.McpAttachResult.CopiedToClipboard ->
+                                    "MCP attach: clipboard" to "${result.target.displayName}: ${result.reason}"
+                            }
+                            ai.rever.bossterm.compose.notification.NotificationService
+                                .showNotification(title = title, message = message, withSound = false)
                         }
                     }
                 )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1024,14 +1024,29 @@ fun TabbedTerminal(
         // not just when the user toggled mcpEnabled. The dot reflects reality.
         val mcpRunningPort by ai.rever.bossterm.compose.mcp.McpTerminalRegistry
             .runningPort.collectAsState()
+        // Hoisted state so an in-flight attach survives a brief unmount of
+        // the indicator (e.g. settings toggling mcpShowStatusIndicator off).
+        val mcpScope = rememberCoroutineScope()
+        var attachStatus by remember {
+            mutableStateOf<ai.rever.bossterm.compose.mcp.AttachStatus?>(null)
+        }
+        // Auto-dismiss the toast a few seconds after completion.
+        LaunchedEffect(attachStatus) {
+            val s = attachStatus
+            if (s is ai.rever.bossterm.compose.mcp.AttachStatus.Done) {
+                kotlinx.coroutines.delay(5000)
+                if (attachStatus === s) attachStatus = null
+            }
+        }
         if (mcpRunningPort != null && settings.mcpShowStatusIndicator) {
-            val mcpScope = rememberCoroutineScope()
             val mcpServerName = ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
                 .current?.serverName ?: "bossterm"
-            Box(
+            Column(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(top = 4.dp, end = 8.dp)
+                    .padding(top = 4.dp, end = 8.dp),
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 ai.rever.bossterm.compose.mcp.McpStatusIndicator(
                     enabled = true,
@@ -1043,20 +1058,17 @@ fun TabbedTerminal(
                     },
                     onAttachRequest = { target ->
                         val port = mcpRunningPort ?: return@McpStatusIndicator
+                        attachStatus = ai.rever.bossterm.compose.mcp.AttachStatus.Pending(target)
                         mcpScope.launch {
                             val result = ai.rever.bossterm.compose.mcp
                                 .McpCliAttacher.attach(target, mcpServerName, port)
-                            val (title, message) = when (result) {
-                                is ai.rever.bossterm.compose.mcp.McpAttachResult.Success ->
-                                    "MCP attached" to "${result.target.displayName}: ${result.detail.ifEmpty { "ok" }}"
-                                is ai.rever.bossterm.compose.mcp.McpAttachResult.CopiedToClipboard ->
-                                    "MCP attach: clipboard" to "${result.target.displayName}: ${result.reason}"
-                            }
-                            ai.rever.bossterm.compose.notification.NotificationService
-                                .showNotification(title = title, message = message, withSound = false)
+                            attachStatus = ai.rever.bossterm.compose.mcp.AttachStatus.Done(result)
                         }
                     }
                 )
+                attachStatus?.let { status ->
+                    ai.rever.bossterm.compose.mcp.AttachToast(status = status)
+                }
             }
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -142,6 +142,7 @@ fun TabbedTerminal(
     onWindowTitleChange: (String) -> Unit = {},
     onNewWindow: () -> Unit = {},
     onShowSettings: () -> Unit = {},
+    onShowMcpSettings: () -> Unit = onShowSettings,
     onShowWelcomeWizard: (() -> Unit)? = null,
     menuActions: MenuActions? = null,
     isWindowFocused: () -> Boolean = { true },
@@ -698,8 +699,9 @@ fun TabbedTerminal(
     // Tab UI layout with focus overlay support
     Box(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
-            // Tab bar at top (show when multiple tabs or alwaysShowTabBar setting is enabled)
-            if (tabController.tabs.size > 1 || settings.alwaysShowTabBar) {
+            // Tab bar at top (show when multiple tabs, alwaysShowTabBar is set,
+            // or the MCP server is on — the bar hosts the MCP status indicator).
+            if (tabController.tabs.size > 1 || settings.alwaysShowTabBar || settings.mcpEnabled) {
             TabBar(
                 tabs = tabController.tabs,
                 activeTabIndex = tabController.activeTabIndex,
@@ -719,7 +721,9 @@ fun TabbedTerminal(
                     val extractedTab = tabController.extractTab(index) ?: return@TabBar
                     // Create new window and transfer both tab and split state
                     WindowManager.createWindowWithTab(extractedTab, splitState)
-                }
+                },
+                mcpEnabled = settings.mcpEnabled,
+                onMcpIndicatorClick = onShowMcpSettings
             )
         }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -31,6 +31,13 @@ import ai.rever.bossterm.compose.ContextMenuElement
 import ai.rever.bossterm.compose.ContextMenuItem
 import ai.rever.bossterm.compose.ContextMenuSection
 import ai.rever.bossterm.compose.ContextMenuSubmenu
+import ai.rever.bossterm.compose.mcp.AttachStatus
+import ai.rever.bossterm.compose.mcp.AttachToast
+import ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
+import ai.rever.bossterm.compose.mcp.McpAttachTarget
+import ai.rever.bossterm.compose.mcp.McpCliAttacher
+import ai.rever.bossterm.compose.mcp.McpStatusIndicator
+import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.ai.AIAssistantDefinition
 import ai.rever.bossterm.compose.ai.AIAssistants
 import ai.rever.bossterm.compose.ai.AICommandInterceptor
@@ -703,29 +710,42 @@ fun TabbedTerminal(
     // context menu and the terminal canvas's right-click menu. Hoisted to
     // TabbedTerminal scope so the in-flight Pending → Done toast state is
     // a single source of truth across both entry points.
-    val mcpRunningPort by ai.rever.bossterm.compose.mcp.McpTerminalRegistry
-        .runningPort.collectAsState()
+    val mcpRunningPort by McpTerminalRegistry.runningPort.collectAsState()
     val mcpScope = rememberCoroutineScope()
-    var attachStatus by remember {
-        mutableStateOf<ai.rever.bossterm.compose.mcp.AttachStatus?>(null)
-    }
-    LaunchedEffect(attachStatus) {
+    var attachStatus by remember { mutableStateOf<AttachStatus?>(null) }
+    var mcpAttaching by remember { mutableStateOf(false) }
+    // Auto-dismiss the Done toast a few seconds after it appears, AND clear
+    // any stale state if the MCP server unbinds — so the toast doesn't pop
+    // back unexpectedly after a brief MCP off-then-on cycle.
+    LaunchedEffect(attachStatus, mcpRunningPort) {
+        if (mcpRunningPort == null) {
+            attachStatus = null
+            return@LaunchedEffect
+        }
         val s = attachStatus
-        if (s is ai.rever.bossterm.compose.mcp.AttachStatus.Done) {
+        if (s is AttachStatus.Done) {
             kotlinx.coroutines.delay(5000)
             if (attachStatus === s) attachStatus = null
         }
     }
-    val mcpServerName = ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
-        .current?.serverName ?: "bossterm"
-    val fireMcpAttach: (ai.rever.bossterm.compose.mcp.McpAttachTarget) -> Unit = { target ->
-        val port = ai.rever.bossterm.compose.mcp.McpTerminalRegistry.runningPort.value
-        if (port != null) {
-            attachStatus = ai.rever.bossterm.compose.mcp.AttachStatus.Pending(target)
-            mcpScope.launch {
-                val result = ai.rever.bossterm.compose.mcp
-                    .McpCliAttacher.attach(target, mcpServerName, port)
-                attachStatus = ai.rever.bossterm.compose.mcp.AttachStatus.Done(result)
+    val mcpServerName = LocalBossTermMcpConfig.current?.serverName ?: "bossterm"
+    val fireMcpAttach: (McpAttachTarget) -> Unit = { target ->
+        // De-dupe: ignore clicks while an attach is in flight from any
+        // right-click entry point. The Settings panel maintains its own
+        // independent guard.
+        if (!mcpAttaching) {
+            val port = McpTerminalRegistry.runningPort.value
+            if (port != null) {
+                mcpAttaching = true
+                attachStatus = AttachStatus.Pending(target)
+                mcpScope.launch {
+                    try {
+                        val result = McpCliAttacher.attach(target, mcpServerName, port)
+                        attachStatus = AttachStatus.Done(result)
+                    } finally {
+                        mcpAttaching = false
+                    }
+                }
             }
         }
     }
@@ -1009,13 +1029,13 @@ fun TabbedTerminal(
                     // is actually bound. Each entry fires the shared
                     // fireMcpAttach so the AttachToast surfaces the result
                     // in the same place the indicator's right-click does.
-                    if (ai.rever.bossterm.compose.mcp.McpTerminalRegistry.runningPort.value != null) {
+                    if (McpTerminalRegistry.runningPort.value != null) {
                         val mcpAttachItems: List<ContextMenuElement> = listOf(
                             ContextMenuSection(id = "mcp_section", label = "MCP"),
                             ContextMenuSubmenu(
                                 id = "mcp_attach_submenu",
                                 label = "Attach MCP to…",
-                                items = ai.rever.bossterm.compose.mcp.McpAttachTarget.entries.map { target ->
+                                items = McpAttachTarget.entries.map { target ->
                                     ContextMenuItem(
                                         id = "mcp_attach_${target.name}",
                                         label = target.displayName,
@@ -1090,7 +1110,7 @@ fun TabbedTerminal(
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 if (settings.mcpShowStatusIndicator) {
-                    ai.rever.bossterm.compose.mcp.McpStatusIndicator(
+                    McpStatusIndicator(
                         enabled = true,
                         onClick = onShowMcpSettings,
                         onHideRequest = {
@@ -1102,7 +1122,7 @@ fun TabbedTerminal(
                     )
                 }
                 attachStatus?.let { status ->
-                    ai.rever.bossterm.compose.mcp.AttachToast(status = status)
+                    AttachToast(status = status)
                 }
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1125,7 +1125,12 @@ fun TabbedTerminal(
                                 copy(mcpShowStatusIndicator = false)
                             }
                         },
-                        onAttachRequest = fireMcpAttach
+                        onAttachRequest = fireMcpAttach,
+                        onTurnOffRequest = {
+                            SettingsManager.instance.updateSetting {
+                                copy(mcpEnabled = false)
+                            }
+                        }
                     )
                 }
                 attachStatus?.let { status ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1002,7 +1002,7 @@ fun TabbedTerminal(
                         val mcpAttachItems: List<ContextMenuElement> = listOf(
                             ContextMenuSubmenu(
                                 id = "mcp_attach_submenu",
-                                label = "Attach MCP to…",
+                                label = "Attach BossTerm MCP to…",
                                 items = McpAttachTarget.entries.map { target ->
                                     val prefix = if (target in attached) "✓ " else ""
                                     ContextMenuItem(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -33,6 +33,7 @@ import ai.rever.bossterm.compose.ContextMenuSubmenu
 import ai.rever.bossterm.compose.mcp.AttachStatus
 import ai.rever.bossterm.compose.mcp.AttachToast
 import ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
+import ai.rever.bossterm.compose.mcp.McpAttachResult
 import ai.rever.bossterm.compose.mcp.McpAttachTarget
 import ai.rever.bossterm.compose.mcp.McpCliAttacher
 import ai.rever.bossterm.compose.mcp.McpStatusIndicator
@@ -740,6 +741,9 @@ fun TabbedTerminal(
                 mcpScope.launch {
                     try {
                         val result = McpCliAttacher.attach(target, mcpServerName, port)
+                        if (result is McpAttachResult.Success) {
+                            McpTerminalRegistry.markAttached(target)
+                        }
                         attachStatus = AttachStatus.Done(result)
                     } finally {
                         mcpAttaching = false
@@ -991,15 +995,19 @@ fun TabbedTerminal(
                     // when the Ktor server is actually bound. Each entry fires
                     // the shared fireMcpAttach so the AttachToast surfaces the
                     // result in the same place the indicator's right-click does.
+                    // Already-attached CLIs get a "✓ " prefix in their label so
+                    // the user can see at a glance what's wired up.
                     if (McpTerminalRegistry.runningPort.value != null) {
+                        val attached = McpTerminalRegistry.attachedTargets.value
                         val mcpAttachItems: List<ContextMenuElement> = listOf(
                             ContextMenuSubmenu(
                                 id = "mcp_attach_submenu",
                                 label = "Attach MCP to…",
                                 items = McpAttachTarget.entries.map { target ->
+                                    val prefix = if (target in attached) "✓ " else ""
                                     ContextMenuItem(
                                         id = "mcp_attach_${target.name}",
-                                        label = target.displayName,
+                                        label = "$prefix${target.displayName}",
                                         action = { fireMcpAttach(target) }
                                     )
                                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1073,14 +1073,15 @@ fun TabbedTerminal(
             )
         }
 
-        // MCP status indicator + toast — floats over the top-right of the
-        // content area (same slot the global-hotkey hint uses), visible
-        // regardless of whether the tab bar is shown. Only renders when the
-        // Ktor server has actually bound the port (registry.runningPort != null),
-        // not just when the user toggled mcpEnabled. The dot reflects reality.
-        // Both right-click paths (indicator's own menu + the terminal canvas's
-        // menu) drive attachStatus, which the AttachToast surfaces here.
-        if (mcpRunningPort != null && settings.mcpShowStatusIndicator) {
+        // MCP status indicator + toast overlay. Lives in the top-right slot
+        // when MCP is bound. Two independent visibility gates:
+        //   - indicator pill: requires settings.mcpShowStatusIndicator (user
+        //     can hide it without disabling MCP).
+        //   - toast: shown whenever attachStatus is non-null, regardless of
+        //     whether the indicator is visible — so a user who hid the pill
+        //     and triggered an attach from the terminal canvas's right-click
+        //     still gets feedback.
+        if (mcpRunningPort != null) {
             Column(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
@@ -1088,16 +1089,18 @@ fun TabbedTerminal(
                 horizontalAlignment = Alignment.End,
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                ai.rever.bossterm.compose.mcp.McpStatusIndicator(
-                    enabled = true,
-                    onClick = onShowMcpSettings,
-                    onHideRequest = {
-                        SettingsManager.instance.updateSetting {
-                            copy(mcpShowStatusIndicator = false)
-                        }
-                    },
-                    onAttachRequest = fireMcpAttach
-                )
+                if (settings.mcpShowStatusIndicator) {
+                    ai.rever.bossterm.compose.mcp.McpStatusIndicator(
+                        enabled = true,
+                        onClick = onShowMcpSettings,
+                        onHideRequest = {
+                            SettingsManager.instance.updateSetting {
+                                copy(mcpShowStatusIndicator = false)
+                            }
+                        },
+                        onAttachRequest = fireMcpAttach
+                    )
+                }
                 attachStatus?.let { status ->
                     ai.rever.bossterm.compose.mcp.AttachToast(status = status)
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1032,7 +1032,12 @@ fun TabbedTerminal(
             ) {
                 ai.rever.bossterm.compose.mcp.McpStatusIndicator(
                     enabled = true,
-                    onClick = onShowMcpSettings
+                    onClick = onShowMcpSettings,
+                    onHideRequest = {
+                        SettingsManager.instance.updateSetting {
+                            copy(mcpShowStatusIndicator = false)
+                        }
+                    }
                 )
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1026,6 +1026,8 @@ fun TabbedTerminal(
             .runningPort.collectAsState()
         if (mcpRunningPort != null && settings.mcpShowStatusIndicator) {
             val mcpScope = rememberCoroutineScope()
+            val mcpServerName = ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
+                .current?.serverName ?: "bossterm"
             Box(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
@@ -1040,14 +1042,10 @@ fun TabbedTerminal(
                         }
                     },
                     onAttachRequest = { target ->
-                        // Same shell-out + clipboard fallback path the
-                        // Settings panel's buttons use. Surface result via
-                        // a system notification so the user gets feedback
-                        // even though they're not looking at Settings.
                         val port = mcpRunningPort ?: return@McpStatusIndicator
                         mcpScope.launch {
                             val result = ai.rever.bossterm.compose.mcp
-                                .McpCliAttacher.attach(target, port)
+                                .McpCliAttacher.attach(target, mcpServerName, port)
                             val (title, message) = when (result) {
                                 is ai.rever.bossterm.compose.mcp.McpAttachResult.Success ->
                                     "MCP attached" to "${result.target.displayName}: ${result.detail.ifEmpty { "ok" }}"

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -701,7 +701,15 @@ fun TabbedTerminal(
         Column(modifier = Modifier.fillMaxSize()) {
             // Tab bar at top (show when multiple tabs, alwaysShowTabBar is set,
             // or the MCP indicator is on — the bar hosts the MCP status indicator).
-            val showMcpIndicator = settings.mcpEnabled && settings.mcpShowStatusIndicator
+            //
+            // The MCP indicator only shows when the manager has *actually* bound
+            // the port (runningPort != null) — not just when the user toggled
+            // mcpEnabled. Prevents a false-positive dot in embedder builds that
+            // forgot to construct BossTermMcpManager, and in cases where the
+            // bind failed (e.g. port already in use).
+            val mcpRunningPort by ai.rever.bossterm.compose.mcp.McpTerminalRegistry
+                .runningPort.collectAsState()
+            val showMcpIndicator = mcpRunningPort != null && settings.mcpShowStatusIndicator
             if (tabController.tabs.size > 1 || settings.alwaysShowTabBar || showMcpIndicator) {
             TabBar(
                 tabs = tabController.tabs,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -700,8 +700,9 @@ fun TabbedTerminal(
     Box(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
             // Tab bar at top (show when multiple tabs, alwaysShowTabBar is set,
-            // or the MCP server is on — the bar hosts the MCP status indicator).
-            if (tabController.tabs.size > 1 || settings.alwaysShowTabBar || settings.mcpEnabled) {
+            // or the MCP indicator is on — the bar hosts the MCP status indicator).
+            val showMcpIndicator = settings.mcpEnabled && settings.mcpShowStatusIndicator
+            if (tabController.tabs.size > 1 || settings.alwaysShowTabBar || showMcpIndicator) {
             TabBar(
                 tabs = tabController.tabs,
                 activeTabIndex = tabController.activeTabIndex,
@@ -722,7 +723,7 @@ fun TabbedTerminal(
                     // Create new window and transfer both tab and split state
                     WindowManager.createWindowWithTab(extractedTab, splitState)
                 },
-                mcpEnabled = settings.mcpEnabled,
+                mcpEnabled = showMcpIndicator,
                 onMcpIndicatorClick = onShowMcpSettings
             )
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1100,15 +1100,14 @@ fun TabbedTerminal(
             )
         }
 
-        // MCP status indicator + toast overlay. Lives in the top-right slot
-        // when MCP is bound. Two independent visibility gates:
-        //   - indicator pill: requires settings.mcpShowStatusIndicator (user
-        //     can hide it without disabling MCP).
-        //   - toast: shown whenever attachStatus is non-null, regardless of
-        //     whether the indicator is visible — so a user who hid the pill
-        //     and triggered an attach from the terminal canvas's right-click
-        //     still gets feedback.
-        if (mcpRunningPort != null) {
+        // MCP status indicator + toast overlay. Top-right slot.
+        //   - Indicator pill renders whenever the user has not hidden it
+        //     (`mcpShowStatusIndicator`). When MCP is bound it shows green
+        //     "MCP on"; when off, red "MCP off". The right-click menu adapts.
+        //   - Toast renders whenever attachStatus is non-null. Attaches
+        //     can't happen when MCP is off, so toast naturally stays
+        //     dormant in that state.
+        if (settings.mcpShowStatusIndicator || attachStatus != null) {
             Column(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
@@ -1130,7 +1129,13 @@ fun TabbedTerminal(
                             SettingsManager.instance.updateSetting {
                                 copy(mcpEnabled = false)
                             }
-                        }
+                        },
+                        onTurnOnRequest = {
+                            SettingsManager.instance.updateSetting {
+                                copy(mcpEnabled = true)
+                            }
+                        },
+                        isUserEnabled = settings.mcpEnabled
                     )
                 }
                 attachStatus?.let { status ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -740,6 +740,34 @@ class TabbedTerminalState {
      * @param tabId Target tab ID. If null, uses the active tab.
      * @return The focused session, or null if tab not found
      */
+    /**
+     * Locate a [TerminalSession] within a tab by its session/pane id.
+     *
+     * @param tabId The tab to search in.
+     * @param paneId Specific pane to find. When non-null, searches the
+     *   tab's split tree for a pane whose `session.id` equals this value.
+     *   When null, returns the tab's focused pane (if it's split) or the
+     *   tab's primary session (if it's not).
+     * @return The matching session, or null if `tabId` is unknown or
+     *   `paneId` was provided but not found within that tab.
+     *
+     * Use this when an MCP / external caller has a pane id from
+     * `run_in_panel` and wants to address that specific pane in a
+     * follow-up tool call (send_input, read_scrollback, etc).
+     */
+    fun findSession(tabId: String, paneId: String? = null): TerminalSession? {
+        val tab = getTabById(tabId) ?: return null
+        val splitState = splitStates[tabId]
+        if (paneId == null) {
+            return splitState?.getFocusedSession() ?: tab
+        }
+        if (splitState != null) {
+            return splitState.getAllPanes().firstOrNull { it.session.id == paneId }?.session
+        }
+        // Single-pane tab: paneId only matches if it's the tab's own session id.
+        return if (tab.id == paneId) tab else null
+    }
+
     fun getFocusedSplitSession(tabId: String? = null): TerminalSession? {
         val resolvedTabId = resolveTabId(tabId) ?: return null
         val splitState = splitStates[resolvedTabId] ?: return null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -630,8 +630,14 @@ class TabbedTerminalState {
                     ?.let { pane -> splitState.closePane(pane.id) }
             }
         }
-        val effectiveRatio = (ratio ?: settings.splitDefaultRatio).coerceIn(0.05f, 0.95f)
-        return splitState.splitFocusedPane(orientation, newSession, effectiveRatio)
+        // splitFocusedPane's `ratio` is "fraction of the ORIGINAL pane"
+        // (per SplitNode.kt:32,43). Our public ratio param is "fraction of
+        // the NEW pane" because that's how the UI / MCP describe it.
+        // Invert here so callers don't have to. Default 0.5 is symmetric
+        // either way, so the UI's keyboard-shortcut splits keep their
+        // existing behavior.
+        val newPaneRatio = (ratio ?: settings.splitDefaultRatio).coerceIn(0.05f, 0.95f)
+        return splitState.splitFocusedPane(orientation, newSession, 1f - newPaneRatio)
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -762,7 +762,13 @@ class TabbedTerminalState {
             return splitState?.getFocusedSession() ?: tab
         }
         if (splitState != null) {
-            return splitState.getAllPanes().firstOrNull { it.session.id == paneId }?.session
+            // Match either the wrapping SplitNode.Pane.id (what
+            // splitFocusedPane / run_in_panel return) or the underlying
+            // TerminalSession.id (what individual tabs are identified by).
+            // The two are distinct UUIDs even for the same logical pane.
+            return splitState.getAllPanes()
+                .firstOrNull { it.id == paneId || it.session.id == paneId }
+                ?.session
         }
         // Single-pane tab: paneId only matches if it's the tab's own session id.
         return if (tab.id == paneId) tab else null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -568,10 +568,13 @@ class TabbedTerminalState {
      * The new pane appears to the right of the focused pane.
      *
      * @param tabId Target tab ID. If null, uses the active tab.
+     * @param ratio Optional size of the new pane as a fraction of the
+     *   parent's width. When null, falls back to
+     *   `settings.splitDefaultRatio`. Clamped to 0.05..0.95.
      * @return The session ID of the new pane, or null if the split failed
      */
-    fun splitVertical(tabId: String? = null): String? {
-        return performSplit(SplitOrientation.VERTICAL, tabId)
+    fun splitVertical(tabId: String? = null, ratio: Float? = null): String? {
+        return performSplit(SplitOrientation.VERTICAL, tabId, ratio)
     }
 
     /**
@@ -581,16 +584,23 @@ class TabbedTerminalState {
      * The new pane appears below the focused pane.
      *
      * @param tabId Target tab ID. If null, uses the active tab.
+     * @param ratio Optional size of the new pane as a fraction of the
+     *   parent's height. When null, falls back to
+     *   `settings.splitDefaultRatio`. Clamped to 0.05..0.95.
      * @return The session ID of the new pane, or null if the split failed
      */
-    fun splitHorizontal(tabId: String? = null): String? {
-        return performSplit(SplitOrientation.HORIZONTAL, tabId)
+    fun splitHorizontal(tabId: String? = null, ratio: Float? = null): String? {
+        return performSplit(SplitOrientation.HORIZONTAL, tabId, ratio)
     }
 
     /**
      * Internal helper to perform a split in the given orientation.
      */
-    private fun performSplit(orientation: SplitOrientation, tabId: String?): String? {
+    private fun performSplit(
+        orientation: SplitOrientation,
+        tabId: String?,
+        ratio: Float? = null
+    ): String? {
         val resolvedTabId = resolveTabId(tabId) ?: return null
         val controller = tabController ?: return null
         val tab = controller.getTabById(resolvedTabId) as? TerminalTab ?: return null
@@ -620,7 +630,8 @@ class TabbedTerminalState {
                     ?.let { pane -> splitState.closePane(pane.id) }
             }
         }
-        return splitState.splitFocusedPane(orientation, newSession, settings.splitDefaultRatio)
+        val effectiveRatio = (ratio ?: settings.splitDefaultRatio).coerceIn(0.05f, 0.95f)
+        return splitState.splitFocusedPane(orientation, newSession, effectiveRatio)
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -573,8 +573,12 @@ class TabbedTerminalState {
      *   `settings.splitDefaultRatio`. Clamped to 0.05..0.95.
      * @return The session ID of the new pane, or null if the split failed
      */
-    fun splitVertical(tabId: String? = null, ratio: Float? = null): String? {
-        return performSplit(SplitOrientation.VERTICAL, tabId, ratio)
+    fun splitVertical(
+        tabId: String? = null,
+        ratio: Float? = null,
+        initialCommand: String? = null
+    ): String? {
+        return performSplit(SplitOrientation.VERTICAL, tabId, ratio, initialCommand)
     }
 
     /**
@@ -589,17 +593,26 @@ class TabbedTerminalState {
      *   `settings.splitDefaultRatio`. Clamped to 0.05..0.95.
      * @return The session ID of the new pane, or null if the split failed
      */
-    fun splitHorizontal(tabId: String? = null, ratio: Float? = null): String? {
-        return performSplit(SplitOrientation.HORIZONTAL, tabId, ratio)
+    fun splitHorizontal(
+        tabId: String? = null,
+        ratio: Float? = null,
+        initialCommand: String? = null
+    ): String? {
+        return performSplit(SplitOrientation.HORIZONTAL, tabId, ratio, initialCommand)
     }
 
     /**
      * Internal helper to perform a split in the given orientation.
+     *
+     * @param initialCommand Optional command to run in the new pane once its shell is ready
+     *   (OSC 133;A or fallback delay). Held by the session bootstrap so the bytes are not
+     *   eaten by shell startup output (banner, rc-file sourcing, prompt draw).
      */
     private fun performSplit(
         orientation: SplitOrientation,
         tabId: String?,
-        ratio: Float? = null
+        ratio: Float? = null,
+        initialCommand: String? = null
     ): String? {
         val resolvedTabId = resolveTabId(tabId) ?: return null
         val controller = tabController ?: return null
@@ -612,7 +625,8 @@ class TabbedTerminalState {
         } else null
 
         val newSession = controller.createSessionForSplit(
-            workingDir = workingDir
+            workingDir = workingDir,
+            initialCommand = initialCommand
         )
         // Assign onProcessExit after creation so the lambda captures newSession directly,
         // avoiding the fragile var-ref pattern where the lambda closes over a mutable var.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpConfig.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpConfig.kt
@@ -94,7 +94,19 @@ data class BossTermMcpConfig(
      * embedder add app-specific tools (`server.addTool(...)`). Defaults to a
      * no-op.
      */
-    val additionalTools: ServerToolRegistrar = {}
+    val additionalTools: ServerToolRegistrar = {},
+    /**
+     * Per-tool description overrides for built-in BossTerm MCP tools. Keys are
+     * unprefixed built-in names (e.g. `"list_tabs"`, `"send_input"`); values
+     * replace the default description string advertised to MCP clients.
+     *
+     * Useful when the embedder wants to clarify behavior in their host app —
+     * e.g. "lists tabs in `MyIDE`'s integrated terminal" rather than the
+     * generic default. Unknown keys are silently ignored; tool names that
+     * aren't overridden keep their built-in description. Empty map means
+     * "no overrides".
+     */
+    val customToolDescriptions: Map<String, String> = emptyMap()
 )
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpConfig.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpConfig.kt
@@ -1,0 +1,110 @@
+package ai.rever.bossterm.compose.mcp
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+
+/**
+ * Hook signature for embedders that want to register additional MCP tools
+ * on top of the built-in seven. Called once per [Server] after the built-in
+ * tools are registered. The embedder owns the names of any tools added here;
+ * [BossTermMcpConfig.toolNamePrefix] is NOT applied to them.
+ */
+typealias ServerToolRegistrar = (Server) -> Unit
+
+/**
+ * Configuration object that other applications embedding BossTerm pass when
+ * constructing [BossTermMcpManager]. Lets the embedder brand the MCP server,
+ * namespace tools, lock out write tools, set first-launch defaults, add
+ * custom tools, and control whether the MCP entry appears in the in-app
+ * Settings UI.
+ *
+ * All fields have defaults that match what plain `bossterm-app` ships, so
+ * callers that don't care about embedding can pass `BossTermMcpConfig()` (or
+ * omit the constructor argument).
+ *
+ * Example embedder wiring (in your `fun main()`):
+ *
+ * ```kotlin
+ * val mcpConfig = BossTermMcpConfig(
+ *     serverName = "bossconsole",
+ *     serverVersion = "0.4.2",
+ *     toolNamePrefix = "bossconsole_",
+ *     allowWriteTools = false,                   // read-only MCP
+ *     defaultPort = 7878,
+ *     defaultEnabled = true,
+ *     additionalTools = { server ->
+ *         server.addTool(name = "show_panel", description = "...", inputSchema = ...) { ... }
+ *     }
+ * )
+ * val mcpScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+ * val mcpManager = BossTermMcpManager(
+ *     registry = McpTerminalRegistry,
+ *     settingsManager = SettingsManager.instance,
+ *     parentScope = mcpScope,
+ *     config = mcpConfig
+ * )
+ * mcpManager.start()
+ *
+ * application {
+ *     CompositionLocalProvider(LocalBossTermMcpConfig provides mcpConfig) {
+ *         // your TabbedTerminal / SettingsWindow tree
+ *     }
+ * }
+ * ```
+ */
+data class BossTermMcpConfig(
+    /** Reported as `Implementation.name`. MCP clients see this string. */
+    val serverName: String = "bossterm",
+    /** Reported as `Implementation.version`. */
+    val serverVersion: String = "1.0",
+    /**
+     * Optional prefix applied to every built-in tool name. For example,
+     * `"bossconsole_"` yields tools named `bossconsole_list_tabs`,
+     * `bossconsole_read_scrollback`, etc. Empty string disables prefixing.
+     */
+    val toolNamePrefix: String = "",
+    /**
+     * When `false`, the write tools (`send_input`, `send_signal`) are not
+     * registered. Use this for embedders that want LLMs to observe but not
+     * drive their shells.
+     */
+    val allowWriteTools: Boolean = true,
+    /**
+     * First-launch port written to settings when the embedder has never
+     * been initialized on this machine (controlled via the
+     * `mcpConfigured` settings flag). After that the user's setting wins.
+     */
+    val defaultPort: Int = 7676,
+    /**
+     * First-launch enabled state written to settings when the embedder has
+     * never been initialized on this machine. After that the user's setting
+     * wins. Default `false` for opt-in safety in plain bossterm-app.
+     */
+    val defaultEnabled: Boolean = false,
+    /**
+     * When `false`, the MCP entry is hidden from the Settings side rail and
+     * any host that respects this flag (e.g. the bossterm-app Tools menu).
+     * The status indicator in the tab bar is still driven by user settings
+     * — toggle that off via [mcpShowStatusIndicator] in TerminalSettings.
+     */
+    val showInSettingsUi: Boolean = true,
+    /**
+     * Embedder hook called after the built-in tools are registered. Lets the
+     * embedder add app-specific tools (`server.addTool(...)`). Defaults to a
+     * no-op.
+     */
+    val additionalTools: ServerToolRegistrar = {}
+)
+
+/**
+ * Composition local exposing the embedder's [BossTermMcpConfig] to the
+ * settings UI so it can adapt its labels and visibility without each
+ * composable threading the config through its parameters.
+ *
+ * `null` means no embedder provided one. The MCP settings section renders a
+ * "how to configure" note in that case so users understand why toggling has
+ * no effect.
+ */
+val LocalBossTermMcpConfig: ProvidableCompositionLocal<BossTermMcpConfig?> =
+    compositionLocalOf { null }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -1,24 +1,30 @@
 package ai.rever.bossterm.compose.mcp
 
-import ai.rever.bossterm.compose.TabbedTerminalState
 import ai.rever.bossterm.compose.settings.SettingsManager
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.cio.CIOApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
+import io.ktor.server.request.host
+import io.ktor.server.request.httpMethod
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import java.net.BindException
 
@@ -26,27 +32,34 @@ import java.net.BindException
  * Lifecycle wrapper that brings up the BossTerm in-process MCP server on a
  * loopback-only embedded Ktor (CIO) HTTP server, driven by user settings.
  *
+ * The manager is meant to be constructed **once per JVM** in `fun main()` and
+ * exposes tabs from every window via [McpTerminalRegistry]. Window-scoped
+ * lifecycles only need to register/unregister their [TabbedTerminalState]
+ * with the registry; they should not instantiate this class themselves.
+ *
  * Behavior:
  *  - On [start] the manager begins observing [SettingsManager.settings] and
  *    reconciles the running server with the current `(mcpEnabled, mcpPort)`
  *    pair. Toggling `mcpEnabled` brings the server up/down; changing
- *    `mcpPort` while enabled performs a stop-then-start. Unrelated setting
- *    changes are ignored.
+ *    `mcpPort` while enabled performs a stop-then-start.
  *  - On [stop] the watcher is cancelled and any running Ktor engine is
- *    stopped with a short grace period.
- *  - The server always binds to `127.0.0.1` — never `0.0.0.0` or a public
- *    interface. Path is `/mcp`.
+ *    stopped asynchronously on a background coroutine. Caller does not
+ *    block.
+ *  - The server always binds to `127.0.0.1` — never `0.0.0.0`.
+ *  - Every request must arrive with a `Host` header pointing at a loopback
+ *    name (`127.0.0.1` or `localhost`, optionally with the bound port).
+ *    Other Host values are rejected with 403 to defend against DNS
+ *    rebinding from a browser tab.
+ *  - The endpoint is logged at INFO with the full URL when the server
+ *    comes up, so users can see where to point clients.
  *
  * Thread-safety: reconcile is serialized via a [Mutex] so concurrent
  * settings emissions cannot double-start the engine. A [BindException]
  * (e.g. port-in-use) is caught and logged; the engine reference stays null
  * and the next settings emission will trigger a new attempt.
- *
- * This class does not touch the UI and must not be initialised from a
- * Composable.
  */
 class BossTermMcpManager(
-    private val state: TabbedTerminalState,
+    private val registry: McpTerminalRegistry,
     private val settingsManager: SettingsManager,
     private val parentScope: CoroutineScope
 ) {
@@ -55,8 +68,8 @@ class BossTermMcpManager(
 
     private val mutex = Mutex()
 
-    // Guarded by [mutex] (and also by ordered emission from a single
-    // collector coroutine, but the mutex covers stop() racing collect()).
+    // Guarded by [mutex]. The Server itself is hoisted to a class-level field
+    // and re-bound to a transport each time the engine restarts.
     private var runningEngine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
     private var runningPort: Int? = null
 
@@ -74,13 +87,15 @@ class BossTermMcpManager(
     }
 
     /**
-     * Cancel the watcher and stop the Ktor engine (if running) with a short
-     * grace period. Idempotent; blocks briefly while Ktor stops.
+     * Cancel the watcher and stop the Ktor engine on a background coroutine.
+     * Returns immediately — does not block the caller's thread. Idempotent.
      */
     fun stop() {
         watcherJob?.cancel()
         watcherJob = null
-        runBlocking {
+        // Async shutdown so callers (including Compose onDispose on the UI
+        // thread) don't block waiting for Ktor's grace period.
+        parentScope.launch(Dispatchers.IO) {
             mutex.withLock { stopRunningEngineLocked() }
         }
     }
@@ -102,27 +117,47 @@ class BossTermMcpManager(
                     startEngineLocked(desired.port)
                 }
                 else -> {
-                    // No-op: either both disabled or already running on the
-                    // requested port.
+                    // No-op.
                 }
             }
         }
     }
 
     private fun startEngineLocked(port: Int) {
+        val mcpServer = BossTermMcpServer(registry).createServer()
+        val allowedHosts = setOf("127.0.0.1", "localhost", "127.0.0.1:$port", "localhost:$port")
         try {
             log.info("Starting BossTerm MCP server on http://{}:{}{}", HOST, port, PATH)
             val engine = embeddedServer(CIO, host = HOST, port = port) {
                 install(SSE)
+                // DNS-rebinding defense: only accept Host headers that name a
+                // loopback target. Anything else (e.g. attacker.example
+                // resolving to 127.0.0.1 in a victim browser) gets 403.
+                intercept(ApplicationCallPipeline.Plugins) {
+                    val host = call.request.host()
+                    val hostHeader = call.request.headers["Host"]?.lowercase() ?: host.lowercase()
+                    if (hostHeader !in allowedHosts) {
+                        call.respondText(
+                            "Forbidden: Host header '$hostHeader' is not a loopback target.",
+                            status = HttpStatusCode.Forbidden
+                        )
+                        finish()
+                        return@intercept
+                    }
+                }
                 routing {
                     route(PATH) {
-                        mcp { BossTermMcpServer(state).createServer() }
+                        mcp { mcpServer }
                     }
                 }
             }
             engine.start(wait = false)
             runningEngine = engine
             runningPort = port
+            log.info(
+                "BossTerm MCP server ready: http://{}:{}{} (SSE transport, {} state(s) registered)",
+                HOST, port, PATH, registry.stateCount()
+            )
         } catch (e: BindException) {
             log.warn(
                 "BossTerm MCP server failed to bind {}:{} (port in use?): {}",
@@ -137,11 +172,13 @@ class BossTermMcpManager(
         }
     }
 
-    private fun stopRunningEngineLocked() {
+    private suspend fun stopRunningEngineLocked() {
         val engine = runningEngine ?: return
         val port = runningPort
         try {
-            engine.stop(STOP_GRACE_MS, STOP_TIMEOUT_MS)
+            withContext(Dispatchers.IO) {
+                engine.stop(STOP_GRACE_MS, STOP_TIMEOUT_MS)
+            }
             log.info("BossTerm MCP server stopped (port {})", port)
         } catch (e: Throwable) {
             log.warn("Error while stopping BossTerm MCP server on port {}: {}", port, e.message)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -183,12 +183,15 @@ class BossTermMcpManager(
                         return@intercept
                     }
                 }
-                // Use the Routing.mcp(path, ...) overload, not Route.mcp{}.
-                // SDK 0.8.3's Route.mcp ignores the parent route's path and
-                // mounts at the application root; the Routing overload
-                // honors the requested path correctly.
+                // SDK 0.8.3 quirk: both `Route.mcp { ... }` and
+                // `Routing.mcp(path, ...) { ... }` end up mounting SSE +
+                // POST at the application root regardless of any wrapping
+                // route, because the path overload's inner lambda re-invokes
+                // mcp(routing, block) against the original Routing. So we
+                // mount at root directly and advertise the URL as
+                // http://127.0.0.1:<port>/ — clients register that URL.
                 routing {
-                    mcp(path = PATH) { mcpServer }
+                    mcp { mcpServer }
                 }
             }
             engine.start(wait = false)
@@ -272,7 +275,8 @@ class BossTermMcpManager(
 
     private companion object {
         private const val HOST = "127.0.0.1"
-        private const val PATH = "/mcp"
+        /** Path the SSE/POST endpoints are reachable at. SDK 0.8.3 only honors root. */
+        private const val PATH = "/"
         private const val STOP_GRACE_MS = 500L
         private const val STOP_TIMEOUT_MS = 1500L
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -1,0 +1,162 @@
+package ai.rever.bossterm.compose.mcp
+
+import ai.rever.bossterm.compose.TabbedTerminalState
+import ai.rever.bossterm.compose.settings.SettingsManager
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.cio.CIOApplicationEngine
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.sse.SSE
+import io.modelcontextprotocol.kotlin.sdk.server.mcp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.slf4j.LoggerFactory
+import java.net.BindException
+
+/**
+ * Lifecycle wrapper that brings up the BossTerm in-process MCP server on a
+ * loopback-only embedded Ktor (CIO) HTTP server, driven by user settings.
+ *
+ * Behavior:
+ *  - On [start] the manager begins observing [SettingsManager.settings] and
+ *    reconciles the running server with the current `(mcpEnabled, mcpPort)`
+ *    pair. Toggling `mcpEnabled` brings the server up/down; changing
+ *    `mcpPort` while enabled performs a stop-then-start. Unrelated setting
+ *    changes are ignored.
+ *  - On [stop] the watcher is cancelled and any running Ktor engine is
+ *    stopped with a short grace period.
+ *  - The server always binds to `127.0.0.1` — never `0.0.0.0` or a public
+ *    interface. Path is `/mcp`.
+ *
+ * Thread-safety: reconcile is serialized via a [Mutex] so concurrent
+ * settings emissions cannot double-start the engine. A [BindException]
+ * (e.g. port-in-use) is caught and logged; the engine reference stays null
+ * and the next settings emission will trigger a new attempt.
+ *
+ * This class does not touch the UI and must not be initialised from a
+ * Composable.
+ */
+class BossTermMcpManager(
+    private val state: TabbedTerminalState,
+    private val settingsManager: SettingsManager,
+    private val parentScope: CoroutineScope
+) {
+
+    private val log = LoggerFactory.getLogger(BossTermMcpManager::class.java)
+
+    private val mutex = Mutex()
+
+    // Guarded by [mutex] (and also by ordered emission from a single
+    // collector coroutine, but the mutex covers stop() racing collect()).
+    private var runningEngine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
+    private var runningPort: Int? = null
+
+    private var watcherJob: Job? = null
+
+    /** Begin observing settings. Idempotent. Safe to call multiple times. */
+    fun start() {
+        if (watcherJob?.isActive == true) return
+        watcherJob = parentScope.launch {
+            settingsManager.settings
+                .map { McpConfig(enabled = it.mcpEnabled, port = it.mcpPort) }
+                .distinctUntilChanged()
+                .collect { config -> reconcile(config) }
+        }
+    }
+
+    /**
+     * Cancel the watcher and stop the Ktor engine (if running) with a short
+     * grace period. Idempotent; blocks briefly while Ktor stops.
+     */
+    fun stop() {
+        watcherJob?.cancel()
+        watcherJob = null
+        runBlocking {
+            mutex.withLock { stopRunningEngineLocked() }
+        }
+    }
+
+    private suspend fun reconcile(desired: McpConfig) {
+        mutex.withLock {
+            val currentPort = runningPort
+            val currentlyRunning = runningEngine != null
+
+            when {
+                !desired.enabled && currentlyRunning -> {
+                    stopRunningEngineLocked()
+                }
+                desired.enabled && !currentlyRunning -> {
+                    startEngineLocked(desired.port)
+                }
+                desired.enabled && currentlyRunning && currentPort != desired.port -> {
+                    stopRunningEngineLocked()
+                    startEngineLocked(desired.port)
+                }
+                else -> {
+                    // No-op: either both disabled or already running on the
+                    // requested port.
+                }
+            }
+        }
+    }
+
+    private fun startEngineLocked(port: Int) {
+        try {
+            log.info("Starting BossTerm MCP server on http://{}:{}{}", HOST, port, PATH)
+            val engine = embeddedServer(CIO, host = HOST, port = port) {
+                install(SSE)
+                routing {
+                    route(PATH) {
+                        mcp { BossTermMcpServer(state).createServer() }
+                    }
+                }
+            }
+            engine.start(wait = false)
+            runningEngine = engine
+            runningPort = port
+        } catch (e: BindException) {
+            log.warn(
+                "BossTerm MCP server failed to bind {}:{} (port in use?): {}",
+                HOST, port, e.message
+            )
+            runningEngine = null
+            runningPort = null
+        } catch (e: Throwable) {
+            log.error("BossTerm MCP server failed to start on {}:{}", HOST, port, e)
+            runningEngine = null
+            runningPort = null
+        }
+    }
+
+    private fun stopRunningEngineLocked() {
+        val engine = runningEngine ?: return
+        val port = runningPort
+        try {
+            engine.stop(STOP_GRACE_MS, STOP_TIMEOUT_MS)
+            log.info("BossTerm MCP server stopped (port {})", port)
+        } catch (e: Throwable) {
+            log.warn("Error while stopping BossTerm MCP server on port {}: {}", port, e.message)
+        } finally {
+            runningEngine = null
+            runningPort = null
+        }
+    }
+
+    private data class McpConfig(val enabled: Boolean, val port: Int)
+
+    private companion object {
+        private const val HOST = "127.0.0.1"
+        private const val PATH = "/mcp"
+        private const val STOP_GRACE_MS = 500L
+        private const val STOP_TIMEOUT_MS = 1500L
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -80,18 +80,32 @@ class BossTermMcpManager(
     fun start() {
         if (watcherJob?.isActive == true) return
 
-        // First-launch reconciliation: if this install has never seen the
-        // MCP defaults, write the embedder's chosen values and mark
-        // configured. Runs at most once per install — after the flag flips,
-        // the user owns mcpEnabled / mcpPort.
+        // First-launch reconciliation. Two distinct cases share the
+        // `mcpConfigured = false` state:
+        //   1) Brand-new install — apply the embedder's defaults.
+        //   2) Existing user upgrading from a build that didn't yet have
+        //      the mcpConfigured field — preserve their saved mcpEnabled /
+        //      mcpPort and just flip the marker so future launches no-op.
+        // We tell the two apart via SettingsManager.wasFreshInstall, which
+        // is true only when no settings.json existed at load time.
         val current = settingsManager.settings.value
         if (!current.mcpConfigured) {
-            settingsManager.updateSetting {
-                copy(
-                    mcpEnabled = config.defaultEnabled,
-                    mcpPort = config.defaultPort,
-                    mcpConfigured = true
+            if (settingsManager.wasFreshInstall) {
+                log.info(
+                    "MCP first-launch defaults applied: enabled={}, port={}",
+                    config.defaultEnabled, config.defaultPort
                 )
+                settingsManager.updateSetting {
+                    copy(
+                        mcpEnabled = config.defaultEnabled,
+                        mcpPort = config.defaultPort,
+                        mcpConfigured = true
+                    )
+                }
+            } else {
+                // Upgrade path: do not touch the user's mcpEnabled / mcpPort.
+                log.info("MCP marker absent on existing install; preserving user settings")
+                settingsManager.updateSetting { copy(mcpConfigured = true) }
             }
         }
 
@@ -171,6 +185,7 @@ class BossTermMcpManager(
             engine.start(wait = false)
             runningEngine = engine
             runningPort = port
+            registry.setRunning(port)
             log.info(
                 "BossTerm MCP server ready: http://{}:{}{} (SSE transport, {} state(s) registered)",
                 HOST, port, PATH, registry.stateCount()
@@ -202,6 +217,7 @@ class BossTermMcpManager(
         } finally {
             runningEngine = null
             runningPort = null
+            registry.setStopped()
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -76,7 +76,13 @@ class BossTermMcpManager(
     private var runningEngine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
     private var runningPort: Int? = null
 
+    // Holds the live BossTermMcpServer wrapper so the disabled-tools watcher
+    // can call applyDisabledSet() against the same instance the transport is bound to.
+    // Null when no engine is running.
+    private var runningServer: BossTermMcpServer? = null
+
     private var watcherJob: Job? = null
+    private var disabledToolsWatcherJob: Job? = null
 
     /** Begin observing settings. Idempotent. Safe to call multiple times. */
     fun start() {
@@ -122,6 +128,25 @@ class BossTermMcpManager(
                 .distinctUntilChanged()
                 .collect { desired -> reconcile(desired) }
         }
+
+        // Independent watcher: settings-UI toggles of disabledMcpTools push add/remove
+        // to whatever live server is currently bound. No-op when the engine is stopped
+        // (applyDisabledSet returns early if no server has been built).
+        //
+        // `mutex.withLock` here only guards the read of [runningServer] against engine
+        // start/stop (which also holds the mutex). The actual SDK-mutation race is
+        // serialized internally by BossTermMcpServer.applyDisabledSet via its own
+        // toolsLock — that's what makes the concurrent manage_tools-handler path safe.
+        disabledToolsWatcherJob = parentScope.launch {
+            settingsManager.settings
+                .map { it.disabledMcpTools }
+                .distinctUntilChanged()
+                .collect { disabled ->
+                    mutex.withLock {
+                        runningServer?.applyDisabledSet(disabled)
+                    }
+                }
+        }
     }
 
     /**
@@ -131,6 +156,8 @@ class BossTermMcpManager(
     fun stop() {
         watcherJob?.cancel()
         watcherJob = null
+        disabledToolsWatcherJob?.cancel()
+        disabledToolsWatcherJob = null
         // Async shutdown so callers (including Compose onDispose on the UI
         // thread) don't block waiting for Ktor's grace period.
         parentScope.launch(Dispatchers.IO) {
@@ -162,7 +189,8 @@ class BossTermMcpManager(
     }
 
     private fun startEngineLocked(port: Int) {
-        val mcpServer = BossTermMcpServer(registry, config).createServer()
+        val mcpServerWrapper = BossTermMcpServer(registry, config, settingsManager)
+        val mcpServer = mcpServerWrapper.createServer()
         val allowedHosts = setOf("127.0.0.1", "localhost", "127.0.0.1:$port", "localhost:$port")
         try {
             log.info("Starting BossTerm MCP server on http://{}:{}{}", HOST, port, PATH)
@@ -197,6 +225,7 @@ class BossTermMcpManager(
             engine.start(wait = false)
             runningEngine = engine
             runningPort = port
+            runningServer = mcpServerWrapper
             registry.setRunning(port)
             log.info(
                 "BossTerm MCP server ready: http://{}:{}{} (SSE transport, {} state(s) registered)",
@@ -210,10 +239,12 @@ class BossTermMcpManager(
             )
             runningEngine = null
             runningPort = null
+            runningServer = null
         } catch (e: Throwable) {
             log.error("BossTerm MCP server failed to start on {}:{}", HOST, port, e)
             runningEngine = null
             runningPort = null
+            runningServer = null
         }
     }
 
@@ -267,6 +298,7 @@ class BossTermMcpManager(
         } finally {
             runningEngine = null
             runningPort = null
+            runningServer = null
             registry.setStopped()
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -237,11 +237,13 @@ class BossTermMcpManager(
                 "BossTerm MCP server failed to bind {}:{} (port in use?): {}",
                 HOST, port, e.message
             )
+            mcpServerWrapper.detachServer()
             runningEngine = null
             runningPort = null
             runningServer = null
         } catch (e: Throwable) {
             log.error("BossTerm MCP server failed to start on {}:{}", HOST, port, e)
+            mcpServerWrapper.detachServer()
             runningEngine = null
             runningPort = null
             runningServer = null
@@ -296,6 +298,11 @@ class BossTermMcpManager(
         } catch (e: Throwable) {
             log.warn("Error while stopping BossTerm MCP server on port {}: {}", port, e.message)
         } finally {
+            // Detach the wrapper first so any in-flight manage_tools handler
+            // (or a stray applyDisabledSet from the watcher) becomes a no-op
+            // instead of mutating a Server that's no longer bound to any
+            // transport.
+            runningServer?.detachServer()
             runningEngine = null
             runningPort = null
             runningServer = null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -18,6 +18,9 @@ import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -223,8 +226,20 @@ class BossTermMcpManager(
         if (targets.isEmpty()) return
         log.info("Auto-reattaching {} CLI(s) to new endpoint…", targets.size)
         parentScope.launch(Dispatchers.IO) {
-            targets.forEach { target ->
-                val result = McpCliAttacher.attach(target, config.serverName, port, quiet = true)
+            // Fan out: each CLI's mcp add/remove operates on its own config
+            // file, so they're independent. Running sequentially used to add
+            // up to ~5-10s for four targets; parallel keeps total time bound
+            // by the slowest one (~1-2s).
+            val outcomes = coroutineScope {
+                targets.map { target ->
+                    async {
+                        target to McpCliAttacher.attach(
+                            target, config.serverName, port, quiet = true
+                        )
+                    }
+                }.awaitAll()
+            }
+            outcomes.forEach { (target, result) ->
                 if (result is McpAttachResult.CopiedToClipboard) {
                     log.warn(
                         "Auto-reattach failed for {}: {}; dropping from persisted set",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -12,7 +12,6 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.request.host
 import io.ktor.server.request.httpMethod
 import io.ktor.server.response.respondText
-import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
@@ -176,10 +175,12 @@ class BossTermMcpManager(
                         return@intercept
                     }
                 }
+                // Use the Routing.mcp(path, ...) overload, not Route.mcp{}.
+                // SDK 0.8.3's Route.mcp ignores the parent route's path and
+                // mounts at the application root; the Routing overload
+                // honors the requested path correctly.
                 routing {
-                    route(PATH) {
-                        mcp { mcpServer }
-                    }
+                    mcp(path = PATH) { mcpServer }
                 }
             }
             engine.start(wait = false)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -61,7 +61,8 @@ import java.net.BindException
 class BossTermMcpManager(
     private val registry: McpTerminalRegistry,
     private val settingsManager: SettingsManager,
-    private val parentScope: CoroutineScope
+    private val parentScope: CoroutineScope,
+    private val config: BossTermMcpConfig = BossTermMcpConfig()
 ) {
 
     private val log = LoggerFactory.getLogger(BossTermMcpManager::class.java)
@@ -78,11 +79,27 @@ class BossTermMcpManager(
     /** Begin observing settings. Idempotent. Safe to call multiple times. */
     fun start() {
         if (watcherJob?.isActive == true) return
+
+        // First-launch reconciliation: if this install has never seen the
+        // MCP defaults, write the embedder's chosen values and mark
+        // configured. Runs at most once per install — after the flag flips,
+        // the user owns mcpEnabled / mcpPort.
+        val current = settingsManager.settings.value
+        if (!current.mcpConfigured) {
+            settingsManager.updateSetting {
+                copy(
+                    mcpEnabled = config.defaultEnabled,
+                    mcpPort = config.defaultPort,
+                    mcpConfigured = true
+                )
+            }
+        }
+
         watcherJob = parentScope.launch {
             settingsManager.settings
                 .map { McpConfig(enabled = it.mcpEnabled, port = it.mcpPort) }
                 .distinctUntilChanged()
-                .collect { config -> reconcile(config) }
+                .collect { desired -> reconcile(desired) }
         }
     }
 
@@ -124,7 +141,7 @@ class BossTermMcpManager(
     }
 
     private fun startEngineLocked(port: Int) {
-        val mcpServer = BossTermMcpServer(registry).createServer()
+        val mcpServer = BossTermMcpServer(registry, config).createServer()
         val allowedHosts = setOf("127.0.0.1", "localhost", "127.0.0.1:$port", "localhost:$port")
         try {
             log.info("Starting BossTerm MCP server on http://{}:{}{}", HOST, port, PATH)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -79,6 +79,11 @@ class BossTermMcpManager(
     fun start() {
         if (watcherJob?.isActive == true) return
 
+        // Hydrate the runtime attached-targets set from persisted settings so
+        // the indicator/menu reflect prior-session state immediately, and
+        // the auto-reattach loop below has the right targets to refresh.
+        registry.hydrate(settingsManager.settings.value.mcpAttachedTo)
+
         // First-launch reconciliation. Two distinct cases share the
         // `mcpConfigured = false` state:
         //   1) Brand-new install — apply the embedder's defaults.
@@ -191,6 +196,7 @@ class BossTermMcpManager(
                 "BossTerm MCP server ready: http://{}:{}{} (SSE transport, {} state(s) registered)",
                 HOST, port, PATH, registry.stateCount()
             )
+            launchAutoReattach(port)
         } catch (e: BindException) {
             log.warn(
                 "BossTerm MCP server failed to bind {}:{} (port in use?): {}",
@@ -202,6 +208,31 @@ class BossTermMcpManager(
             log.error("BossTerm MCP server failed to start on {}:{}", HOST, port, e)
             runningEngine = null
             runningPort = null
+        }
+    }
+
+    /**
+     * Re-run `<cli> mcp add` (quiet mode) for every CLI in the persisted
+     * attached-targets set. Lets a user's saved attachments survive port
+     * changes between launches — and fixes them silently. If a CLI's
+     * binary is missing now (uninstalled since last run), we drop it from
+     * the persisted set instead of polluting the clipboard.
+     */
+    private fun launchAutoReattach(port: Int) {
+        val targets = registry.attachedTargets.value
+        if (targets.isEmpty()) return
+        log.info("Auto-reattaching {} CLI(s) to new endpoint…", targets.size)
+        parentScope.launch(Dispatchers.IO) {
+            targets.forEach { target ->
+                val result = McpCliAttacher.attach(target, config.serverName, port, quiet = true)
+                if (result is McpAttachResult.CopiedToClipboard) {
+                    log.warn(
+                        "Auto-reattach failed for {}: {}; dropping from persisted set",
+                        target.displayName, result.reason
+                    )
+                    registry.markDetached(target)
+                }
+            }
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -110,7 +110,7 @@ class BossTermMcpManager(
 
         watcherJob = parentScope.launch {
             settingsManager.settings
-                .map { McpConfig(enabled = it.mcpEnabled, port = it.mcpPort) }
+                .map { McpRuntimeConfig(enabled = it.mcpEnabled, port = it.mcpPort) }
                 .distinctUntilChanged()
                 .collect { desired -> reconcile(desired) }
         }
@@ -130,7 +130,7 @@ class BossTermMcpManager(
         }
     }
 
-    private suspend fun reconcile(desired: McpConfig) {
+    private suspend fun reconcile(desired: McpRuntimeConfig) {
         mutex.withLock {
             val currentPort = runningPort
             val currentlyRunning = runningEngine != null
@@ -222,7 +222,7 @@ class BossTermMcpManager(
         }
     }
 
-    private data class McpConfig(val enabled: Boolean, val port: Int)
+    private data class McpRuntimeConfig(val enabled: Boolean, val port: Int)
 
     private companion object {
         private const val HOST = "127.0.0.1"

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.floatOrNull
@@ -59,7 +60,8 @@ import kotlinx.serialization.json.putJsonObject
  */
 class BossTermMcpServer(
     private val registry: McpTerminalRegistry = McpTerminalRegistry,
-    private val config: BossTermMcpConfig = BossTermMcpConfig()
+    private val config: BossTermMcpConfig = BossTermMcpConfig(),
+    private val settingsManager: SettingsManager = SettingsManager.instance
 ) {
 
     private val json: Json = Json {
@@ -70,6 +72,58 @@ class BossTermMcpServer(
 
     /** Returns the built-in tool name with the embedder's configured prefix applied. */
     private fun toolName(builtin: String): String = config.toolNamePrefix + builtin
+
+    /**
+     * Returns the description an embedder has supplied for [builtin] via
+     * [BossTermMcpConfig.customToolDescriptions], or [default] when none is set.
+     * Lookup uses the unprefixed built-in name so embedders write
+     * `customToolDescriptions = mapOf("list_tabs" to "…")` regardless of any
+     * configured tool-name prefix.
+     */
+    private fun describe(builtin: String, default: String): String =
+        config.customToolDescriptions[builtin] ?: default
+
+    // Name-indexed registration functions. Defined here (not inline in createServer) so
+    // manage_tools / applyDisabledSet can re-register a previously-disabled tool against
+    // the live Server without rebuilding the whole instance. Names mirror
+    // BUILT_IN_READ_TOOLS / BUILT_IN_WRITE_TOOLS so the settings UI can render toggles
+    // without duplicating the list.
+    private val readToolRegistrations: Map<String, (Server) -> Unit> = mapOf(
+        "list_tabs" to ::registerListTabs,
+        "get_active_tab" to ::registerGetActiveTab,
+        "read_scrollback" to ::registerReadScrollback,
+        "search_output" to ::registerSearchOutput,
+        "get_last_command" to ::registerGetLastCommand,
+        "read_debug_console" to ::registerReadDebugConsole
+    )
+    private val writeToolRegistrations: Map<String, (Server) -> Unit> = mapOf(
+        "send_input" to ::registerSendInput,
+        "send_signal" to ::registerSendSignal,
+        "run_in_panel" to ::registerRunInPanel
+    )
+
+    /** Reserved tools that callers cannot disable. */
+    private val undisablableTools: Set<String> = UNDISABLABLE_TOOLS
+
+    // Hold the live Server so applyDisabledSet can mutate it.
+    private var serverRef: Server? = null
+
+    // Serializes concurrent applyDisabledSet callers. Two paths invoke it: the
+    // manage_tools MCP handler (no external lock) and the BossTermMcpManager
+    // settings watcher (holds the manager's mutex, but that mutex doesn't cover
+    // the MCP-handler path). The MCP SDK's Server.tools is a plain MutableMap
+    // without documented thread-safety, so a containsKey → addTool/removeTool
+    // sequence on two threads could otherwise double-register or corrupt state.
+    private val toolsLock = Any()
+
+    /**
+     * Names of every built-in tool the current config could expose (write tools are
+     * excluded when [BossTermMcpConfig.allowWriteTools] is false). Stable order:
+     * reads first, then writes.
+     */
+    fun availableToolNames(): List<String> =
+        readToolRegistrations.keys.toList() +
+            if (config.allowWriteTools) writeToolRegistrations.keys.toList() else emptyList()
 
     /**
      * Build and return a fully configured [Server] with all BossTerm tools
@@ -87,24 +141,53 @@ class BossTermMcpServer(
                 )
             )
         )
+        serverRef = server
 
-        registerListTabs(server)
-        registerGetActiveTab(server)
-        registerReadScrollback(server)
-        registerSearchOutput(server)
-        registerGetLastCommand(server)
-        registerReadDebugConsole(server)
-        if (config.allowWriteTools) {
-            registerSendInput(server)
-            registerSendSignal(server)
-            registerRunInPanel(server)
+        val disabled = settingsManager.settings.value.disabledMcpTools
+        for ((name, register) in readToolRegistrations) {
+            if (name !in disabled) register(server)
         }
+        if (config.allowWriteTools) {
+            for ((name, register) in writeToolRegistrations) {
+                if (name !in disabled) register(server)
+            }
+        }
+        // manage_tools is always registered — without it there's no way to
+        // re-enable other tools from MCP after they've been disabled.
+        registerManageTools(server)
 
         // Embedder hook: register app-specific tools after built-ins. Names
         // are NOT prefixed — embedder owns them.
         config.additionalTools(server)
 
         return server
+    }
+
+    /**
+     * Sync the live server's exposed tool set to match [disabled]. Adds back any
+     * available tool not in the set; removes any tool that is. No-op if no server
+     * has been built yet.
+     *
+     * Safe to call from any thread; the body runs under [toolsLock] so concurrent
+     * callers (the manage_tools MCP handler and the settings watcher in
+     * BossTermMcpManager) are serialized. Without this, the containsKey →
+     * addTool/removeTool sequence could double-register a tool against the SDK's
+     * non-thread-safe Server.tools map.
+     */
+    fun applyDisabledSet(disabled: Set<String>) {
+        val server = serverRef ?: return
+        synchronized(toolsLock) {
+            for (name in availableToolNames()) {
+                val prefixed = toolName(name)
+                val present = server.tools.containsKey(prefixed)
+                val shouldBeExposed = name !in disabled
+                if (shouldBeExposed && !present) {
+                    (readToolRegistrations[name] ?: writeToolRegistrations[name])?.invoke(server)
+                } else if (!shouldBeExposed && present) {
+                    server.removeTool(prefixed)
+                }
+            }
+        }
     }
 
     // -----------------------------------------------------------------
@@ -114,9 +197,12 @@ class BossTermMcpServer(
     private fun registerListTabs(server: Server) {
         server.addTool(
             name = toolName("list_tabs"),
-            description = "List all open terminal tabs across all windows. Each tab includes " +
-                    "id, title, working directory, pid, and isActive (true if the tab is the " +
-                    "currently selected tab of its window).",
+            description = describe(
+                "list_tabs",
+                "List all open terminal tabs across all windows. Each tab includes " +
+                        "id, title, working directory, pid, and isActive (true if the tab is the " +
+                        "currently selected tab of its window)."
+            ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {},
                 required = emptyList()
@@ -136,8 +222,11 @@ class BossTermMcpServer(
     private fun registerGetActiveTab(server: Server) {
         server.addTool(
             name = toolName("get_active_tab"),
-            description = "Return the active tab of the primary window (the first window opened " +
-                    "that is still alive), or null if no tab is active.",
+            description = describe(
+                "get_active_tab",
+                "Return the active tab of the primary window (the first window opened " +
+                        "that is still alive), or null if no tab is active."
+            ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {},
                 required = emptyList()
@@ -160,10 +249,13 @@ class BossTermMcpServer(
     private fun registerReadScrollback(server: Server) {
         server.addTool(
             name = toolName("read_scrollback"),
-            description = "Read the last N lines from a tab/pane's terminal buffer " +
-                    "(history + visible screen) as plain UTF-8 text. Trailing whitespace per " +
-                    "line is stripped. When `pane_id` is supplied, reads the specific split " +
-                    "pane (returned by run_in_panel); otherwise reads the focused pane.",
+            description = describe(
+                "read_scrollback",
+                "Read the last N lines from a tab/pane's terminal buffer " +
+                        "(history + visible screen) as plain UTF-8 text. Trailing whitespace per " +
+                        "line is stripped. When `pane_id` is supplied, reads the specific split " +
+                        "pane (returned by run_in_panel); otherwise reads the focused pane."
+            ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -228,12 +320,15 @@ class BossTermMcpServer(
     private fun registerSearchOutput(server: Server) {
         server.addTool(
             name = toolName("search_output"),
-            description = "Regex-search the entire scrollback (history + screen) of a tab/pane. " +
-                    "Returns matching rows with positional info. Row numbers follow buffer " +
-                    "convention: negative for history (oldest = -historyLinesCount), 0..height-1 " +
-                    "for screen. The response also includes historyLinesCount and height so " +
-                    "clients can convert to 1-based line numbers if desired. When `pane_id` is " +
-                    "supplied, searches that specific split pane; otherwise the focused pane.",
+            description = describe(
+                "search_output",
+                "Regex-search the entire scrollback (history + screen) of a tab/pane. " +
+                        "Returns matching rows with positional info. Row numbers follow buffer " +
+                        "convention: negative for history (oldest = -historyLinesCount), 0..height-1 " +
+                        "for screen. The response also includes historyLinesCount and height so " +
+                        "clients can convert to 1-based line numbers if desired. When `pane_id` is " +
+                        "supplied, searches that specific split pane; otherwise the focused pane."
+            ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -331,12 +426,15 @@ class BossTermMcpServer(
     private fun registerGetLastCommand(server: Server) {
         server.addTool(
             name = toolName("get_last_command"),
-            description = "Return the most recently completed shell command for a tab " +
-                    "(as captured via OSC 133), or null if no command has finished yet. " +
-                    "Requires shell integration — see shell-integration.md. " +
-                    "Note: `commandText` is currently always null; only `exitCode`, `startedAtMs`, " +
-                    "`finishedAtMs`, `durationMs`, and `cwd` are populated. Capturing the typed " +
-                    "command text reliably is a follow-up.",
+            description = describe(
+                "get_last_command",
+                "Return the most recently completed shell command for a tab " +
+                        "(as captured via OSC 133), or null if no command has finished yet. " +
+                        "Requires shell integration — see shell-integration.md. " +
+                        "Note: `commandText` is currently always null; only `exitCode`, `startedAtMs`, " +
+                        "`finishedAtMs`, `durationMs`, and `cwd` are populated. Capturing the typed " +
+                        "command text reliably is a follow-up."
+            ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -380,10 +478,13 @@ class BossTermMcpServer(
     private fun registerSendInput(server: Server) {
         server.addTool(
             name = toolName("send_input"),
-            description = "Write text to a tab's shell stdin. The caller is responsible for " +
-                    "appending a trailing '\\n' if they want a command to actually execute. " +
-                    "When `pane_id` is supplied (e.g. the value returned by run_in_panel), " +
-                    "writes go to that specific split; otherwise to the tab's primary session.",
+            description = describe(
+                "send_input",
+                "Write text to a tab's shell stdin. The caller is responsible for " +
+                        "appending a trailing '\\n' if they want a command to actually execute. " +
+                        "When `pane_id` is supplied (e.g. the value returned by run_in_panel), " +
+                        "writes go to that specific split; otherwise to the tab's primary session."
+            ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -429,10 +530,13 @@ class BossTermMcpServer(
     private fun registerSendSignal(server: Server) {
         server.addTool(
             name = toolName("send_signal"),
-            description = "Send a control signal to a tab's shell. Allowed signals: " +
-                    "'ctrl_c' (interrupt), 'ctrl_d' (EOF), 'ctrl_z' (suspend). When `pane_id` " +
-                    "is supplied, the signal targets that specific split; otherwise the tab's " +
-                    "primary session.",
+            description = describe(
+                "send_signal",
+                "Send a control signal to a tab's shell. Allowed signals: " +
+                        "'ctrl_c' (interrupt), 'ctrl_d' (EOF), 'ctrl_z' (suspend). When `pane_id` " +
+                        "is supplied, the signal targets that specific split; otherwise the tab's " +
+                        "primary session."
+            ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -495,14 +599,16 @@ class BossTermMcpServer(
     private fun registerRunInPanel(server: Server) {
         server.addTool(
             name = toolName("run_in_panel"),
-            description = "Open a new terminal panel and write a script to it. Modes: " +
-                    "'new_tab' (fresh tab with initialCommand), 'horizontal_split' (split " +
-                    "below focused pane), 'vertical_split' (split beside focused pane). " +
-                    "Include '\\n' in the script to submit it as a command. " +
-                    "Note: in 'new_tab' mode, the response returns as soon as the tab is " +
-                    "created; the shell may still be initializing for ~1s before the script " +
-                    "actually runs. Use list_tabs / read_scrollback after a short delay if " +
-                    "you need to observe results.",
+            description = describe(
+                "run_in_panel",
+                "Open a new terminal panel and write a script to it. Modes: " +
+                        "'new_tab' (fresh tab with initialCommand), 'horizontal_split' (split " +
+                        "below focused pane), 'vertical_split' (split beside focused pane). " +
+                        "Include '\\n' in the script to submit it as a command. " +
+                        "All three modes wait for the shell's OSC 133;A prompt-ready signal " +
+                        "(or the configured fallback delay) before sending the script, so the " +
+                        "command runs cleanly rather than racing with shell startup."
+            ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("panel") {
@@ -554,11 +660,9 @@ class BossTermMcpServer(
 
             when (panel) {
                 "new_tab" -> {
-                    // TabController.createTab auto-appends '\n' to
-                    // initialCommand, while the split path uses raw
-                    // writeUserInput (no auto-newline). Normalize a single
-                    // trailing newline so the tool's `\n means submit`
-                    // contract is consistent across all three modes.
+                    // Both createTab and the split path (createSessionForSplit) hold
+                    // initialCommand until OSC 133;A and auto-append '\n', so strip
+                    // any caller-provided trailing newline for a consistent contract.
                     val normalizedScript = script.removeSuffix("\n")
                     val newId = state.createTab(
                         workingDir = workingDir,
@@ -575,20 +679,15 @@ class BossTermMcpServer(
                     val configuredDefault = SettingsManager.instance.settings.value.mcpDefaultSplitRatio
                     val requestedRatio = args.optionalFloat("split_ratio")
                     val effectiveRatio = (requestedRatio ?: configuredDefault).coerceIn(0.05f, 0.95f)
+                    // Normalize the trailing newline: createSessionForSplit's initialCommand
+                    // path auto-appends '\n', matching the new_tab branch. An empty script
+                    // means "just split, don't run anything".
+                    val normalizedScript = script.removeSuffix("\n").ifEmpty { null }
                     val paneId = if (panel == "horizontal_split") {
-                        state.splitHorizontal(targetTabId, ratio = effectiveRatio)
+                        state.splitHorizontal(targetTabId, ratio = effectiveRatio, initialCommand = normalizedScript)
                     } else {
-                        state.splitVertical(targetTabId, ratio = effectiveRatio)
+                        state.splitVertical(targetTabId, ratio = effectiveRatio, initialCommand = normalizedScript)
                     } ?: return@addTool errorResult("Split failed (terminal too small?)")
-                    // Write directly to the new pane via its id rather than
-                    // relying on focused-pane state. Avoids any timing race
-                    // where user input or UI re-focuses between splitFocusedPane
-                    // and the write call.
-                    val newSession = state.findSession(targetTabId, paneId)
-                        ?: return@addTool errorResult(
-                            "Split returned paneId '$paneId' but the pane could not be located"
-                        )
-                    newSession.writeUserInput(script)
                     val payload = RunInPanelResult(ok = true, tabId = targetTabId, paneId = paneId)
                     successJson(json.encodeToString(RunInPanelResult.serializer(), payload))
                 }
@@ -606,10 +705,13 @@ class BossTermMcpServer(
     private fun registerReadDebugConsole(server: Server) {
         server.addTool(
             name = toolName("read_debug_console"),
-            description = "Read recent entries from a tab's debug-data buffer (PTY output, " +
-                    "user input, console-log entries). Per-tab circular buffer; cap is " +
-                    "settings.debugMaxChunks (default 1000). Supports incremental polling via " +
-                    "since_index and filtering via sources.",
+            description = describe(
+                "read_debug_console",
+                "Read recent entries from a tab's debug-data buffer (PTY output, " +
+                        "user input, console-log entries). Per-tab circular buffer; cap is " +
+                        "settings.debugMaxChunks (default 1000). Supports incremental polling via " +
+                        "since_index and filtering via sources."
+            ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -692,6 +794,90 @@ class BossTermMcpServer(
     }
 
     // -----------------------------------------------------------------
+    // Tool: manage_tools
+    // -----------------------------------------------------------------
+
+    private fun registerManageTools(server: Server) {
+        server.addTool(
+            name = toolName("manage_tools"),
+            description = "Manage which BossTerm MCP built-in tools are exposed to clients. " +
+                    "Operation 'list' returns every available built-in with its current enabled " +
+                    "state. 'enable' / 'disable' take a 'names' array of unprefixed built-in " +
+                    "names (e.g. 'send_input'); changes apply live (the tool list updates without " +
+                    "restarting the server) and persist to settings.json. 'manage_tools' itself " +
+                    "cannot be disabled.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("operation") {
+                        put("type", "string")
+                        put("description", "One of: list, enable, disable.")
+                    }
+                    putJsonObject("names") {
+                        put("type", "array")
+                        put(
+                            "description",
+                            "Unprefixed built-in tool names. Required for 'enable' and 'disable'."
+                        )
+                    }
+                },
+                required = listOf("operation")
+            )
+        ) { request ->
+            val args = request.arguments
+            val operation = args.requireString("operation")?.lowercase()
+                ?: return@addTool errorResult("Missing required argument: operation")
+
+            when (operation) {
+                "list" -> {
+                    val currentDisabled = settingsManager.settings.value.disabledMcpTools
+                    val items = availableToolNames().map { name ->
+                        ManageToolItem(name = name, enabled = name !in currentDisabled)
+                    }
+                    successJson(
+                        json.encodeToString(
+                            ManageToolsListResult.serializer(),
+                            ManageToolsListResult(tools = items)
+                        )
+                    )
+                }
+                "enable", "disable" -> {
+                    val names = args.optionalStringList("names")
+                        ?: return@addTool errorResult("Missing required argument: names")
+                    if (names.isEmpty()) {
+                        return@addTool errorResult("'names' must contain at least one tool name")
+                    }
+                    val available = availableToolNames().toSet()
+                    val unknown = names.filter { it !in available }
+                    if (unknown.isNotEmpty()) {
+                        return@addTool errorResult(
+                            "Unknown tool name(s): ${unknown.joinToString()}. " +
+                                "Available: ${available.joinToString()}"
+                        )
+                    }
+                    if (operation == "disable") {
+                        val reserved = names.filter { it in undisablableTools }
+                        if (reserved.isNotEmpty()) {
+                            return@addTool errorResult(
+                                "Cannot disable reserved tool(s): ${reserved.joinToString()}"
+                            )
+                        }
+                    }
+                    settingsManager.updateSetting {
+                        val next = disabledMcpTools.toMutableSet()
+                        if (operation == "enable") next.removeAll(names.toSet()) else next.addAll(names)
+                        copy(disabledMcpTools = next)
+                    }
+                    applyDisabledSet(settingsManager.settings.value.disabledMcpTools)
+                    successJson(json.encodeToString(OkResult.serializer(), OkResult(ok = true)))
+                }
+                else -> errorResult(
+                    "Unknown operation '$operation'. Expected: list, enable, disable."
+                )
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------
 
@@ -761,6 +947,13 @@ class BossTermMcpServer(
         if (el is JsonNull) return null
         val prim = el.jsonPrimitive
         return prim.floatOrNull ?: prim.content.toFloatOrNull()
+    }
+
+    private fun JsonObject?.optionalStringList(key: String): List<String>? {
+        val el: JsonElement = this?.get(key) ?: return null
+        if (el is JsonNull) return null
+        val arr = el as? JsonArray ?: return null
+        return arr.mapNotNull { (it as? JsonPrimitive)?.content }
     }
 
     // -----------------------------------------------------------------
@@ -851,9 +1044,43 @@ class BossTermMcpServer(
         val stats: DebugConsoleStats
     )
 
+    @Serializable
+    data class ManageToolItem(val name: String, val enabled: Boolean)
+
+    @Serializable
+    data class ManageToolsListResult(val tools: List<ManageToolItem>)
+
     companion object {
         private const val DEFAULT_SCROLLBACK_LINES = 200
         private const val DEFAULT_SEARCH_MAX_MATCHES = 50
         private const val DEFAULT_DEBUG_CHUNKS = 100
+
+        /**
+         * Unprefixed built-in read tool names, in display order. Single source of
+         * truth shared with the settings UI so toggle rows can't drift from the
+         * tools actually registered.
+         */
+        val BUILT_IN_READ_TOOLS: List<String> = listOf(
+            "list_tabs",
+            "get_active_tab",
+            "read_scrollback",
+            "search_output",
+            "get_last_command",
+            "read_debug_console"
+        )
+
+        /** Unprefixed built-in write tool names, in display order. */
+        val BUILT_IN_WRITE_TOOLS: List<String> = listOf(
+            "send_input",
+            "send_signal",
+            "run_in_panel"
+        )
+
+        /**
+         * Tools that may never be disabled. `manage_tools` is the only escape hatch
+         * once everything else has been turned off, so disabling it would brick the
+         * MCP surface.
+         */
+        val UNDISABLABLE_TOOLS: Set<String> = setOf("manage_tools")
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -160,8 +160,10 @@ class BossTermMcpServer(
     private fun registerReadScrollback(server: Server) {
         server.addTool(
             name = toolName("read_scrollback"),
-            description = "Read the last N lines from a tab's terminal buffer (history + visible " +
-                    "screen) as plain UTF-8 text. Trailing whitespace per line is stripped.",
+            description = "Read the last N lines from a tab/pane's terminal buffer " +
+                    "(history + visible screen) as plain UTF-8 text. Trailing whitespace per " +
+                    "line is stripped. When `pane_id` is supplied, reads the specific split " +
+                    "pane (returned by run_in_panel); otherwise reads the focused pane.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -172,6 +174,11 @@ class BossTermMcpServer(
                         put("type", "integer")
                         put("description", "Maximum number of lines to return from the end. Default 200.")
                         put("minimum", 1)
+                    }
+                    putJsonObject("pane_id") {
+                        put("type", "string")
+                        put("description", "Optional specific pane within the tab " +
+                                "(returned by run_in_panel). Omit to read the focused pane.")
                     }
                 },
                 required = listOf("tab_id")
@@ -184,10 +191,16 @@ class BossTermMcpServer(
             if (requested < 1) {
                 return@addTool errorResult("'lines' must be >= 1 (got $requested)")
             }
-            val tab = registry.findTab(tabId)
+            val paneId = args.requireString("pane_id")
+            val state = registry.findState(tabId)
                 ?: return@addTool errorResult("Unknown tab_id: $tabId")
+            val session = state.findSession(tabId, paneId)
+                ?: return@addTool errorResult(
+                    if (paneId != null) "Unknown pane_id '$paneId' in tab '$tabId'"
+                    else "No session for tab_id: $tabId"
+                )
 
-            val snapshot = tab.textBuffer.createSnapshot()
+            val snapshot = session.textBuffer.createSnapshot()
             val totalAvailable = snapshot.historyLinesCount + snapshot.height
             val take = minOf(requested, totalAvailable)
 
@@ -215,11 +228,12 @@ class BossTermMcpServer(
     private fun registerSearchOutput(server: Server) {
         server.addTool(
             name = toolName("search_output"),
-            description = "Regex-search the entire scrollback (history + screen) of a tab. " +
+            description = "Regex-search the entire scrollback (history + screen) of a tab/pane. " +
                     "Returns matching rows with positional info. Row numbers follow buffer " +
                     "convention: negative for history (oldest = -historyLinesCount), 0..height-1 " +
                     "for screen. The response also includes historyLinesCount and height so " +
-                    "clients can convert to 1-based line numbers if desired.",
+                    "clients can convert to 1-based line numbers if desired. When `pane_id` is " +
+                    "supplied, searches that specific split pane; otherwise the focused pane.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -239,6 +253,11 @@ class BossTermMcpServer(
                         put("type", "boolean")
                         put("description", "If true, perform case-insensitive matching. Default false.")
                     }
+                    putJsonObject("pane_id") {
+                        put("type", "string")
+                        put("description", "Optional specific pane within the tab " +
+                                "(returned by run_in_panel). Omit to search the focused pane.")
+                    }
                 },
                 required = listOf("tab_id", "pattern")
             )
@@ -253,8 +272,14 @@ class BossTermMcpServer(
                 return@addTool errorResult("'max_matches' must be >= 1 (got $maxMatches)")
             }
             val ignoreCase = args.optionalBoolean("ignore_case") ?: false
-            val tab = registry.findTab(tabId)
+            val paneId = args.requireString("pane_id")
+            val state = registry.findState(tabId)
                 ?: return@addTool errorResult("Unknown tab_id: $tabId")
+            val session = state.findSession(tabId, paneId)
+                ?: return@addTool errorResult(
+                    if (paneId != null) "Unknown pane_id '$paneId' in tab '$tabId'"
+                    else "No session for tab_id: $tabId"
+                )
 
             val options = if (ignoreCase) setOf(RegexOption.IGNORE_CASE) else emptySet()
             val regex = try {
@@ -263,7 +288,7 @@ class BossTermMcpServer(
                 return@addTool errorResult("Invalid regex: ${e.message ?: e::class.simpleName}")
             }
 
-            val snapshot = tab.textBuffer.createSnapshot()
+            val snapshot = session.textBuffer.createSnapshot()
             val matches = ArrayList<SearchMatch>()
             var truncated = false
 
@@ -355,8 +380,10 @@ class BossTermMcpServer(
     private fun registerSendInput(server: Server) {
         server.addTool(
             name = toolName("send_input"),
-            description = "Write text to the tab's shell stdin. The caller is responsible for " +
-                    "appending a trailing '\\n' if they want a command to actually execute.",
+            description = "Write text to a tab's shell stdin. The caller is responsible for " +
+                    "appending a trailing '\\n' if they want a command to actually execute. " +
+                    "When `pane_id` is supplied (e.g. the value returned by run_in_panel), " +
+                    "writes go to that specific split; otherwise to the tab's primary session.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -367,6 +394,11 @@ class BossTermMcpServer(
                         put("type", "string")
                         put("description", "Raw text to write. Include '\\n' to submit.")
                     }
+                    putJsonObject("pane_id") {
+                        put("type", "string")
+                        put("description", "Optional specific pane within the tab " +
+                                "(returned by run_in_panel). Omit to target the tab's primary session.")
+                    }
                 },
                 required = listOf("tab_id", "text")
             )
@@ -376,13 +408,16 @@ class BossTermMcpServer(
                 ?: return@addTool errorResult("Missing required argument: tab_id")
             val text = args.requireString("text")
                 ?: return@addTool errorResult("Missing required argument: text")
+            val paneId = args.requireString("pane_id")
 
             val state = registry.findState(tabId)
                 ?: return@addTool errorResult("Unknown tab_id: $tabId")
-            val sent = state.write(text, tabId)
-            if (!sent) {
-                return@addTool errorResult("Failed to write to tab_id: $tabId")
-            }
+            val session = state.findSession(tabId, paneId)
+                ?: return@addTool errorResult(
+                    if (paneId != null) "Unknown pane_id '$paneId' in tab '$tabId'"
+                    else "No session for tab_id: $tabId"
+                )
+            session.writeUserInput(text)
             successJson(json.encodeToString(OkResult.serializer(), OkResult(ok = true)))
         }
     }
@@ -394,8 +429,10 @@ class BossTermMcpServer(
     private fun registerSendSignal(server: Server) {
         server.addTool(
             name = toolName("send_signal"),
-            description = "Send a control signal to the tab's shell. Allowed signals: " +
-                    "'ctrl_c' (interrupt), 'ctrl_d' (EOF), 'ctrl_z' (suspend).",
+            description = "Send a control signal to a tab's shell. Allowed signals: " +
+                    "'ctrl_c' (interrupt), 'ctrl_d' (EOF), 'ctrl_z' (suspend). When `pane_id` " +
+                    "is supplied, the signal targets that specific split; otherwise the tab's " +
+                    "primary session.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -406,6 +443,11 @@ class BossTermMcpServer(
                         put("type", "string")
                         put("description", "One of: ctrl_c, ctrl_d, ctrl_z.")
                     }
+                    putJsonObject("pane_id") {
+                        put("type", "string")
+                        put("description", "Optional specific pane within the tab " +
+                                "(returned by run_in_panel).")
+                    }
                 },
                 required = listOf("tab_id", "signal")
             )
@@ -415,21 +457,33 @@ class BossTermMcpServer(
                 ?: return@addTool errorResult("Missing required argument: tab_id")
             val signal = args.requireString("signal")
                 ?: return@addTool errorResult("Missing required argument: signal")
+            val paneId = args.requireString("pane_id")
 
             val state = registry.findState(tabId)
                 ?: return@addTool errorResult("Unknown tab_id: $tabId")
+            val session = state.findSession(tabId, paneId)
+                ?: return@addTool errorResult(
+                    if (paneId != null) "Unknown pane_id '$paneId' in tab '$tabId'"
+                    else "No session for tab_id: $tabId"
+                )
 
-            val delivered = when (signal.lowercase()) {
-                "ctrl_c" -> state.sendCtrlC(tabId)
-                "ctrl_d" -> state.sendInput(byteArrayOf(0x04), tabId)
-                "ctrl_z" -> state.sendInput(byteArrayOf(0x1A), tabId)
+            val bytes = when (signal.lowercase()) {
+                "ctrl_c" -> byteArrayOf(0x03)
+                "ctrl_d" -> byteArrayOf(0x04)
+                "ctrl_z" -> byteArrayOf(0x1A)
                 else -> return@addTool errorResult(
                     "Unknown signal: '$signal'. Expected one of: ctrl_c, ctrl_d, ctrl_z."
                 )
             }
-            if (!delivered) {
-                return@addTool errorResult("Failed to deliver signal to tab_id: $tabId")
-            }
+            // TerminalSession interface doesn't surface writeRawBytes; cast
+            // to the concrete TerminalTab implementation (the only one in
+            // tree — both primary tabs and split-created sessions are
+            // TerminalTab instances).
+            val tab = session as? TerminalTab
+                ?: return@addTool errorResult(
+                    "Session does not support raw byte writes (signal delivery requires TerminalTab)"
+                )
+            tab.writeRawBytes(bytes)
             successJson(json.encodeToString(OkResult.serializer(), OkResult(ok = true)))
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -27,11 +27,16 @@ import kotlinx.serialization.json.putJsonObject
  *
  * This class is transport-agnostic — it only wires tool definitions and
  * handlers onto a [Server] instance. Binding the server to a transport
- * (e.g. Ktor + SSE/HTTP) is the caller's responsibility.
+ * (e.g. Ktor + SSE) is the caller's responsibility.
+ *
+ * The server aggregates tabs from every registered [TabbedTerminalState] via
+ * [McpTerminalRegistry], so a single MCP endpoint can expose all open
+ * Windows. Tab ids are UUIDs (globally unique), which lets tools resolve a
+ * tab back to its owning state without needing a window id.
  *
  * Tool surface (all tools take a `tab_id` argument unless otherwise noted):
- *   - `list_tabs`         — enumerate all open tabs.
- *   - `get_active_tab`    — return the currently active tab, or null.
+ *   - `list_tabs`         — enumerate all open tabs across all windows.
+ *   - `get_active_tab`    — return the active tab of the primary window.
  *   - `read_scrollback`   — read the last N lines from a tab's buffer.
  *   - `search_output`     — regex-search a tab's buffer.
  *   - `get_last_command`  — return the most recently completed OSC 133 command.
@@ -43,12 +48,9 @@ import kotlinx.serialization.json.putJsonObject
  * thread-safe (buffer snapshots, [TabbedTerminalState] input queue) or
  * read-only accesses to [TerminalTab] fields that are themselves
  * thread-safe (`MutableState`, `MutableStateFlow`).
- *
- * @param state The live [TabbedTerminalState] to expose. The server holds a
- *   strong reference for the lifetime of the registered tools.
  */
 class BossTermMcpServer(
-    private val state: TabbedTerminalState
+    private val registry: McpTerminalRegistry = McpTerminalRegistry
 ) {
 
     private val json: Json = Json {
@@ -92,16 +94,17 @@ class BossTermMcpServer(
     private fun registerListTabs(server: Server) {
         server.addTool(
             name = "list_tabs",
-            description = "List all open terminal tabs with their id, title, working directory, " +
-                    "pid, and whether each is the active tab.",
+            description = "List all open terminal tabs across all windows. Each tab includes " +
+                    "id, title, working directory, pid, and isActive (true if the tab is the " +
+                    "currently selected tab of its window).",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {},
                 required = emptyList()
             )
         ) { _ ->
-            val activeId = state.activeTabId
-            val infos = state.tabs.map { it.toTabInfo(activeId) }
-            val payload = ListTabsResult(tabs = infos, activeTabId = activeId)
+            val infos = registry.collectTabInfos()
+            val primaryActiveId = registry.primaryState()?.activeTabId
+            val payload = ListTabsResult(tabs = infos, activeTabId = primaryActiveId)
             successJson(json.encodeToString(ListTabsResult.serializer(), payload))
         }
     }
@@ -113,19 +116,19 @@ class BossTermMcpServer(
     private fun registerGetActiveTab(server: Server) {
         server.addTool(
             name = "get_active_tab",
-            description = "Return information about the currently active tab, or null if no tab is active.",
+            description = "Return the active tab of the primary window (the first window opened " +
+                    "that is still alive), or null if no tab is active.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {},
                 required = emptyList()
             )
         ) { _ ->
-            val activeId = state.activeTabId
-            val info = state.activeTab?.toTabInfo(activeId)
-            val text = if (info == null) {
-                "null"
-            } else {
-                json.encodeToString(TabInfo.serializer(), info)
-            }
+            val primary = registry.primaryState()
+            val activeId = primary?.activeTabId
+            val info = primary?.activeTab?.toTabInfo(activeId)
+            // The literal JSON `null` is valid output — clients calling
+            // JSON.parse get a real null. Cheaper than wrapping in `{tab: null}`.
+            val text = if (info == null) "null" else json.encodeToString(TabInfo.serializer(), info)
             successJson(text)
         }
     }
@@ -137,8 +140,8 @@ class BossTermMcpServer(
     private fun registerReadScrollback(server: Server) {
         server.addTool(
             name = "read_scrollback",
-            description = "Read the last N lines from a tab's terminal buffer (history + visible screen) " +
-                    "as plain UTF-8 text. Trailing whitespace per line is stripped.",
+            description = "Read the last N lines from a tab's terminal buffer (history + visible " +
+                    "screen) as plain UTF-8 text. Trailing whitespace per line is stripped.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -161,7 +164,7 @@ class BossTermMcpServer(
             if (requested < 1) {
                 return@addTool errorResult("'lines' must be >= 1 (got $requested)")
             }
-            val tab = state.getTabById(tabId)
+            val tab = registry.findTab(tabId)
                 ?: return@addTool errorResult("Unknown tab_id: $tabId")
 
             val snapshot = tab.textBuffer.createSnapshot()
@@ -194,7 +197,9 @@ class BossTermMcpServer(
             name = "search_output",
             description = "Regex-search the entire scrollback (history + screen) of a tab. " +
                     "Returns matching rows with positional info. Row numbers follow buffer " +
-                    "convention: negative for history, 0..height-1 for screen.",
+                    "convention: negative for history (oldest = -historyLinesCount), 0..height-1 " +
+                    "for screen. The response also includes historyLinesCount and height so " +
+                    "clients can convert to 1-based line numbers if desired.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -228,7 +233,7 @@ class BossTermMcpServer(
                 return@addTool errorResult("'max_matches' must be >= 1 (got $maxMatches)")
             }
             val ignoreCase = args.optionalBoolean("ignore_case") ?: false
-            val tab = state.getTabById(tabId)
+            val tab = registry.findTab(tabId)
                 ?: return@addTool errorResult("Unknown tab_id: $tabId")
 
             val options = if (ignoreCase) setOf(RegexOption.IGNORE_CASE) else emptySet()
@@ -264,7 +269,12 @@ class BossTermMcpServer(
                 row++
             }
 
-            val payload = SearchOutputResult(matches = matches, truncated = truncated)
+            val payload = SearchOutputResult(
+                matches = matches,
+                truncated = truncated,
+                historyLinesCount = snapshot.historyLinesCount,
+                height = snapshot.height
+            )
             successJson(json.encodeToString(SearchOutputResult.serializer(), payload))
         }
     }
@@ -278,7 +288,10 @@ class BossTermMcpServer(
             name = "get_last_command",
             description = "Return the most recently completed shell command for a tab " +
                     "(as captured via OSC 133), or null if no command has finished yet. " +
-                    "Requires shell integration — see shell-integration.md.",
+                    "Requires shell integration — see shell-integration.md. " +
+                    "Note: `commandText` is currently always null; only `exitCode`, `startedAtMs`, " +
+                    "`finishedAtMs`, `durationMs`, and `cwd` are populated. Capturing the typed " +
+                    "command text reliably is a follow-up.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("tab_id") {
@@ -292,10 +305,12 @@ class BossTermMcpServer(
             val args = request.arguments
             val tabId = args.requireString("tab_id")
                 ?: return@addTool errorResult("Missing required argument: tab_id")
-            val tab = state.getTabById(tabId)
+            val tab = registry.findTab(tabId)
                 ?: return@addTool errorResult("Unknown tab_id: $tabId")
 
             val last = tab.lastCommand.value
+            // Literal JSON `null` when no command has completed yet (same pattern
+            // as get_active_tab).
             val text = if (last == null) {
                 "null"
             } else {
@@ -342,9 +357,11 @@ class BossTermMcpServer(
             val text = args.requireString("text")
                 ?: return@addTool errorResult("Missing required argument: text")
 
+            val state = registry.findState(tabId)
+                ?: return@addTool errorResult("Unknown tab_id: $tabId")
             val sent = state.write(text, tabId)
             if (!sent) {
-                return@addTool errorResult("Unknown tab_id: $tabId")
+                return@addTool errorResult("Failed to write to tab_id: $tabId")
             }
             successJson(json.encodeToString(OkResult.serializer(), OkResult(ok = true)))
         }
@@ -379,6 +396,9 @@ class BossTermMcpServer(
             val signal = args.requireString("signal")
                 ?: return@addTool errorResult("Missing required argument: signal")
 
+            val state = registry.findState(tabId)
+                ?: return@addTool errorResult("Unknown tab_id: $tabId")
+
             val delivered = when (signal.lowercase()) {
                 "ctrl_c" -> state.sendCtrlC(tabId)
                 "ctrl_d" -> state.sendInput(byteArrayOf(0x04), tabId)
@@ -388,7 +408,7 @@ class BossTermMcpServer(
                 )
             }
             if (!delivered) {
-                return@addTool errorResult("Unknown tab_id: $tabId")
+                return@addTool errorResult("Failed to deliver signal to tab_id: $tabId")
             }
             successJson(json.encodeToString(OkResult.serializer(), OkResult(ok = true)))
         }
@@ -397,6 +417,13 @@ class BossTermMcpServer(
     // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------
+
+    private fun McpTerminalRegistry.collectTabInfos(): List<TabInfo> {
+        return allTabs().map { tab ->
+            val owning = findState(tab.id)
+            tab.toTabInfo(owning?.activeTabId)
+        }
+    }
 
     private fun TerminalTab.toTabInfo(activeId: String?): TabInfo {
         return TabInfo(
@@ -435,7 +462,6 @@ class BossTermMcpServer(
         val el: JsonElement = this?.get(key) ?: return null
         if (el is JsonNull) return null
         val prim = el.jsonPrimitive
-        // For strings the SDK passes JsonPrimitive with isString=true; for raw values fall back to content.
         return prim.content
     }
 
@@ -489,7 +515,9 @@ class BossTermMcpServer(
     @Serializable
     data class SearchOutputResult(
         val matches: List<SearchMatch>,
-        val truncated: Boolean
+        val truncated: Boolean,
+        val historyLinesCount: Int,
+        val height: Int
     )
 
     @Serializable

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.compose.mcp
 
 import ai.rever.bossterm.compose.TabbedTerminalState
+import ai.rever.bossterm.compose.debug.ChunkSource
 import ai.rever.bossterm.compose.tabs.TerminalTab
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
@@ -11,6 +12,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -35,13 +37,17 @@ import kotlinx.serialization.json.putJsonObject
  * tab back to its owning state without needing a window id.
  *
  * Tool surface (all tools take a `tab_id` argument unless otherwise noted):
- *   - `list_tabs`         — enumerate all open tabs across all windows.
- *   - `get_active_tab`    — return the active tab of the primary window.
- *   - `read_scrollback`   — read the last N lines from a tab's buffer.
- *   - `search_output`     — regex-search a tab's buffer.
- *   - `get_last_command`  — return the most recently completed OSC 133 command.
- *   - `send_input`        — write raw text to a tab's stdin (queued).
- *   - `send_signal`       — send ctrl_c / ctrl_d / ctrl_z to a tab (queued).
+ *   - `list_tabs`           — enumerate all open tabs across all windows.
+ *   - `get_active_tab`      — return the active tab of the primary window.
+ *   - `read_scrollback`     — read the last N lines from a tab's buffer.
+ *   - `search_output`       — regex-search a tab's buffer.
+ *   - `get_last_command`    — return the most recently completed OSC 133 command.
+ *   - `read_debug_console`  — read recent entries from a tab's debug-data buffer.
+ *
+ * Write tools (gated by `BossTermMcpConfig.allowWriteTools`):
+ *   - `send_input`          — write raw text to a tab's stdin (queued).
+ *   - `send_signal`         — send ctrl_c / ctrl_d / ctrl_z to a tab (queued).
+ *   - `run_in_panel`        — open a new tab / split pane and run a script in it.
  *
  * Threading: tool handlers run on whatever coroutine context the MCP
  * transport dispatches them on. All operations performed here are either
@@ -85,9 +91,11 @@ class BossTermMcpServer(
         registerReadScrollback(server)
         registerSearchOutput(server)
         registerGetLastCommand(server)
+        registerReadDebugConsole(server)
         if (config.allowWriteTools) {
             registerSendInput(server)
             registerSendSignal(server)
+            registerRunInPanel(server)
         }
 
         // Embedder hook: register app-specific tools after built-ins. Names
@@ -425,6 +433,177 @@ class BossTermMcpServer(
     }
 
     // -----------------------------------------------------------------
+    // Tool: run_in_panel
+    // -----------------------------------------------------------------
+
+    private fun registerRunInPanel(server: Server) {
+        server.addTool(
+            name = toolName("run_in_panel"),
+            description = "Open a new terminal panel and write a script to it. Modes: " +
+                    "'new_tab' (fresh tab with initialCommand), 'horizontal_split' (split " +
+                    "below focused pane), 'vertical_split' (split beside focused pane). The " +
+                    "caller appends '\\n' to script if they want it to execute.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("panel") {
+                        put("type", "string")
+                        put("description", "One of: new_tab, horizontal_split, vertical_split.")
+                    }
+                    putJsonObject("script") {
+                        put("type", "string")
+                        put("description", "Raw text to write to the new panel's shell. Include '\\n' to submit.")
+                    }
+                    putJsonObject("tab_id") {
+                        put("type", "string")
+                        put("description", "Optional source tab id. Required for splits; " +
+                                "defaults to the primary window's active tab.")
+                    }
+                    putJsonObject("working_dir") {
+                        put("type", "string")
+                        put("description", "Optional working directory for the new panel. " +
+                                "For splits, defaults to the inherited cwd via OSC 7.")
+                    }
+                },
+                required = listOf("panel", "script")
+            )
+        ) { request ->
+            val args = request.arguments
+            val panel = args.requireString("panel")?.lowercase()
+                ?: return@addTool errorResult("Missing required argument: panel")
+            val script = args.requireString("script")
+                ?: return@addTool errorResult("Missing required argument: script")
+            val requestedTabId = args.requireString("tab_id")
+            val workingDir = args.requireString("working_dir")
+
+            // Resolve the target state. If tab_id given, find the state that
+            // owns it. Otherwise use the primary registered window.
+            val state: TabbedTerminalState = if (requestedTabId != null) {
+                registry.findState(requestedTabId)
+                    ?: return@addTool errorResult("Unknown tab_id: $requestedTabId")
+            } else {
+                registry.primaryState()
+                    ?: return@addTool errorResult("No registered terminal window")
+            }
+
+            when (panel) {
+                "new_tab" -> {
+                    val newId = state.createTab(
+                        workingDir = workingDir,
+                        initialCommand = script
+                    ) ?: return@addTool errorResult("Failed to create tab")
+                    val payload = RunInPanelResult(ok = true, tabId = newId, paneId = null)
+                    successJson(json.encodeToString(RunInPanelResult.serializer(), payload))
+                }
+                "horizontal_split", "vertical_split" -> {
+                    val targetTabId = requestedTabId
+                        ?: state.activeTabId
+                        ?: return@addTool errorResult("No active tab to split")
+                    val paneId = if (panel == "horizontal_split") {
+                        state.splitHorizontal(targetTabId)
+                    } else {
+                        state.splitVertical(targetTabId)
+                    } ?: return@addTool errorResult("Split failed (terminal too small?)")
+                    // After splitFocusedPane the focus moves to the new pane,
+                    // so writeToFocusedPane targets it.
+                    val wrote = state.writeToFocusedPane(script, targetTabId)
+                    if (!wrote) {
+                        return@addTool errorResult("Split succeeded but write to new pane failed")
+                    }
+                    val payload = RunInPanelResult(ok = true, tabId = targetTabId, paneId = paneId)
+                    successJson(json.encodeToString(RunInPanelResult.serializer(), payload))
+                }
+                else -> errorResult(
+                    "Unknown panel: '$panel'. Expected one of: new_tab, horizontal_split, vertical_split."
+                )
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Tool: read_debug_console
+    // -----------------------------------------------------------------
+
+    private fun registerReadDebugConsole(server: Server) {
+        server.addTool(
+            name = toolName("read_debug_console"),
+            description = "Read recent entries from a tab's debug-data buffer (PTY output, " +
+                    "user input, console-log entries). Per-tab circular buffer; cap is " +
+                    "settings.debugMaxChunks (default 1000). Supports incremental polling via " +
+                    "since_index and filtering via sources.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("tab_id") {
+                        put("type", "string")
+                        put("description", "Stable tab id (see list_tabs).")
+                    }
+                    putJsonObject("max_chunks") {
+                        put("type", "integer")
+                        put("description", "Maximum entries to return. Default 100, clamped to 1..1000.")
+                        put("minimum", 1)
+                    }
+                    putJsonObject("since_index") {
+                        put("type", "integer")
+                        put("description", "Return only chunks with index > since_index. " +
+                                "Use the previous response's stats.newestIndex for polling.")
+                    }
+                    putJsonObject("sources") {
+                        put("type", "array")
+                        put(
+                            "description",
+                            "Filter to a subset of sources: PTY_OUTPUT, USER_INPUT, " +
+                                    "EMULATOR_GENERATED, CONSOLE_LOG. Unknown names are " +
+                                    "silently ignored."
+                        )
+                    }
+                },
+                required = listOf("tab_id")
+            )
+        ) { request ->
+            val args = request.arguments
+            val tabId = args.requireString("tab_id")
+                ?: return@addTool errorResult("Missing required argument: tab_id")
+            val tab = registry.findTab(tabId)
+                ?: return@addTool errorResult("Unknown tab_id: $tabId")
+            val collector = tab.debugCollector
+                ?: return@addTool errorResult("Debug collector not initialized for this tab")
+
+            val maxChunks = (args.optionalInt("max_chunks") ?: DEFAULT_DEBUG_CHUNKS)
+                .coerceIn(1, MAX_DEBUG_CHUNKS)
+            val sinceIndex = args.optionalInt("since_index")?.coerceAtLeast(0)
+            val sourcesFilter: Set<ChunkSource>? = (args?.get("sources") as? JsonArray)
+                ?.mapNotNull { item ->
+                    runCatching { ChunkSource.valueOf(item.jsonPrimitive.content) }.getOrNull()
+                }
+                ?.toSet()
+                ?.takeUnless { it.isEmpty() }
+
+            var seq = collector.getDebugChunks().asSequence()
+            if (sinceIndex != null) seq = seq.filter { it.index > sinceIndex }
+            if (sourcesFilter != null) seq = seq.filter { it.source in sourcesFilter }
+            val resultChunks = seq.toList().takeLast(maxChunks).map { chunk ->
+                DebugConsoleChunk(
+                    index = chunk.index,
+                    timestamp = chunk.timestamp,
+                    source = chunk.source.name,
+                    data = String(chunk.data)
+                )
+            }
+
+            val rawStats = collector.getStats()
+            val statsDto = DebugConsoleStats(
+                totalChunks = rawStats.totalChunksRecorded,
+                chunksStored = rawStats.chunksStored,
+                oldestIndex = rawStats.earliestChunkIndex,
+                newestIndex = rawStats.latestChunkIndex,
+                debugEnabled = tab.debugEnabled.value
+            )
+
+            val payload = ReadDebugConsoleResult(chunks = resultChunks, stats = statsDto)
+            successJson(json.encodeToString(ReadDebugConsoleResult.serializer(), payload))
+        }
+    }
+
+    // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------
 
@@ -546,8 +725,41 @@ class BossTermMcpServer(
     @Serializable
     data class ErrorResult(val error: String)
 
+    @Serializable
+    data class RunInPanelResult(
+        val ok: Boolean,
+        val tabId: String,
+        /** Non-null only for split modes — the new pane's session id. */
+        val paneId: String?
+    )
+
+    @Serializable
+    data class DebugConsoleChunk(
+        val index: Int,
+        val timestamp: Long,
+        val source: String,
+        val data: String
+    )
+
+    @Serializable
+    data class DebugConsoleStats(
+        val totalChunks: Int,
+        val chunksStored: Int,
+        val oldestIndex: Int?,
+        val newestIndex: Int?,
+        val debugEnabled: Boolean
+    )
+
+    @Serializable
+    data class ReadDebugConsoleResult(
+        val chunks: List<DebugConsoleChunk>,
+        val stats: DebugConsoleStats
+    )
+
     companion object {
         private const val DEFAULT_SCROLLBACK_LINES = 200
         private const val DEFAULT_SEARCH_MAX_MATCHES = 50
+        private const val DEFAULT_DEBUG_CHUNKS = 100
+        private const val MAX_DEBUG_CHUNKS = 1000
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1,0 +1,517 @@
+package ai.rever.bossterm.compose.mcp
+
+import ai.rever.bossterm.compose.TabbedTerminalState
+import ai.rever.bossterm.compose.tabs.TerminalTab
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * Builds the in-process MCP server that exposes BossTerm tabs/terminals to
+ * external Model Context Protocol clients.
+ *
+ * This class is transport-agnostic — it only wires tool definitions and
+ * handlers onto a [Server] instance. Binding the server to a transport
+ * (e.g. Ktor + SSE/HTTP) is the caller's responsibility.
+ *
+ * Tool surface (all tools take a `tab_id` argument unless otherwise noted):
+ *   - `list_tabs`         — enumerate all open tabs.
+ *   - `get_active_tab`    — return the currently active tab, or null.
+ *   - `read_scrollback`   — read the last N lines from a tab's buffer.
+ *   - `search_output`     — regex-search a tab's buffer.
+ *   - `get_last_command`  — return the most recently completed OSC 133 command.
+ *   - `send_input`        — write raw text to a tab's stdin (queued).
+ *   - `send_signal`       — send ctrl_c / ctrl_d / ctrl_z to a tab (queued).
+ *
+ * Threading: tool handlers run on whatever coroutine context the MCP
+ * transport dispatches them on. All operations performed here are either
+ * thread-safe (buffer snapshots, [TabbedTerminalState] input queue) or
+ * read-only accesses to [TerminalTab] fields that are themselves
+ * thread-safe (`MutableState`, `MutableStateFlow`).
+ *
+ * @param state The live [TabbedTerminalState] to expose. The server holds a
+ *   strong reference for the lifetime of the registered tools.
+ */
+class BossTermMcpServer(
+    private val state: TabbedTerminalState
+) {
+
+    private val json: Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = true
+    }
+
+    /**
+     * Build and return a fully configured [Server] with all BossTerm tools
+     * registered. Caller is responsible for connecting a transport.
+     */
+    fun createServer(): Server {
+        val server = Server(
+            serverInfo = Implementation(
+                name = SERVER_NAME,
+                version = SERVER_VERSION
+            ),
+            options = ServerOptions(
+                capabilities = ServerCapabilities(
+                    tools = ServerCapabilities.Tools(listChanged = true)
+                )
+            )
+        )
+
+        registerListTabs(server)
+        registerGetActiveTab(server)
+        registerReadScrollback(server)
+        registerSearchOutput(server)
+        registerGetLastCommand(server)
+        registerSendInput(server)
+        registerSendSignal(server)
+
+        return server
+    }
+
+    // -----------------------------------------------------------------
+    // Tool: list_tabs
+    // -----------------------------------------------------------------
+
+    private fun registerListTabs(server: Server) {
+        server.addTool(
+            name = "list_tabs",
+            description = "List all open terminal tabs with their id, title, working directory, " +
+                    "pid, and whether each is the active tab.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {},
+                required = emptyList()
+            )
+        ) { _ ->
+            val activeId = state.activeTabId
+            val infos = state.tabs.map { it.toTabInfo(activeId) }
+            val payload = ListTabsResult(tabs = infos, activeTabId = activeId)
+            successJson(json.encodeToString(ListTabsResult.serializer(), payload))
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Tool: get_active_tab
+    // -----------------------------------------------------------------
+
+    private fun registerGetActiveTab(server: Server) {
+        server.addTool(
+            name = "get_active_tab",
+            description = "Return information about the currently active tab, or null if no tab is active.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {},
+                required = emptyList()
+            )
+        ) { _ ->
+            val activeId = state.activeTabId
+            val info = state.activeTab?.toTabInfo(activeId)
+            val text = if (info == null) {
+                "null"
+            } else {
+                json.encodeToString(TabInfo.serializer(), info)
+            }
+            successJson(text)
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Tool: read_scrollback
+    // -----------------------------------------------------------------
+
+    private fun registerReadScrollback(server: Server) {
+        server.addTool(
+            name = "read_scrollback",
+            description = "Read the last N lines from a tab's terminal buffer (history + visible screen) " +
+                    "as plain UTF-8 text. Trailing whitespace per line is stripped.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("tab_id") {
+                        put("type", "string")
+                        put("description", "Stable tab id (see list_tabs).")
+                    }
+                    putJsonObject("lines") {
+                        put("type", "integer")
+                        put("description", "Maximum number of lines to return from the end. Default 200.")
+                        put("minimum", 1)
+                    }
+                },
+                required = listOf("tab_id")
+            )
+        ) { request ->
+            val args = request.arguments
+            val tabId = args.requireString("tab_id")
+                ?: return@addTool errorResult("Missing required argument: tab_id")
+            val requested = args.optionalInt("lines") ?: DEFAULT_SCROLLBACK_LINES
+            if (requested < 1) {
+                return@addTool errorResult("'lines' must be >= 1 (got $requested)")
+            }
+            val tab = state.getTabById(tabId)
+                ?: return@addTool errorResult("Unknown tab_id: $tabId")
+
+            val snapshot = tab.textBuffer.createSnapshot()
+            val totalAvailable = snapshot.historyLinesCount + snapshot.height
+            val take = minOf(requested, totalAvailable)
+
+            // Iterate the most recent `take` rows. Buffer row indices run from
+            // `-historyLinesCount` (oldest) through `height - 1` (bottom of screen).
+            val endExclusive = snapshot.height
+            val startInclusive = endExclusive - take
+            val lines = ArrayList<String>(take)
+            var row = startInclusive
+            while (row < endExclusive) {
+                val text = snapshot.getLine(row).text
+                lines.add(text.trimEnd())
+                row++
+            }
+
+            val payload = ReadScrollbackResult(lines = lines, totalAvailable = totalAvailable)
+            successJson(json.encodeToString(ReadScrollbackResult.serializer(), payload))
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Tool: search_output
+    // -----------------------------------------------------------------
+
+    private fun registerSearchOutput(server: Server) {
+        server.addTool(
+            name = "search_output",
+            description = "Regex-search the entire scrollback (history + screen) of a tab. " +
+                    "Returns matching rows with positional info. Row numbers follow buffer " +
+                    "convention: negative for history, 0..height-1 for screen.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("tab_id") {
+                        put("type", "string")
+                        put("description", "Stable tab id (see list_tabs).")
+                    }
+                    putJsonObject("pattern") {
+                        put("type", "string")
+                        put("description", "Regex pattern. Kotlin/Java regex syntax.")
+                    }
+                    putJsonObject("max_matches") {
+                        put("type", "integer")
+                        put("description", "Maximum matches to return before truncating. Default 50.")
+                        put("minimum", 1)
+                    }
+                    putJsonObject("ignore_case") {
+                        put("type", "boolean")
+                        put("description", "If true, perform case-insensitive matching. Default false.")
+                    }
+                },
+                required = listOf("tab_id", "pattern")
+            )
+        ) { request ->
+            val args = request.arguments
+            val tabId = args.requireString("tab_id")
+                ?: return@addTool errorResult("Missing required argument: tab_id")
+            val pattern = args.requireString("pattern")
+                ?: return@addTool errorResult("Missing required argument: pattern")
+            val maxMatches = args.optionalInt("max_matches") ?: DEFAULT_SEARCH_MAX_MATCHES
+            if (maxMatches < 1) {
+                return@addTool errorResult("'max_matches' must be >= 1 (got $maxMatches)")
+            }
+            val ignoreCase = args.optionalBoolean("ignore_case") ?: false
+            val tab = state.getTabById(tabId)
+                ?: return@addTool errorResult("Unknown tab_id: $tabId")
+
+            val options = if (ignoreCase) setOf(RegexOption.IGNORE_CASE) else emptySet()
+            val regex = try {
+                Regex(pattern, options)
+            } catch (e: Exception) {
+                return@addTool errorResult("Invalid regex: ${e.message ?: e::class.simpleName}")
+            }
+
+            val snapshot = tab.textBuffer.createSnapshot()
+            val matches = ArrayList<SearchMatch>()
+            var truncated = false
+
+            val firstRow = -snapshot.historyLinesCount
+            val lastRowExclusive = snapshot.height
+            var row = firstRow
+            outer@ while (row < lastRowExclusive) {
+                val lineText = snapshot.getLine(row).text
+                for (m in regex.findAll(lineText)) {
+                    if (matches.size >= maxMatches) {
+                        truncated = true
+                        break@outer
+                    }
+                    matches.add(
+                        SearchMatch(
+                            row = row,
+                            line = lineText.trimEnd(),
+                            matchStart = m.range.first,
+                            matchEnd = m.range.last + 1
+                        )
+                    )
+                }
+                row++
+            }
+
+            val payload = SearchOutputResult(matches = matches, truncated = truncated)
+            successJson(json.encodeToString(SearchOutputResult.serializer(), payload))
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Tool: get_last_command
+    // -----------------------------------------------------------------
+
+    private fun registerGetLastCommand(server: Server) {
+        server.addTool(
+            name = "get_last_command",
+            description = "Return the most recently completed shell command for a tab " +
+                    "(as captured via OSC 133), or null if no command has finished yet. " +
+                    "Requires shell integration — see shell-integration.md.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("tab_id") {
+                        put("type", "string")
+                        put("description", "Stable tab id (see list_tabs).")
+                    }
+                },
+                required = listOf("tab_id")
+            )
+        ) { request ->
+            val args = request.arguments
+            val tabId = args.requireString("tab_id")
+                ?: return@addTool errorResult("Missing required argument: tab_id")
+            val tab = state.getTabById(tabId)
+                ?: return@addTool errorResult("Unknown tab_id: $tabId")
+
+            val last = tab.lastCommand.value
+            val text = if (last == null) {
+                "null"
+            } else {
+                val dto = LastCommandDto(
+                    commandText = last.commandText,
+                    exitCode = last.exitCode,
+                    startedAtMs = last.startedAtMs,
+                    finishedAtMs = last.finishedAtMs,
+                    durationMs = last.finishedAtMs - last.startedAtMs,
+                    cwd = last.cwd
+                )
+                json.encodeToString(LastCommandDto.serializer(), dto)
+            }
+            successJson(text)
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Tool: send_input
+    // -----------------------------------------------------------------
+
+    private fun registerSendInput(server: Server) {
+        server.addTool(
+            name = "send_input",
+            description = "Write text to the tab's shell stdin. The caller is responsible for " +
+                    "appending a trailing '\\n' if they want a command to actually execute.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("tab_id") {
+                        put("type", "string")
+                        put("description", "Stable tab id (see list_tabs).")
+                    }
+                    putJsonObject("text") {
+                        put("type", "string")
+                        put("description", "Raw text to write. Include '\\n' to submit.")
+                    }
+                },
+                required = listOf("tab_id", "text")
+            )
+        ) { request ->
+            val args = request.arguments
+            val tabId = args.requireString("tab_id")
+                ?: return@addTool errorResult("Missing required argument: tab_id")
+            val text = args.requireString("text")
+                ?: return@addTool errorResult("Missing required argument: text")
+
+            val sent = state.write(text, tabId)
+            if (!sent) {
+                return@addTool errorResult("Unknown tab_id: $tabId")
+            }
+            successJson(json.encodeToString(OkResult.serializer(), OkResult(ok = true)))
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Tool: send_signal
+    // -----------------------------------------------------------------
+
+    private fun registerSendSignal(server: Server) {
+        server.addTool(
+            name = "send_signal",
+            description = "Send a control signal to the tab's shell. Allowed signals: " +
+                    "'ctrl_c' (interrupt), 'ctrl_d' (EOF), 'ctrl_z' (suspend).",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("tab_id") {
+                        put("type", "string")
+                        put("description", "Stable tab id (see list_tabs).")
+                    }
+                    putJsonObject("signal") {
+                        put("type", "string")
+                        put("description", "One of: ctrl_c, ctrl_d, ctrl_z.")
+                    }
+                },
+                required = listOf("tab_id", "signal")
+            )
+        ) { request ->
+            val args = request.arguments
+            val tabId = args.requireString("tab_id")
+                ?: return@addTool errorResult("Missing required argument: tab_id")
+            val signal = args.requireString("signal")
+                ?: return@addTool errorResult("Missing required argument: signal")
+
+            val delivered = when (signal.lowercase()) {
+                "ctrl_c" -> state.sendCtrlC(tabId)
+                "ctrl_d" -> state.sendInput(byteArrayOf(0x04), tabId)
+                "ctrl_z" -> state.sendInput(byteArrayOf(0x1A), tabId)
+                else -> return@addTool errorResult(
+                    "Unknown signal: '$signal'. Expected one of: ctrl_c, ctrl_d, ctrl_z."
+                )
+            }
+            if (!delivered) {
+                return@addTool errorResult("Unknown tab_id: $tabId")
+            }
+            successJson(json.encodeToString(OkResult.serializer(), OkResult(ok = true)))
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private fun TerminalTab.toTabInfo(activeId: String?): TabInfo {
+        return TabInfo(
+            id = id,
+            title = title.value,
+            cwd = workingDirectory.value,
+            pid = processHandle.value?.getPid(),
+            isActive = id == activeId
+        )
+    }
+
+    private fun successJson(text: String): CallToolResult {
+        return CallToolResult(
+            content = listOf(TextContent(text = text)),
+            isError = false,
+            structuredContent = null,
+            meta = null
+        )
+    }
+
+    private fun errorResult(message: String): CallToolResult {
+        val body = json.encodeToString(ErrorResult.serializer(), ErrorResult(error = message))
+        return CallToolResult(
+            content = listOf(TextContent(text = body)),
+            isError = true,
+            structuredContent = null,
+            meta = null
+        )
+    }
+
+    // -----------------------------------------------------------------
+    // Argument helpers (lenient on numeric/boolean string forms)
+    // -----------------------------------------------------------------
+
+    private fun JsonObject?.requireString(key: String): String? {
+        val el: JsonElement = this?.get(key) ?: return null
+        if (el is JsonNull) return null
+        val prim = el.jsonPrimitive
+        // For strings the SDK passes JsonPrimitive with isString=true; for raw values fall back to content.
+        return prim.content
+    }
+
+    private fun JsonObject?.optionalInt(key: String): Int? {
+        val el: JsonElement = this?.get(key) ?: return null
+        if (el is JsonNull) return null
+        val prim = el.jsonPrimitive
+        return prim.intOrNull ?: prim.content.toIntOrNull()
+    }
+
+    private fun JsonObject?.optionalBoolean(key: String): Boolean? {
+        val el: JsonElement = this?.get(key) ?: return null
+        if (el is JsonNull) return null
+        val prim = el.jsonPrimitive
+        return prim.booleanOrNull ?: prim.content.toBooleanStrictOrNull()
+    }
+
+    // -----------------------------------------------------------------
+    // Wire-format DTOs
+    // -----------------------------------------------------------------
+
+    @Serializable
+    data class TabInfo(
+        val id: String,
+        val title: String,
+        val cwd: String?,
+        val pid: Long?,
+        val isActive: Boolean
+    )
+
+    @Serializable
+    data class ListTabsResult(
+        val tabs: List<TabInfo>,
+        val activeTabId: String?
+    )
+
+    @Serializable
+    data class ReadScrollbackResult(
+        val lines: List<String>,
+        val totalAvailable: Int
+    )
+
+    @Serializable
+    data class SearchMatch(
+        val row: Int,
+        val line: String,
+        val matchStart: Int,
+        val matchEnd: Int
+    )
+
+    @Serializable
+    data class SearchOutputResult(
+        val matches: List<SearchMatch>,
+        val truncated: Boolean
+    )
+
+    @Serializable
+    data class LastCommandDto(
+        val commandText: String?,
+        val exitCode: Int,
+        val startedAtMs: Long,
+        val finishedAtMs: Long,
+        val durationMs: Long,
+        val cwd: String?
+    )
+
+    @Serializable
+    data class OkResult(val ok: Boolean)
+
+    @Serializable
+    data class ErrorResult(val error: String)
+
+    companion object {
+        private const val SERVER_NAME = "bossterm"
+        private const val SERVER_VERSION = "1.0"
+        private const val DEFAULT_SCROLLBACK_LINES = 200
+        private const val DEFAULT_SEARCH_MAX_MATCHES = 50
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -2,6 +2,7 @@ package ai.rever.bossterm.compose.mcp
 
 import ai.rever.bossterm.compose.TabbedTerminalState
 import ai.rever.bossterm.compose.debug.ChunkSource
+import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.tabs.TerminalTab
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
@@ -18,6 +19,7 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.floatOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -463,6 +465,13 @@ class BossTermMcpServer(
                         put("description", "Optional working directory for the new panel. " +
                                 "For splits, defaults to the inherited cwd via OSC 7.")
                     }
+                    putJsonObject("split_ratio") {
+                        put("type", "number")
+                        put("description", "Optional split size (0.05..0.95) — fraction of " +
+                                "the parent's dimension the NEW pane gets. Only meaningful " +
+                                "for horizontal_split / vertical_split. Defaults to the " +
+                                "user-configured `mcpDefaultSplitRatio` setting (typically 0.3).")
+                    }
                 },
                 required = listOf("panel", "script")
             )
@@ -498,10 +507,14 @@ class BossTermMcpServer(
                     val targetTabId = requestedTabId
                         ?: state.activeTabId
                         ?: return@addTool errorResult("No active tab to split")
+                    // Resolve effective ratio: per-call override > user setting > 0.3 fallback.
+                    val configuredDefault = SettingsManager.instance.settings.value.mcpDefaultSplitRatio
+                    val requestedRatio = args.optionalFloat("split_ratio")
+                    val effectiveRatio = (requestedRatio ?: configuredDefault).coerceIn(0.05f, 0.95f)
                     val paneId = if (panel == "horizontal_split") {
-                        state.splitHorizontal(targetTabId)
+                        state.splitHorizontal(targetTabId, ratio = effectiveRatio)
                     } else {
-                        state.splitVertical(targetTabId)
+                        state.splitVertical(targetTabId, ratio = effectiveRatio)
                     } ?: return@addTool errorResult("Split failed (terminal too small?)")
                     // After splitFocusedPane the focus moves to the new pane,
                     // so writeToFocusedPane targets it.
@@ -666,6 +679,13 @@ class BossTermMcpServer(
         if (el is JsonNull) return null
         val prim = el.jsonPrimitive
         return prim.booleanOrNull ?: prim.content.toBooleanStrictOrNull()
+    }
+
+    private fun JsonObject?.optionalFloat(key: String): Float? {
+        val el: JsonElement = this?.get(key) ?: return null
+        if (el is JsonNull) return null
+        val prim = el.jsonPrimitive
+        return prim.floatOrNull ?: prim.content.toFloatOrNull()
     }
 
     // -----------------------------------------------------------------

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -50,7 +50,8 @@ import kotlinx.serialization.json.putJsonObject
  * thread-safe (`MutableState`, `MutableStateFlow`).
  */
 class BossTermMcpServer(
-    private val registry: McpTerminalRegistry = McpTerminalRegistry
+    private val registry: McpTerminalRegistry = McpTerminalRegistry,
+    private val config: BossTermMcpConfig = BossTermMcpConfig()
 ) {
 
     private val json: Json = Json {
@@ -59,6 +60,9 @@ class BossTermMcpServer(
         explicitNulls = true
     }
 
+    /** Returns the built-in tool name with the embedder's configured prefix applied. */
+    private fun toolName(builtin: String): String = config.toolNamePrefix + builtin
+
     /**
      * Build and return a fully configured [Server] with all BossTerm tools
      * registered. Caller is responsible for connecting a transport.
@@ -66,8 +70,8 @@ class BossTermMcpServer(
     fun createServer(): Server {
         val server = Server(
             serverInfo = Implementation(
-                name = SERVER_NAME,
-                version = SERVER_VERSION
+                name = config.serverName,
+                version = config.serverVersion
             ),
             options = ServerOptions(
                 capabilities = ServerCapabilities(
@@ -81,8 +85,14 @@ class BossTermMcpServer(
         registerReadScrollback(server)
         registerSearchOutput(server)
         registerGetLastCommand(server)
-        registerSendInput(server)
-        registerSendSignal(server)
+        if (config.allowWriteTools) {
+            registerSendInput(server)
+            registerSendSignal(server)
+        }
+
+        // Embedder hook: register app-specific tools after built-ins. Names
+        // are NOT prefixed — embedder owns them.
+        config.additionalTools(server)
 
         return server
     }
@@ -93,7 +103,7 @@ class BossTermMcpServer(
 
     private fun registerListTabs(server: Server) {
         server.addTool(
-            name = "list_tabs",
+            name = toolName("list_tabs"),
             description = "List all open terminal tabs across all windows. Each tab includes " +
                     "id, title, working directory, pid, and isActive (true if the tab is the " +
                     "currently selected tab of its window).",
@@ -115,7 +125,7 @@ class BossTermMcpServer(
 
     private fun registerGetActiveTab(server: Server) {
         server.addTool(
-            name = "get_active_tab",
+            name = toolName("get_active_tab"),
             description = "Return the active tab of the primary window (the first window opened " +
                     "that is still alive), or null if no tab is active.",
             inputSchema = ToolSchema(
@@ -139,7 +149,7 @@ class BossTermMcpServer(
 
     private fun registerReadScrollback(server: Server) {
         server.addTool(
-            name = "read_scrollback",
+            name = toolName("read_scrollback"),
             description = "Read the last N lines from a tab's terminal buffer (history + visible " +
                     "screen) as plain UTF-8 text. Trailing whitespace per line is stripped.",
             inputSchema = ToolSchema(
@@ -194,7 +204,7 @@ class BossTermMcpServer(
 
     private fun registerSearchOutput(server: Server) {
         server.addTool(
-            name = "search_output",
+            name = toolName("search_output"),
             description = "Regex-search the entire scrollback (history + screen) of a tab. " +
                     "Returns matching rows with positional info. Row numbers follow buffer " +
                     "convention: negative for history (oldest = -historyLinesCount), 0..height-1 " +
@@ -285,7 +295,7 @@ class BossTermMcpServer(
 
     private fun registerGetLastCommand(server: Server) {
         server.addTool(
-            name = "get_last_command",
+            name = toolName("get_last_command"),
             description = "Return the most recently completed shell command for a tab " +
                     "(as captured via OSC 133), or null if no command has finished yet. " +
                     "Requires shell integration — see shell-integration.md. " +
@@ -334,7 +344,7 @@ class BossTermMcpServer(
 
     private fun registerSendInput(server: Server) {
         server.addTool(
-            name = "send_input",
+            name = toolName("send_input"),
             description = "Write text to the tab's shell stdin. The caller is responsible for " +
                     "appending a trailing '\\n' if they want a command to actually execute.",
             inputSchema = ToolSchema(
@@ -373,7 +383,7 @@ class BossTermMcpServer(
 
     private fun registerSendSignal(server: Server) {
         server.addTool(
-            name = "send_signal",
+            name = toolName("send_signal"),
             description = "Send a control signal to the tab's shell. Allowed signals: " +
                     "'ctrl_c' (interrupt), 'ctrl_d' (EOF), 'ctrl_z' (suspend).",
             inputSchema = ToolSchema(
@@ -537,8 +547,6 @@ class BossTermMcpServer(
     data class ErrorResult(val error: String)
 
     companion object {
-        private const val SERVER_NAME = "bossterm"
-        private const val SERVER_VERSION = "1.0"
         private const val DEFAULT_SCROLLBACK_LINES = 200
         private const val DEFAULT_SEARCH_MAX_MATCHES = 50
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -443,8 +443,12 @@ class BossTermMcpServer(
             name = toolName("run_in_panel"),
             description = "Open a new terminal panel and write a script to it. Modes: " +
                     "'new_tab' (fresh tab with initialCommand), 'horizontal_split' (split " +
-                    "below focused pane), 'vertical_split' (split beside focused pane). The " +
-                    "caller appends '\\n' to script if they want it to execute.",
+                    "below focused pane), 'vertical_split' (split beside focused pane). " +
+                    "Include '\\n' in the script to submit it as a command. " +
+                    "Note: in 'new_tab' mode, the response returns as soon as the tab is " +
+                    "created; the shell may still be initializing for ~1s before the script " +
+                    "actually runs. Use list_tabs / read_scrollback after a short delay if " +
+                    "you need to observe results.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("panel") {
@@ -496,9 +500,15 @@ class BossTermMcpServer(
 
             when (panel) {
                 "new_tab" -> {
+                    // TabController.createTab auto-appends '\n' to
+                    // initialCommand, while the split path uses raw
+                    // writeUserInput (no auto-newline). Normalize a single
+                    // trailing newline so the tool's `\n means submit`
+                    // contract is consistent across all three modes.
+                    val normalizedScript = script.removeSuffix("\n")
                     val newId = state.createTab(
                         workingDir = workingDir,
-                        initialCommand = script
+                        initialCommand = normalizedScript.ifEmpty { null }
                     ) ?: return@addTool errorResult("Failed to create tab")
                     val payload = RunInPanelResult(ok = true, tabId = newId, paneId = null)
                     successJson(json.encodeToString(RunInPanelResult.serializer(), payload))
@@ -580,12 +590,20 @@ class BossTermMcpServer(
             val collector = tab.debugCollector
                 ?: return@addTool errorResult("Debug collector not initialized for this tab")
 
+            // Cap to the user's configured buffer size — bumping
+            // `settings.debugMaxChunks` should actually let MCP read the
+            // deeper history they opted into.
+            val maxAllowed = SettingsManager.instance.settings.value
+                .debugMaxChunks.coerceAtLeast(1)
             val maxChunks = (args.optionalInt("max_chunks") ?: DEFAULT_DEBUG_CHUNKS)
-                .coerceIn(1, MAX_DEBUG_CHUNKS)
+                .coerceIn(1, maxAllowed)
             val sinceIndex = args.optionalInt("since_index")?.coerceAtLeast(0)
             val sourcesFilter: Set<ChunkSource>? = (args?.get("sources") as? JsonArray)
                 ?.mapNotNull { item ->
-                    runCatching { ChunkSource.valueOf(item.jsonPrimitive.content) }.getOrNull()
+                    val raw = item.jsonPrimitive.content
+                    // Case-insensitive lookup — agents writing "pty_output"
+                    // shouldn't silently see zero results.
+                    ChunkSource.entries.firstOrNull { it.name.equals(raw, ignoreCase = true) }
                 }
                 ?.toSet()
                 ?.takeUnless { it.isEmpty() }
@@ -780,6 +798,5 @@ class BossTermMcpServer(
         private const val DEFAULT_SCROLLBACK_LINES = 200
         private const val DEFAULT_SEARCH_MAX_MATCHES = 50
         private const val DEFAULT_DEBUG_CHUNKS = 100
-        private const val MAX_DEBUG_CHUNKS = 1000
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -174,9 +174,23 @@ class BossTermMcpServer(
      * addTool/removeTool sequence could double-register a tool against the SDK's
      * non-thread-safe Server.tools map.
      */
-    fun applyDisabledSet(disabled: Set<String>) {
-        val server = serverRef ?: return
+    /**
+     * Signal that the live [Server] this wrapper was bound to has been torn down
+     * (engine stop or app shutdown). Subsequent [applyDisabledSet] calls become
+     * no-ops. The wrapper itself is not reusable after this — a new instance is
+     * created for each engine start in [BossTermMcpManager].
+     */
+    fun detachServer() {
         synchronized(toolsLock) {
+            serverRef = null
+        }
+    }
+
+    fun applyDisabledSet(disabled: Set<String>) {
+        synchronized(toolsLock) {
+            // Read the ref inside the lock so a concurrent detachServer() can't
+            // null it between the check and the mutations.
+            val server = serverRef ?: return
             for (name in availableToolNames()) {
                 val prefixed = toolName(name)
                 val present = server.tools.containsKey(prefixed)
@@ -383,7 +397,12 @@ class BossTermMcpServer(
                 return@addTool errorResult("Invalid regex: ${e.message ?: e::class.simpleName}")
             }
 
-            val snapshot = session.textBuffer.createSnapshot()
+            // Use the lock-free incremental snapshot for the full-scrollback scan
+            // — matches the codebase's stated 94%-lock-reduction pattern (CLAUDE.md),
+            // and search_output can touch the entire history so the savings matter.
+            // read_scrollback above stays on createSnapshot() because it caps at
+            // the most recent N lines and the lock window is trivially short.
+            val snapshot = session.textBuffer.createIncrementalSnapshot()
             val matches = ArrayList<SearchMatch>()
             var truncated = false
 
@@ -734,7 +753,9 @@ class BossTermMcpServer(
                             "description",
                             "Filter to a subset of sources: PTY_OUTPUT, USER_INPUT, " +
                                     "EMULATOR_GENERATED, CONSOLE_LOG. Unknown names are " +
-                                    "silently ignored."
+                                    "silently dropped. Omit the key entirely to get every " +
+                                    "source; an empty array (or one containing only unknown " +
+                                    "names) returns no chunks."
                         )
                     }
                 },
@@ -757,6 +778,10 @@ class BossTermMcpServer(
             val maxChunks = (args.optionalInt("max_chunks") ?: DEFAULT_DEBUG_CHUNKS)
                 .coerceIn(1, maxAllowed)
             val sinceIndex = args.optionalInt("since_index")?.coerceAtLeast(0)
+            // null only when the caller omitted `sources` entirely (or it wasn't
+            // an array). A supplied-but-empty filter is honored strictly: the
+            // caller explicitly asked for nothing, so return nothing rather than
+            // silently dropping the filter and surprising them with all chunks.
             val sourcesFilter: Set<ChunkSource>? = (args?.get("sources") as? JsonArray)
                 ?.mapNotNull { item ->
                     val raw = item.jsonPrimitive.content
@@ -765,7 +790,6 @@ class BossTermMcpServer(
                     ChunkSource.entries.firstOrNull { it.name.equals(raw, ignoreCase = true) }
                 }
                 ?.toSet()
-                ?.takeUnless { it.isEmpty() }
 
             var seq = collector.getDebugChunks().asSequence()
             if (sinceIndex != null) seq = seq.filter { it.index > sinceIndex }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -580,12 +580,15 @@ class BossTermMcpServer(
                     } else {
                         state.splitVertical(targetTabId, ratio = effectiveRatio)
                     } ?: return@addTool errorResult("Split failed (terminal too small?)")
-                    // After splitFocusedPane the focus moves to the new pane,
-                    // so writeToFocusedPane targets it.
-                    val wrote = state.writeToFocusedPane(script, targetTabId)
-                    if (!wrote) {
-                        return@addTool errorResult("Split succeeded but write to new pane failed")
-                    }
+                    // Write directly to the new pane via its id rather than
+                    // relying on focused-pane state. Avoids any timing race
+                    // where user input or UI re-focuses between splitFocusedPane
+                    // and the write call.
+                    val newSession = state.findSession(targetTabId, paneId)
+                        ?: return@addTool errorResult(
+                            "Split returned paneId '$paneId' but the pane could not be located"
+                        )
+                    newSession.writeUserInput(script)
                     val payload = RunInPanelResult(ok = true, tabId = targetTabId, paneId = paneId)
                     successJson(json.encodeToString(RunInPanelResult.serializer(), payload))
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/LastCommandTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/LastCommandTracker.kt
@@ -1,0 +1,108 @@
+package ai.rever.bossterm.compose.mcp
+
+import ai.rever.bossterm.compose.tabs.TerminalTab
+import ai.rever.bossterm.terminal.model.CommandStateListener
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Immutable record of the most recently completed shell command for a tab.
+ *
+ * Populated from OSC 133 shell-integration sequences (A/B/C/D). See
+ * [CommandStateListener] and `.claude/rules/shell-integration.md` for the
+ * sequence semantics and required shell setup.
+ *
+ * @property commandText Best-effort capture of the command line that ran.
+ *   Currently always `null` because reliably extracting the typed command from
+ *   the text buffer at OSC 133;B time is fragile (multi-line prompts, prompt
+ *   markers not yet present in buffer, RPROMPT, etc.) and we prefer "null over
+ *   wrong". The field is kept so future work can populate it without changing
+ *   the wire shape consumed by the MCP tool.
+ * @property exitCode Process exit code reported by OSC 133;D (0 = success).
+ * @property startedAtMs Epoch millis when OSC 133;B (command start) fired.
+ *   Falls back to the OSC 133;A time, or the finish time if neither was seen.
+ * @property finishedAtMs Epoch millis when OSC 133;D (command finished) fired.
+ * @property cwd Working directory captured at command-start time (OSC 7).
+ *   May be `null` if no OSC 7 had been emitted before the command ran.
+ */
+data class LastCommand(
+    val commandText: String?,
+    val exitCode: Int,
+    val startedAtMs: Long,
+    val finishedAtMs: Long,
+    val cwd: String?
+)
+
+/**
+ * Per-tab tracker that listens for OSC 133 command-state events and publishes
+ * the most recently completed command into [TerminalTab.lastCommand].
+ *
+ * Lifetime: one instance per tab, registered alongside the existing
+ * [ai.rever.bossterm.compose.notification.CommandNotificationHandler]. The
+ * notification handler is left untouched; this listener is additive.
+ *
+ * Threading: listener callbacks may arrive off the UI thread (driven by the
+ * emulator on `Dispatchers.Default`). All mutable state lives in plain fields
+ * on this object — guarded by [lock] for write visibility — and is published
+ * through [TerminalTab.lastCommand] (a [MutableStateFlow], which is
+ * thread-safe). Compose snapshot state is intentionally not touched here.
+ */
+class LastCommandTracker(
+    private val tab: TerminalTab
+) : CommandStateListener {
+
+    private val lock = Any()
+
+    // In-progress state for the currently-running command. Reset on D.
+    private var promptStartedAtMs: Long = 0L
+    private var commandStartedAtMs: Long = 0L
+    private var cwdAtStart: String? = null
+    private var pendingCapture: Boolean = false
+
+    override fun onPromptStarted() {
+        synchronized(lock) {
+            promptStartedAtMs = System.currentTimeMillis()
+        }
+    }
+
+    override fun onCommandStarted() {
+        // OSC 133;B — user pressed Enter, command is about to execute.
+        // Capture CWD now (before the command can chdir) and start the clock.
+        val nowMs = System.currentTimeMillis()
+        val cwdNow = tab.workingDirectory.value
+        synchronized(lock) {
+            commandStartedAtMs = nowMs
+            cwdAtStart = cwdNow
+            pendingCapture = true
+        }
+        // NOTE: We intentionally do NOT attempt to read the command text from
+        // the text buffer here. See [LastCommand.commandText] kdoc.
+    }
+
+    override fun onCommandFinished(exitCode: Int) {
+        val finishedAtMs = System.currentTimeMillis()
+        val started: Long
+        val cwd: String?
+        synchronized(lock) {
+            // If we never saw a B, fall back to A, then to the finish time so
+            // duration is non-negative.
+            started = when {
+                pendingCapture && commandStartedAtMs > 0L -> commandStartedAtMs
+                promptStartedAtMs > 0L -> promptStartedAtMs
+                else -> finishedAtMs
+            }
+            cwd = cwdAtStart ?: tab.workingDirectory.value
+            // Reset transient state for the next command.
+            commandStartedAtMs = 0L
+            cwdAtStart = null
+            pendingCapture = false
+        }
+
+        tab.lastCommand.value = LastCommand(
+            commandText = null,
+            exitCode = exitCode,
+            startedAtMs = started,
+            finishedAtMs = finishedAtMs,
+            cwd = cwd
+        )
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -44,9 +44,14 @@ enum class McpAttachTarget(
     val persistenceKey: String,
     /** Command run first to remove any existing entry. Errors ignored. `{NAME}` is replaced. */
     private val removeCommand: List<String>?,
-    /** Primary command. `{URL}` and `{NAME}` get replaced at call time. */
-    private val addCommand: List<String>,
-    /** Help text + ready-to-paste config when the shell-out fails. */
+    /**
+     * Primary command. `{URL}` and `{NAME}` get replaced at call time. `null`
+     * marks the CLI as having no non-interactive `mcp add` form — the attach
+     * helper skips the shell-out entirely and goes straight to the clipboard
+     * fallback. (Currently OpenCode, which only exposes a TUI prompt.)
+     */
+    private val addCommand: List<String>?,
+    /** Help text + ready-to-paste config when the shell-out fails or is skipped. */
     private val clipboardFallback: String
 ) {
     CLAUDE_CODE(
@@ -106,8 +111,13 @@ enum class McpAttachTarget(
     OPENCODE(
         displayName = "OpenCode",
         persistenceKey = "OPENCODE",
-        removeCommand = listOf("opencode", "mcp", "remove", "{NAME}"),
-        addCommand = listOf("opencode", "mcp", "add", "{NAME}", "--transport", "sse", "{URL}"),
+        // opencode 0.x's `mcp add` is an interactive TUI prompt with no
+        // positional / flag form — running it from a non-tty parent just
+        // prints help and exits 1. Mark addCommand = null so the attacher
+        // skips the shell-out and goes straight to clipboard. removeCommand
+        // is set to null for symmetry (we shouldn't try to invoke it either).
+        removeCommand = null,
+        addCommand = null,
         clipboardFallback = """
             // Merge into ~/.config/opencode/opencode.json
             {
@@ -121,8 +131,8 @@ enum class McpAttachTarget(
         """.trimIndent()
     );
 
-    fun resolvedAddCommand(name: String, url: String): List<String> =
-        addCommand.map { it.replace("{NAME}", name).replace("{URL}", url) }
+    fun resolvedAddCommand(name: String, url: String): List<String>? =
+        addCommand?.map { it.replace("{NAME}", name).replace("{URL}", url) }
 
     fun resolvedRemoveCommand(name: String): List<String>? =
         removeCommand?.map { it.replace("{NAME}", name) }
@@ -206,6 +216,22 @@ object McpCliAttacher {
                 }
 
                 val cmd = target.resolvedAddCommand(serverName, url)
+                if (cmd == null) {
+                    // CLI has no non-interactive `mcp add` (e.g. OpenCode TUI
+                    // prompt). Skip the shell-out and drop the config snippet
+                    // on the clipboard so the user can paste it manually.
+                    log.info(
+                        "{} has no scriptable `mcp add` — {}",
+                        target.displayName,
+                        if (quiet) "skipping (quiet mode)" else "copying fallback to clipboard"
+                    )
+                    if (!quiet) copyToClipboard(target.resolvedClipboard(serverName, url))
+                    val suffix = if (quiet) "" else " — config copied to clipboard"
+                    return@withContext McpAttachResult.CopiedToClipboard(
+                        target,
+                        "manual setup required (no scriptable `mcp add`)$suffix"
+                    )
+                }
                 log.info("Attaching {} via: {}", target.displayName, cmd.joinToString(" "))
                 val result = runProcess(cmd)
                 if (result.exitCode == 0) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -212,16 +212,25 @@ object McpCliAttacher {
                     log.info("Attach succeeded for {}", target.displayName)
                     McpAttachResult.Success(target, result.output.trim().take(160))
                 } else {
-                    val reason = if (result.timedOut) {
+                    val baseReason = if (result.timedOut) {
                         "timed out after ${PROCESS_TIMEOUT_SECONDS}s"
                     } else {
                         "exit ${result.exitCode}"
                     }
-                    log.warn("Attach for {} failed ({}); {}", target.displayName, reason,
+                    // Surface the CLI's own last error line so the user can
+                    // tell e.g. "MCP is disabled by your administrator" apart
+                    // from generic "exit 1" failures.
+                    val cliMessage = result.output.lastErrorLine()
+                    val combinedReason = if (cliMessage.isNullOrEmpty()) {
+                        baseReason
+                    } else {
+                        "$baseReason: $cliMessage"
+                    }
+                    log.warn("Attach for {} failed ({}); {}", target.displayName, combinedReason,
                         if (quiet) "quiet mode — clipboard untouched" else "copying fallback to clipboard")
                     if (!quiet) copyToClipboard(target.resolvedClipboard(serverName, url))
                     val suffix = if (quiet) "" else " — config copied to clipboard"
-                    McpAttachResult.CopiedToClipboard(target, "$reason$suffix")
+                    McpAttachResult.CopiedToClipboard(target, "$combinedReason$suffix")
                 }
             } catch (e: CancellationException) {
                 // Coroutine cancellation must propagate untouched — never
@@ -303,6 +312,22 @@ object McpCliAttacher {
             }
         }
     }
+
+    /**
+     * Pull the last non-blank line from a CLI's combined stdout+stderr so we
+     * can include it in the toast / log when a shell-out fails. Trims to a
+     * reasonable length and strips ANSI sequences that some CLIs leak.
+     */
+    private fun String.lastErrorLine(): String? {
+        if (isBlank()) return null
+        val stripped = replace(ANSI_ESCAPE_REGEX, "")
+        return stripped.lineSequence()
+            .map { it.trim() }
+            .lastOrNull { it.isNotEmpty() }
+            ?.take(160)
+    }
+
+    private val ANSI_ESCAPE_REGEX = Regex("\\[[;\\d]*[a-zA-Z]")
 
     private fun copyToClipboard(text: String) {
         try {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -78,8 +78,20 @@ enum class McpAttachTarget(
     GEMINI(
         displayName = "Gemini CLI",
         persistenceKey = "GEMINI",
+        // Verified against `gemini mcp add --help` (gemini-cli 0.28.x):
+        //   Usage: gemini mcp add [options] <name> <commandOrUrl> [args...]
+        // The previous "{NAME} --transport sse {URL}" order had Gemini
+        // parse "--transport" as the commandOrUrl positional → exit 52.
+        // `--scope user` writes to the user-global config file rather
+        // than the project-local one, matching the behavior of the
+        // other CLIs' `mcp add` defaults.
         removeCommand = listOf("gemini", "mcp", "remove", "{NAME}"),
-        addCommand = listOf("gemini", "mcp", "add", "{NAME}", "--transport", "sse", "{URL}"),
+        addCommand = listOf(
+            "gemini", "mcp", "add",
+            "{NAME}", "{URL}",
+            "--transport", "sse",
+            "--scope", "user"
+        ),
         clipboardFallback = """
             // Merge into ~/.gemini/settings.json
             {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -141,18 +141,24 @@ object McpCliAttacher {
     suspend fun attach(target: McpAttachTarget, serverName: String, port: Int): McpAttachResult =
         withContext(Dispatchers.IO) {
             val url = "http://127.0.0.1:$port/mcp"
-
-            // First, best-effort remove. Many CLIs' `mcp add` is not
-            // idempotent — this turns "already exists" errors into a
-            // silent no-op so a re-click of the button just works.
-            target.resolvedRemoveCommand(serverName)?.let { removeCmd ->
-                runProcess(removeCmd, allowFailure = true)
-            }
-
-            val cmd = target.resolvedAddCommand(serverName, url)
-            log.info("Attaching {} via: {}", target.displayName, cmd.joinToString(" "))
             try {
-                val result = runProcess(cmd, allowFailure = false)
+                // First, best-effort remove. Many CLIs' `mcp add` is not
+                // idempotent — this turns "already exists" errors into a
+                // silent no-op so a re-click of the button just works.
+                // Wrapped in its own try so a missing binary on remove
+                // doesn't short-circuit the whole attempt (although the
+                // outer catch would still reach a CopiedToClipboard).
+                target.resolvedRemoveCommand(serverName)?.let { removeCmd ->
+                    try {
+                        runProcess(removeCmd)
+                    } catch (_: Throwable) {
+                        // ignore: idempotency convenience only
+                    }
+                }
+
+                val cmd = target.resolvedAddCommand(serverName, url)
+                log.info("Attaching {} via: {}", target.displayName, cmd.joinToString(" "))
+                val result = runProcess(cmd)
                 if (result.exitCode == 0) {
                     log.info("Attach succeeded for {}", target.displayName)
                     McpAttachResult.Success(target, result.output.trim().take(160))
@@ -184,13 +190,10 @@ object McpCliAttacher {
      * Run [cmd] with a hard 15s timeout. Closes the child's stdin immediately
      * to defuse interactive prompts, and waits for the process before reading
      * stdout — so a hung CLI gets killed by destroyForcibly instead of
-     * stalling our read forever.
-     *
-     * If [allowFailure], non-zero exit and timeouts are returned as-is
-     * (caller decides what to do). Otherwise the caller treats anything
-     * non-zero as failure.
+     * stalling our read forever. The caller decides how to interpret
+     * non-zero exits / timeouts.
      */
-    private fun runProcess(cmd: List<String>, allowFailure: Boolean): ProcessOutcome {
+    private fun runProcess(cmd: List<String>): ProcessOutcome {
         val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
         // Signal EOF to any CLI that might be waiting on stdin.
         try {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -34,6 +34,12 @@ import java.util.concurrent.TimeUnit
  */
 enum class McpAttachTarget(
     val displayName: String,
+    /**
+     * Stable string written into settings.json's `mcpAttachedTo` set.
+     * Keep these values frozen across enum renames — old persisted state
+     * depends on them. New targets must pick a fresh, non-colliding key.
+     */
+    val persistenceKey: String,
     /** Command run first to remove any existing entry. Errors ignored. `{NAME}` is replaced. */
     private val removeCommand: List<String>?,
     /** Primary command. `{URL}` and `{NAME}` get replaced at call time. */
@@ -43,12 +49,14 @@ enum class McpAttachTarget(
 ) {
     CLAUDE_CODE(
         displayName = "Claude Code",
+        persistenceKey = "CLAUDE_CODE",
         removeCommand = listOf("claude", "mcp", "remove", "{NAME}"),
         addCommand = listOf("claude", "mcp", "add", "--transport", "sse", "{NAME}", "{URL}"),
         clipboardFallback = "claude mcp add --transport sse {NAME} {URL}"
     ),
     CODEX(
         displayName = "Codex",
+        persistenceKey = "CODEX",
         removeCommand = listOf("codex", "mcp", "remove", "{NAME}"),
         addCommand = listOf("codex", "mcp", "add", "{NAME}", "--transport", "sse", "{URL}"),
         clipboardFallback = """
@@ -60,6 +68,7 @@ enum class McpAttachTarget(
     ),
     GEMINI(
         displayName = "Gemini CLI",
+        persistenceKey = "GEMINI",
         removeCommand = listOf("gemini", "mcp", "remove", "{NAME}"),
         addCommand = listOf("gemini", "mcp", "add", "{NAME}", "--transport", "sse", "{URL}"),
         clipboardFallback = """
@@ -75,6 +84,7 @@ enum class McpAttachTarget(
     ),
     OPENCODE(
         displayName = "OpenCode",
+        persistenceKey = "OPENCODE",
         removeCommand = listOf("opencode", "mcp", "remove", "{NAME}"),
         addCommand = listOf("opencode", "mcp", "add", "{NAME}", "--transport", "sse", "{URL}"),
         clipboardFallback = """
@@ -98,6 +108,12 @@ enum class McpAttachTarget(
 
     fun resolvedClipboard(name: String, url: String): String =
         clipboardFallback.replace("{NAME}", name).replace("{URL}", url)
+
+    companion object {
+        /** Look up a target by its stable [persistenceKey]. Null if unknown. */
+        fun fromPersistenceKey(key: String): McpAttachTarget? =
+            entries.firstOrNull { it.persistenceKey == key }
+    }
 }
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -9,6 +9,35 @@ import java.awt.datatransfer.StringSelection
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
+// Node one-liners that edit ~/.config/opencode/opencode.json directly —
+// OpenCode's own `mcp add` is an interactive TUI prompt with no scripted
+// form. Each script takes argv positional[s]: NAME (and URL for the add
+// variant). Node is guaranteed to be on PATH wherever `opencode` is
+// installed (OpenCode ships as an npm package), so the dependency is
+// essentially free.
+//
+// Kept as top-level file-private constants because Kotlin enum entries
+// can't reference their own companion-object members at construction
+// time — the companion initializes after the entries.
+private const val OPENCODE_ADD_SCRIPT = "" +
+    "const fs=require('fs'),os=require('os'),p=require('path');" +
+    "const f=os.homedir()+'/.config/opencode/opencode.json';" +
+    "fs.mkdirSync(p.dirname(f),{recursive:true});" +
+    "const c=fs.existsSync(f)&&fs.statSync(f).size>0?JSON.parse(fs.readFileSync(f,'utf8')):{};" +
+    "c.mcp=c.mcp||{};" +
+    "c.mcp[process.argv[1]]={type:'remote',url:process.argv[2],enabled:true};" +
+    "fs.writeFileSync(f,JSON.stringify(c,null,2));" +
+    "console.log('Wrote '+f);"
+
+private const val OPENCODE_REMOVE_SCRIPT = "" +
+    "const fs=require('fs'),os=require('os');" +
+    "const f=os.homedir()+'/.config/opencode/opencode.json';" +
+    "if(!fs.existsSync(f))process.exit(0);" +
+    "const c=JSON.parse(fs.readFileSync(f,'utf8')||'{}');" +
+    "if(!c.mcp||!c.mcp[process.argv[1]])process.exit(0);" +
+    "delete c.mcp[process.argv[1]];" +
+    "fs.writeFileSync(f,JSON.stringify(c,null,2));"
+
 /**
  * One-click attach helper that registers this BossTerm MCP endpoint with a
  * third-party AI CLI via the CLI's native `mcp` subcommand. Falls back to
@@ -111,20 +140,27 @@ enum class McpAttachTarget(
     OPENCODE(
         displayName = "OpenCode",
         persistenceKey = "OPENCODE",
-        // opencode 0.x's `mcp add` is an interactive TUI prompt with no
-        // positional / flag form — running it from a non-tty parent just
-        // prints help and exits 1. Mark addCommand = null so the attacher
-        // skips the shell-out and goes straight to clipboard. removeCommand
-        // is set to null for symmetry (we shouldn't try to invoke it either).
-        removeCommand = null,
-        addCommand = null,
+        // opencode 1.x's `mcp add` is an interactive TUI prompt with no
+        // scriptable form. Workaround: edit `~/.config/opencode/opencode.json`
+        // directly via a tiny node one-liner. node is guaranteed to be on
+        // PATH whenever `opencode` is installed (opencode ships as an npm
+        // package), so the dependency is essentially free.
+        removeCommand = listOf(
+            "node", "-e", OPENCODE_REMOVE_SCRIPT,
+            "{NAME}"
+        ),
+        addCommand = listOf(
+            "node", "-e", OPENCODE_ADD_SCRIPT,
+            "{NAME}", "{URL}"
+        ),
         clipboardFallback = """
             // Merge into ~/.config/opencode/opencode.json
             {
               "mcp": {
                 "{NAME}": {
                   "type": "remote",
-                  "url": "{URL}"
+                  "url": "{URL}",
+                  "enabled": true
                 }
               }
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -21,16 +21,18 @@ import java.util.concurrent.TimeUnit
  * `http://127.0.0.1:<port>` endpoint.
  *
  * Tested CLI shapes (last verified May 2026):
- *  - Claude Code:  `claude mcp add --transport sse <name> <url>` (verified)
- *  - Codex:        `codex mcp add <name> --transport sse <url>` (best-effort; falls back to ~/.codex/config.toml snippet)
- *  - Gemini CLI:   `gemini mcp add <name> --transport sse <url>` (best-effort; falls back to ~/.gemini/settings.json snippet)
- *  - OpenCode:     `opencode mcp add <name> --transport sse <url>` (best-effort; falls back to ~/.config/opencode/opencode.json snippet)
+ *  - Claude Code: `claude mcp add --transport sse <name> <url>` (verified)
+ *  - Codex 0.130: `codex mcp add <name> --url <url>` (registers OK, but
+ *      Codex only speaks streamable HTTP — runtime connection to BossTerm's
+ *      current SSE-only SDK will fail until the SDK is upgraded)
+ *  - Gemini 0.28: `gemini mcp add <name> --transport sse <url>` (verified)
+ *  - OpenCode 1.1: `opencode mcp add` is interactive in this version, no
+ *      flags accepted — will exit non-zero, clipboard fallback fires.
  *
- * If any of the best-effort commands turn out to have a different
- * subcommand in your installed version, the clipboard fallback path
- * handles it gracefully — the only visual symptom is the amber
- * "exit N — config copied to clipboard" status instead of the green
- * success line.
+ * If any best-effort command turns out to have a different subcommand
+ * in your installed version, the clipboard fallback path handles it
+ * gracefully — visual symptom is the amber "exit N — config copied to
+ * clipboard" status.
  */
 enum class McpAttachTarget(
     val displayName: String,
@@ -57,12 +59,19 @@ enum class McpAttachTarget(
     CODEX(
         displayName = "Codex",
         persistenceKey = "CODEX",
+        // codex-cli 0.130 uses `--url <url>` and only supports streamable
+        // HTTP (no SSE client). The registration will succeed but at
+        // runtime Codex won't actually connect to BossTerm's SDK-0.8.3
+        // SSE endpoint — that needs an SDK upgrade to expose streamable
+        // HTTP transport. Tracked as a follow-up.
         removeCommand = listOf("codex", "mcp", "remove", "{NAME}"),
-        addCommand = listOf("codex", "mcp", "add", "{NAME}", "--transport", "sse", "{URL}"),
+        addCommand = listOf("codex", "mcp", "add", "{NAME}", "--url", "{URL}"),
         clipboardFallback = """
             # Append to ~/.codex/config.toml
+            # Note: codex only speaks streamable HTTP; BossTerm currently
+            # serves SSE so the runtime connection will fail until the SDK
+            # is upgraded.
             [mcp_servers.{NAME}]
-            type = "sse"
             url = "{URL}"
         """.trimIndent()
     ),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -348,6 +348,13 @@ object McpCliAttacher {
             } catch (_: Throwable) {
                 // ignore
             }
+            // We waitFor() before reading stdout. This is safe because `mcp add`
+            // output is at most a few lines of status text — far below the OS
+            // pipe buffer (~64 KB on Linux, ~8 KB on small Windows shells). If a
+            // future CLI ever spams more than that without exiting, it would
+            // block on its write and we'd hit the 15 s timeout instead of a
+            // clean read. If that becomes a problem, drain inputStream on a
+            // worker thread alongside the waitFor.
             val finished = try {
                 process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             } catch (e: InterruptedException) {
@@ -401,7 +408,10 @@ object McpCliAttacher {
             ?.take(160)
     }
 
-    private val ANSI_ESCAPE_REGEX = Regex("\\[[;\\d]*[a-zA-Z]")
+    // CSI-form ANSI escapes: ESC '[' params* final. Covers SGR / cursor
+    // sequences a CLI typically emits in `mcp add` output. Does not cover
+    // OSC / DCS / single-char escapes — those don't appear in CLI status text.
+    private val ANSI_ESCAPE_REGEX = Regex("\\u001B\\[[;\\d]*[a-zA-Z]")
 
     private fun copyToClipboard(text: String) {
         try {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -138,8 +138,16 @@ object McpCliAttacher {
      * @param serverName MCP identifier the third-party CLI will use. Pass
      *   `BossTermMcpConfig.serverName` so embedders' brand is honored.
      * @param port loopback port the server is bound to.
+     * @param quiet when true, failures don't write the clipboard fallback
+     *   (used by the manager's auto-reattach on startup so a missing CLI
+     *   doesn't pollute the user's clipboard at launch).
      */
-    suspend fun attach(target: McpAttachTarget, serverName: String, port: Int): McpAttachResult =
+    suspend fun attach(
+        target: McpAttachTarget,
+        serverName: String,
+        port: Int,
+        quiet: Boolean = false
+    ): McpAttachResult =
         withContext(Dispatchers.IO) {
             val url = "http://127.0.0.1:$port/mcp"
             try {
@@ -169,9 +177,11 @@ object McpCliAttacher {
                     } else {
                         "exit ${result.exitCode}"
                     }
-                    log.warn("Attach for {} failed ({}); copying fallback to clipboard", target.displayName, reason)
-                    copyToClipboard(target.resolvedClipboard(serverName, url))
-                    McpAttachResult.CopiedToClipboard(target, "$reason — config copied to clipboard")
+                    log.warn("Attach for {} failed ({}); {}", target.displayName, reason,
+                        if (quiet) "quiet mode — clipboard untouched" else "copying fallback to clipboard")
+                    if (!quiet) copyToClipboard(target.resolvedClipboard(serverName, url))
+                    val suffix = if (quiet) "" else " — config copied to clipboard"
+                    McpAttachResult.CopiedToClipboard(target, "$reason$suffix")
                 }
             } catch (e: CancellationException) {
                 // Coroutine cancellation must propagate untouched — never
@@ -179,13 +189,16 @@ object McpCliAttacher {
                 throw e
             } catch (e: IOException) {
                 // Binary not on PATH is the most common cause.
-                log.warn("Could not spawn {} ({}); copying fallback to clipboard", target.displayName, e.message)
-                copyToClipboard(target.resolvedClipboard(serverName, url))
-                McpAttachResult.CopiedToClipboard(target, "CLI not found — config copied to clipboard")
+                log.warn("Could not spawn {} ({}); {}", target.displayName, e.message,
+                    if (quiet) "quiet mode — clipboard untouched" else "copying fallback to clipboard")
+                if (!quiet) copyToClipboard(target.resolvedClipboard(serverName, url))
+                val suffix = if (quiet) "" else " — config copied to clipboard"
+                McpAttachResult.CopiedToClipboard(target, "CLI not found$suffix")
             } catch (e: Exception) {
                 log.warn("Unexpected error attaching {}: {}", target.displayName, e.message)
-                copyToClipboard(target.resolvedClipboard(serverName, url))
-                McpAttachResult.CopiedToClipboard(target, "${e::class.simpleName} — config copied to clipboard")
+                if (!quiet) copyToClipboard(target.resolvedClipboard(serverName, url))
+                val suffix = if (quiet) "" else " — config copied to clipboard"
+                McpAttachResult.CopiedToClipboard(target, "${e::class.simpleName}$suffix")
             }
         }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -1,0 +1,136 @@
+package ai.rever.bossterm.compose.mcp
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * The four AI CLIs we expose one-click attach buttons for in the MCP
+ * settings panel. Each target has both a primary shell command we'll
+ * attempt to run and a human-readable fallback string we drop on the
+ * clipboard if the binary isn't installed or the command fails.
+ *
+ * URLs are templated with the placeholder `{URL}` so the resolved
+ * endpoint (`http://127.0.0.1:<port>/mcp`) gets substituted at call time.
+ */
+enum class McpAttachTarget(
+    val displayName: String,
+    /** ProcessBuilder command list. `{URL}` gets replaced. */
+    private val command: List<String>,
+    /** Help text + ready-to-paste config when the shell-out fails. */
+    private val clipboardFallback: String
+) {
+    CLAUDE_CODE(
+        displayName = "Claude Code",
+        command = listOf("claude", "mcp", "add", "--transport", "sse", "bossterm", "{URL}"),
+        clipboardFallback = "claude mcp add --transport sse bossterm {URL}"
+    ),
+    CODEX(
+        displayName = "Codex",
+        command = listOf("codex", "mcp", "add", "bossterm", "--transport", "sse", "{URL}"),
+        clipboardFallback = """
+            # Add to ~/.codex/config.toml
+            [mcp_servers.bossterm]
+            type = "sse"
+            url = "{URL}"
+        """.trimIndent()
+    ),
+    GEMINI(
+        displayName = "Gemini CLI",
+        command = listOf("gemini", "mcp", "add", "bossterm", "--transport", "sse", "{URL}"),
+        clipboardFallback = """
+            // Add to ~/.gemini/settings.json under mcpServers
+            "bossterm": {
+              "httpUrl": "{URL}"
+            }
+        """.trimIndent()
+    ),
+    OPENCODE(
+        displayName = "OpenCode",
+        command = listOf("opencode", "mcp", "add", "bossterm", "--transport", "sse", "{URL}"),
+        clipboardFallback = """
+            // Add to ~/.config/opencode/opencode.json under mcp
+            "bossterm": {
+              "type": "remote",
+              "url": "{URL}"
+            }
+        """.trimIndent()
+    );
+
+    fun resolvedCommand(url: String): List<String> = command.map { it.replace("{URL}", url) }
+    fun resolvedClipboard(url: String): String = clipboardFallback.replace("{URL}", url)
+}
+
+/**
+ * Result of a one-click attach attempt. The UI uses these to render an
+ * inline status line under each button.
+ */
+sealed class McpAttachResult {
+    abstract val target: McpAttachTarget
+
+    /** The CLI accepted the registration. `detail` is up to ~120 chars of output. */
+    data class Success(override val target: McpAttachTarget, val detail: String) : McpAttachResult()
+
+    /** Binary missing or command failed — fallback text was dropped on the clipboard. */
+    data class CopiedToClipboard(
+        override val target: McpAttachTarget,
+        val reason: String
+    ) : McpAttachResult()
+}
+
+/**
+ * Best-effort registration of this BossTerm MCP endpoint with a third-party
+ * AI CLI. Tries the CLI's native `mcp add` subcommand; on failure (binary
+ * not on PATH, command not supported, non-zero exit) the resolved config
+ * snippet is written to the system clipboard so the user can paste it
+ * manually.
+ *
+ * Pure I/O — invoke from a coroutine on [Dispatchers.IO].
+ */
+object McpCliAttacher {
+
+    private val log = LoggerFactory.getLogger(McpCliAttacher::class.java)
+
+    suspend fun attach(target: McpAttachTarget, port: Int): McpAttachResult =
+        withContext(Dispatchers.IO) {
+            val url = "http://127.0.0.1:$port/mcp"
+            val cmd = target.resolvedCommand(url)
+            log.info("Attaching {} via: {}", target.displayName, cmd.joinToString(" "))
+            try {
+                val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+                val output = process.inputStream.bufferedReader().readText()
+                val finished = process.waitFor(15, TimeUnit.SECONDS)
+                if (finished && process.exitValue() == 0) {
+                    log.info("Attach succeeded for {}: {}", target.displayName, output.trim())
+                    McpAttachResult.Success(target, output.trim().take(160))
+                } else {
+                    if (!finished) process.destroyForcibly()
+                    val reason = if (!finished) "timed out after 15s" else "exit ${process.exitValue()}"
+                    log.warn("Attach for {} failed ({}); copying fallback to clipboard", target.displayName, reason)
+                    copyToClipboard(target.resolvedClipboard(url))
+                    McpAttachResult.CopiedToClipboard(target, "$reason — config copied to clipboard")
+                }
+            } catch (e: IOException) {
+                // Binary not on PATH is the most common cause.
+                log.warn("Could not spawn {} ({}); copying fallback to clipboard", target.displayName, e.message)
+                copyToClipboard(target.resolvedClipboard(url))
+                McpAttachResult.CopiedToClipboard(target, "CLI not found — config copied to clipboard")
+            } catch (e: Exception) {
+                log.warn("Unexpected error attaching {}: {}", target.displayName, e.message)
+                copyToClipboard(target.resolvedClipboard(url))
+                McpAttachResult.CopiedToClipboard(target, "${e::class.simpleName} — config copied to clipboard")
+            }
+        }
+
+    private fun copyToClipboard(text: String) {
+        try {
+            Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(text), null)
+        } catch (e: Throwable) {
+            log.warn("Failed to write to system clipboard: {}", e.message)
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -86,9 +86,21 @@ enum class McpAttachTarget(
     CLAUDE_CODE(
         displayName = "Claude Code",
         persistenceKey = "CLAUDE_CODE",
+        // `--scope user` is critical: without it, `claude mcp add` writes
+        // to the LOCAL (project-cwd) scope, so the entry only works when
+        // Claude Code is launched from the BossTerm directory. With user
+        // scope the entry lives in ~/.claude.json's userScope block and
+        // applies in every project. `claude mcp remove` without --scope
+        // finds the entry regardless of where it lives, so this also
+        // cleans up legacy local-scope entries from before this fix.
         removeCommand = listOf("claude", "mcp", "remove", "{NAME}"),
-        addCommand = listOf("claude", "mcp", "add", "--transport", "sse", "{NAME}", "{URL}"),
-        clipboardFallback = "claude mcp add --transport sse {NAME} {URL}"
+        addCommand = listOf(
+            "claude", "mcp", "add",
+            "--scope", "user",
+            "--transport", "sse",
+            "{NAME}", "{URL}"
+        ),
+        clipboardFallback = "claude mcp add --scope user --transport sse {NAME} {URL}"
     ),
     CODEX(
         displayName = "Codex",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -9,60 +9,94 @@ import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 /**
- * The four AI CLIs we expose one-click attach buttons for in the MCP
- * settings panel. Each target has both a primary shell command we'll
- * attempt to run and a human-readable fallback string we drop on the
- * clipboard if the binary isn't installed or the command fails.
+ * One-click attach helper that registers this BossTerm MCP endpoint with a
+ * third-party AI CLI via the CLI's native `mcp` subcommand. Falls back to
+ * dropping a ready-to-paste config snippet on the system clipboard if the
+ * CLI binary is missing, the command fails, or the call times out.
  *
- * URLs are templated with the placeholder `{URL}` so the resolved
- * endpoint (`http://127.0.0.1:<port>/mcp`) gets substituted at call time.
+ * The `{NAME}` placeholder in command/clipboard templates is filled with
+ * the embedder's `BossTermMcpConfig.serverName` (or `"bossterm"` for the
+ * default app), and `{URL}` with the resolved
+ * `http://127.0.0.1:<port>/mcp` endpoint.
+ *
+ * Tested CLI shapes (last verified May 2026):
+ *  - Claude Code:  `claude mcp add --transport sse <name> <url>` (verified)
+ *  - Codex:        `codex mcp add <name> --transport sse <url>` (best-effort; falls back to ~/.codex/config.toml snippet)
+ *  - Gemini CLI:   `gemini mcp add <name> --transport sse <url>` (best-effort; falls back to ~/.gemini/settings.json snippet)
+ *  - OpenCode:     `opencode mcp add <name> --transport sse <url>` (best-effort; falls back to ~/.config/opencode/opencode.json snippet)
+ *
+ * If any of the best-effort commands turn out to have a different
+ * subcommand in your installed version, the clipboard fallback path
+ * handles it gracefully — the only visual symptom is the amber
+ * "exit N — config copied to clipboard" status instead of the green
+ * success line.
  */
 enum class McpAttachTarget(
     val displayName: String,
-    /** ProcessBuilder command list. `{URL}` gets replaced. */
-    private val command: List<String>,
+    /** Command run first to remove any existing entry. Errors ignored. `{NAME}` is replaced. */
+    private val removeCommand: List<String>?,
+    /** Primary command. `{URL}` and `{NAME}` get replaced at call time. */
+    private val addCommand: List<String>,
     /** Help text + ready-to-paste config when the shell-out fails. */
     private val clipboardFallback: String
 ) {
     CLAUDE_CODE(
         displayName = "Claude Code",
-        command = listOf("claude", "mcp", "add", "--transport", "sse", "bossterm", "{URL}"),
-        clipboardFallback = "claude mcp add --transport sse bossterm {URL}"
+        removeCommand = listOf("claude", "mcp", "remove", "{NAME}"),
+        addCommand = listOf("claude", "mcp", "add", "--transport", "sse", "{NAME}", "{URL}"),
+        clipboardFallback = "claude mcp add --transport sse {NAME} {URL}"
     ),
     CODEX(
         displayName = "Codex",
-        command = listOf("codex", "mcp", "add", "bossterm", "--transport", "sse", "{URL}"),
+        removeCommand = listOf("codex", "mcp", "remove", "{NAME}"),
+        addCommand = listOf("codex", "mcp", "add", "{NAME}", "--transport", "sse", "{URL}"),
         clipboardFallback = """
-            # Add to ~/.codex/config.toml
-            [mcp_servers.bossterm]
+            # Append to ~/.codex/config.toml
+            [mcp_servers.{NAME}]
             type = "sse"
             url = "{URL}"
         """.trimIndent()
     ),
     GEMINI(
         displayName = "Gemini CLI",
-        command = listOf("gemini", "mcp", "add", "bossterm", "--transport", "sse", "{URL}"),
+        removeCommand = listOf("gemini", "mcp", "remove", "{NAME}"),
+        addCommand = listOf("gemini", "mcp", "add", "{NAME}", "--transport", "sse", "{URL}"),
         clipboardFallback = """
-            // Add to ~/.gemini/settings.json under mcpServers
-            "bossterm": {
-              "httpUrl": "{URL}"
+            // Merge into ~/.gemini/settings.json
+            {
+              "mcpServers": {
+                "{NAME}": {
+                  "httpUrl": "{URL}"
+                }
+              }
             }
         """.trimIndent()
     ),
     OPENCODE(
         displayName = "OpenCode",
-        command = listOf("opencode", "mcp", "add", "bossterm", "--transport", "sse", "{URL}"),
+        removeCommand = listOf("opencode", "mcp", "remove", "{NAME}"),
+        addCommand = listOf("opencode", "mcp", "add", "{NAME}", "--transport", "sse", "{URL}"),
         clipboardFallback = """
-            // Add to ~/.config/opencode/opencode.json under mcp
-            "bossterm": {
-              "type": "remote",
-              "url": "{URL}"
+            // Merge into ~/.config/opencode/opencode.json
+            {
+              "mcp": {
+                "{NAME}": {
+                  "type": "remote",
+                  "url": "{URL}"
+                }
+              }
             }
         """.trimIndent()
     );
 
-    fun resolvedCommand(url: String): List<String> = command.map { it.replace("{URL}", url) }
-    fun resolvedClipboard(url: String): String = clipboardFallback.replace("{URL}", url)
+    fun resolvedAddCommand(name: String, url: String): List<String> =
+        addCommand.map { it.replace("{NAME}", name).replace("{URL}", url) }
+
+    fun resolvedRemoveCommand(name: String): List<String>? =
+        removeCommand?.map { it.replace("{NAME}", name) }
+
+    fun resolvedClipboard(name: String, url: String): String =
+        clipboardFallback.replace("{NAME}", name).replace("{URL}", url)
 }
 
 /**
@@ -72,7 +106,7 @@ enum class McpAttachTarget(
 sealed class McpAttachResult {
     abstract val target: McpAttachTarget
 
-    /** The CLI accepted the registration. `detail` is up to ~120 chars of output. */
+    /** The CLI accepted the registration. `detail` is up to ~160 chars of output. */
     data class Success(override val target: McpAttachTarget, val detail: String) : McpAttachResult()
 
     /** Binary missing or command failed — fallback text was dropped on the clipboard. */
@@ -84,47 +118,106 @@ sealed class McpAttachResult {
 
 /**
  * Best-effort registration of this BossTerm MCP endpoint with a third-party
- * AI CLI. Tries the CLI's native `mcp add` subcommand; on failure (binary
- * not on PATH, command not supported, non-zero exit) the resolved config
- * snippet is written to the system clipboard so the user can paste it
- * manually.
+ * AI CLI. See [McpAttachTarget] kdoc for the contract and tested-versions
+ * matrix.
  *
- * Pure I/O — invoke from a coroutine on [Dispatchers.IO].
+ * Idempotent: the `remove` subcommand runs first (errors ignored) so
+ * repeated clicks don't fail with "already exists".
  */
 object McpCliAttacher {
 
     private val log = LoggerFactory.getLogger(McpCliAttacher::class.java)
 
-    suspend fun attach(target: McpAttachTarget, port: Int): McpAttachResult =
+    /** Per-process timeout for any single shell-out. */
+    private const val PROCESS_TIMEOUT_SECONDS = 15L
+
+    /**
+     * Attempt to register the BossTerm MCP server with [target].
+     *
+     * @param serverName MCP identifier the third-party CLI will use. Pass
+     *   `BossTermMcpConfig.serverName` so embedders' brand is honored.
+     * @param port loopback port the server is bound to.
+     */
+    suspend fun attach(target: McpAttachTarget, serverName: String, port: Int): McpAttachResult =
         withContext(Dispatchers.IO) {
             val url = "http://127.0.0.1:$port/mcp"
-            val cmd = target.resolvedCommand(url)
+
+            // First, best-effort remove. Many CLIs' `mcp add` is not
+            // idempotent — this turns "already exists" errors into a
+            // silent no-op so a re-click of the button just works.
+            target.resolvedRemoveCommand(serverName)?.let { removeCmd ->
+                runProcess(removeCmd, allowFailure = true)
+            }
+
+            val cmd = target.resolvedAddCommand(serverName, url)
             log.info("Attaching {} via: {}", target.displayName, cmd.joinToString(" "))
             try {
-                val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
-                val output = process.inputStream.bufferedReader().readText()
-                val finished = process.waitFor(15, TimeUnit.SECONDS)
-                if (finished && process.exitValue() == 0) {
-                    log.info("Attach succeeded for {}: {}", target.displayName, output.trim())
-                    McpAttachResult.Success(target, output.trim().take(160))
+                val result = runProcess(cmd, allowFailure = false)
+                if (result.exitCode == 0) {
+                    log.info("Attach succeeded for {}", target.displayName)
+                    McpAttachResult.Success(target, result.output.trim().take(160))
                 } else {
-                    if (!finished) process.destroyForcibly()
-                    val reason = if (!finished) "timed out after 15s" else "exit ${process.exitValue()}"
+                    val reason = if (result.timedOut) {
+                        "timed out after ${PROCESS_TIMEOUT_SECONDS}s"
+                    } else {
+                        "exit ${result.exitCode}"
+                    }
                     log.warn("Attach for {} failed ({}); copying fallback to clipboard", target.displayName, reason)
-                    copyToClipboard(target.resolvedClipboard(url))
+                    copyToClipboard(target.resolvedClipboard(serverName, url))
                     McpAttachResult.CopiedToClipboard(target, "$reason — config copied to clipboard")
                 }
             } catch (e: IOException) {
                 // Binary not on PATH is the most common cause.
                 log.warn("Could not spawn {} ({}); copying fallback to clipboard", target.displayName, e.message)
-                copyToClipboard(target.resolvedClipboard(url))
+                copyToClipboard(target.resolvedClipboard(serverName, url))
                 McpAttachResult.CopiedToClipboard(target, "CLI not found — config copied to clipboard")
             } catch (e: Exception) {
                 log.warn("Unexpected error attaching {}: {}", target.displayName, e.message)
-                copyToClipboard(target.resolvedClipboard(url))
+                copyToClipboard(target.resolvedClipboard(serverName, url))
                 McpAttachResult.CopiedToClipboard(target, "${e::class.simpleName} — config copied to clipboard")
             }
         }
+
+    private data class ProcessOutcome(val exitCode: Int, val output: String, val timedOut: Boolean)
+
+    /**
+     * Run [cmd] with a hard 15s timeout. Closes the child's stdin immediately
+     * to defuse interactive prompts, and waits for the process before reading
+     * stdout — so a hung CLI gets killed by destroyForcibly instead of
+     * stalling our read forever.
+     *
+     * If [allowFailure], non-zero exit and timeouts are returned as-is
+     * (caller decides what to do). Otherwise the caller treats anything
+     * non-zero as failure.
+     */
+    private fun runProcess(cmd: List<String>, allowFailure: Boolean): ProcessOutcome {
+        val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+        // Signal EOF to any CLI that might be waiting on stdin.
+        try {
+            process.outputStream.close()
+        } catch (_: Throwable) {
+            // ignore
+        }
+        val finished = process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        if (!finished) {
+            process.destroyForcibly()
+            // Drain whatever the child already wrote, but cap so we don't
+            // sit on a giant buffer.
+            val partial = try {
+                process.inputStream.bufferedReader().readText().take(160)
+            } catch (_: Throwable) {
+                ""
+            }
+            return ProcessOutcome(exitCode = -1, output = partial, timedOut = true)
+        }
+        // Process is done; read is bounded.
+        val output = try {
+            process.inputStream.bufferedReader().readText()
+        } catch (_: Throwable) {
+            ""
+        }
+        return ProcessOutcome(exitCode = process.exitValue(), output = output, timedOut = false)
+    }
 
     private fun copyToClipboard(text: String) {
         try {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit
  * The `{NAME}` placeholder in command/clipboard templates is filled with
  * the embedder's `BossTermMcpConfig.serverName` (or `"bossterm"` for the
  * default app), and `{URL}` with the resolved
- * `http://127.0.0.1:<port>/mcp` endpoint.
+ * `http://127.0.0.1:<port>` endpoint.
  *
  * Tested CLI shapes (last verified May 2026):
  *  - Claude Code:  `claude mcp add --transport sse <name> <url>` (verified)
@@ -165,7 +165,10 @@ object McpCliAttacher {
         quiet: Boolean = false
     ): McpAttachResult =
         withContext(Dispatchers.IO) {
-            val url = "http://127.0.0.1:$port/mcp"
+            // SDK 0.8.3 mounts SSE+POST at the application root; the path
+            // overload is broken (see BossTermMcpManager kdoc). So the URL
+            // we register with each CLI is loopback + port, no path suffix.
+            val url = "http://127.0.0.1:$port"
             try {
                 // First, best-effort remove. Many CLIs' `mcp add` is not
                 // idempotent — this turns "already exists" errors into a

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.mcp
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
@@ -172,6 +173,10 @@ object McpCliAttacher {
                     copyToClipboard(target.resolvedClipboard(serverName, url))
                     McpAttachResult.CopiedToClipboard(target, "$reason — config copied to clipboard")
                 }
+            } catch (e: CancellationException) {
+                // Coroutine cancellation must propagate untouched — never
+                // swallow it into a CopiedToClipboard result.
+                throw e
             } catch (e: IOException) {
                 // Binary not on PATH is the most common cause.
                 log.warn("Could not spawn {} ({}); copying fallback to clipboard", target.displayName, e.message)
@@ -192,34 +197,58 @@ object McpCliAttacher {
      * stdout — so a hung CLI gets killed by destroyForcibly instead of
      * stalling our read forever. The caller decides how to interpret
      * non-zero exits / timeouts.
+     *
+     * Coroutine-cancellation-aware: if the dispatcher interrupts the thread
+     * mid-wait (e.g. the user closed the window), the child process is
+     * destroyForcibly'd before the InterruptedException is rethrown, so we
+     * don't leave a `claude mcp add` zombie running after dispose.
      */
     private fun runProcess(cmd: List<String>): ProcessOutcome {
         val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
-        // Signal EOF to any CLI that might be waiting on stdin.
         try {
-            process.outputStream.close()
-        } catch (_: Throwable) {
-            // ignore
-        }
-        val finished = process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        if (!finished) {
-            process.destroyForcibly()
-            // Drain whatever the child already wrote, but cap so we don't
-            // sit on a giant buffer.
-            val partial = try {
-                process.inputStream.bufferedReader().readText().take(160)
+            // Signal EOF to any CLI that might be waiting on stdin.
+            try {
+                process.outputStream.close()
+            } catch (_: Throwable) {
+                // ignore
+            }
+            val finished = try {
+                process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            } catch (e: InterruptedException) {
+                // Coroutine cancelled while we waited; rethrow as cancellation
+                // so callers don't mistake it for a CLI failure.
+                Thread.currentThread().interrupt()
+                throw CancellationException("Attach process interrupted").also { it.initCause(e) }
+            }
+            if (!finished) {
+                process.destroyForcibly()
+                // Drain whatever the child already wrote, but cap so we don't
+                // sit on a giant buffer.
+                val partial = try {
+                    process.inputStream.bufferedReader().readText().take(160)
+                } catch (_: Throwable) {
+                    ""
+                }
+                return ProcessOutcome(exitCode = -1, output = partial, timedOut = true)
+            }
+            // Process is done; read is bounded.
+            val output = try {
+                process.inputStream.bufferedReader().readText()
             } catch (_: Throwable) {
                 ""
             }
-            return ProcessOutcome(exitCode = -1, output = partial, timedOut = true)
+            return ProcessOutcome(exitCode = process.exitValue(), output = output, timedOut = false)
+        } finally {
+            // Defense in depth: never leak a child process if anything above
+            // throws (cancellation, I/O failure, etc).
+            if (process.isAlive) {
+                try {
+                    process.destroyForcibly()
+                } catch (_: Throwable) {
+                    // ignore
+                }
+            }
         }
-        // Process is done; read is bounded.
-        val output = try {
-            process.inputStream.bufferedReader().readText()
-        } catch (_: Throwable) {
-            ""
-        }
-        return ProcessOutcome(exitCode = process.exitValue(), output = output, timedOut = false)
     }
 
     private fun copyToClipboard(text: String) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -36,8 +36,6 @@ import ai.rever.bossterm.compose.features.ContextMenuController
 private val McpOnColor = Color(0xFF4CAF50) // green
 private val McpOnGlow = Color(0x33_4C_AF_50) // 20% green halo
 private val McpOnLabelColor = Color(0xFFCFEFD4)
-// Keep label naming back-compat for AttachToast usages.
-private val McpLabelColor = McpOnLabelColor
 private val McpOffColor = Color(0xFFE57373) // red
 private val McpOffGlow = Color(0x33_E5_73_73) // 20% red halo
 private val McpOffLabelColor = Color(0xFFF2C9C9)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -3,27 +3,30 @@ package ai.rever.bossterm.compose.mcp
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 private val McpOnColor = Color(0xFF4CAF50) // green
 private val McpOnGlow = Color(0x33_4C_AF_50) // 20% green halo
+private val McpLabelColor = Color(0xFFCFEFD4)
 
 /**
- * Small clickable dot in the top-right of the tab bar showing MCP server
- * status. Visible only when the MCP server is enabled in settings; clicking
- * opens the Settings dialog at the MCP category so users can inspect the
- * endpoint or turn it off.
- *
- * Rendered inside the tab bar so it lives next to the new-tab button. The
- * tab bar is forced visible while MCP is on (see TabbedTerminal) so the
- * indicator never gets hidden even in single-tab mode.
+ * Small clickable "MCP on" pill in the top-right overlay layer. The green
+ * dot says the server is running; the inline label removes any ambiguity
+ * for a user glancing at the corner of the window. Clicking opens the
+ * Settings dialog at the MCP category so users can inspect the endpoint
+ * or turn it off.
  */
 @Composable
 fun McpStatusIndicator(
@@ -33,23 +36,34 @@ fun McpStatusIndicator(
 ) {
     if (!enabled) return
 
-    Box(
+    Row(
         modifier = modifier
-            .size(28.dp)
-            .clickable(onClick = onClick),
-        contentAlignment = Alignment.Center
+            .clickable(onClick = onClick)
+            .padding(horizontal = 6.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
     ) {
-        // Soft halo for a "live" look without being distracting.
         Box(
-            modifier = Modifier
-                .size(16.dp)
-                .background(McpOnGlow, CircleShape)
-        )
-        Box(
-            modifier = Modifier
-                .size(10.dp)
-                .background(McpOnColor, CircleShape)
-                .border(1.dp, Color(0xFF388E3C), CircleShape)
+            modifier = Modifier.size(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            // Soft halo for a "live" look without being distracting.
+            Box(
+                modifier = Modifier
+                    .size(16.dp)
+                    .background(McpOnGlow, CircleShape)
+            )
+            Box(
+                modifier = Modifier
+                    .size(10.dp)
+                    .background(McpOnColor, CircleShape)
+                    .border(1.dp, Color(0xFF388E3C), CircleShape)
+            )
+        }
+        Text(
+            text = "MCP on",
+            color = McpLabelColor,
+            fontSize = 11.sp
         )
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -266,7 +266,7 @@ private fun McpStatusTooltip(
             fontWeight = FontWeight.SemiBold
         )
         Text(
-            text = "Endpoint: http://127.0.0.1:$runningPort/mcp",
+            text = "Endpoint: http://127.0.0.1:$runningPort",
             color = McpToastTextColor,
             fontSize = 11.sp
         )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -1,0 +1,55 @@
+package ai.rever.bossterm.compose.mcp
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+private val McpOnColor = Color(0xFF4CAF50) // green
+private val McpOnGlow = Color(0x33_4C_AF_50) // 20% green halo
+
+/**
+ * Small clickable dot in the top-right of the tab bar showing MCP server
+ * status. Visible only when the MCP server is enabled in settings; clicking
+ * opens the Settings dialog at the MCP category so users can inspect the
+ * endpoint or turn it off.
+ *
+ * Rendered inside the tab bar so it lives next to the new-tab button. The
+ * tab bar is forced visible while MCP is on (see TabbedTerminal) so the
+ * indicator never gets hidden even in single-tab mode.
+ */
+@Composable
+fun McpStatusIndicator(
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (!enabled) return
+
+    Box(
+        modifier = modifier
+            .size(28.dp)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        // Soft halo for a "live" look without being distracting.
+        Box(
+            modifier = Modifier
+                .size(16.dp)
+                .background(McpOnGlow, CircleShape)
+        )
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .background(McpOnColor, CircleShape)
+                .border(1.dp, Color(0xFF388E3C), CircleShape)
+        )
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -71,6 +71,7 @@ fun McpStatusIndicator(
     onHideRequest: () -> Unit = {},
     onAttachRequest: (McpAttachTarget) -> Unit = {},
     onShowSettings: () -> Unit = onClick,
+    onTurnOffRequest: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     if (!enabled) return
@@ -95,7 +96,8 @@ fun McpStatusIndicator(
         val items = buildIndicatorMenuItems(
             attached = attached,
             onAttachRequest = onAttachRequest,
-            onShowSettings = onShowSettings
+            onShowSettings = onShowSettings,
+            onTurnOffRequest = onTurnOffRequest
         )
         contextMenuController.showMenu(0f, 0f, items)
     }
@@ -155,15 +157,19 @@ fun McpStatusIndicator(
  *       Gemini CLI
  *     ✓ OpenCode
  *   MCP Settings…
+ *   ─────
+ *   Turn MCP off
  *
- * The "✓ " prefix marks CLIs already attached in this session. The
- * indicator can be hidden via the Settings panel toggle
- * ("Show Status Indicator in Tab Bar") — no longer in this menu.
+ * The "✓ " prefix marks CLIs already attached in this session.
+ * The indicator is only visible while MCP is on, so the toggle item is
+ * always "Turn MCP off"; the inverse direction is reachable via the
+ * Settings panel or the Tools menu.
  */
 private fun buildIndicatorMenuItems(
     attached: Set<McpAttachTarget>,
     onAttachRequest: (McpAttachTarget) -> Unit,
-    onShowSettings: () -> Unit
+    onShowSettings: () -> Unit,
+    onTurnOffRequest: () -> Unit
 ): List<ContextMenuController.MenuElement> {
     val attachSubmenuItems: List<ContextMenuController.MenuElement> =
         McpAttachTarget.entries.map { target ->
@@ -186,7 +192,14 @@ private fun buildIndicatorMenuItems(
         enabled = true,
         action = onShowSettings
     )
-    return listOf(attachSubmenu, settings)
+    val separator = ContextMenuController.MenuSeparator(id = "mcp_indicator_sep")
+    val turnOff = ContextMenuController.MenuItem(
+        id = "mcp_turn_off",
+        label = "Turn MCP off",
+        enabled = true,
+        action = onTurnOffRequest
+    )
+    return listOf(attachSubmenu, settings, separator, turnOff)
 }
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -35,7 +35,13 @@ import ai.rever.bossterm.compose.features.ContextMenuController
 
 private val McpOnColor = Color(0xFF4CAF50) // green
 private val McpOnGlow = Color(0x33_4C_AF_50) // 20% green halo
-private val McpLabelColor = Color(0xFFCFEFD4)
+private val McpOnLabelColor = Color(0xFFCFEFD4)
+// Keep label naming back-compat for AttachToast usages.
+private val McpLabelColor = McpOnLabelColor
+private val McpOffColor = Color(0xFFE57373) // red
+private val McpOffGlow = Color(0x33_E5_73_73) // 20% red halo
+private val McpOffLabelColor = Color(0xFFF2C9C9)
+private val McpOffBorderColor = Color(0xFFB71C1C)
 private val McpToastBg = Color(0xCC_1E_1E_1E)
 private val McpToastTextColor = Color(0xFFE0E0E0)
 private val McpToastSuccessColor = Color(0xFF4CAF50)
@@ -72,32 +78,35 @@ fun McpStatusIndicator(
     onAttachRequest: (McpAttachTarget) -> Unit = {},
     onShowSettings: () -> Unit = onClick,
     onTurnOffRequest: () -> Unit = {},
+    onTurnOnRequest: () -> Unit = {},
+    /** User's `settings.mcpEnabled` (intent) — drives the toggle menu label. */
+    isUserEnabled: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     if (!enabled) return
 
-    // Right-click → quick attach buttons + hide. Same set of CLIs as the
-    // Settings panel's "Attach to AI CLI" section. Items for already-attached
-    // CLIs get a "✓ " prefix so the user can see status at a glance.
-    // The host wires onAttachRequest to McpCliAttacher and onHideRequest to
-    // flip mcpShowStatusIndicator.
+    // Right-click (or left-click — same dark popup) → attach submenu,
+    // settings, and a state-aware toggle. The visual state (green/on vs
+    // red/off) reflects actual binding via runningPort; the menu's toggle
+    // label uses isUserEnabled so an "intent is on but bind failed" case
+    // still offers a meaningful action ("Turn MCP off" to reset, then on).
     //
-    // Uses the project's ContextMenuController (renders a dark Swing
-    // JPopupMenu) instead of foundation's ContextMenuArea so the styling
-    // matches the terminal canvas's own right-click menu.
+    // Uses the project's ContextMenuController so the popup style matches
+    // the terminal canvas's own right-click menu.
     val attached = McpTerminalRegistry.attachedTargets.collectAsState().value
     val runningPort = McpTerminalRegistry.runningPort.collectAsState().value
+    val isRunning = runningPort != null
     val contextMenuController = remember { ContextMenuController() }
 
-    // Both left- and right-click open the same dark popup. Settings has
-    // moved into the popup as "MCP Settings…" — the pill itself is a pure
-    // menu launcher now.
     val openMenu: () -> Unit = {
         val items = buildIndicatorMenuItems(
             attached = attached,
+            isRunning = isRunning,
+            isUserEnabled = isUserEnabled,
             onAttachRequest = onAttachRequest,
             onShowSettings = onShowSettings,
-            onTurnOffRequest = onTurnOffRequest
+            onTurnOffRequest = onTurnOffRequest,
+            onTurnOnRequest = onTurnOnRequest
         )
         contextMenuController.showMenu(0f, 0f, items)
     }
@@ -121,26 +130,29 @@ fun McpStatusIndicator(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
+            val dotColor = if (isRunning) McpOnColor else McpOffColor
+            val haloColor = if (isRunning) McpOnGlow else McpOffGlow
+            val borderColor = if (isRunning) Color(0xFF388E3C) else McpOffBorderColor
+            val labelColor = if (isRunning) McpOnLabelColor else McpOffLabelColor
             Box(
                 modifier = Modifier.size(16.dp),
                 contentAlignment = Alignment.Center
             ) {
-                // Soft halo for a "live" look without being distracting.
                 Box(
                     modifier = Modifier
                         .size(16.dp)
-                        .background(McpOnGlow, CircleShape)
+                        .background(haloColor, CircleShape)
                 )
                 Box(
                     modifier = Modifier
                         .size(10.dp)
-                        .background(McpOnColor, CircleShape)
-                        .border(1.dp, Color(0xFF388E3C), CircleShape)
+                        .background(dotColor, CircleShape)
+                        .border(1.dp, borderColor, CircleShape)
                 )
             }
             Text(
-                text = "MCP on",
-                color = McpLabelColor,
+                text = if (isRunning) "MCP on" else "MCP off",
+                color = labelColor,
                 fontSize = 11.sp
             )
         }
@@ -150,26 +162,30 @@ fun McpStatusIndicator(
 /**
  * Build the dark-themed right-click menu for the [McpStatusIndicator].
  *
- * Layout:
- *   Attach ▸
- *     ✓ Claude Code
- *       Codex
- *       Gemini CLI
- *     ✓ OpenCode
+ * Layout (running):
+ *   Attach ▸ (4 CLIs, "✓ " prefix for attached)
  *   MCP Settings…
  *   ─────
  *   Turn MCP off
  *
- * The "✓ " prefix marks CLIs already attached in this session.
- * The indicator is only visible while MCP is on, so the toggle item is
- * always "Turn MCP off"; the inverse direction is reachable via the
- * Settings panel or the Tools menu.
+ * Layout (off):
+ *   Attach ▸                ← disabled (no server to point CLIs at)
+ *   MCP Settings…
+ *   ─────
+ *   Turn MCP on
+ *
+ * The toggle label uses `isUserEnabled` (intent) rather than `isRunning`
+ * so a bind-failure state ("intent on, but port busy") still offers a
+ * meaningful action — toggle off to reset.
  */
 private fun buildIndicatorMenuItems(
     attached: Set<McpAttachTarget>,
+    isRunning: Boolean,
+    isUserEnabled: Boolean,
     onAttachRequest: (McpAttachTarget) -> Unit,
     onShowSettings: () -> Unit,
-    onTurnOffRequest: () -> Unit
+    onTurnOffRequest: () -> Unit,
+    onTurnOnRequest: () -> Unit
 ): List<ContextMenuController.MenuElement> {
     val attachSubmenuItems: List<ContextMenuController.MenuElement> =
         McpAttachTarget.entries.map { target ->
@@ -177,7 +193,7 @@ private fun buildIndicatorMenuItems(
             ContextMenuController.MenuItem(
                 id = "mcp_attach_${target.name}",
                 label = "${prefix}${target.displayName}",
-                enabled = true,
+                enabled = isRunning,
                 action = { onAttachRequest(target) }
             )
         }
@@ -193,13 +209,22 @@ private fun buildIndicatorMenuItems(
         action = onShowSettings
     )
     val separator = ContextMenuController.MenuSeparator(id = "mcp_indicator_sep")
-    val turnOff = ContextMenuController.MenuItem(
-        id = "mcp_turn_off",
-        label = "Turn MCP off",
-        enabled = true,
-        action = onTurnOffRequest
-    )
-    return listOf(attachSubmenu, settings, separator, turnOff)
+    val toggle = if (isUserEnabled) {
+        ContextMenuController.MenuItem(
+            id = "mcp_turn_off",
+            label = "Turn MCP off",
+            enabled = true,
+            action = onTurnOffRequest
+        )
+    } else {
+        ContextMenuController.MenuItem(
+            id = "mcp_turn_on",
+            label = "Turn MCP on",
+            enabled = true,
+            action = onTurnOnRequest
+        )
+    }
+    return listOf(attachSubmenu, settings, separator, toggle)
 }
 
 /**
@@ -220,19 +245,31 @@ private fun McpStatusTooltip(
             .widthIn(max = 380.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
+        if (runningPort == null) {
+            Text(
+                text = "MCP server is off",
+                color = McpOffLabelColor,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = "Click the pill to turn it on, or open MCP Settings…",
+                color = McpToastTextColor,
+                fontSize = 11.sp
+            )
+            return@Column
+        }
         Text(
             text = "MCP server running",
             color = McpToastSuccessColor,
             fontSize = 12.sp,
             fontWeight = FontWeight.SemiBold
         )
-        if (runningPort != null) {
-            Text(
-                text = "Endpoint: http://127.0.0.1:$runningPort/mcp",
-                color = McpToastTextColor,
-                fontSize = 11.sp
-            )
-        }
+        Text(
+            text = "Endpoint: http://127.0.0.1:$runningPort/mcp",
+            color = McpToastTextColor,
+            fontSize = 11.sp
+        )
         if (attached.isEmpty()) {
             Text(
                 text = "No CLIs attached yet — right-click to attach.",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -10,11 +10,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -22,6 +25,25 @@ import androidx.compose.ui.unit.sp
 private val McpOnColor = Color(0xFF4CAF50) // green
 private val McpOnGlow = Color(0x33_4C_AF_50) // 20% green halo
 private val McpLabelColor = Color(0xFFCFEFD4)
+private val McpToastBg = Color(0xCC_1E_1E_1E)
+private val McpToastTextColor = Color(0xFFE0E0E0)
+private val McpToastSuccessColor = Color(0xFF4CAF50)
+private val McpToastWarnColor = Color(0xFFFFC107)
+
+/**
+ * Lifecycle state of a one-click attach attempt, used by [AttachToast] to
+ * surface progress and result inline in the window (cross-platform, unlike
+ * [ai.rever.bossterm.compose.notification.NotificationService] which is
+ * macOS-only).
+ */
+sealed class AttachStatus {
+    abstract val target: McpAttachTarget
+
+    data class Pending(override val target: McpAttachTarget) : AttachStatus()
+    data class Done(val result: McpAttachResult) : AttachStatus() {
+        override val target: McpAttachTarget get() = result.target
+    }
+}
 
 /**
  * Small clickable "MCP on" pill in the top-right overlay layer. The green
@@ -81,5 +103,46 @@ fun McpStatusIndicator(
                 fontSize = 11.sp
             )
         }
+    }
+}
+
+/**
+ * Small inline pill rendered next to the [McpStatusIndicator] while an
+ * attach attempt is in flight or has just completed. Cross-platform — the
+ * `NotificationService` system-notification path only fires on macOS, but
+ * this toast works everywhere because it lives in the Compose tree.
+ *
+ * The hosting composable is responsible for clearing the status after a
+ * delay; this composable just renders whatever's passed in.
+ */
+@Composable
+fun AttachToast(
+    status: AttachStatus,
+    modifier: Modifier = Modifier
+) {
+    val (text, color) = when (status) {
+        is AttachStatus.Pending ->
+            "Attaching ${status.target.displayName}…" to McpToastTextColor
+        is AttachStatus.Done -> when (val r = status.result) {
+            is McpAttachResult.Success -> {
+                val tail = if (r.detail.isNotEmpty()) " — ${r.detail.take(80)}" else ""
+                "✓ ${r.target.displayName} attached$tail" to McpToastSuccessColor
+            }
+            is McpAttachResult.CopiedToClipboard ->
+                "${r.target.displayName}: ${r.reason}" to McpToastWarnColor
+        }
+    }
+    Box(
+        modifier = modifier
+            .widthIn(max = 360.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .background(McpToastBg)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = text,
+            color = color,
+            fontSize = 11.sp
+        )
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -35,18 +35,20 @@ fun McpStatusIndicator(
     enabled: Boolean,
     onClick: () -> Unit,
     onHideRequest: () -> Unit = {},
+    onAttachRequest: (McpAttachTarget) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     if (!enabled) return
 
-    // Right-click → "Hide MCP Indicator". Driven by ContextMenuArea so the
-    // menu uses the same native popup as text fields elsewhere in Compose
-    // Desktop. The host wires onHideRequest to flip mcpShowStatusIndicator.
+    // Right-click → quick attach buttons + hide. Same set of CLIs as the
+    // Settings panel's "Attach to AI CLI" section. The host wires
+    // onAttachRequest to McpCliAttacher and onHideRequest to flip
+    // mcpShowStatusIndicator.
     ContextMenuArea(
         items = {
-            listOf(
-                ContextMenuItem("Hide MCP Indicator") { onHideRequest() }
-            )
+            McpAttachTarget.entries.map { target ->
+                ContextMenuItem("Attach ${target.displayName}") { onAttachRequest(target) }
+            } + ContextMenuItem("Hide MCP Indicator") { onHideRequest() }
         }
     ) {
         Row(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -70,6 +70,7 @@ fun McpStatusIndicator(
     onClick: () -> Unit,
     onHideRequest: () -> Unit = {},
     onAttachRequest: (McpAttachTarget) -> Unit = {},
+    onShowSettings: () -> Unit = onClick,
     modifier: Modifier = Modifier
 ) {
     if (!enabled) return
@@ -102,6 +103,7 @@ fun McpStatusIndicator(
                         val items = buildIndicatorMenuItems(
                             attached = attached,
                             onAttachRequest = onAttachRequest,
+                            onShowSettings = onShowSettings,
                             onHideRequest = onHideRequest
                         )
                         contextMenuController.showMenu(0f, 0f, items)
@@ -139,24 +141,46 @@ fun McpStatusIndicator(
 
 /**
  * Build the dark-themed right-click menu for the [McpStatusIndicator].
- * Same item set foundation's ContextMenuArea used to produce, expressed as
- * [ContextMenuController.MenuItem]s so the project's native JPopupMenu
- * renderer can style them like the rest of the terminal context menus.
+ *
+ * Layout:
+ *   Attach ▸
+ *     ✓ Claude Code
+ *       Codex
+ *       Gemini CLI
+ *     ✓ OpenCode
+ *   MCP Settings…
+ *   ─────
+ *   Hide MCP Indicator
+ *
+ * The "✓ " prefix marks CLIs already attached in this session.
  */
 private fun buildIndicatorMenuItems(
     attached: Set<McpAttachTarget>,
     onAttachRequest: (McpAttachTarget) -> Unit,
+    onShowSettings: () -> Unit,
     onHideRequest: () -> Unit
 ): List<ContextMenuController.MenuElement> {
-    val attachItems = McpAttachTarget.entries.map { target ->
-        val prefix = if (target in attached) "✓ " else ""
-        ContextMenuController.MenuItem(
-            id = "mcp_attach_${target.name}",
-            label = "${prefix}Attach ${target.displayName}",
-            enabled = true,
-            action = { onAttachRequest(target) }
-        )
-    }
+    val attachSubmenuItems: List<ContextMenuController.MenuElement> =
+        McpAttachTarget.entries.map { target ->
+            val prefix = if (target in attached) "✓ " else ""
+            ContextMenuController.MenuItem(
+                id = "mcp_attach_${target.name}",
+                label = "${prefix}${target.displayName}",
+                enabled = true,
+                action = { onAttachRequest(target) }
+            )
+        }
+    val attachSubmenu = ContextMenuController.MenuSubmenu(
+        id = "mcp_attach_submenu",
+        label = "Attach",
+        items = attachSubmenuItems
+    )
+    val settings = ContextMenuController.MenuItem(
+        id = "mcp_settings",
+        label = "MCP Settings…",
+        enabled = true,
+        action = onShowSettings
+    )
     val separator = ContextMenuController.MenuSeparator(id = "mcp_indicator_sep")
     val hide = ContextMenuController.MenuItem(
         id = "mcp_hide_indicator",
@@ -164,7 +188,7 @@ private fun buildIndicatorMenuItems(
         enabled = true,
         action = onHideRequest
     )
-    return attachItems + separator + hide
+    return listOf(attachSubmenu, settings, separator, hide)
 }
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -2,11 +2,15 @@ package ai.rever.bossterm.compose.mcp
 
 import androidx.compose.foundation.ContextMenuArea
 import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.TooltipPlacement
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -20,6 +24,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -53,6 +59,7 @@ sealed class AttachStatus {
  * Settings dialog at the MCP category so users can inspect the endpoint
  * or turn it off.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun McpStatusIndicator(
     enabled: Boolean,
@@ -69,6 +76,7 @@ fun McpStatusIndicator(
     // The host wires onAttachRequest to McpCliAttacher and onHideRequest to
     // flip mcpShowStatusIndicator.
     val attached = McpTerminalRegistry.attachedTargets.collectAsState().value
+    val runningPort = McpTerminalRegistry.runningPort.collectAsState().value
     ContextMenuArea(
         items = {
             McpAttachTarget.entries.map { target ->
@@ -77,35 +85,97 @@ fun McpStatusIndicator(
             } + ContextMenuItem("Hide MCP Indicator") { onHideRequest() }
         }
     ) {
-        Row(
-            modifier = modifier
-                .clickable(onClick = onClick)
-                .padding(horizontal = 6.dp, vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        TooltipArea(
+            tooltip = { McpStatusTooltip(runningPort = runningPort, attached = attached) },
+            delayMillis = 350,
+            tooltipPlacement = TooltipPlacement.CursorPoint(
+                offset = DpOffset(0.dp, 16.dp)
+            )
         ) {
-            Box(
-                modifier = Modifier.size(16.dp),
-                contentAlignment = Alignment.Center
+            Row(
+                modifier = modifier
+                    .clickable(onClick = onClick)
+                    .padding(horizontal = 6.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
             ) {
-                // Soft halo for a "live" look without being distracting.
                 Box(
-                    modifier = Modifier
-                        .size(16.dp)
-                        .background(McpOnGlow, CircleShape)
-                )
-                Box(
-                    modifier = Modifier
-                        .size(10.dp)
-                        .background(McpOnColor, CircleShape)
-                        .border(1.dp, Color(0xFF388E3C), CircleShape)
+                    modifier = Modifier.size(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    // Soft halo for a "live" look without being distracting.
+                    Box(
+                        modifier = Modifier
+                            .size(16.dp)
+                            .background(McpOnGlow, CircleShape)
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(10.dp)
+                            .background(McpOnColor, CircleShape)
+                            .border(1.dp, Color(0xFF388E3C), CircleShape)
+                    )
+                }
+                Text(
+                    text = "MCP on",
+                    color = McpLabelColor,
+                    fontSize = 11.sp
                 )
             }
+        }
+    }
+}
+
+/**
+ * Hover tooltip body for [McpStatusIndicator]. Surfaces the bound endpoint
+ * URL and the list of CLIs that this session has attached so far. Always
+ * shown via [TooltipArea]; rendered as a small dark rounded card.
+ */
+@Composable
+private fun McpStatusTooltip(
+    runningPort: Int?,
+    attached: Set<McpAttachTarget>
+) {
+    Column(
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(McpToastBg)
+            .padding(horizontal = 10.dp, vertical = 8.dp)
+            .widthIn(max = 380.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(
+            text = "MCP server running",
+            color = McpToastSuccessColor,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+        if (runningPort != null) {
             Text(
-                text = "MCP on",
-                color = McpLabelColor,
+                text = "Endpoint: http://127.0.0.1:$runningPort/mcp",
+                color = McpToastTextColor,
                 fontSize = 11.sp
             )
+        }
+        if (attached.isEmpty()) {
+            Text(
+                text = "No CLIs attached yet — right-click to attach.",
+                color = McpToastTextColor,
+                fontSize = 11.sp
+            )
+        } else {
+            Text(
+                text = "Attached this session:",
+                color = McpToastTextColor,
+                fontSize = 11.sp
+            )
+            McpAttachTarget.entries.filter { it in attached }.forEach { target ->
+                Text(
+                    text = "  ✓ ${target.displayName}",
+                    color = McpToastSuccessColor,
+                    fontSize = 11.sp
+                )
+            }
         }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -1,5 +1,7 @@
 package ai.rever.bossterm.compose.mcp
 
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -32,38 +34,50 @@ private val McpLabelColor = Color(0xFFCFEFD4)
 fun McpStatusIndicator(
     enabled: Boolean,
     onClick: () -> Unit,
+    onHideRequest: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     if (!enabled) return
 
-    Row(
-        modifier = modifier
-            .clickable(onClick = onClick)
-            .padding(horizontal = 6.dp, vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp)
-    ) {
-        Box(
-            modifier = Modifier.size(16.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            // Soft halo for a "live" look without being distracting.
-            Box(
-                modifier = Modifier
-                    .size(16.dp)
-                    .background(McpOnGlow, CircleShape)
-            )
-            Box(
-                modifier = Modifier
-                    .size(10.dp)
-                    .background(McpOnColor, CircleShape)
-                    .border(1.dp, Color(0xFF388E3C), CircleShape)
+    // Right-click → "Hide MCP Indicator". Driven by ContextMenuArea so the
+    // menu uses the same native popup as text fields elsewhere in Compose
+    // Desktop. The host wires onHideRequest to flip mcpShowStatusIndicator.
+    ContextMenuArea(
+        items = {
+            listOf(
+                ContextMenuItem("Hide MCP Indicator") { onHideRequest() }
             )
         }
-        Text(
-            text = "MCP on",
-            color = McpLabelColor,
-            fontSize = 11.sp
-        )
+    ) {
+        Row(
+            modifier = modifier
+                .clickable(onClick = onClick)
+                .padding(horizontal = 6.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Box(
+                modifier = Modifier.size(16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                // Soft halo for a "live" look without being distracting.
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .background(McpOnGlow, CircleShape)
+                )
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .background(McpOnColor, CircleShape)
+                        .border(1.dp, Color(0xFF388E3C), CircleShape)
+                )
+            }
+            Text(
+                text = "MCP on",
+                color = McpLabelColor,
+                fontSize = 11.sp
+            )
+        }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -95,8 +95,7 @@ fun McpStatusIndicator(
         val items = buildIndicatorMenuItems(
             attached = attached,
             onAttachRequest = onAttachRequest,
-            onShowSettings = onShowSettings,
-            onHideRequest = onHideRequest
+            onShowSettings = onShowSettings
         )
         contextMenuController.showMenu(0f, 0f, items)
     }
@@ -156,16 +155,15 @@ fun McpStatusIndicator(
  *       Gemini CLI
  *     ✓ OpenCode
  *   MCP Settings…
- *   ─────
- *   Hide MCP Indicator
  *
- * The "✓ " prefix marks CLIs already attached in this session.
+ * The "✓ " prefix marks CLIs already attached in this session. The
+ * indicator can be hidden via the Settings panel toggle
+ * ("Show Status Indicator in Tab Bar") — no longer in this menu.
  */
 private fun buildIndicatorMenuItems(
     attached: Set<McpAttachTarget>,
     onAttachRequest: (McpAttachTarget) -> Unit,
-    onShowSettings: () -> Unit,
-    onHideRequest: () -> Unit
+    onShowSettings: () -> Unit
 ): List<ContextMenuController.MenuElement> {
     val attachSubmenuItems: List<ContextMenuController.MenuElement> =
         McpAttachTarget.entries.map { target ->
@@ -188,14 +186,7 @@ private fun buildIndicatorMenuItems(
         enabled = true,
         action = onShowSettings
     )
-    val separator = ContextMenuController.MenuSeparator(id = "mcp_indicator_sep")
-    val hide = ContextMenuController.MenuItem(
-        id = "mcp_hide_indicator",
-        label = "Hide MCP Indicator",
-        enabled = true,
-        action = onHideRequest
-    )
-    return listOf(attachSubmenu, settings, separator, hide)
+    return listOf(attachSubmenu, settings)
 }
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -1,7 +1,5 @@
 package ai.rever.bossterm.compose.mcp
 
-import androidx.compose.foundation.ContextMenuArea
-import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.TooltipPlacement
@@ -20,14 +18,20 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ai.rever.bossterm.compose.features.ContextMenuController
 
 private val McpOnColor = Color(0xFF4CAF50) // green
 private val McpOnGlow = Color(0x33_4C_AF_50) // 20% green halo
@@ -59,7 +63,7 @@ sealed class AttachStatus {
  * Settings dialog at the MCP category so users can inspect the endpoint
  * or turn it off.
  */
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
 @Composable
 fun McpStatusIndicator(
     enabled: Boolean,
@@ -75,55 +79,92 @@ fun McpStatusIndicator(
     // CLIs get a "✓ " prefix so the user can see status at a glance.
     // The host wires onAttachRequest to McpCliAttacher and onHideRequest to
     // flip mcpShowStatusIndicator.
+    //
+    // Uses the project's ContextMenuController (renders a dark Swing
+    // JPopupMenu) instead of foundation's ContextMenuArea so the styling
+    // matches the terminal canvas's own right-click menu.
     val attached = McpTerminalRegistry.attachedTargets.collectAsState().value
     val runningPort = McpTerminalRegistry.runningPort.collectAsState().value
-    ContextMenuArea(
-        items = {
-            McpAttachTarget.entries.map { target ->
-                val prefix = if (target in attached) "✓ " else ""
-                ContextMenuItem("${prefix}Attach ${target.displayName}") { onAttachRequest(target) }
-            } + ContextMenuItem("Hide MCP Indicator") { onHideRequest() }
-        }
+    val contextMenuController = remember { ContextMenuController() }
+
+    TooltipArea(
+        tooltip = { McpStatusTooltip(runningPort = runningPort, attached = attached) },
+        delayMillis = 350,
+        tooltipPlacement = TooltipPlacement.CursorPoint(
+            offset = DpOffset(0.dp, 16.dp)
+        )
     ) {
-        TooltipArea(
-            tooltip = { McpStatusTooltip(runningPort = runningPort, attached = attached) },
-            delayMillis = 350,
-            tooltipPlacement = TooltipPlacement.CursorPoint(
-                offset = DpOffset(0.dp, 16.dp)
-            )
-        ) {
-            Row(
-                modifier = modifier
-                    .clickable(onClick = onClick)
-                    .padding(horizontal = 6.dp, vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp)
-            ) {
-                Box(
-                    modifier = Modifier.size(16.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    // Soft halo for a "live" look without being distracting.
-                    Box(
-                        modifier = Modifier
-                            .size(16.dp)
-                            .background(McpOnGlow, CircleShape)
-                    )
-                    Box(
-                        modifier = Modifier
-                            .size(10.dp)
-                            .background(McpOnColor, CircleShape)
-                            .border(1.dp, Color(0xFF388E3C), CircleShape)
-                    )
+        Row(
+            modifier = modifier
+                .clickable(onClick = onClick)
+                .onPointerEvent(PointerEventType.Press) { event ->
+                    if (event.button == PointerButton.Secondary) {
+                        val items = buildIndicatorMenuItems(
+                            attached = attached,
+                            onAttachRequest = onAttachRequest,
+                            onHideRequest = onHideRequest
+                        )
+                        contextMenuController.showMenu(0f, 0f, items)
+                    }
                 }
-                Text(
-                    text = "MCP on",
-                    color = McpLabelColor,
-                    fontSize = 11.sp
+                .padding(horizontal = 6.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Box(
+                modifier = Modifier.size(16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                // Soft halo for a "live" look without being distracting.
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .background(McpOnGlow, CircleShape)
+                )
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .background(McpOnColor, CircleShape)
+                        .border(1.dp, Color(0xFF388E3C), CircleShape)
                 )
             }
+            Text(
+                text = "MCP on",
+                color = McpLabelColor,
+                fontSize = 11.sp
+            )
         }
     }
+}
+
+/**
+ * Build the dark-themed right-click menu for the [McpStatusIndicator].
+ * Same item set foundation's ContextMenuArea used to produce, expressed as
+ * [ContextMenuController.MenuItem]s so the project's native JPopupMenu
+ * renderer can style them like the rest of the terminal context menus.
+ */
+private fun buildIndicatorMenuItems(
+    attached: Set<McpAttachTarget>,
+    onAttachRequest: (McpAttachTarget) -> Unit,
+    onHideRequest: () -> Unit
+): List<ContextMenuController.MenuElement> {
+    val attachItems = McpAttachTarget.entries.map { target ->
+        val prefix = if (target in attached) "✓ " else ""
+        ContextMenuController.MenuItem(
+            id = "mcp_attach_${target.name}",
+            label = "${prefix}Attach ${target.displayName}",
+            enabled = true,
+            action = { onAttachRequest(target) }
+        )
+    }
+    val separator = ContextMenuController.MenuSeparator(id = "mcp_indicator_sep")
+    val hide = ContextMenuController.MenuItem(
+        id = "mcp_hide_indicator",
+        label = "Hide MCP Indicator",
+        enabled = true,
+        action = onHideRequest
+    )
+    return attachItems + separator + hide
 }
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -63,13 +64,16 @@ fun McpStatusIndicator(
     if (!enabled) return
 
     // Right-click → quick attach buttons + hide. Same set of CLIs as the
-    // Settings panel's "Attach to AI CLI" section. The host wires
-    // onAttachRequest to McpCliAttacher and onHideRequest to flip
-    // mcpShowStatusIndicator.
+    // Settings panel's "Attach to AI CLI" section. Items for already-attached
+    // CLIs get a "✓ " prefix so the user can see status at a glance.
+    // The host wires onAttachRequest to McpCliAttacher and onHideRequest to
+    // flip mcpShowStatusIndicator.
+    val attached = McpTerminalRegistry.attachedTargets.collectAsState().value
     ContextMenuArea(
         items = {
             McpAttachTarget.entries.map { target ->
-                ContextMenuItem("Attach ${target.displayName}") { onAttachRequest(target) }
+                val prefix = if (target in attached) "✓ " else ""
+                ContextMenuItem("${prefix}Attach ${target.displayName}") { onAttachRequest(target) }
             } + ContextMenuItem("Hide MCP Indicator") { onHideRequest() }
         }
     ) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -151,7 +151,7 @@ fun McpStatusIndicator(
                 )
             }
             Text(
-                text = if (isRunning) "MCP on" else "MCP off",
+                text = if (isRunning) "BossTerm MCP on" else "BossTerm MCP off",
                 color = labelColor,
                 fontSize = 11.sp
             )
@@ -204,7 +204,7 @@ private fun buildIndicatorMenuItems(
     )
     val settings = ContextMenuController.MenuItem(
         id = "mcp_settings",
-        label = "MCP Settings…",
+        label = "BossTerm MCP Settings…",
         enabled = true,
         action = onShowSettings
     )
@@ -212,14 +212,14 @@ private fun buildIndicatorMenuItems(
     val toggle = if (isUserEnabled) {
         ContextMenuController.MenuItem(
             id = "mcp_turn_off",
-            label = "Turn MCP off",
+            label = "Turn BossTerm MCP off",
             enabled = true,
             action = onTurnOffRequest
         )
     } else {
         ContextMenuController.MenuItem(
             id = "mcp_turn_on",
-            label = "Turn MCP on",
+            label = "Turn BossTerm MCP on",
             enabled = true,
             action = onTurnOnRequest
         )
@@ -247,20 +247,20 @@ private fun McpStatusTooltip(
     ) {
         if (runningPort == null) {
             Text(
-                text = "MCP server is off",
+                text = "BossTerm MCP server is off",
                 color = McpOffLabelColor,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.SemiBold
             )
             Text(
-                text = "Click the pill to turn it on, or open MCP Settings…",
+                text = "Click the pill to turn it on, or open BossTerm MCP Settings…",
                 color = McpToastTextColor,
                 fontSize = 11.sp
             )
             return@Column
         }
         Text(
-            text = "MCP server running",
+            text = "BossTerm MCP server running",
             color = McpToastSuccessColor,
             fontSize = 12.sp,
             fontWeight = FontWeight.SemiBold

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -88,6 +88,19 @@ fun McpStatusIndicator(
     val runningPort = McpTerminalRegistry.runningPort.collectAsState().value
     val contextMenuController = remember { ContextMenuController() }
 
+    // Both left- and right-click open the same dark popup. Settings has
+    // moved into the popup as "MCP Settings…" — the pill itself is a pure
+    // menu launcher now.
+    val openMenu: () -> Unit = {
+        val items = buildIndicatorMenuItems(
+            attached = attached,
+            onAttachRequest = onAttachRequest,
+            onShowSettings = onShowSettings,
+            onHideRequest = onHideRequest
+        )
+        contextMenuController.showMenu(0f, 0f, items)
+    }
+
     TooltipArea(
         tooltip = { McpStatusTooltip(runningPort = runningPort, attached = attached) },
         delayMillis = 350,
@@ -97,16 +110,10 @@ fun McpStatusIndicator(
     ) {
         Row(
             modifier = modifier
-                .clickable(onClick = onClick)
+                .clickable(onClick = openMenu)
                 .onPointerEvent(PointerEventType.Press) { event ->
                     if (event.button == PointerButton.Secondary) {
-                        val items = buildIndicatorMenuItems(
-                            attached = attached,
-                            onAttachRequest = onAttachRequest,
-                            onShowSettings = onShowSettings,
-                            onHideRequest = onHideRequest
-                        )
-                        contextMenuController.showMenu(0f, 0f, items)
+                        openMenu()
                     }
                 }
                 .padding(horizontal = 6.dp, vertical = 4.dp),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -1,0 +1,62 @@
+package ai.rever.bossterm.compose.mcp
+
+import ai.rever.bossterm.compose.TabbedTerminalState
+import ai.rever.bossterm.compose.tabs.TerminalTab
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Process-wide registry of live [TabbedTerminalState] instances exposed to the
+ * MCP server. Each application Window registers its own state on creation and
+ * unregisters on dispose. Tab ids are UUIDs (globally unique across windows),
+ * so the MCP tools can resolve a tab to its owning state by id alone.
+ *
+ * Why a registry instead of a per-Window manager: the MCP server binds a
+ * single TCP port. Running one manager per Window means the second Window
+ * silently fails to bind (BindException). This registry lets a single
+ * app-wide manager expose tabs from every Window through one endpoint.
+ *
+ * Thread-safety: backed by a [CopyOnWriteArrayList], safe for concurrent
+ * reads from MCP tool handlers and writes from Window lifecycle callbacks.
+ */
+object McpTerminalRegistry {
+
+    private val states = CopyOnWriteArrayList<TabbedTerminalState>()
+
+    /** Register a state. Idempotent — duplicate registrations are ignored. */
+    fun register(state: TabbedTerminalState) {
+        if (!states.contains(state)) {
+            states.add(state)
+        }
+    }
+
+    /** Unregister a state. No-op if not present. */
+    fun unregister(state: TabbedTerminalState) {
+        states.remove(state)
+    }
+
+    /** All tabs across all registered states, in registration order. */
+    fun allTabs(): List<TerminalTab> = states.flatMap { it.tabs }
+
+    /**
+     * Find the state that owns [tabId], or null if no registered state knows
+     * about that tab id.
+     */
+    fun findState(tabId: String): TabbedTerminalState? =
+        states.firstOrNull { it.getTabById(tabId) != null }
+
+    /**
+     * Find a tab by id across all registered states, or null if unknown.
+     */
+    fun findTab(tabId: String): TerminalTab? =
+        states.firstNotNullOfOrNull { it.getTabById(tabId) }
+
+    /**
+     * The "primary" state used by [get_active_tab]. In a multi-window app
+     * there is no globally-correct answer; returning the first registered
+     * state is documented as the v1 behavior and is stable.
+     */
+    fun primaryState(): TabbedTerminalState? = states.firstOrNull()
+
+    /** Total registered state count. Useful for diagnostics/tests. */
+    fun stateCount(): Int = states.size
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -2,6 +2,9 @@ package ai.rever.bossterm.compose.mcp
 
 import ai.rever.bossterm.compose.TabbedTerminalState
 import ai.rever.bossterm.compose.tabs.TerminalTab
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -59,4 +62,30 @@ object McpTerminalRegistry {
 
     /** Total registered state count. Useful for diagnostics/tests. */
     fun stateCount(): Int = states.size
+
+    // -----------------------------------------------------------------
+    // Server running state — owned by BossTermMcpManager, read by UI.
+    // -----------------------------------------------------------------
+
+    private val _runningPort = MutableStateFlow<Int?>(null)
+
+    /**
+     * Port the MCP Ktor engine is currently bound to, or `null` when no
+     * server is running. Used by the in-app status indicator so the dot
+     * only lights up when the manager has successfully bound — never just
+     * because the user toggled the setting. Reflects reality, not intent.
+     *
+     * Updated by [BossTermMcpManager] on successful start / on stop.
+     */
+    val runningPort: StateFlow<Int?> = _runningPort.asStateFlow()
+
+    /** @suppress Manager-only. Mark the server as running on [port]. */
+    internal fun setRunning(port: Int) {
+        _runningPort.value = port
+    }
+
+    /** @suppress Manager-only. Mark the server as stopped. */
+    internal fun setStopped() {
+        _runningPort.value = null
+    }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -95,10 +95,12 @@ object McpTerminalRegistry {
     // attach succeeds; read by the Settings panel and the right-click menus
     // to surface "✓ attached" status.
     //
-    // Process-wide and in-memory (no settings persistence): the CLI's own
-    // config file is the canonical record. This flow just remembers what
-    // *we* asked the CLI to do during this session so the UI can stop
-    // pretending every click is the first one. Cleared on app restart.
+    // Persisted across runs via [TerminalSettings.mcpAttachedTo] so the
+    // next session's auto-reattach has the right targets. The CLI's own
+    // config file remains the canonical record; this flow is the manager's
+    // mirror of it. Persisted as the stable [McpAttachTarget.persistenceKey]
+    // strings (not the raw enum names) so future enum renames don't drop
+    // saved state.
     // -----------------------------------------------------------------
 
     private val _attachedTargets = MutableStateFlow<Set<McpAttachTarget>>(emptySet())
@@ -114,10 +116,8 @@ object McpTerminalRegistry {
      *   correct ✓ marks immediately and the manager's auto-reattach loop
      *   has the right targets to refresh.
      */
-    internal fun hydrate(persistedNames: Set<String>) {
-        val targets = persistedNames.mapNotNull { name ->
-            runCatching { McpAttachTarget.valueOf(name) }.getOrNull()
-        }.toSet()
+    internal fun hydrate(persistedKeys: Set<String>) {
+        val targets = persistedKeys.mapNotNull { McpAttachTarget.fromPersistenceKey(it) }.toSet()
         _attachedTargets.value = targets
     }
 
@@ -140,7 +140,13 @@ object McpTerminalRegistry {
     }
 
     private fun persist(targets: Set<McpAttachTarget>) {
-        val names = targets.map { it.name }.toSet()
-        SettingsManager.instance.updateSetting { copy(mcpAttachedTo = names) }
+        // Sort by enum-declaration order so settings.json is deterministic
+        // across saves (kotlinx.serialization writes whatever the Set
+        // iterator yields, which isn't ordering-stable for HashSet).
+        val keys = McpAttachTarget.entries
+            .filter { it in targets }
+            .map { it.persistenceKey }
+            .toSet()
+        SettingsManager.instance.updateSetting { copy(mcpAttachedTo = keys) }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -88,4 +88,30 @@ object McpTerminalRegistry {
     internal fun setStopped() {
         _runningPort.value = null
     }
+
+    // -----------------------------------------------------------------
+    // Attached-CLI tracking — written by McpCliAttacher's callers when an
+    // attach succeeds; read by the Settings panel and the right-click menus
+    // to surface "✓ attached" status.
+    //
+    // Process-wide and in-memory (no settings persistence): the CLI's own
+    // config file is the canonical record. This flow just remembers what
+    // *we* asked the CLI to do during this session so the UI can stop
+    // pretending every click is the first one. Cleared on app restart.
+    // -----------------------------------------------------------------
+
+    private val _attachedTargets = MutableStateFlow<Set<McpAttachTarget>>(emptySet())
+
+    /** Set of CLIs we've successfully attached this BossTerm endpoint to in this session. */
+    val attachedTargets: StateFlow<Set<McpAttachTarget>> = _attachedTargets.asStateFlow()
+
+    /** @suppress Internal — recorded by attach callers on Success. */
+    internal fun markAttached(target: McpAttachTarget) {
+        _attachedTargets.value = _attachedTargets.value + target
+    }
+
+    /** @suppress Internal — recorded when a future detach action runs (no UI yet). */
+    internal fun markDetached(target: McpAttachTarget) {
+        _attachedTargets.value = _attachedTargets.value - target
+    }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.compose.mcp
 
 import ai.rever.bossterm.compose.TabbedTerminalState
+import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.tabs.TerminalTab
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -102,16 +103,44 @@ object McpTerminalRegistry {
 
     private val _attachedTargets = MutableStateFlow<Set<McpAttachTarget>>(emptySet())
 
-    /** Set of CLIs we've successfully attached this BossTerm endpoint to in this session. */
+    /** Set of CLIs this BossTerm endpoint is registered with. Hydrated from
+     *  TerminalSettings.mcpAttachedTo on manager start; persisted back on
+     *  every mark*. */
     val attachedTargets: StateFlow<Set<McpAttachTarget>> = _attachedTargets.asStateFlow()
 
-    /** @suppress Internal — recorded by attach callers on Success. */
-    internal fun markAttached(target: McpAttachTarget) {
-        _attachedTargets.value = _attachedTargets.value + target
+    /**
+     * @suppress Manager-only. Replace the runtime set with the persisted
+     *   names from settings. Called once on app start so the UI shows the
+     *   correct ✓ marks immediately and the manager's auto-reattach loop
+     *   has the right targets to refresh.
+     */
+    internal fun hydrate(persistedNames: Set<String>) {
+        val targets = persistedNames.mapNotNull { name ->
+            runCatching { McpAttachTarget.valueOf(name) }.getOrNull()
+        }.toSet()
+        _attachedTargets.value = targets
     }
 
-    /** @suppress Internal — recorded when a future detach action runs (no UI yet). */
+    /** @suppress Internal — recorded by attach callers on Success. Persists to settings. */
+    internal fun markAttached(target: McpAttachTarget) {
+        val next = _attachedTargets.value + target
+        if (next != _attachedTargets.value) {
+            _attachedTargets.value = next
+            persist(next)
+        }
+    }
+
+    /** @suppress Internal — recorded when an attach fails (auto-reattach) or user detaches. */
     internal fun markDetached(target: McpAttachTarget) {
-        _attachedTargets.value = _attachedTargets.value - target
+        val next = _attachedTargets.value - target
+        if (next != _attachedTargets.value) {
+            _attachedTargets.value = next
+            persist(next)
+        }
+    }
+
+    private fun persist(targets: Set<McpAttachTarget>) {
+        val names = targets.map { it.name }.toSet()
+        SettingsManager.instance.updateSetting { copy(mcpAttachedTo = names) }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -64,6 +64,14 @@ object McpTerminalRegistry {
     /** Total registered state count. Useful for diagnostics/tests. */
     fun stateCount(): Int = states.size
 
+    /**
+     * Snapshot of every currently-registered [TabbedTerminalState], in
+     * registration order. Returned as a defensive copy — mutating the result
+     * does not affect the registry. Embedders use this from their
+     * `additionalTools` blocks to iterate windows when defining custom MCP tools.
+     */
+    fun allStates(): List<TabbedTerminalState> = states.toList()
+
     // -----------------------------------------------------------------
     // Server running state — owned by BossTermMcpManager, read by UI.
     // -----------------------------------------------------------------

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsCategory.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsCategory.kt
@@ -88,6 +88,11 @@ enum class SettingsCategory(
         icon = Icons.Default.KeyboardArrowUp,
         description = "System-wide hotkey to summon BossTerm"
     ),
+    MCP(
+        displayName = "MCP Server",
+        icon = Icons.Default.Share,
+        description = "In-process Model Context Protocol endpoint for AI clients"
+    ),
     ABOUT(
         displayName = "About",
         icon = Icons.Default.Favorite,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsCategory.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsCategory.kt
@@ -89,7 +89,7 @@ enum class SettingsCategory(
         description = "System-wide hotkey to summon BossTerm"
     ),
     MCP(
-        displayName = "MCP Server",
+        displayName = "BossTerm MCP",
         icon = Icons.Default.Share,
         description = "In-process Model Context Protocol endpoint for AI clients"
     ),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
@@ -24,6 +24,20 @@ class SettingsManager(private val customSettingsPath: String? = null) {
      */
     val settings: StateFlow<TerminalSettings> = _settings.asStateFlow()
 
+    /**
+     * `true` if the settings file did not exist when [loadFromFile] last ran
+     * (i.e. this process started against a brand-new install). `false` if a
+     * settings file was already on disk (the common upgrade path). Initially
+     * `false`; set inside [loadFromFile].
+     *
+     * Used by [ai.rever.bossterm.compose.mcp.BossTermMcpManager] to decide
+     * whether to apply embedder-supplied first-launch defaults: applying them
+     * to an existing user's settings on upgrade would silently overwrite
+     * their saved choices.
+     */
+    var wasFreshInstall: Boolean = false
+        private set
+
     private val json = Json {
         prettyPrint = true
         ignoreUnknownKeys = true
@@ -100,6 +114,7 @@ class SettingsManager(private val customSettingsPath: String? = null) {
     fun loadFromFile() {
         try {
             if (settingsFile.exists()) {
+                wasFreshInstall = false
                 val jsonString = settingsFile.readText()
                 val loadedSettings = json.decodeFromString<TerminalSettings>(jsonString)
                 _settings.value = loadedSettings
@@ -109,6 +124,7 @@ class SettingsManager(private val customSettingsPath: String? = null) {
                 // This ensures new settings (like globalHotkey*) are written with defaults
                 saveToFile()
             } else {
+                wasFreshInstall = true
                 println("No settings file found, using defaults")
                 // Save defaults on first run
                 saveToFile()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
@@ -41,9 +41,13 @@ fun SettingsPanel(
     onSettingsSave: (() -> Unit)? = null,
     onResetToDefaults: () -> Unit,
     onRestartApp: (() -> Unit)? = null,
+    /** Initial category. Null falls back to [SettingsCategory.default]. */
+    initialCategory: SettingsCategory? = null,
     modifier: Modifier = Modifier
 ) {
-    var selectedCategory by remember { mutableStateOf(SettingsCategory.default) }
+    var selectedCategory by remember(initialCategory) {
+        mutableStateOf(initialCategory ?: SettingsCategory.default)
+    }
     var showResetConfirmation by remember { mutableStateOf(false) }
 
     Row(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
@@ -45,9 +45,21 @@ fun SettingsPanel(
     initialCategory: SettingsCategory? = null,
     modifier: Modifier = Modifier
 ) {
-    var selectedCategory by remember(initialCategory) {
-        mutableStateOf(initialCategory ?: SettingsCategory.default)
+    // Embedder may have hidden the MCP category. When that happens we drop it
+    // from the nav rail and refuse to honor it as the initial category.
+    val mcpCfg = ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig.current
+    val hiddenCategories: Set<SettingsCategory> = remember(mcpCfg) {
+        if (mcpCfg?.showInSettingsUi == false) setOf(SettingsCategory.MCP) else emptySet()
     }
+    val visibleCategories = remember(hiddenCategories) {
+        SettingsCategory.entries.filter { it !in hiddenCategories }
+    }
+    val resolvedInitial = if (initialCategory != null && initialCategory !in hiddenCategories) {
+        initialCategory
+    } else {
+        SettingsCategory.default
+    }
+    var selectedCategory by remember(resolvedInitial) { mutableStateOf(resolvedInitial) }
     var showResetConfirmation by remember { mutableStateOf(false) }
 
     Row(
@@ -57,6 +69,7 @@ fun SettingsPanel(
     ) {
         // Left navigation rail
         NavigationRail(
+            categories = visibleCategories,
             selectedCategory = selectedCategory,
             onCategorySelected = { selectedCategory = it },
             modifier = Modifier
@@ -178,6 +191,7 @@ fun SettingsPanel(
  */
 @Composable
 private fun NavigationRail(
+    categories: List<SettingsCategory>,
     selectedCategory: SettingsCategory,
     onCategorySelected: (SettingsCategory) -> Unit,
     modifier: Modifier = Modifier
@@ -190,7 +204,7 @@ private fun NavigationRail(
             .verticalScroll(scrollState)
             .padding(vertical = 8.dp)
     ) {
-        SettingsCategory.entries.forEach { category ->
+        categories.forEach { category ->
             val isSelected = category == selectedCategory
             NavigationRailItem(
                 category = category,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
@@ -367,7 +367,8 @@ private fun SettingsContent(
             )
             SettingsCategory.MCP -> McpSettingsSection(
                 settings = settings,
-                onSettingsChange = onSettingsChange
+                onSettingsChange = onSettingsChange,
+                onSettingsSave = onSettingsSave
             )
             SettingsCategory.ABOUT -> AboutSection()
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
@@ -347,6 +347,10 @@ private fun SettingsContent(
                 onSettingsChange = onSettingsChange,
                 onSettingsSave = onSettingsSave
             )
+            SettingsCategory.MCP -> McpSettingsSection(
+                settings = settings,
+                onSettingsChange = onSettingsChange
+            )
             SettingsCategory.ABOUT -> AboutSection()
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsWindow.kt
@@ -26,7 +26,9 @@ private const val SETTINGS_DEBOUNCE_MS = 100L
 fun SettingsWindow(
     visible: Boolean,
     onDismiss: () -> Unit,
-    onRestartApp: (() -> Unit)? = null
+    onRestartApp: (() -> Unit)? = null,
+    /** Optional category to open the panel at. Null falls back to [SettingsCategory.default]. */
+    initialCategory: SettingsCategory? = null
 ) {
     if (!visible) return
 
@@ -77,7 +79,8 @@ fun SettingsWindow(
             onResetToDefaults = {
                 settingsManager.resetToDefaults()
             },
-            onRestartApp = onRestartApp
+            onRestartApp = onRestartApp,
+            initialCategory = initialCategory
         )
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -735,6 +735,25 @@ data class TerminalSettings(
      */
     val alwaysShowTabBar: Boolean = false,
 
+    // ===== MCP Server Settings =====
+
+    /**
+     * Enable the in-process Model Context Protocol (MCP) server.
+     * When true, BossTerm exposes a streamable-HTTP MCP endpoint on localhost
+     * so external tools (e.g. AI assistants) can introspect and control the
+     * terminal. Defaults to false for opt-in safety - the server only starts
+     * when this flag is explicitly enabled.
+     */
+    val mcpEnabled: Boolean = false,
+
+    /**
+     * Localhost TCP port for the in-process MCP server's streamable-HTTP endpoint.
+     * Only used when mcpEnabled is true. Change this if the default port conflicts
+     * with another service on your machine.
+     * Default: 7676
+     */
+    val mcpPort: Int = 7676,
+
     // ===== AI Assistant Settings =====
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -790,6 +790,17 @@ data class TerminalSettings(
     val mcpAttachedTo: Set<String> = emptySet(),
 
     /**
+     * Unprefixed built-in names of BossTerm MCP tools that should NOT be exposed
+     * to clients (e.g. "send_input", "run_in_panel"). Default: empty (all tools
+     * exposed). Edited via the settings UI or the `manage_tools` MCP tool;
+     * changes apply live without restarting the server.
+     *
+     * Note: `manage_tools` is always exposed and cannot be added to this set —
+     * disabling it would leave no way to re-enable other tools from MCP.
+     */
+    val disabledMcpTools: Set<String> = emptySet(),
+
+    /**
      * Set to `true` the first time [ai.rever.bossterm.compose.mcp.BossTermMcpManager]
      * starts so that embedder-supplied first-launch defaults
      * (`BossTermMcpConfig.defaultEnabled` / `defaultPort`) are applied

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -735,6 +735,14 @@ data class TerminalSettings(
      */
     val alwaysShowTabBar: Boolean = false,
 
+    /**
+     * Show the small dim "Cmd+1"/"Ctrl+1" hotkey hint label in the top-right
+     * of each window (native title bar mode) or in the trailing slot of the
+     * custom title bar. Hidden by default since global hotkeys are advanced
+     * and the hint adds visual clutter for users who don't use them.
+     */
+    val showGlobalHotkeyHint: Boolean = false,
+
     // ===== MCP Server Settings =====
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -771,6 +771,15 @@ data class TerminalSettings(
     val mcpShowStatusIndicator: Boolean = true,
 
     /**
+     * Default size of the new pane (as a fraction of the parent's
+     * dimension) when MCP `run_in_panel` opens a horizontal or vertical
+     * split and the caller hasn't supplied `split_ratio` explicitly.
+     * Range: 0.1..0.9. Default 0.3 — large enough for an `htop` / `tail`,
+     * small enough to keep the agent's primary workspace visible.
+     */
+    val mcpDefaultSplitRatio: Float = 0.3f,
+
+    /**
      * Names (enum `.name`) of [ai.rever.bossterm.compose.mcp.McpAttachTarget]s
      * that this BossTerm endpoint is registered with via the user's
      * AI CLIs. Persisted across runs so the manager can silently

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -771,6 +771,16 @@ data class TerminalSettings(
     val mcpShowStatusIndicator: Boolean = true,
 
     /**
+     * Names (enum `.name`) of [ai.rever.bossterm.compose.mcp.McpAttachTarget]s
+     * that this BossTerm endpoint is registered with via the user's
+     * AI CLIs. Persisted across runs so the manager can silently
+     * re-run `<cli> mcp add` on next startup — refreshing the URL if
+     * the port changed and surfacing the ✓ marks in the UI immediately.
+     * Unknown / removed enum names are silently ignored at load.
+     */
+    val mcpAttachedTo: Set<String> = emptySet(),
+
+    /**
      * Set to `true` the first time [ai.rever.bossterm.compose.mcp.BossTermMcpManager]
      * starts so that embedder-supplied first-launch defaults
      * (`BossTermMcpConfig.defaultEnabled` / `defaultPort`) are applied

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -762,6 +762,16 @@ data class TerminalSettings(
      */
     val mcpShowStatusIndicator: Boolean = true,
 
+    /**
+     * Set to `true` the first time [ai.rever.bossterm.compose.mcp.BossTermMcpManager]
+     * starts so that embedder-supplied first-launch defaults
+     * (`BossTermMcpConfig.defaultEnabled` / `defaultPort`) are applied
+     * exactly once. After this flag flips to true, the user's `mcpEnabled`
+     * / `mcpPort` choices are authoritative and embedder defaults no longer
+     * override them.
+     */
+    val mcpConfigured: Boolean = false,
+
     // ===== AI Assistant Settings =====
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -754,6 +754,14 @@ data class TerminalSettings(
      */
     val mcpPort: Int = 7676,
 
+    /**
+     * Show the small green status indicator in the tab bar while the MCP
+     * server is running. Has no effect when mcpEnabled is false. Turning
+     * this off also stops forcing the tab bar to render in single-tab mode
+     * for the indicator's sake.
+     */
+    val mcpShowStatusIndicator: Boolean = true,
+
     // ===== AI Assistant Settings =====
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/GlobalHotkeySection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/GlobalHotkeySection.kt
@@ -69,6 +69,16 @@ fun GlobalHotkeySection(
                     isMacOS = isMacOS
                 )
             }
+
+            SettingsToggle(
+                label = "Show Hotkey Hint in Window",
+                checked = settings.showGlobalHotkeyHint,
+                onCheckedChange = { onSettingsChange(settings.copy(showGlobalHotkeyHint = it)) },
+                description = "Display a small dim label (e.g. \"⌘1\") in the top-right of each " +
+                        "window showing its assigned global hotkey. Off by default — the hint is " +
+                        "only useful if you actively use global hotkeys.",
+                enabled = settings.globalHotkeyEnabled
+            )
         }
 
         Spacer(modifier = Modifier.height(24.dp))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -106,8 +106,11 @@ fun McpSettingsSection(
                 value = settings.mcpDefaultSplitRatio,
                 onValueChange = { onSettingsChange(settings.copy(mcpDefaultSplitRatio = it)) },
                 onValueChangeFinished = onSettingsSave,
-                valueRange = 0.1f..0.9f,
-                steps = 15, // 0.1, 0.15, 0.2, ..., 0.9 = 17 stops, 15 internal steps
+                // Range matches run_in_panel's per-call split_ratio clamp
+                // (0.05..0.95) so any value an agent might send is also
+                // representable in the UI. Step size 0.05.
+                valueRange = 0.05f..0.95f,
+                steps = 17, // 0.05, 0.10, ..., 0.95 = 19 stops, 17 internal steps
                 valueDisplay = { "${(it * 100).toInt()}%" },
                 description = "When an MCP agent opens a split via `run_in_panel` without " +
                         "specifying split_ratio, the new pane gets this fraction of the " +

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -98,6 +98,20 @@ fun McpSettingsSection(
                         "is running. Click the dot to jump to this settings page.",
                 enabled = settings.mcpEnabled
             )
+
+            ai.rever.bossterm.compose.settings.components.SettingsSlider(
+                label = "Default Split Size for `run_in_panel`",
+                value = settings.mcpDefaultSplitRatio,
+                onValueChange = { onSettingsChange(settings.copy(mcpDefaultSplitRatio = it)) },
+                valueRange = 0.1f..0.9f,
+                steps = 15, // 0.1, 0.15, 0.2, ..., 0.9 = 17 stops, 15 internal steps
+                valueDisplay = { "${(it * 100).toInt()}%" },
+                description = "When an MCP agent opens a split via `run_in_panel` without " +
+                        "specifying split_ratio, the new pane gets this fraction of the " +
+                        "parent's size. Smaller values (~30%) keep the agent's main pane " +
+                        "visible; larger values give the script more real estate.",
+                enabled = settings.mcpEnabled
+            )
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -1,0 +1,65 @@
+package ai.rever.bossterm.compose.settings.sections
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ai.rever.bossterm.compose.settings.TerminalSettings
+import ai.rever.bossterm.compose.settings.components.SettingsNumberInput
+import ai.rever.bossterm.compose.settings.components.SettingsSection
+import ai.rever.bossterm.compose.settings.components.SettingsToggle
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+
+/**
+ * MCP server settings: toggle the in-process Model Context Protocol server
+ * and pick a localhost port. Endpoint is always `http://127.0.0.1:<port>/mcp`
+ * over SSE; the server only binds when enabled. Off by default so the port
+ * isn't opened until the user opts in.
+ */
+@Composable
+fun McpSettingsSection(
+    settings: TerminalSettings,
+    onSettingsChange: (TerminalSettings) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        SettingsSection(title = "MCP Server") {
+            SettingsToggle(
+                label = "Enable MCP Server",
+                checked = settings.mcpEnabled,
+                onCheckedChange = { onSettingsChange(settings.copy(mcpEnabled = it)) },
+                description = "Bind an in-process Model Context Protocol server on " +
+                        "127.0.0.1 so external tools (e.g. AI clients) can read scrollback, " +
+                        "search output, and drive your tabs. Toggling takes effect immediately."
+            )
+
+            SettingsNumberInput(
+                label = "Port",
+                value = settings.mcpPort,
+                onValueChange = { onSettingsChange(settings.copy(mcpPort = it)) },
+                range = 1..65535,
+                description = "Localhost port the server listens on. Default 7676. " +
+                        "Changing while enabled will rebind to the new port.",
+                enabled = settings.mcpEnabled
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Inline endpoint + security note. Kept in the section instead of as
+        // a toggle description so it can update with the port value.
+        Text(
+            text = "Endpoint when enabled: http://127.0.0.1:${settings.mcpPort}/mcp\n" +
+                    "Server binds loopback only and rejects non-loopback Host headers (403). " +
+                    "Tools include both read access (scrollback, search, last command) and " +
+                    "write access (send_input, send_signal). Any process running as your " +
+                    "user can reach the endpoint while it is enabled.",
+            color = TextMuted,
+            fontSize = 12.sp
+        )
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -101,7 +101,8 @@ fun McpSettingsSection(
 
         AttachToCliSection(
             port = settings.mcpPort,
-            enabled = settings.mcpEnabled
+            enabled = settings.mcpEnabled,
+            serverName = cfg?.serverName ?: "bossterm"
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -135,7 +136,8 @@ fun McpSettingsSection(
 @Composable
 private fun AttachToCliSection(
     port: Int,
-    enabled: Boolean
+    enabled: Boolean,
+    serverName: String
 ) {
     val scope = rememberCoroutineScope()
     // Last-attempt status per target so each button can show its own
@@ -166,7 +168,7 @@ private fun AttachToCliSection(
                         lastResult = null
                         scope.launch {
                             try {
-                                lastResult = McpCliAttacher.attach(target, port)
+                                lastResult = McpCliAttacher.attach(target, serverName, port)
                             } finally {
                                 inFlight = null
                             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -29,6 +30,7 @@ import ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
 import ai.rever.bossterm.compose.mcp.McpAttachResult
 import ai.rever.bossterm.compose.mcp.McpAttachTarget
 import ai.rever.bossterm.compose.mcp.McpCliAttacher
+import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.TerminalSettings
@@ -140,9 +142,9 @@ private fun AttachToCliSection(
     serverName: String
 ) {
     val scope = rememberCoroutineScope()
-    // Last-attempt status per target so each button can show its own
-    // success/fallback line without clobbering the others.
-    var lastResult by remember { mutableStateOf<McpAttachResult?>(null) }
+    // Per-target status so clicking different buttons in sequence preserves
+    // each line — without this every click clobbers the others.
+    val lastResults = remember { mutableStateMapOf<McpAttachTarget, McpAttachResult>() }
     var inFlight by remember { mutableStateOf<McpAttachTarget?>(null) }
 
     SettingsSection(title = "Attach to AI CLI") {
@@ -165,10 +167,10 @@ private fun AttachToCliSection(
                 Button(
                     onClick = {
                         inFlight = target
-                        lastResult = null
+                        lastResults.remove(target)
                         scope.launch {
                             try {
-                                lastResult = McpCliAttacher.attach(target, serverName, port)
+                                lastResults[target] = McpCliAttacher.attach(target, serverName, port)
                             } finally {
                                 inFlight = null
                             }
@@ -176,7 +178,7 @@ private fun AttachToCliSection(
                     },
                     enabled = enabled && inFlight == null,
                     colors = ButtonDefaults.buttonColors(
-                        backgroundColor = Color(0xFF2D6CDF),
+                        backgroundColor = AccentColor,
                         contentColor = Color.White,
                         disabledBackgroundColor = Color(0xFF3A3A3A),
                         disabledContentColor = Color(0xFF888888)
@@ -190,7 +192,11 @@ private fun AttachToCliSection(
             }
         }
 
-        lastResult?.let { result ->
+        // Per-target status lines, one per attempted target. Stack vertically
+        // so a user who clicks several buttons in sequence can see the
+        // outcome for each.
+        McpAttachTarget.entries.forEach { target ->
+            val result = lastResults[target] ?: return@forEach
             val (label, color) = when (result) {
                 is McpAttachResult.Success ->
                     "✓ ${result.target.displayName} attached" +

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
+import ai.rever.bossterm.compose.mcp.BossTermMcpServer
 import ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
 import ai.rever.bossterm.compose.mcp.McpAttachResult
 import ai.rever.bossterm.compose.mcp.McpAttachTarget
@@ -71,9 +72,9 @@ fun McpSettingsSection(
             Spacer(modifier = Modifier.height(16.dp))
         }
 
-        SettingsSection(title = "MCP Server") {
+        SettingsSection(title = "BossTerm MCP Server") {
             SettingsToggle(
-                label = "Enable MCP Server",
+                label = "Enable BossTerm MCP Server",
                 checked = settings.mcpEnabled,
                 onCheckedChange = { onSettingsChange(settings.copy(mcpEnabled = it)) },
                 description = "Bind an in-process Model Context Protocol server on " +
@@ -95,7 +96,7 @@ fun McpSettingsSection(
                 label = "Show Status Indicator in Tab Bar",
                 checked = settings.mcpShowStatusIndicator,
                 onCheckedChange = { onSettingsChange(settings.copy(mcpShowStatusIndicator = it)) },
-                description = "Display a small green dot in the tab bar while the MCP server " +
+                description = "Display a small green dot in the tab bar while the BossTerm MCP server " +
                         "is running. Click the dot to jump to this settings page.",
                 enabled = settings.mcpEnabled
             )
@@ -115,6 +116,14 @@ fun McpSettingsSection(
                 enabled = settings.mcpEnabled
             )
         }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ExposedToolsSection(
+            settings = settings,
+            onSettingsChange = onSettingsChange,
+            allowWriteTools = cfg?.allowWriteTools != false
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -141,6 +150,102 @@ fun McpSettingsSection(
             fontSize = 12.sp
         )
     }
+}
+
+/**
+ * Per-tool toggles that control which built-in BossTerm MCP tools are exposed
+ * to clients. Reads/writes the same `disabledMcpTools` setting that the
+ * `manage_tools` MCP tool edits, so toggling here is identical to a remote
+ * agent calling `manage_tools` with `disable` / `enable`. Changes apply live
+ * (no server restart needed).
+ *
+ * Write tools (send_input, send_signal, run_in_panel) only render when the
+ * embedder's config allows write tools at all — otherwise they're never
+ * registered regardless of this toggle, so showing them would mislead.
+ */
+@Composable
+private fun ExposedToolsSection(
+    settings: TerminalSettings,
+    onSettingsChange: (TerminalSettings) -> Unit,
+    allowWriteTools: Boolean
+) {
+    val disabled = settings.disabledMcpTools
+
+    fun setEnabled(toolName: String, enable: Boolean) {
+        val next = disabled.toMutableSet()
+        if (enable) next.remove(toolName) else next.add(toolName)
+        onSettingsChange(settings.copy(disabledMcpTools = next))
+    }
+
+    SettingsSection(title = "Exposed Tools") {
+        Text(
+            text = "Pick which built-in BossTerm MCP tools clients can call. Toggling here " +
+                    "is equivalent to calling the `manage_tools` MCP tool — both update the " +
+                    "same setting and apply live without restarting the server. The " +
+                    "`manage_tools` tool itself is always exposed so disabling everything " +
+                    "leaves a way back.",
+            color = TextMuted,
+            fontSize = 12.sp,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        ToolGroupLabel("Read tools")
+        BossTermMcpServer.BUILT_IN_READ_TOOLS.forEach { name ->
+            SettingsToggle(
+                label = name,
+                checked = name !in disabled,
+                onCheckedChange = { setEnabled(name, it) },
+                description = toolDescription(name),
+                enabled = settings.mcpEnabled
+            )
+        }
+
+        if (allowWriteTools) {
+            Spacer(modifier = Modifier.height(8.dp))
+            ToolGroupLabel("Write tools")
+            BossTermMcpServer.BUILT_IN_WRITE_TOOLS.forEach { name ->
+                SettingsToggle(
+                    label = name,
+                    checked = name !in disabled,
+                    onCheckedChange = { setEnabled(name, it) },
+                    description = toolDescription(name),
+                    enabled = settings.mcpEnabled
+                )
+            }
+        } else {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Write tools are disabled by this build's configuration (allowWriteTools=false).",
+                color = TextMuted,
+                fontSize = 11.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun ToolGroupLabel(text: String) {
+    Text(
+        text = text,
+        color = TextPrimary,
+        fontSize = 12.sp,
+        modifier = Modifier.padding(top = 4.dp, bottom = 4.dp)
+    )
+}
+
+/** Short, user-facing one-liner for each tool. Kept terse — the MCP tool descriptions
+ *  in BossTermMcpServer carry the full schema details for clients. */
+private fun toolDescription(name: String): String = when (name) {
+    "list_tabs" -> "Enumerate every open terminal tab across all windows."
+    "get_active_tab" -> "Return the active tab of the primary window."
+    "read_scrollback" -> "Read the last N lines from a tab/pane's buffer."
+    "search_output" -> "Regex-search a tab/pane's scrollback for matches."
+    "get_last_command" -> "Return the most recently completed OSC 133 command."
+    "read_debug_console" -> "Read recent entries from a tab's debug-data buffer."
+    "send_input" -> "Write raw text (including newlines) to a tab/pane's stdin."
+    "send_signal" -> "Send ctrl_c / ctrl_d / ctrl_z to a tab/pane."
+    "run_in_panel" -> "Open a new tab or split pane and run a script in it."
+    else -> name
 }
 
 /**
@@ -259,7 +364,7 @@ private fun AttachToCliSection(
 
         if (!enabled) {
             Text(
-                text = "Turn on the MCP server above to enable these buttons.",
+                text = "Turn on the BossTerm MCP server above to enable these buttons.",
                 color = TextMuted,
                 fontSize = 12.sp,
                 modifier = Modifier.padding(top = 6.dp)
@@ -284,7 +389,7 @@ private fun ConfigurationBanner() {
         verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
         Text(
-            text = "MCP is not wired up in this build.",
+            text = "BossTerm MCP is not wired up in this build.",
             color = TextPrimary,
             fontSize = 13.sp
         )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -1,24 +1,40 @@
 package ai.rever.bossterm.compose.settings.sections
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.settings.components.SettingsNumberInput
 import ai.rever.bossterm.compose.settings.components.SettingsSection
 import ai.rever.bossterm.compose.settings.components.SettingsToggle
-import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 
 /**
  * MCP server settings: toggle the in-process Model Context Protocol server
  * and pick a localhost port. Endpoint is always `http://127.0.0.1:<port>/mcp`
  * over SSE; the server only binds when enabled. Off by default so the port
  * isn't opened until the user opts in.
+ *
+ * When an embedder has provided a [ai.rever.bossterm.compose.mcp.BossTermMcpConfig]
+ * via [LocalBossTermMcpConfig], the inline endpoint note surfaces the configured
+ * server name. When the composition local is null (no manager was constructed
+ * by the host application), the section renders a short note pointing at the
+ * docs so users understand why toggling has no effect.
  */
 @Composable
 fun McpSettingsSection(
@@ -26,7 +42,19 @@ fun McpSettingsSection(
     onSettingsChange: (TerminalSettings) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val cfg = LocalBossTermMcpConfig.current
+
     Column(modifier = modifier) {
+
+        // No-manager banner: shown when the embedder hasn't wired
+        // BossTermMcpManager in their fun main(). Toggles below still render
+        // so users see what would be available — the manager is what actually
+        // binds the port.
+        if (cfg == null) {
+            ConfigurationBanner()
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
         SettingsSection(title = "MCP Server") {
             SettingsToggle(
                 label = "Enable MCP Server",
@@ -59,16 +87,68 @@ fun McpSettingsSection(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Inline endpoint + security note. Kept in the section instead of as
-        // a toggle description so it can update with the port value.
+        // Inline endpoint + security note. Includes the embedder's configured
+        // server name when available so users know how the server identifies
+        // itself to clients.
+        val serverIdLine = cfg?.let { "Server identifier: ${it.serverName} v${it.serverVersion}\n" } ?: ""
         Text(
-            text = "Endpoint when enabled: http://127.0.0.1:${settings.mcpPort}/mcp\n" +
+            text = serverIdLine +
+                    "Endpoint when enabled: http://127.0.0.1:${settings.mcpPort}/mcp\n" +
                     "Server binds loopback only and rejects non-loopback Host headers (403). " +
-                    "Tools include both read access (scrollback, search, last command) and " +
-                    "write access (send_input, send_signal). Any process running as your " +
-                    "user can reach the endpoint while it is enabled.",
+                    "Tools include read access (scrollback, search, last command)" +
+                    (if (cfg?.allowWriteTools != false) " and write access (send_input, send_signal)" else "") +
+                    ". Any process running as your user can reach the endpoint while it is enabled.",
             color = TextMuted,
             fontSize = 12.sp
+        )
+    }
+}
+
+/**
+ * Banner rendered inside [McpSettingsSection] when no [BossTermMcpConfig] is
+ * provided by the host. Explains the embedding contract in a single short
+ * code snippet so a developer running someone else's app knows where to look.
+ */
+@Composable
+private fun ConfigurationBanner() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(Color(0x33_FF_C1_07)) // soft amber tint
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Text(
+            text = "MCP is not wired up in this build.",
+            color = TextPrimary,
+            fontSize = 13.sp
+        )
+        Text(
+            text = "The settings below persist, but no Ktor server is bound because the host " +
+                    "application has not constructed a BossTermMcpManager. To enable it, call " +
+                    "the snippet below in your fun main():",
+            color = TextMuted,
+            fontSize = 12.sp
+        )
+        Text(
+            text = "val mcpScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)\n" +
+                    "val mcpConfig = BossTermMcpConfig(serverName = \"yourapp\")\n" +
+                    "val mcpManager = BossTermMcpManager(\n" +
+                    "    registry = McpTerminalRegistry,\n" +
+                    "    settingsManager = SettingsManager.instance,\n" +
+                    "    parentScope = mcpScope,\n" +
+                    "    config = mcpConfig\n" +
+                    ")\n" +
+                    "mcpManager.start()\n" +
+                    "application {\n" +
+                    "    CompositionLocalProvider(LocalBossTermMcpConfig provides mcpConfig) {\n" +
+                    "        // your TabbedTerminal tree\n" +
+                    "    }\n" +
+                    "}",
+            color = TextPrimary,
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace
         )
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -46,6 +46,15 @@ fun McpSettingsSection(
                         "Changing while enabled will rebind to the new port.",
                 enabled = settings.mcpEnabled
             )
+
+            SettingsToggle(
+                label = "Show Status Indicator in Tab Bar",
+                checked = settings.mcpShowStatusIndicator,
+                onCheckedChange = { onSettingsChange(settings.copy(mcpShowStatusIndicator = it)) },
+                description = "Display a small green dot in the tab bar while the MCP server " +
+                        "is running. Click the dot to jump to this settings page.",
+                enabled = settings.mcpEnabled
+            )
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -55,6 +55,7 @@ import ai.rever.bossterm.compose.settings.components.SettingsToggle
 fun McpSettingsSection(
     settings: TerminalSettings,
     onSettingsChange: (TerminalSettings) -> Unit,
+    onSettingsSave: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val cfg = LocalBossTermMcpConfig.current
@@ -103,6 +104,7 @@ fun McpSettingsSection(
                 label = "Default Split Size for `run_in_panel`",
                 value = settings.mcpDefaultSplitRatio,
                 onValueChange = { onSettingsChange(settings.copy(mcpDefaultSplitRatio = it)) },
+                onValueChangeFinished = onSettingsSave,
                 valueRange = 0.1f..0.9f,
                 steps = 15, // 0.1, 0.15, 0.2, ..., 0.9 = 17 stops, 15 internal steps
                 valueDisplay = { "${(it * 100).toInt()}%" },

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -146,6 +147,10 @@ private fun AttachToCliSection(
     // each line — without this every click clobbers the others.
     val lastResults = remember { mutableStateMapOf<McpAttachTarget, McpAttachResult>() }
     var inFlight by remember { mutableStateOf<McpAttachTarget?>(null) }
+    // Process-wide attached set, shared with the right-click menus so the
+    // Settings panel agrees with what the indicator shows.
+    val attached by ai.rever.bossterm.compose.mcp.McpTerminalRegistry
+        .attachedTargets.collectAsState()
 
     SettingsSection(title = "Attach to AI CLI") {
         Text(
@@ -165,13 +170,19 @@ private fun AttachToCliSection(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             McpAttachTarget.entries.forEach { target ->
+                val isAttached = target in attached
                 Button(
                     onClick = {
                         inFlight = target
                         lastResults.remove(target)
                         scope.launch {
                             try {
-                                lastResults[target] = McpCliAttacher.attach(target, serverName, port)
+                                val result = McpCliAttacher.attach(target, serverName, port)
+                                if (result is McpAttachResult.Success) {
+                                    ai.rever.bossterm.compose.mcp.McpTerminalRegistry
+                                        .markAttached(target)
+                                }
+                                lastResults[target] = result
                             } finally {
                                 inFlight = null
                             }
@@ -185,33 +196,49 @@ private fun AttachToCliSection(
                         disabledContentColor = Color(0xFF888888)
                     )
                 ) {
-                    Text(
-                        text = if (inFlight == target) "Attaching…" else "Attach ${target.displayName}",
-                        fontSize = 12.sp
-                    )
+                    val label = when {
+                        inFlight == target -> "Attaching…"
+                        isAttached -> "✓ ${target.displayName} (re-attach)"
+                        else -> "Attach ${target.displayName}"
+                    }
+                    Text(text = label, fontSize = 12.sp)
                 }
             }
         }
 
-        // Per-target status lines, one per attempted target. Stack vertically
-        // so a user who clicks several buttons in sequence can see the
-        // outcome for each.
+        // Per-target status. Two stacked lines per target when relevant:
+        //   - Persistent attached state from the process-wide registry
+        //     (survives the transient lastResults clear).
+        //   - Last-attempt result with detail / clipboard fallback reason.
         McpAttachTarget.entries.forEach { target ->
-            val result = lastResults[target] ?: return@forEach
-            val (label, color) = when (result) {
-                is McpAttachResult.Success ->
-                    "✓ ${result.target.displayName} attached" +
-                        (if (result.detail.isNotEmpty()) " — ${result.detail}" else "") to
-                        Color(0xFF4CAF50)
-                is McpAttachResult.CopiedToClipboard ->
-                    "${result.target.displayName}: ${result.reason}" to Color(0xFFFFC107)
+            val isAttached = target in attached
+            val result = lastResults[target]
+            if (!isAttached && result == null) return@forEach
+
+            if (isAttached) {
+                Text(
+                    text = "✓ ${target.displayName} is currently attached",
+                    color = Color(0xFF4CAF50),
+                    fontSize = 12.sp,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
             }
-            Text(
-                text = label,
-                color = color,
-                fontSize = 12.sp,
-                modifier = Modifier.padding(top = 8.dp)
-            )
+            if (result != null) {
+                val (label, color) = when (result) {
+                    is McpAttachResult.Success ->
+                        "Last attempt: ✓ ${result.target.displayName} attached" +
+                            (if (result.detail.isNotEmpty()) " — ${result.detail}" else "") to
+                            Color(0xFF4CAF50)
+                    is McpAttachResult.CopiedToClipboard ->
+                        "Last attempt: ${result.target.displayName}: ${result.reason}" to Color(0xFFFFC107)
+                }
+                Text(
+                    text = label,
+                    color = color,
+                    fontSize = 11.sp,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
         }
 
         if (!enabled) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -3,20 +3,32 @@ package ai.rever.bossterm.compose.settings.sections
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
 import ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
+import ai.rever.bossterm.compose.mcp.McpAttachResult
+import ai.rever.bossterm.compose.mcp.McpAttachTarget
+import ai.rever.bossterm.compose.mcp.McpCliAttacher
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.TerminalSettings
@@ -87,6 +99,13 @@ fun McpSettingsSection(
 
         Spacer(modifier = Modifier.height(16.dp))
 
+        AttachToCliSection(
+            port = settings.mcpPort,
+            enabled = settings.mcpEnabled
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
         // Inline endpoint + security note. Includes the embedder's configured
         // server name when available so users know how the server identifies
         // itself to clients.
@@ -101,6 +120,99 @@ fun McpSettingsSection(
             color = TextMuted,
             fontSize = 12.sp
         )
+    }
+}
+
+/**
+ * One-click attach buttons for the four AI CLIs that ship with BossTerm's
+ * AI Assistants menu. Each button tries the CLI's native `mcp add`
+ * subcommand; on failure (binary missing, command not supported, non-zero
+ * exit) the relevant config snippet is copied to the clipboard.
+ *
+ * Buttons disable themselves when MCP is off — attaching is pointless
+ * before the server is bound.
+ */
+@Composable
+private fun AttachToCliSection(
+    port: Int,
+    enabled: Boolean
+) {
+    val scope = rememberCoroutineScope()
+    // Last-attempt status per target so each button can show its own
+    // success/fallback line without clobbering the others.
+    var lastResult by remember { mutableStateOf<McpAttachResult?>(null) }
+    var inFlight by remember { mutableStateOf<McpAttachTarget?>(null) }
+
+    SettingsSection(title = "Attach to AI CLI") {
+        Text(
+            text = "Register this BossTerm MCP endpoint with your favorite AI CLI. " +
+                    "Each button shells out to the CLI's `mcp add` command. " +
+                    "If the CLI isn't installed (or the command fails), the right " +
+                    "config snippet is copied to your clipboard.",
+            color = TextMuted,
+            fontSize = 12.sp,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            McpAttachTarget.entries.forEach { target ->
+                Button(
+                    onClick = {
+                        inFlight = target
+                        lastResult = null
+                        scope.launch {
+                            try {
+                                lastResult = McpCliAttacher.attach(target, port)
+                            } finally {
+                                inFlight = null
+                            }
+                        }
+                    },
+                    enabled = enabled && inFlight == null,
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = Color(0xFF2D6CDF),
+                        contentColor = Color.White,
+                        disabledBackgroundColor = Color(0xFF3A3A3A),
+                        disabledContentColor = Color(0xFF888888)
+                    )
+                ) {
+                    Text(
+                        text = if (inFlight == target) "Attaching…" else "Attach ${target.displayName}",
+                        fontSize = 12.sp
+                    )
+                }
+            }
+        }
+
+        lastResult?.let { result ->
+            val (label, color) = when (result) {
+                is McpAttachResult.Success ->
+                    "✓ ${result.target.displayName} attached" +
+                        (if (result.detail.isNotEmpty()) " — ${result.detail}" else "") to
+                        Color(0xFF4CAF50)
+                is McpAttachResult.CopiedToClipboard ->
+                    "${result.target.displayName}: ${result.reason}" to Color(0xFFFFC107)
+            }
+            Text(
+                text = label,
+                color = color,
+                fontSize = 12.sp,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
+
+        if (!enabled) {
+            Text(
+                text = "Turn on the MCP server above to enable these buttons.",
+                color = TextMuted,
+                fontSize = 12.sp,
+                modifier = Modifier.padding(top = 6.dp)
+            )
+        }
     }
 }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -150,7 +150,8 @@ private fun AttachToCliSection(
     SettingsSection(title = "Attach to AI CLI") {
         Text(
             text = "Register this BossTerm MCP endpoint with your favorite AI CLI. " +
-                    "Each button shells out to the CLI's `mcp add` command. " +
+                    "Each button removes any existing entry of the same name, then runs " +
+                    "the CLI's `mcp add` command — so repeated clicks are safe. " +
                     "If the CLI isn't installed (or the command fails), the right " +
                     "config snippet is copied to your clipboard.",
             color = TextMuted,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -41,7 +41,7 @@ import ai.rever.bossterm.compose.settings.components.SettingsToggle
 
 /**
  * MCP server settings: toggle the in-process Model Context Protocol server
- * and pick a localhost port. Endpoint is always `http://127.0.0.1:<port>/mcp`
+ * and pick a localhost port. Endpoint is always `http://127.0.0.1:<port>`
  * over SSE; the server only binds when enabled. Off by default so the port
  * isn't opened until the user opts in.
  *
@@ -116,7 +116,7 @@ fun McpSettingsSection(
         val serverIdLine = cfg?.let { "Server identifier: ${it.serverName} v${it.serverVersion}\n" } ?: ""
         Text(
             text = serverIdLine +
-                    "Endpoint when enabled: http://127.0.0.1:${settings.mcpPort}/mcp\n" +
+                    "Endpoint when enabled: http://127.0.0.1:${settings.mcpPort}\n" +
                     "Server binds loopback only and rejects non-loopback Host headers (403). " +
                     "Tools include read access (scrollback, search, last command)" +
                     (if (cfg?.allowWriteTools != false) " and write access (send_input, send_signal)" else "") +

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -1,7 +1,6 @@
 package ai.rever.bossterm.compose.tabs
 
 import ai.rever.bossterm.compose.features.ContextMenuController
-import ai.rever.bossterm.compose.mcp.McpStatusIndicator
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -43,8 +42,6 @@ fun TabBar(
     onTabClosed: (Int) -> Unit,
     onNewTab: () -> Unit,
     onTabMoveToNewWindow: (Int) -> Unit = {},
-    mcpEnabled: Boolean = false,
-    onMcpIndicatorClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     // Context menu controller for tab right-click menu
@@ -119,13 +116,6 @@ fun TabBar(
                     tint = Color.White
                 )
             }
-
-            // MCP server status — small green dot when the in-process MCP
-            // server is bound. Click opens Settings at the MCP category.
-            McpStatusIndicator(
-                enabled = mcpEnabled,
-                onClick = onMcpIndicatorClick
-            )
         }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.compose.tabs
 
 import ai.rever.bossterm.compose.features.ContextMenuController
+import ai.rever.bossterm.compose.mcp.McpStatusIndicator
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -42,6 +43,8 @@ fun TabBar(
     onTabClosed: (Int) -> Unit,
     onNewTab: () -> Unit,
     onTabMoveToNewWindow: (Int) -> Unit = {},
+    mcpEnabled: Boolean = false,
+    onMcpIndicatorClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     // Context menu controller for tab right-click menu
@@ -116,6 +119,13 @@ fun TabBar(
                     tint = Color.White
                 )
             }
+
+            // MCP server status — small green dot when the in-process MCP
+            // server is bound. Click opens Settings at the MCP category.
+            McpStatusIndicator(
+                enabled = mcpEnabled,
+                onClick = onMcpIndicatorClick
+            )
         }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -488,7 +488,8 @@ class TabController(
         arguments: List<String> = emptyList(),
         sessionTitle: String = "Split",
         onProcessExit: (() -> Unit)? = null,
-        tabId: String? = null
+        tabId: String? = null,
+        initialCommand: String? = null
     ): TerminalSession {
         // Validate tab ID uniqueness if custom ID provided
         // Note: We check against tabs list for consistency, even though split sessions
@@ -680,9 +681,11 @@ class TabController(
             textBuffer.endBatch()
         }
 
-        // Initialize the terminal session (spawn PTY, start coroutines)
-        // Note: We don't pass onProcessExit since split pane lifecycle is managed separately
-        initializeTerminalSession(session, workingDir, effectiveCommand, effectiveArguments)
+        // Initialize the terminal session (spawn PTY, start coroutines).
+        // Note: onProcessExit is wired on the TerminalTab itself (line 630), not passed here.
+        // initialCommand is held until OSC 133;A (or the fallback delay) so the shell is
+        // ready before bytes go down the PTY — same contract as createTab.
+        initializeTerminalSession(session, workingDir, effectiveCommand, effectiveArguments, initialCommand)
 
         return session
     }
@@ -1129,6 +1132,22 @@ class TabController(
                 // Connect terminal output to PTY for bidirectional communication
                 tab.terminal.setTerminalOutput(ProcessTerminalOutput(handle, tab))
 
+                // Pre-register the OSC 133;A (prompt-started) listener BEFORE the
+                // emulator/PTY-reader coroutines start. Otherwise a fast shell can
+                // print its prompt and the emulator can dispatch onPromptStarted()
+                // before the (originally-inline) registration coroutine runs —
+                // causing the deferred to time out on `initialCommandDelayMs`
+                // instead of firing on the actual signal.
+                val initialPromptReady: CompletableDeferred<Unit>? =
+                    if (initialCommand != null) CompletableDeferred() else null
+                val initialPromptListener: CommandStateListener? = initialPromptReady?.let { ready ->
+                    object : CommandStateListener {
+                        override fun onPromptStarted() {
+                            ready.complete(Unit)
+                        }
+                    }.also { tab.terminal.addCommandStateListener(it) }
+                }
+
                 // Start emulator processing coroutine
                 // Note: Initial prompt will display via ModelListener → requestImmediateRedraw()
                 // when buffer content changes. No need for premature redraw here.
@@ -1171,22 +1190,15 @@ class TabController(
                     }
                 }
 
-                // Send initial command if provided (after terminal is ready)
-                // Uses OSC 133;A (prompt started) signal for proper synchronization,
-                // with configurable fallback delay for shells without OSC 133 support
+                // Send initial command if provided (after terminal is ready).
+                // The OSC 133;A listener was already registered above (before the
+                // emulator loop launched) so we can't miss the prompt-started signal.
+                // This coroutine just waits on the pre-registered deferred and writes
+                // the command when the shell is ready (or after the fallback delay).
                 if (initialCommand != null) {
+                    val promptReady = checkNotNull(initialPromptReady)
+                    val promptListener = checkNotNull(initialPromptListener)
                     launch(Dispatchers.IO) {
-                        // Create a deferred that will be completed when first prompt appears
-                        val promptReady = CompletableDeferred<Unit>()
-
-                        // Add a temporary listener to detect OSC 133;A (prompt started)
-                        val promptListener = object : CommandStateListener {
-                            override fun onPromptStarted() {
-                                promptReady.complete(Unit)
-                            }
-                        }
-                        tab.terminal.addCommandStateListener(promptListener)
-
                         try {
                             // Wait for either OSC 133;A signal OR fallback timeout
                             val result = withTimeoutOrNull(settings.initialCommandDelayMs.toLong()) {
@@ -1236,7 +1248,7 @@ class TabController(
                             // Send the command followed by newline
                             handle.write(initialCommand + "\n")
                         } finally {
-                            // Clean up the temporary listener
+                            // Clean up the pre-registered listener
                             tab.terminal.removeCommandStateListener(promptListener)
                         }
                     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -321,7 +321,9 @@ class TabController(
             }
         })
 
-        // Register command state listener for notifications (OSC 133 shell integration)
+        // Register command state listener for notifications (OSC 133 shell integration).
+        // Also captured in `tab.commandStateListeners` after construction so dispose()
+        // can remove it (see TerminalTab.commandStateListeners docs).
         val notificationHandler = CommandNotificationHandler(
             settings = settings,
             isWindowFocused = isWindowFocused,
@@ -407,10 +409,13 @@ class TabController(
         )
 
         // Register MCP last-command tracker (OSC 133). Additive — does not
-        // affect the notification handler registered earlier.
-        terminal.addCommandStateListener(
-            ai.rever.bossterm.compose.mcp.LastCommandTracker(tab)
-        )
+        // affect the notification handler registered earlier. Both listeners
+        // are recorded on `tab.commandStateListeners` so dispose() can remove
+        // them when the tab closes.
+        val lastCommandTracker = ai.rever.bossterm.compose.mcp.LastCommandTracker(tab)
+        terminal.addCommandStateListener(lastCommandTracker)
+        tab.commandStateListeners.add(notificationHandler)
+        tab.commandStateListeners.add(lastCommandTracker)
 
         // Complete debug collector initialization
         debugCollector?.let { collector ->
@@ -649,10 +654,13 @@ class TabController(
         )
 
         // Register MCP last-command tracker (OSC 133). Additive — does not
-        // affect the notification handler registered earlier.
-        terminal.addCommandStateListener(
-            ai.rever.bossterm.compose.mcp.LastCommandTracker(session)
-        )
+        // affect the notification handler registered earlier. Both listeners
+        // are recorded on the session so dispose() can remove them when the
+        // pane closes.
+        val lastCommandTracker = ai.rever.bossterm.compose.mcp.LastCommandTracker(session)
+        terminal.addCommandStateListener(lastCommandTracker)
+        session.commandStateListeners.add(notificationHandler)
+        session.commandStateListeners.add(lastCommandTracker)
 
         // Complete debug collector initialization
         debugCollector?.let { collector ->
@@ -838,10 +846,12 @@ class TabController(
         )
 
         // Register MCP last-command tracker (OSC 133). Additive — does not
-        // affect the notification handler registered earlier.
-        terminal.addCommandStateListener(
-            ai.rever.bossterm.compose.mcp.LastCommandTracker(tab)
-        )
+        // affect the notification handler registered earlier. Both listeners
+        // are recorded on the tab so dispose() can remove them.
+        val lastCommandTracker = ai.rever.bossterm.compose.mcp.LastCommandTracker(tab)
+        terminal.addCommandStateListener(lastCommandTracker)
+        tab.commandStateListeners.add(notificationHandler)
+        tab.commandStateListeners.add(lastCommandTracker)
 
         debugCollector?.let { collector ->
             collector.setTab(tab)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -406,6 +406,12 @@ class TabController(
             modelListener = modelListener
         )
 
+        // Register MCP last-command tracker (OSC 133). Additive — does not
+        // affect the notification handler registered earlier.
+        terminal.addCommandStateListener(
+            ai.rever.bossterm.compose.mcp.LastCommandTracker(tab)
+        )
+
         // Complete debug collector initialization
         debugCollector?.let { collector ->
             // Set the tab reference now that tab is created
@@ -641,6 +647,12 @@ class TabController(
             modelListener = modelListener
         )
 
+        // Register MCP last-command tracker (OSC 133). Additive — does not
+        // affect the notification handler registered earlier.
+        terminal.addCommandStateListener(
+            ai.rever.bossterm.compose.mcp.LastCommandTracker(session)
+        )
+
         // Complete debug collector initialization
         debugCollector?.let { collector ->
             collector.setTab(session)
@@ -820,6 +832,12 @@ class TabController(
             typeAheadModel = null,  // Type-ahead configured after preConnect
             typeAheadManager = null,
             modelListener = modelListener
+        )
+
+        // Register MCP last-command tracker (OSC 133). Additive — does not
+        // affect the notification handler registered earlier.
+        terminal.addCommandStateListener(
+            ai.rever.bossterm.compose.mcp.LastCommandTracker(tab)
         )
 
         debugCollector?.let { collector ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -249,6 +249,19 @@ data class TerminalTab(
      */
     override val isVisible: MutableState<Boolean> = mutableStateOf(false)
 
+    /**
+     * Most recently completed shell command for this tab, populated by
+     * [ai.rever.bossterm.compose.mcp.LastCommandTracker] via OSC 133 events.
+     * `null` until at least one command has completed.
+     *
+     * Consumed by the in-process MCP server (`get_last_command` tool).
+     * Thread-safe: [kotlinx.coroutines.flow.MutableStateFlow] supports
+     * concurrent writes from listener callbacks (which may run off the UI
+     * thread) and concurrent reads from MCP request handlers.
+     */
+    val lastCommand: kotlinx.coroutines.flow.MutableStateFlow<ai.rever.bossterm.compose.mcp.LastCommand?> =
+        kotlinx.coroutines.flow.MutableStateFlow(null)
+
     // === Content-Anchored Selection ===
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -240,7 +240,19 @@ data class TerminalTab(
      * hours of tab create/close cycles, eventually causing memory pressure
      * and exceptions when references to disposed displays are invoked.
      */
-    val modelListener: ai.rever.bossterm.terminal.model.TerminalModelListener? = null
+    val modelListener: ai.rever.bossterm.terminal.model.TerminalModelListener? = null,
+
+    /**
+     * Command-state listeners we registered against [terminal] in the controller
+     * (e.g. CommandNotificationHandler, LastCommandTracker). Removed in [dispose]
+     * so listeners don't accumulate over hours of tab create/close cycles.
+     *
+     * Same rationale as [modelListener] — anonymous listeners holding references
+     * to a tab's display / state become memory pressure when the terminal itself
+     * outlives the tab (e.g. while we're tearing down asynchronously) and a
+     * source of late callbacks against disposed UI.
+     */
+    val commandStateListeners: MutableList<ai.rever.bossterm.terminal.model.CommandStateListener> = mutableListOf()
 ) : TerminalSession {
     /**
      * Whether this tab is currently rendering to the UI.
@@ -379,6 +391,19 @@ data class TerminalTab(
                 textBuffer.removeModelListener(it)
             } catch (e: Exception) {
                 System.err.println("WARN: Failed to remove model listener: ${e.message}")
+            }
+        }
+
+        // Remove the command-state listeners the controller registered for us.
+        // Same memory-pressure rationale as modelListener above: anonymous OSC 133
+        // listeners (CommandNotificationHandler, LastCommandTracker) would otherwise
+        // remain attached to `terminal` and keep this tab's state reachable until
+        // the terminal itself is collected.
+        for (listener in commandStateListeners) {
+            try {
+                terminal.removeCommandStateListener(listener)
+            } catch (e: Exception) {
+                System.err.println("WARN: Failed to remove command-state listener: ${e.message}")
             }
         }
 

--- a/embedded-example/src/desktopMain/kotlin/ai/rever/bossterm/embedded/Main.kt
+++ b/embedded-example/src/desktopMain/kotlin/ai/rever/bossterm/embedded/Main.kt
@@ -6,6 +6,10 @@ import ai.rever.bossterm.compose.ContextMenuSubmenu
 import ai.rever.bossterm.compose.EmbeddableTerminal
 import ai.rever.bossterm.compose.PlatformServices
 import ai.rever.bossterm.compose.getPlatformServices
+import ai.rever.bossterm.compose.mcp.BossTermMcpConfig
+import ai.rever.bossterm.compose.mcp.BossTermMcpManager
+import ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
+import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.rememberEmbeddableTerminalState
 import ai.rever.bossterm.compose.onboarding.OnboardingWizard
 import ai.rever.bossterm.compose.settings.SettingsManager
@@ -24,7 +28,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 /**
  * Custom PlatformServices wrapper that logs process spawn events.
@@ -51,15 +64,92 @@ private class LoggingPlatformServices(
  * - Focus transitions between parent UI and terminal
  * - Multiple embedded terminals
  */
-fun main() = application {
-    val windowState = rememberWindowState(width = 1200.dp, height = 800.dp)
+fun main() {
+    // === BossTerm MCP setup ============================================
+    // Demonstrates two embedder hooks on BossTermMcpConfig:
+    //   1. customToolDescriptions — replace the default description of a built-in
+    //      tool so MCP clients see app-specific wording. Keys are unprefixed
+    //      built-in names (e.g. "list_tabs"). Unmentioned tools keep their default.
+    //   2. additionalTools — register app-specific MCP tools alongside the built-ins.
+    //      The lambda receives the live `Server` so the embedder can call
+    //      `server.addTool(...)` directly. Tool names here are NOT prefixed —
+    //      the embedder owns the namespace.
+    // The user still has to toggle "Enable BossTerm MCP Server" in settings for
+    // the Ktor endpoint to bind (defaultEnabled = true below skips that on a
+    // fresh install).
+    val mcpScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val mcpConfig = BossTermMcpConfig(
+        serverName = "bossterm-embedded-example",
+        // `defaultEnabled` is honored only on the very first BossTerm launch on this
+        // machine (gated by the global `mcpConfigured` flag in ~/.bossterm/settings.json).
+        // If you've already run another BossTerm-based app on this machine, the setting
+        // here is ignored and the user's persisted mcpEnabled value wins. Toggle MCP
+        // on/off in Settings → BossTerm MCP if needed.
+        defaultEnabled = true,
+        customToolDescriptions = mapOf(
+            "list_tabs" to "List terminal tabs hosted by the BossTerm Embedded Example app. " +
+                    "This host embeds a single primary tab plus an optional compact bottom-panel " +
+                    "tab when the user opens it from the sidebar."
+        ),
+        additionalTools = { server ->
+            // Custom tool: returns metadata about the host app. Demonstrates the
+            // minimum boilerplate for an embedder-defined MCP tool — zero-arg
+            // schema, JSON text content, no error path.
+            server.addTool(
+                name = "embedded_example_app_info",
+                description = "Return metadata about the host application " +
+                        "(BossTerm Embedded Example): app name, build flavor, and a " +
+                        "short usage hint. Demonstrates embedder-registered tools.",
+                inputSchema = ToolSchema(
+                    properties = buildJsonObject {},
+                    required = emptyList()
+                )
+            ) { _ ->
+                val body = buildJsonObject {
+                    put("appName", "BossTerm Embedded Example")
+                    put("flavor", "single-window, two-terminal demo")
+                    put(
+                        "hint",
+                        "The sidebar's buttons drive the primary terminal directly; " +
+                                "the compact bottom-panel terminal is opened on demand."
+                    )
+                }
+                CallToolResult(
+                    content = listOf(TextContent(text = body.toString())),
+                    isError = false,
+                    structuredContent = null,
+                    meta = null
+                )
+            }
+        }
+    )
+    val mcpManager = BossTermMcpManager(
+        registry = McpTerminalRegistry,
+        settingsManager = SettingsManager.instance,
+        parentScope = mcpScope,
+        config = mcpConfig
+    )
+    mcpManager.start()
 
-    Window(
-        onCloseRequest = ::exitApplication,
-        title = "BossTerm Embedded Example",
-        state = windowState
-    ) {
-        EmbeddedExampleApp()
+    try {
+        application {
+            val windowState = rememberWindowState(width = 1200.dp, height = 800.dp)
+
+            // Expose the config to the settings UI so it can render the embedder's
+            // server name in the endpoint note and respect showInSettingsUi.
+            CompositionLocalProvider(LocalBossTermMcpConfig provides mcpConfig) {
+                Window(
+                    onCloseRequest = ::exitApplication,
+                    title = "BossTerm Embedded Example",
+                    state = windowState
+                ) {
+                    EmbeddedExampleApp()
+                }
+            }
+        }
+    } finally {
+        mcpManager.stop()
+        mcpScope.cancel()
     }
 }
 

--- a/tabbed-example/src/desktopMain/kotlin/ai/rever/bossterm/tabbed/Main.kt
+++ b/tabbed-example/src/desktopMain/kotlin/ai/rever/bossterm/tabbed/Main.kt
@@ -8,6 +8,10 @@ import ai.rever.bossterm.compose.TabbedTerminal
 import ai.rever.bossterm.compose.TabbedTerminalState
 import ai.rever.bossterm.compose.TerminalTabInfo
 import ai.rever.bossterm.compose.getPlatformServices
+import ai.rever.bossterm.compose.mcp.BossTermMcpConfig
+import ai.rever.bossterm.compose.mcp.BossTermMcpManager
+import ai.rever.bossterm.compose.mcp.LocalBossTermMcpConfig
+import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.rememberTabbedTerminalState
 import ai.rever.bossterm.compose.menu.MenuActions
 import ai.rever.bossterm.compose.onboarding.OnboardingWizard
@@ -28,10 +32,20 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.*
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import java.awt.event.WindowEvent
 import java.awt.event.WindowFocusListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 /**
  * Example application demonstrating BossTerm's TabbedTerminal component.
@@ -50,33 +64,117 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * Run with: ./gradlew :tabbed-example:run
  */
-fun main() = application {
-    // Track all open windows
-    val windows = remember { mutableStateListOf(WindowState()) }
-
-    // Create new window
-    fun createWindow() {
-        windows.add(WindowState())
-    }
-
-    // Close window
-    fun closeWindow(index: Int) {
-        if (windows.size > 1) {
-            windows.removeAt(index)
-        } else {
-            exitApplication()
+fun main() {
+    // === BossTerm MCP setup ============================================
+    // Demonstrates two embedder hooks on BossTermMcpConfig:
+    //   1. customToolDescriptions — override individual built-in tool descriptions
+    //      so MCP clients see context-specific wording (e.g. "tabs in TabbedTerminal
+    //      windows of the Tabbed Example").
+    //   2. additionalTools — register app-specific MCP tools. Names here are NOT
+    //      prefixed; the embedder owns the namespace.
+    val mcpScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val mcpConfig = BossTermMcpConfig(
+        serverName = "bossterm-tabbed-example",
+        // `defaultEnabled` is honored only on the very first BossTerm launch on this
+        // machine (gated by the global `mcpConfigured` flag in ~/.bossterm/settings.json).
+        // If you've already run another BossTerm-based app on this machine, the setting
+        // here is ignored and the user's persisted mcpEnabled value wins. Toggle MCP
+        // on/off in Settings → BossTerm MCP if needed.
+        defaultEnabled = true,
+        customToolDescriptions = mapOf(
+            "list_tabs" to "List terminal tabs across every TabbedTerminal window in " +
+                    "the BossTerm Tabbed Example. Each window has its own tab bar and " +
+                    "split state; this returns the union, with isActive flagging the " +
+                    "currently selected tab per window."
+        ),
+        additionalTools = { server ->
+            // Custom tool: snapshot of every registered window's tab + pane count.
+            // Returns an array so MCP clients can iterate over windows even though
+            // get_active_tab only returns the primary window's active tab.
+            server.addTool(
+                name = "tabbed_example_window_overview",
+                description = "Return a window-by-window snapshot of the BossTerm Tabbed " +
+                        "Example: per window, the number of tabs and the active tab's id. " +
+                        "Useful when the host has multiple windows open and a client needs " +
+                        "to enumerate them.",
+                inputSchema = ToolSchema(
+                    properties = buildJsonObject {},
+                    required = emptyList()
+                )
+            ) { _ ->
+                val states = McpTerminalRegistry.allStates()
+                val body = buildJsonObject {
+                    put("appName", "BossTerm Tabbed Example")
+                    put("windowCount", states.size)
+                    put(
+                        "windows",
+                        buildJsonArray {
+                            states.forEachIndexed { index, state ->
+                                add(
+                                    buildJsonObject {
+                                        put("index", index)
+                                        put("tabCount", state.tabCount)
+                                        put("activeTabId", state.activeTabId ?: "")
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+                CallToolResult(
+                    content = listOf(TextContent(text = body.toString())),
+                    isError = false,
+                    structuredContent = null,
+                    meta = null
+                )
+            }
         }
-    }
+    )
+    val mcpManager = BossTermMcpManager(
+        registry = McpTerminalRegistry,
+        settingsManager = SettingsManager.instance,
+        parentScope = mcpScope,
+        config = mcpConfig
+    )
+    mcpManager.start()
 
-    // Render all windows
-    windows.forEachIndexed { index, windowState ->
-        TabbedTerminalWindow(
-            windowState = windowState,
-            windowIndex = index,
-            totalWindows = windows.size,
-            onCloseRequest = { closeWindow(index) },
-            onNewWindow = { createWindow() }
-        )
+    try {
+        application {
+            // Track all open windows
+            val windows = remember { mutableStateListOf(WindowState()) }
+
+            // Create new window
+            fun createWindow() {
+                windows.add(WindowState())
+            }
+
+            // Close window
+            fun closeWindow(index: Int) {
+                if (windows.size > 1) {
+                    windows.removeAt(index)
+                } else {
+                    exitApplication()
+                }
+            }
+
+            // Expose the config to the settings UI so it can show the embedder's
+            // server name in the endpoint note and honor showInSettingsUi.
+            CompositionLocalProvider(LocalBossTermMcpConfig provides mcpConfig) {
+                // Render all windows
+                windows.forEachIndexed { index, windowState ->
+                    TabbedTerminalWindow(
+                        windowState = windowState,
+                        windowIndex = index,
+                        totalWindows = windows.size,
+                        onCloseRequest = { closeWindow(index) },
+                        onNewWindow = { createWindow() }
+                    )
+                }
+            }
+        }
+    } finally {
+        mcpManager.stop()
+        mcpScope.cancel()
     }
 }
 


### PR DESCRIPTION
## Summary

Adds an in-process MCP server to BossTerm so AI clients (Claude Code, etc.) can
read scrollback, search output, drive shells, and observe command completions
across every open window. Built as a library-friendly module that other apps
embedding `compose-ui` can rebrand and reconfigure.

The server is **off by default** and binds **127.0.0.1 only** with a
DNS-rebinding gate. Users opt in via a new \"MCP Server\" category in Settings
or a Tools-menu toggle.

## What's in here

**Core server** — `compose-ui/.../mcp/`
- `BossTermMcpServer`: 7 tools — `list_tabs`, `get_active_tab`,
  `read_scrollback`, `search_output`, `get_last_command`, `send_input`,
  `send_signal`. Transport-agnostic.
- `BossTermMcpManager`: app-singleton lifecycle wrapper. Watches
  `mcpEnabled` / `mcpPort` settings, brings up an embedded Ktor CIO server
  on `http://127.0.0.1:<port>/mcp` (SSE), rejects non-loopback Host
  headers with 403.
- `McpTerminalRegistry`: process-wide registry of \`TabbedTerminalState\`
  instances so a single endpoint exposes tabs from every window.
- `LastCommandTracker`: per-tab OSC 133 listener publishing the most
  recently completed command (exit code, duration, cwd).

**Embedder API** — `BossTermMcpConfig`
- \`serverName\` / \`serverVersion\` — branding shown to MCP clients
- \`toolNamePrefix\` — namespace built-ins (e.g. \`bossconsole_list_tabs\`)
- \`allowWriteTools\` — drop \`send_input\` / \`send_signal\` for read-only
- \`defaultPort\` / \`defaultEnabled\` — first-launch values
- \`showInSettingsUi\` — hide the Settings category for embedders that
  don't want MCP exposed
- \`additionalTools\` — hook to register app-specific tools

**UI surfaces**
- New \"MCP Server\" category in the Settings dialog with toggle / port
  input / indicator visibility flag, plus an inline note showing the
  endpoint URL and configured server identifier.
- Tools menu submenu with a live \`CheckboxItem\` and Settings deep-link.
- Small green status indicator in the tab bar's trailing slot, only
  visible when the Ktor server is *actually* bound (driven by
  \`McpTerminalRegistry.runningPort\`, not just the user setting).
  Clicking it opens Settings directly on the MCP category.
- Settings panel renders a \"how to configure\" banner for embedders that
  haven't wired up a manager.

**Security defaults**
- Off by default (\`mcpEnabled = false\`); opt-in.
- Loopback bind only (\`127.0.0.1\`, never \`0.0.0.0\`).
- DNS-rebinding gate: requests whose Host header isn't a loopback target
  get 403.
- \`BindException\` on port-in-use is caught + logged \`warn\` rather than
  crashing.

## Test plan

- [ ] Build green: \`./gradlew :bossterm-app:compileKotlinDesktop --no-daemon\`
- [ ] Toggle \`mcpEnabled\` in \`~/.bossterm/settings.json\` (or via the
      Settings UI / Tools menu). Verify within ~100ms:
      - Manager logs \`Starting BossTerm MCP server on http://127.0.0.1:<port>/mcp\`
      - Green dot appears in the tab bar
      - \`lsof -nP -iTCP:<port> -sTCP:LISTEN\` shows the bound process
- [ ] Toggle off → server stops, dot disappears, port released
- [ ] \`curl -i -N http://127.0.0.1:<port>/mcp/sse\` returns 200 +
      \`text/event-stream\`; announces a message endpoint
- [ ] \`curl -i -H 'Host: evil.example' http://127.0.0.1:<port>/mcp/sse\`
      returns 403
- [ ] Connect an MCP client; \`tools/list\` shows the 7 tools
- [ ] Open multiple windows: tabs from all windows appear in
      \`list_tabs\`; closing one window doesn't kill the server
- [ ] Upgrade safety: with a pre-existing \`settings.json\` from before
      this PR (no \`mcpConfigured\` key), launch this build and confirm
      existing \`mcpEnabled\` / \`mcpPort\` values are *preserved*, not
      reset to defaults

## Out of scope (follow-ups noted in self-review)

- JVM shutdown hook races the async \`stop()\` — Ktor may not get its
  graceful 1.5s window. Sockets close on process exit anyway. (M1)
- Inner \`McpConfig\` data class shadows the embedder \`config\` name. (M2)
- Minor unused imports / hardcoded FQNs in 3-4 spots. (M3)
- \`additionalTools\` hook may collide with built-in names; document
  the rule or check. (M4)
- \`Main.kt\` CompositionLocalProvider isn't re-indented. (M5)
- \`commandText\` in \`get_last_command\` is permanently null pending a
  reliable buffer-extraction strategy. (L5)

Generated with [Claude Code](https://claude.com/claude-code)