### PR TITLE
perf(mcp): Serena-style response shortening + projection args + null omission

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.floatOrNull
 import kotlinx.serialization.json.intOrNull
@@ -67,7 +68,12 @@ class BossTermMcpServer(
     private val json: Json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = true
-        explicitNulls = true
+        // Omit null-valued fields from the wire format. Saves 7–12 bytes per
+        // null per record. The one place we intentionally emit a literal JSON
+        // `null` is get_active_tab's "no active tab" case, which is hand-built
+        // (`if (info == null) "null" else …`), not via a serializer — so this
+        // flip doesn't affect it.
+        explicitNulls = false
     }
 
     /** Returns the built-in tool name with the embedder's configured prefix applied. */
@@ -323,7 +329,27 @@ class BossTermMcpServer(
             }
 
             val payload = ReadScrollbackResult(lines = lines, totalAvailable = totalAvailable)
-            successJson(json.encodeToString(ReadScrollbackResult.serializer(), payload))
+            val full = json.encodeToString(ReadScrollbackResult.serializer(), payload)
+            // Progressive fallbacks. Most callers want recent context, so the
+            // first fallback keeps the tail; the final form gives the agent
+            // enough to refine the next call (smaller `lines`).
+            val fallbacks = listOf<() -> String>(
+                {
+                    val tail = lines.takeLast(20)
+                    buildJsonObject {
+                        put("lines", buildJsonArray { for (l in tail) add(JsonPrimitive(l)) })
+                        put("totalAvailable", totalAvailable)
+                        put("shortened", "tail: last ${tail.size} of ${lines.size} requested lines")
+                    }.toString()
+                },
+                {
+                    buildJsonObject {
+                        put("totalAvailable", totalAvailable)
+                        put("shortened", "totals only; retry with a smaller `lines` value")
+                    }.toString()
+                }
+            )
+            successJson(shorten(full, fallbacks))
         }
     }
 
@@ -434,7 +460,58 @@ class BossTermMcpServer(
                 historyLinesCount = snapshot.historyLinesCount,
                 height = snapshot.height
             )
-            successJson(json.encodeToString(SearchOutputResult.serializer(), payload))
+            val full = json.encodeToString(SearchOutputResult.serializer(), payload)
+            // Progressive fallbacks (in decreasing detail) for when `full`
+            // blows past mcpMaxAnswerChars. Each factory returns valid JSON.
+            //
+            //   1. drop SearchMatch.line text (positions only) — usually
+            //      cuts the response by 60–80%.
+            //   2. per-row hit counts — `{rowCounts: {row: n}, totalMatches}`.
+            //   3. just the totals.
+            val fallbacks = listOf<() -> String>(
+                {
+                    val positions = buildJsonArray {
+                        for (m in matches) add(
+                            buildJsonObject {
+                                put("row", m.row)
+                                put("matchStart", m.matchStart)
+                                put("matchEnd", m.matchEnd)
+                            }
+                        )
+                    }
+                    buildJsonObject {
+                        put("matches", positions)
+                        put("truncated", truncated)
+                        put("historyLinesCount", snapshot.historyLinesCount)
+                        put("height", snapshot.height)
+                        put("shortened", "matches: positions only (no line text)")
+                    }.toString()
+                },
+                {
+                    val counts = buildJsonObject {
+                        val perRow = matches.groupingBy { it.row }.eachCount()
+                        for ((r, n) in perRow) put(r.toString(), n)
+                    }
+                    buildJsonObject {
+                        put("rowCounts", counts)
+                        put("totalMatches", matches.size)
+                        put("truncated", truncated)
+                        put("historyLinesCount", snapshot.historyLinesCount)
+                        put("height", snapshot.height)
+                        put("shortened", "rowCounts: hit counts per row")
+                    }.toString()
+                },
+                {
+                    buildJsonObject {
+                        put("totalMatches", matches.size)
+                        put("truncated", truncated)
+                        put("historyLinesCount", snapshot.historyLinesCount)
+                        put("height", snapshot.height)
+                        put("shortened", "totals only")
+                    }.toString()
+                }
+            )
+            successJson(shorten(full, fallbacks))
         }
     }
 
@@ -813,7 +890,36 @@ class BossTermMcpServer(
             )
 
             val payload = ReadDebugConsoleResult(chunks = resultChunks, stats = statsDto)
-            successJson(json.encodeToString(ReadDebugConsoleResult.serializer(), payload))
+            val full = json.encodeToString(ReadDebugConsoleResult.serializer(), payload)
+            // Fallbacks for the bytes-dominate case. `data` is the bulk of any
+            // ReadDebugConsoleResult; dropping it preserves the chunk indexing
+            // info the agent uses to poll and refine.
+            val fallbacks = listOf<() -> String>(
+                {
+                    val metadataChunks = buildJsonArray {
+                        for (c in resultChunks) add(
+                            buildJsonObject {
+                                put("index", c.index)
+                                put("timestamp", c.timestamp)
+                                put("source", c.source)
+                            }
+                        )
+                    }
+                    buildJsonObject {
+                        put("chunks", metadataChunks)
+                        put("stats", json.encodeToJsonElement(DebugConsoleStats.serializer(), statsDto))
+                        put("shortened", "chunks: metadata only (data omitted)")
+                    }.toString()
+                },
+                {
+                    buildJsonObject {
+                        put("stats", json.encodeToJsonElement(DebugConsoleStats.serializer(), statsDto))
+                        put("chunksReturned", resultChunks.size)
+                        put("shortened", "stats only; retry with a smaller `max_chunks` or narrower `sources`")
+                    }.toString()
+                }
+            )
+            successJson(shorten(full, fallbacks))
         }
     }
 
@@ -938,6 +1044,36 @@ class BossTermMcpServer(
             isError = true,
             structuredContent = null,
             meta = null
+        )
+    }
+
+    /**
+     * Progressive shortening for responses that can grow unboundedly.
+     * Mirrors Serena's `_limit_length` pattern (tools_base.py:267-297).
+     *
+     * If [full] fits under the configured `mcpMaxAnswerChars`, it's returned.
+     * Otherwise [fallbacks] are tried in order — each is a factory producing
+     * a progressively smaller (but still well-formed JSON) summary; the first
+     * one that fits wins. If nothing fits, returns a JSON error suggesting
+     * the caller refine the query.
+     *
+     * Each fallback factory MUST return valid JSON the client can parse —
+     * never a truncated prefix of [full]. The goal is "smaller well-formed
+     * answer the agent can reason about", not "truncated blob".
+     */
+    private fun shorten(
+        full: String,
+        fallbacks: List<() -> String>
+    ): String {
+        val cap = settingsManager.settings.value.mcpMaxAnswerChars
+        if (cap <= 0 || full.length <= cap) return full
+        for (factory in fallbacks) {
+            val short = factory()
+            if (short.length <= cap) return short
+        }
+        return json.encodeToString(
+            ErrorResult.serializer(),
+            ErrorResult(error = "Response too large (>$cap chars) and no fallback fit; refine the query.")
         )
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -65,6 +65,8 @@ class BossTermMcpServer(
     private val settingsManager: SettingsManager = SettingsManager.instance
 ) {
 
+    private val log = org.slf4j.LoggerFactory.getLogger(BossTermMcpServer::class.java)
+
     private val json: Json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = true
@@ -224,15 +226,43 @@ class BossTermMcpServer(
                         "currently selected tab of its window)."
             ),
             inputSchema = ToolSchema(
-                properties = buildJsonObject {},
+                properties = buildJsonObject {
+                    putJsonObject("include_fields") {
+                        put("type", "array")
+                        put("description", "Optional allow-list over TabInfo fields: " +
+                                "id, title, cwd, pid, isActive. Omit to get every field. " +
+                                "Useful when you only need a subset (e.g. `[\"id\",\"isActive\"]`).")
+                    }
+                },
                 required = emptyList()
             )
-        ) { _ ->
+        ) { request ->
+            val args = request.arguments
+            val includeFields = args.optionalStringSet("include_fields")
             val infos = registry.collectTabInfos()
             val primaryActiveId = registry.primaryState()?.activeTabId
-            val payload = ListTabsResult(tabs = infos, activeTabId = primaryActiveId)
-            successJson(json.encodeToString(ListTabsResult.serializer(), payload))
+            val text = if (includeFields == null) {
+                val payload = ListTabsResult(tabs = infos, activeTabId = primaryActiveId)
+                json.encodeToString(ListTabsResult.serializer(), payload)
+            } else {
+                buildJsonObject {
+                    put("tabs", buildJsonArray {
+                        for (info in infos) add(tabInfoToJson(info, includeFields))
+                    })
+                    if (primaryActiveId != null) put("activeTabId", primaryActiveId)
+                }.toString()
+            }
+            successJson(text)
         }
+    }
+
+    /** Projects a [TabInfo] onto the given field allow-list. Empty set = no fields. */
+    private fun tabInfoToJson(info: TabInfo, fields: Set<String>): JsonObject = buildJsonObject {
+        if ("id" in fields) put("id", info.id)
+        if ("title" in fields) put("title", info.title)
+        if ("cwd" in fields && info.cwd != null) put("cwd", info.cwd)
+        if ("pid" in fields && info.pid != null) put("pid", info.pid)
+        if ("isActive" in fields) put("isActive", info.isActive)
     }
 
     // -----------------------------------------------------------------
@@ -248,16 +278,28 @@ class BossTermMcpServer(
                         "that is still alive), or null if no tab is active."
             ),
             inputSchema = ToolSchema(
-                properties = buildJsonObject {},
+                properties = buildJsonObject {
+                    putJsonObject("include_fields") {
+                        put("type", "array")
+                        put("description", "Optional allow-list over TabInfo fields: " +
+                                "id, title, cwd, pid, isActive. Omit to get every field.")
+                    }
+                },
                 required = emptyList()
             )
-        ) { _ ->
+        ) { request ->
+            val args = request.arguments
+            val includeFields = args.optionalStringSet("include_fields")
             val primary = registry.primaryState()
             val activeId = primary?.activeTabId
             val info = primary?.activeTab?.toTabInfo(activeId)
             // The literal JSON `null` is valid output — clients calling
             // JSON.parse get a real null. Cheaper than wrapping in `{tab: null}`.
-            val text = if (info == null) "null" else json.encodeToString(TabInfo.serializer(), info)
+            val text = when {
+                info == null -> "null"
+                includeFields == null -> json.encodeToString(TabInfo.serializer(), info)
+                else -> tabInfoToJson(info, includeFields).toString()
+            }
             successJson(text)
         }
     }
@@ -333,7 +375,8 @@ class BossTermMcpServer(
             // Progressive fallbacks. Most callers want recent context, so the
             // first fallback keeps the tail; the final form gives the agent
             // enough to refine the next call (smaller `lines`).
-            val fallbacks = listOf<() -> String>(
+            successJson(shorten(
+                full,
                 {
                     val tail = lines.takeLast(20)
                     buildJsonObject {
@@ -348,8 +391,7 @@ class BossTermMcpServer(
                         put("shortened", "totals only; retry with a smaller `lines` value")
                     }.toString()
                 }
-            )
-            successJson(shorten(full, fallbacks))
+            ))
         }
     }
 
@@ -393,6 +435,12 @@ class BossTermMcpServer(
                         put("description", "Optional specific pane within the tab " +
                                 "(returned by run_in_panel). Omit to search the focused pane.")
                     }
+                    putJsonObject("include_line_text") {
+                        put("type", "boolean")
+                        put("description", "If false, each match returns only row+matchStart+matchEnd " +
+                                "(no line text). Cuts response size by 60–80% on typical scrollback " +
+                                "searches. Default true.")
+                    }
                 },
                 required = listOf("tab_id", "pattern")
             )
@@ -407,6 +455,7 @@ class BossTermMcpServer(
                 return@addTool errorResult("'max_matches' must be >= 1 (got $maxMatches)")
             }
             val ignoreCase = args.optionalBoolean("ignore_case") ?: false
+            val includeLineText = args.optionalBoolean("include_line_text") ?: true
             val paneId = args.requireString("pane_id")
             val state = registry.findState(tabId)
                 ?: return@addTool errorResult("Unknown tab_id: $tabId")
@@ -454,64 +503,70 @@ class BossTermMcpServer(
                 row++
             }
 
-            val payload = SearchOutputResult(
-                matches = matches,
-                truncated = truncated,
-                historyLinesCount = snapshot.historyLinesCount,
-                height = snapshot.height
-            )
-            val full = json.encodeToString(SearchOutputResult.serializer(), payload)
-            // Progressive fallbacks (in decreasing detail) for when `full`
-            // blows past mcpMaxAnswerChars. Each factory returns valid JSON.
-            //
-            //   1. drop SearchMatch.line text (positions only) — usually
-            //      cuts the response by 60–80%.
-            //   2. per-row hit counts — `{rowCounts: {row: n}, totalMatches}`.
-            //   3. just the totals.
-            val fallbacks = listOf<() -> String>(
-                {
-                    val positions = buildJsonArray {
-                        for (m in matches) add(
-                            buildJsonObject {
-                                put("row", m.row)
-                                put("matchStart", m.matchStart)
-                                put("matchEnd", m.matchEnd)
-                            }
-                        )
-                    }
-                    buildJsonObject {
-                        put("matches", positions)
-                        put("truncated", truncated)
-                        put("historyLinesCount", snapshot.historyLinesCount)
-                        put("height", snapshot.height)
-                        put("shortened", "matches: positions only (no line text)")
-                    }.toString()
-                },
-                {
-                    val counts = buildJsonObject {
-                        val perRow = matches.groupingBy { it.row }.eachCount()
-                        for ((r, n) in perRow) put(r.toString(), n)
-                    }
-                    buildJsonObject {
-                        put("rowCounts", counts)
-                        put("totalMatches", matches.size)
-                        put("truncated", truncated)
-                        put("historyLinesCount", snapshot.historyLinesCount)
-                        put("height", snapshot.height)
-                        put("shortened", "rowCounts: hit counts per row")
-                    }.toString()
-                },
-                {
-                    buildJsonObject {
-                        put("totalMatches", matches.size)
-                        put("truncated", truncated)
-                        put("historyLinesCount", snapshot.historyLinesCount)
-                        put("height", snapshot.height)
-                        put("shortened", "totals only")
-                    }.toString()
+            // Build the "positions only" form once; it's the response when
+            // `include_line_text=false`, and the first shortening fallback
+            // when the full payload exceeds the cap.
+            val positionsOnlyJson: () -> String = {
+                val positions = buildJsonArray {
+                    for (m in matches) add(
+                        buildJsonObject {
+                            put("row", m.row)
+                            put("matchStart", m.matchStart)
+                            put("matchEnd", m.matchEnd)
+                        }
+                    )
                 }
+                buildJsonObject {
+                    put("matches", positions)
+                    put("truncated", truncated)
+                    put("historyLinesCount", snapshot.historyLinesCount)
+                    put("height", snapshot.height)
+                    if (!includeLineText) put("includeLineText", false)
+                    else put("shortened", "matches: positions only (no line text)")
+                }.toString()
+            }
+            val rowCountsJson: () -> String = {
+                val counts = buildJsonObject {
+                    val perRow = matches.groupingBy { it.row }.eachCount()
+                    for ((r, n) in perRow) put(r.toString(), n)
+                }
+                buildJsonObject {
+                    put("rowCounts", counts)
+                    put("totalMatches", matches.size)
+                    put("truncated", truncated)
+                    put("historyLinesCount", snapshot.historyLinesCount)
+                    put("height", snapshot.height)
+                    put("shortened", "rowCounts: hit counts per row")
+                }.toString()
+            }
+            val totalsJson: () -> String = {
+                buildJsonObject {
+                    put("totalMatches", matches.size)
+                    put("truncated", truncated)
+                    put("historyLinesCount", snapshot.historyLinesCount)
+                    put("height", snapshot.height)
+                    put("shortened", "totals only")
+                }.toString()
+            }
+
+            val full: String = if (includeLineText) {
+                val payload = SearchOutputResult(
+                    matches = matches,
+                    truncated = truncated,
+                    historyLinesCount = snapshot.historyLinesCount,
+                    height = snapshot.height
+                )
+                json.encodeToString(SearchOutputResult.serializer(), payload)
+            } else {
+                // Caller pre-opted-out of line text; skip the redundant
+                // "drop line text" fallback in the ladder.
+                positionsOnlyJson()
+            }
+
+            successJson(
+                if (includeLineText) shorten(full, positionsOnlyJson, rowCountsJson, totalsJson)
+                else shorten(full, rowCountsJson, totalsJson)
             )
-            successJson(shorten(full, fallbacks))
         }
     }
 
@@ -835,6 +890,12 @@ class BossTermMcpServer(
                                     "names) returns no chunks."
                         )
                     }
+                    putJsonObject("omit_data") {
+                        put("type", "boolean")
+                        put("description", "If true, each chunk returns only index+timestamp+source " +
+                                "(no `data` payload). Use for cheap polling — `data` is the bulk of " +
+                                "every chunk. Default false.")
+                    }
                 },
                 required = listOf("tab_id")
             )
@@ -855,6 +916,7 @@ class BossTermMcpServer(
             val maxChunks = (args.optionalInt("max_chunks") ?: DEFAULT_DEBUG_CHUNKS)
                 .coerceIn(1, maxAllowed)
             val sinceIndex = args.optionalInt("since_index")?.coerceAtLeast(0)
+            val omitData = args.optionalBoolean("omit_data") ?: false
             // null only when the caller omitted `sources` entirely (or it wasn't
             // an array). A supplied-but-empty filter is honored strictly: the
             // caller explicitly asked for nothing, so return nothing rather than
@@ -889,37 +951,45 @@ class BossTermMcpServer(
                 debugEnabled = tab.debugEnabled.value
             )
 
-            val payload = ReadDebugConsoleResult(chunks = resultChunks, stats = statsDto)
-            val full = json.encodeToString(ReadDebugConsoleResult.serializer(), payload)
-            // Fallbacks for the bytes-dominate case. `data` is the bulk of any
-            // ReadDebugConsoleResult; dropping it preserves the chunk indexing
-            // info the agent uses to poll and refine.
-            val fallbacks = listOf<() -> String>(
-                {
-                    val metadataChunks = buildJsonArray {
-                        for (c in resultChunks) add(
-                            buildJsonObject {
-                                put("index", c.index)
-                                put("timestamp", c.timestamp)
-                                put("source", c.source)
-                            }
-                        )
-                    }
-                    buildJsonObject {
-                        put("chunks", metadataChunks)
-                        put("stats", json.encodeToJsonElement(DebugConsoleStats.serializer(), statsDto))
-                        put("shortened", "chunks: metadata only (data omitted)")
-                    }.toString()
-                },
-                {
-                    buildJsonObject {
-                        put("stats", json.encodeToJsonElement(DebugConsoleStats.serializer(), statsDto))
-                        put("chunksReturned", resultChunks.size)
-                        put("shortened", "stats only; retry with a smaller `max_chunks` or narrower `sources`")
-                    }.toString()
+            // Build the "metadata only" form once; it's the response when
+            // `omit_data=true`, and the first shortening fallback when the
+            // full payload exceeds the cap.
+            val metadataOnlyJson: () -> String = {
+                val metadataChunks = buildJsonArray {
+                    for (c in resultChunks) add(
+                        buildJsonObject {
+                            put("index", c.index)
+                            put("timestamp", c.timestamp)
+                            put("source", c.source)
+                        }
+                    )
                 }
+                buildJsonObject {
+                    put("chunks", metadataChunks)
+                    put("stats", json.encodeToJsonElement(DebugConsoleStats.serializer(), statsDto))
+                    if (omitData) put("omitData", true)
+                    else put("shortened", "chunks: metadata only (data omitted)")
+                }.toString()
+            }
+            val statsOnlyJson: () -> String = {
+                buildJsonObject {
+                    put("stats", json.encodeToJsonElement(DebugConsoleStats.serializer(), statsDto))
+                    put("chunksReturned", resultChunks.size)
+                    put("shortened", "stats only; retry with a smaller `max_chunks` or narrower `sources`")
+                }.toString()
+            }
+
+            val full: String = if (omitData) {
+                metadataOnlyJson()
+            } else {
+                val payload = ReadDebugConsoleResult(chunks = resultChunks, stats = statsDto)
+                json.encodeToString(ReadDebugConsoleResult.serializer(), payload)
+            }
+
+            successJson(
+                if (omitData) shorten(full, statsOnlyJson)
+                else shorten(full, metadataOnlyJson, statsOnlyJson)
             )
-            successJson(shorten(full, fallbacks))
         }
     }
 
@@ -1063,14 +1133,29 @@ class BossTermMcpServer(
      */
     private fun shorten(
         full: String,
-        fallbacks: List<() -> String>
+        vararg fallbacks: () -> String
     ): String {
         val cap = settingsManager.settings.value.mcpMaxAnswerChars
         if (cap <= 0 || full.length <= cap) return full
-        for (factory in fallbacks) {
+        for ((i, factory) in fallbacks.withIndex()) {
             val short = factory()
-            if (short.length <= cap) return short
+            if (short.length <= cap) {
+                log.debug(
+                    "mcp shortening: cap={} full={} fallback#{}={} ({}% reduction)",
+                    cap,
+                    full.length,
+                    i,
+                    short.length,
+                    if (full.isEmpty()) 0 else 100 - (short.length * 100 / full.length)
+                )
+                return short
+            }
         }
+        log.debug(
+            "mcp shortening: cap={} full={} ran out of fallbacks; returning error result",
+            cap,
+            full.length
+        )
         return json.encodeToString(
             ErrorResult.serializer(),
             ErrorResult(error = "Response too large (>$cap chars) and no fallback fit; refine the query.")
@@ -1115,6 +1200,9 @@ class BossTermMcpServer(
         val arr = el as? JsonArray ?: return null
         return arr.mapNotNull { (it as? JsonPrimitive)?.content }
     }
+
+    private fun JsonObject?.optionalStringSet(key: String): Set<String>? =
+        optionalStringList(key)?.toSet()
 
     // -----------------------------------------------------------------
     // Wire-format DTOs

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -801,6 +801,22 @@ data class TerminalSettings(
     val disabledMcpTools: Set<String> = emptySet(),
 
     /**
+     * Soft ceiling (in characters) on a single BossTerm MCP tool response.
+     * When a response would exceed this, the tool returns a progressively
+     * smaller summary (e.g. matches-only for `search_output`, metadata-only
+     * for `read_debug_console`, last-N-lines for `read_scrollback`) instead
+     * of the full payload — the agent sees a well-formed JSON it can reason
+     * about and refine, never a truncated mid-response blob.
+     *
+     * Default `150_000` mirrors Serena's `default_max_tool_answer_chars` and
+     * is well above typical responses; it really only kicks in for
+     * pathological cases (regex matching thousands of rows, a giant debug
+     * buffer dump). Lower it to ~50_000 if you want a tighter guardrail.
+     * Advanced setting — no UI control, edit settings.json directly.
+     */
+    val mcpMaxAnswerChars: Int = 150_000,
+
+    /**
      * Set to `true` the first time [ai.rever.bossterm.compose.mcp.BossTermMcpManager]
      * starts so that embedder-supplied first-launch defaults
      * (`BossTermMcpConfig.defaultEnabled` / `defaultPort`) are applied

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpResponseShorteningTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpResponseShorteningTest.kt
@@ -1,0 +1,240 @@
+package ai.rever.bossterm.compose.mcp
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Synthetic benchmarks for the BossTerm MCP response-shortening design.
+ *
+ * We don't have access to a running BossTermMcpServer (no PTY in unit tests),
+ * so these tests rebuild the same DTOs and fallback projections in-process,
+ * serialize them with the same encoder settings (`explicitNulls = false`),
+ * and assert the size-reduction percentages the design plan claims.
+ *
+ * Targets from `~/.claude/plans/witty-petting-floyd.md`:
+ *   - search_output, full → positions-only: ≥70% smaller.
+ *   - read_debug_console, full → metadata-only: ≥90% smaller.
+ *   - TabInfo with null cwd/pid: presence of "cwd"/"pid" keys before vs after.
+ */
+class McpResponseShorteningTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    private val jsonWithNulls = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = true
+    }
+
+    // Minimal DTOs that mirror the wire shapes BossTermMcpServer uses. Keeping
+    // them local to the test avoids reaching into private state on the server
+    // class — the size math is what we're validating, not the wiring.
+
+    @Serializable
+    private data class SearchMatchDto(
+        val row: Int,
+        val line: String,
+        val matchStart: Int,
+        val matchEnd: Int
+    )
+
+    @Serializable
+    private data class SearchOutputResultDto(
+        val matches: List<SearchMatchDto>,
+        val truncated: Boolean,
+        val historyLinesCount: Int,
+        val height: Int
+    )
+
+    @Serializable
+    private data class DebugConsoleChunkDto(
+        val index: Int,
+        val timestamp: Long,
+        val source: String,
+        val data: String
+    )
+
+    @Serializable
+    private data class DebugConsoleStatsDto(
+        val totalChunks: Int,
+        val chunksStored: Int,
+        val oldestIndex: Int?,
+        val newestIndex: Int?,
+        val debugEnabled: Boolean
+    )
+
+    @Serializable
+    private data class ReadDebugConsoleResultDto(
+        val chunks: List<DebugConsoleChunkDto>,
+        val stats: DebugConsoleStatsDto
+    )
+
+    @Serializable
+    private data class TabInfoDto(
+        val id: String,
+        val title: String,
+        val cwd: String?,
+        val pid: Long?,
+        val isActive: Boolean
+    )
+
+    @Test
+    fun searchOutputFullVsPositionsOnly() {
+        // Representative: 200 matches each on a line ~80 chars long.
+        val lineText = "the quick brown fox jumps over the lazy dog ".repeat(2).take(80)
+        val matches = (0 until 200).map { i ->
+            SearchMatchDto(row = i - 50, line = lineText, matchStart = 0, matchEnd = 3)
+        }
+        val full = SearchOutputResultDto(
+            matches = matches,
+            truncated = false,
+            historyLinesCount = 1000,
+            height = 24
+        )
+        val fullJson = json.encodeToString(SearchOutputResultDto.serializer(), full)
+
+        // Same shape as the BossTermMcpServer search_output first fallback.
+        val positionsOnly = buildJsonObject {
+            put(
+                "matches",
+                buildJsonArray {
+                    for (m in matches) add(
+                        buildJsonObject {
+                            put("row", m.row)
+                            put("matchStart", m.matchStart)
+                            put("matchEnd", m.matchEnd)
+                        }
+                    )
+                }
+            )
+            put("truncated", false)
+            put("historyLinesCount", 1000)
+            put("height", 24)
+            put("shortened", "matches: positions only (no line text)")
+        }.toString()
+
+        val reduction = 100 - (positionsOnly.length * 100 / fullJson.length)
+        println("[search_output] full=${fullJson.length}B positions=${positionsOnly.length}B reduction=$reduction%")
+        assertTrue(
+            reduction >= 70,
+            "expected ≥70% reduction, got $reduction% (full=${fullJson.length}, positions=${positionsOnly.length})"
+        )
+    }
+
+    @Test
+    fun readDebugConsoleFullVsMetadataOnly() {
+        // Representative: 800 chunks each ~512 bytes of binary-ish data.
+        val data = "x".repeat(512)
+        val chunks = (0 until 800).map { i ->
+            DebugConsoleChunkDto(
+                index = i,
+                timestamp = 1_700_000_000_000L + i,
+                source = if (i % 2 == 0) "PTY_OUTPUT" else "USER_INPUT",
+                data = data
+            )
+        }
+        val stats = DebugConsoleStatsDto(
+            totalChunks = 9999, chunksStored = 800,
+            oldestIndex = 9200, newestIndex = 9999,
+            debugEnabled = true
+        )
+        val full = ReadDebugConsoleResultDto(chunks = chunks, stats = stats)
+        val fullJson = json.encodeToString(ReadDebugConsoleResultDto.serializer(), full)
+
+        // Same shape as the BossTermMcpServer read_debug_console first fallback.
+        val metadataOnly = buildJsonObject {
+            put(
+                "chunks",
+                buildJsonArray {
+                    for (c in chunks) add(
+                        buildJsonObject {
+                            put("index", c.index)
+                            put("timestamp", c.timestamp)
+                            put("source", c.source)
+                        }
+                    )
+                }
+            )
+            put("stats", json.encodeToJsonElement(DebugConsoleStatsDto.serializer(), stats))
+            put("shortened", "chunks: metadata only (data omitted)")
+        }.toString()
+
+        val reduction = 100 - (metadataOnly.length * 100 / fullJson.length)
+        println("[read_debug_console] full=${fullJson.length}B metadata=${metadataOnly.length}B reduction=$reduction%")
+        assertTrue(
+            reduction >= 90,
+            "expected ≥90% reduction, got $reduction% (full=${fullJson.length}, metadata=${metadataOnly.length})"
+        )
+    }
+
+    @Test
+    fun explicitNullsOmissionForTabInfoNullFields() {
+        // A tab with no shell-integration cwd and no pid yet.
+        val tab = TabInfoDto(
+            id = "abc-123", title = "Shell 1", cwd = null, pid = null, isActive = true
+        )
+        val newWire = json.encodeToString(TabInfoDto.serializer(), tab)
+        val oldWire = jsonWithNulls.encodeToString(TabInfoDto.serializer(), tab)
+
+        println("[TabInfo null cwd+pid] withNulls=${oldWire.length}B omitted=${newWire.length}B")
+
+        // New wire shouldn't carry the keys at all.
+        assertFalse(newWire.contains("\"cwd\""), "expected cwd key omitted, got: $newWire")
+        assertFalse(newWire.contains("\"pid\""), "expected pid key omitted, got: $newWire")
+        // Old wire did carry them.
+        assertTrue(oldWire.contains("\"cwd\":null"), "explicitNulls=true should emit cwd:null")
+        assertTrue(oldWire.contains("\"pid\":null"), "explicitNulls=true should emit pid:null")
+        // Real, non-null fields are still there.
+        assertTrue(newWire.contains("\"id\":\"abc-123\""))
+        assertTrue(newWire.contains("\"isActive\":true"))
+    }
+
+    @Test
+    fun explicitNullsKeepsNonNullValues() {
+        // Sanity: a TabInfo with real values is unchanged in keys.
+        val tab = TabInfoDto(
+            id = "abc-123", title = "Shell 1", cwd = "/tmp", pid = 12345L, isActive = true
+        )
+        val wire = json.encodeToString(TabInfoDto.serializer(), tab)
+        // All five fields should be present.
+        for (key in listOf("\"id\"", "\"title\"", "\"cwd\"", "\"pid\"", "\"isActive\"")) {
+            assertTrue(wire.contains(key), "expected $key in $wire")
+        }
+    }
+
+    @Test
+    fun searchOutputFullVsTotalsOnly() {
+        // The deepest fallback: totals only. Sanity-check it's tiny.
+        val lineText = "x".repeat(80)
+        val matches = (0 until 100).map { i ->
+            SearchMatchDto(row = i, line = lineText, matchStart = 0, matchEnd = 1)
+        }
+        val full = SearchOutputResultDto(matches, false, 0, 24)
+        val fullJson = json.encodeToString(SearchOutputResultDto.serializer(), full)
+
+        val totalsOnly = buildJsonObject {
+            put("totalMatches", matches.size)
+            put("truncated", false)
+            put("historyLinesCount", 0)
+            put("height", 24)
+            put("shortened", "totals only")
+        }.toString()
+
+        println("[search_output totals] full=${fullJson.length}B totals=${totalsOnly.length}B")
+        // Totals dwarfs nothing; assert it's <500 bytes regardless of input size.
+        assertTrue(totalsOnly.length < 500, "totals form should be <500B, got ${totalsOnly.length}")
+    }
+}

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -74,7 +74,11 @@ embedder's `BossTermMcpConfig.allowWriteTools = true`.
 List all open terminal tabs across every window registered with the
 `McpTerminalRegistry`.
 
-- Arguments: none.
+- Arguments:
+  - `include_fields` (optional array) — allow-list over TabInfo fields
+    (`id`, `title`, `cwd`, `pid`, `isActive`). Omit to get every field;
+    pass e.g. `["id", "isActive"]` for a minimal response when listing
+    many tabs.
 - Returns:
   ```json
   {
@@ -98,7 +102,8 @@ List all open terminal tabs across every window registered with the
 Return the active tab of the primary window, or the literal JSON `null` if no
 tab is active.
 
-- Arguments: none.
+- Arguments:
+  - `include_fields` (optional array) — same allow-list as `list_tabs`.
 - Returns: a `TabInfo` object (same shape as in `list_tabs`) or `null`.
 
 ### `read_scrollback`
@@ -126,6 +131,9 @@ Regex-search the entire scrollback (history + screen) of a tab or pane.
     many matches; `truncated` in the response indicates it was hit.
   - `ignore_case` (boolean, default `false`).
   - `pane_id` (string).
+  - `include_line_text` (boolean, default `true`) — if false, each match
+    returns only `row`, `matchStart`, `matchEnd` (no line text). Cuts the
+    response by 60–80% on typical scrollback searches.
 - Returns:
   ```json
   {
@@ -150,7 +158,6 @@ OSC 133). Requires shell integration — see
 - Returns either `null` (no command completed yet) or:
   ```json
   {
-    "commandText": null,
     "exitCode": 0,
     "startedAtMs": 1700000000000,
     "finishedAtMs": 1700000000123,
@@ -158,8 +165,9 @@ OSC 133). Requires shell integration — see
     "cwd": "/home/me"
   }
   ```
-- `commandText` is currently always `null`; capturing the typed command text
-  reliably is a follow-up.
+- `commandText` is omitted from the response — capturing the typed command
+  text reliably is a follow-up. (Null fields are omitted from every
+  BossTerm MCP response; see [Wire format notes](#wire-format-notes).)
 
 ### `read_debug_console`
 
@@ -177,6 +185,9 @@ collection is enabled for the tab. Supports incremental polling via
     `PTY_OUTPUT`, `USER_INPUT`, `EMULATOR_GENERATED`, `CONSOLE_LOG`. Omit the
     key entirely to get every source; an empty array (or one containing only
     unknown names) returns no chunks.
+  - `omit_data` (boolean, default `false`) — if true, each chunk returns
+    only `index`, `timestamp`, `source` (no `data` payload). Use for cheap
+    polling since `data` is the bulk of every chunk.
 - Returns:
   ```json
   {
@@ -528,6 +539,35 @@ A short-circuit in `BossTermMcpServer.applyDisabledSet(...)` performs the
 add/remove against the SDK's live `Server` under an internal lock, so
 concurrent toggles from the UI and a `manage_tools` call don't corrupt the
 tool registry.
+
+## Wire format notes
+
+**Null-valued fields are omitted from every response.** The server's JSON
+encoder runs with `explicitNulls = false`, so a `TabInfo` with no working
+directory comes back as `{id, title, isActive}` rather than
+`{id, title, cwd: null, pid: null, isActive}`. A `LastCommandDto` never
+carries the always-null `commandText`. Same for any other optional field on
+any DTO.
+
+For most clients this is transparent — JSON parsers return the same
+implicit `null` / `undefined` / `None` whether the key is absent or
+explicitly `null`. The only place it bites is code that probes
+*presence* rather than value:
+
+```js
+'commandText' in response  // was true, now false
+Object.hasOwn(response, 'cwd')  // was true, now false when cwd is null
+response.commandText === null  // was true; now undefined
+```
+
+If your client relies on presence semantics, switch to value checks
+(`response.cwd == null` instead of `'cwd' in response`). Set
+`mcpMaxAnswerChars = 0` (no effect on null omission — that's a separate
+encoder setting) if you want everything else big-and-explicit too.
+
+The one place the server intentionally emits a literal top-level JSON
+`null` is `get_active_tab` when there is no active tab — that's hand-built
+outside the encoder and is unaffected by the setting.
 
 ## Response shortening
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -326,6 +326,7 @@ and are persisted to `~/.bossterm/settings.json`.
 | `mcpDefaultSplitRatio`    | `Float`             | `0.3`       | Default new-pane size for `run_in_panel` splits when `split_ratio` is omitted. Range `0.05..0.95`.     |
 | `mcpAttachedTo`           | `Set<String>`       | `{}`        | Stable `persistenceKey`s (e.g. `"CLAUDE_CODE"`) of attached AI CLIs. Used for silent re-attach.        |
 | `disabledMcpTools`        | `Set<String>`       | `{}`        | Unprefixed built-in tool names hidden from clients. Edited via the UI or `manage_tools`.               |
+| `mcpMaxAnswerChars`       | `Int`               | `150_000`   | Soft ceiling on tool response size. When exceeded, the tool returns a progressively smaller summary instead of the full payload — see [Response shortening](#response-shortening). Advanced; no UI control. |
 | `mcpConfigured`           | `Boolean`           | `false`     | Internal first-launch marker. Once `true`, embedder defaults no longer override the user's choice.     |
 
 ## Embedder integration
@@ -527,6 +528,42 @@ A short-circuit in `BossTermMcpServer.applyDisabledSet(...)` performs the
 add/remove against the SDK's live `Server` under an internal lock, so
 concurrent toggles from the UI and a `manage_tools` call don't corrupt the
 tool registry.
+
+## Response shortening
+
+Three built-in tools can return unbounded responses — `search_output`,
+`read_scrollback`, and `read_debug_console` — so each runs its full payload
+through a per-tool fallback ladder. If the full JSON would exceed
+`settings.mcpMaxAnswerChars` (default `150_000`), the server returns a
+progressively smaller well-formed JSON instead. The agent never sees a
+truncated mid-response blob; it sees a smaller object with a `"shortened"`
+key explaining what was dropped, and refines the next call accordingly.
+
+Each shortened response includes a `"shortened"` string describing the
+projection so clients can detect they're looking at a summary. Common
+shortened shapes:
+
+`search_output`
+- **positions only** — `matches` keeps `row`, `matchStart`, `matchEnd`; the
+  matched line text is dropped. Usually 60–80% smaller than full.
+- **row counts** — `{rowCounts: {row: hits}, totalMatches}` instead of per-match
+  records.
+- **totals only** — `{totalMatches, truncated, historyLinesCount, height}`.
+
+`read_scrollback`
+- **tail** — keeps the last 20 lines and reports the requested count.
+- **totals only** — `{totalAvailable}` with a "retry with smaller `lines`"
+  hint.
+
+`read_debug_console`
+- **metadata only** — chunks keep `index`, `timestamp`, `source`; the `data`
+  byte payload is dropped. Great for polling "any new chunks since N".
+- **stats only** — drops the chunks list entirely; agent narrows by
+  `since_index`, `sources`, or `max_chunks` on the next call.
+
+Reduce `mcpMaxAnswerChars` (e.g. to `50_000`) if you want the fallbacks to
+trigger more aggressively in agent loops. Raise it (or set to `0` to
+disable) if you have a custom client that handles large payloads natively.
 
 ## Troubleshooting
 

--- a/docs/wiki/MCP-Server.md
+++ b/docs/wiki/MCP-Server.md
@@ -81,7 +81,11 @@ embedder's `BossTermMcpConfig.allowWriteTools = true`.
 List all open terminal tabs across every window registered with the
 `McpTerminalRegistry`.
 
-- Arguments: none.
+- Arguments:
+  - `include_fields` (optional array) — allow-list over TabInfo fields
+    (`id`, `title`, `cwd`, `pid`, `isActive`). Omit to get every field;
+    pass e.g. `["id", "isActive"]` for a minimal response when listing
+    many tabs.
 - Returns:
   ```json
   {
@@ -105,7 +109,8 @@ List all open terminal tabs across every window registered with the
 Return the active tab of the primary window, or the literal JSON `null` if
 no tab is active.
 
-- Arguments: none.
+- Arguments:
+  - `include_fields` (optional array) — same allow-list as `list_tabs`.
 - Returns: a `TabInfo` object (same shape as in `list_tabs`) or `null`.
 
 ### `read_scrollback`
@@ -133,6 +138,9 @@ Regex-search the entire scrollback (history + screen) of a tab or pane.
     many matches; `truncated` in the response indicates it was hit.
   - `ignore_case` (boolean, default `false`).
   - `pane_id` (string).
+  - `include_line_text` (boolean, default `true`) — if false, each match
+    returns only `row`, `matchStart`, `matchEnd` (no line text). Cuts the
+    response by 60–80% on typical scrollback searches.
 - Returns:
   ```json
   {
@@ -156,7 +164,6 @@ OSC 133). Requires shell integration — see [[Shell-Integration]].
 - Returns either `null` (no command completed yet) or:
   ```json
   {
-    "commandText": null,
     "exitCode": 0,
     "startedAtMs": 1700000000000,
     "finishedAtMs": 1700000000123,
@@ -164,8 +171,9 @@ OSC 133). Requires shell integration — see [[Shell-Integration]].
     "cwd": "/home/me"
   }
   ```
-- `commandText` is currently always `null`; capturing the typed command text
-  reliably is a follow-up.
+- `commandText` is omitted from the response — capturing the typed command
+  text reliably is a follow-up. (Null fields are omitted from every
+  BossTerm MCP response; see [Wire format notes](#wire-format-notes).)
 
 ### `read_debug_console`
 
@@ -183,6 +191,9 @@ collection is enabled for the tab. Supports incremental polling via
     `PTY_OUTPUT`, `USER_INPUT`, `EMULATOR_GENERATED`, `CONSOLE_LOG`. Omit the
     key entirely to get every source; an empty array (or one containing only
     unknown names) returns no chunks.
+  - `omit_data` (boolean, default `false`) — if true, each chunk returns
+    only `index`, `timestamp`, `source` (no `data` payload). Use for cheap
+    polling since `data` is the bulk of every chunk.
 - Returns:
   ```json
   {
@@ -544,6 +555,35 @@ restarting the server.
 `BossTermMcpServer.applyDisabledSet(...)` performs the add/remove against
 the SDK's live `Server` under an internal lock, so concurrent toggles from
 the UI and a `manage_tools` call don't corrupt the tool registry.
+
+---
+
+## Wire format notes
+
+**Null-valued fields are omitted from every response.** The server's JSON
+encoder runs with `explicitNulls = false`, so a `TabInfo` with no working
+directory comes back as `{id, title, isActive}` rather than
+`{id, title, cwd: null, pid: null, isActive}`. A `LastCommandDto` never
+carries the always-null `commandText`. Same for any other optional field
+on any DTO.
+
+For most clients this is transparent — JSON parsers return the same
+implicit `null` / `undefined` / `None` whether the key is absent or
+explicitly `null`. The only place it bites is code that probes
+*presence* rather than value:
+
+```js
+'commandText' in response  // was true, now false
+Object.hasOwn(response, 'cwd')  // was true, now false when cwd is null
+response.commandText === null  // was true; now undefined
+```
+
+If your client relies on presence semantics, switch to value checks
+(`response.cwd == null` instead of `'cwd' in response`).
+
+The one place the server intentionally emits a literal top-level JSON
+`null` is `get_active_tab` when there is no active tab — that's hand-built
+outside the encoder and is unaffected by the setting.
 
 ---
 

--- a/docs/wiki/MCP-Server.md
+++ b/docs/wiki/MCP-Server.md
@@ -336,6 +336,7 @@ All MCP-related fields are persisted to `~/.bossterm/settings.json`.
 | `mcpDefaultSplitRatio`    | `Float`             | `0.3`       | Default new-pane size for `run_in_panel` splits when `split_ratio` is omitted. Range `0.05..0.95`.     |
 | `mcpAttachedTo`           | `Set<String>`       | `{}`        | Stable `persistenceKey`s (e.g. `"CLAUDE_CODE"`) of attached AI CLIs. Used for silent re-attach.        |
 | `disabledMcpTools`        | `Set<String>`       | `{}`        | Unprefixed built-in tool names hidden from clients. Edited via the UI or `manage_tools`.               |
+| `mcpMaxAnswerChars`       | `Int`               | `150_000`   | Soft ceiling on tool response size. When exceeded, the tool returns a progressively smaller summary instead of the full payload — see [Response shortening](#response-shortening). Advanced; no UI control. |
 | `mcpConfigured`           | `Boolean`           | `false`     | Internal first-launch marker. Once `true`, embedder defaults no longer override the user's choice.     |
 
 ---
@@ -543,6 +544,44 @@ restarting the server.
 `BossTermMcpServer.applyDisabledSet(...)` performs the add/remove against
 the SDK's live `Server` under an internal lock, so concurrent toggles from
 the UI and a `manage_tools` call don't corrupt the tool registry.
+
+---
+
+## Response shortening
+
+Three built-in tools can return unbounded responses — `search_output`,
+`read_scrollback`, and `read_debug_console` — so each runs its full payload
+through a per-tool fallback ladder. If the full JSON would exceed
+`settings.mcpMaxAnswerChars` (default `150_000`), the server returns a
+progressively smaller well-formed JSON instead. The agent never sees a
+truncated mid-response blob; it sees a smaller object with a `"shortened"`
+key explaining what was dropped, and refines the next call accordingly.
+
+Each shortened response includes a `"shortened"` string describing the
+projection so clients can detect they're looking at a summary. Common
+shortened shapes:
+
+`search_output`
+- **positions only** — `matches` keeps `row`, `matchStart`, `matchEnd`; the
+  matched line text is dropped. Usually 60–80% smaller than full.
+- **row counts** — `{rowCounts: {row: hits}, totalMatches}` instead of
+  per-match records.
+- **totals only** — `{totalMatches, truncated, historyLinesCount, height}`.
+
+`read_scrollback`
+- **tail** — keeps the last 20 lines and reports the requested count.
+- **totals only** — `{totalAvailable}` with a "retry with smaller `lines`"
+  hint.
+
+`read_debug_console`
+- **metadata only** — chunks keep `index`, `timestamp`, `source`; the `data`
+  byte payload is dropped. Great for polling "any new chunks since N".
+- **stats only** — drops the chunks list entirely; agent narrows by
+  `since_index`, `sources`, or `max_chunks` on the next call.
+
+Reduce `mcpMaxAnswerChars` (e.g. to `50_000`) if you want the fallbacks to
+trigger more aggressively in agent loops. Raise it (or set to `0` to
+disable) if you have a custom client that handles large payloads natively.
 
 ---
 


### PR DESCRIPTION
## Summary

Borrows three language-agnostic patterns from [Serena](https://github.com/oraios/serena):

1. **Progressive response shortening** with a per-tool ladder of fallback projections, gated by a new `mcpMaxAnswerChars` setting (default `150_000`, matches Serena). When the full JSON exceeds the cap, the server returns the first fallback that fits — a smaller well-formed JSON the agent can refine from, never a truncated blob. Wired into `search_output`, `read_scrollback`, `read_debug_console`.

2. **Caller-side projection args** so a client that already knows it doesn't want the heavy field can opt out up front:
   - `search_output` → `include_line_text: bool = true`
   - `read_debug_console` → `omit_data: bool = false`
   - `list_tabs` / `get_active_tab` → `include_fields: Set<String>?` (allow-list over `{id, title, cwd, pid, isActive}`)

3. **Null-field omission** via `explicitNulls = false` on the wire encoder. Drops `"field": null` from every record. ⚠️ Minor wire-format change — see "Wire format note" below.

## Wire format note (minor breaking)

`explicitNulls = false` means clients that probe for *presence* rather than *value* will see a behavior shift:

```js
'commandText' in response       // was true (always-null field), now false
Object.hasOwn(response, 'cwd')   // was true when cwd is null, now false
response.commandText === null    // was true; now undefined
```

For most clients (typed parsers, `?.` chains, `dict.get(...)`) this is transparent. If you rely on presence checks, switch to value checks. Documented in the new "Wire format notes" section of `docs/mcp-server.md`.

## Tool ladders

| Tool | Full | Fallback 1 | Fallback 2 | Fallback 3 |
|------|------|------------|------------|------------|
| `search_output` | matches + line text | positions only (also reached via `include_line_text=false`) | per-row hit counts | totals only |
| `read_scrollback` | requested lines | tail (last 20) | totals only | — |
| `read_debug_console` | chunks + data bytes | chunk metadata (also reached via `omit_data=true`) | stats only | — |

Each shortened response carries a `"shortened"` marker describing the projection so clients can detect it.

## Observability

`shorten()` logs at `DEBUG` whenever a fallback fires, including the cap, full size, fallback index, and reduction percentage. Helpful for figuring out why a client sees a `"shortened"` response in the wild.

## Test plan

- [x] `./gradlew :compose-ui:compileKotlinDesktop :bossterm-app :embedded-example :tabbed-example :compileKotlinDesktop` — clean.
- [x] `./gradlew :compose-ui:desktopTest --tests McpResponseShorteningTest` — new synthetic benchmark asserts the design plan's size-reduction targets hold:
  - `search_output` (200 matches × ~80-char lines): ≥70% reduction at positions-only.
  - `read_debug_console` (800 chunks × ~512 byte data): ≥90% reduction at metadata-only.
  - `TabInfo` with null `cwd`/`pid`: keys omitted from response under `explicitNulls = false`.
- [ ] Spot-check `get_active_tab`'s no-active-tab path still returns literal JSON `null` (hand-built outside the serializer; should be unaffected by `explicitNulls`).
- [ ] Manually exercise `include_line_text=false`, `omit_data=true`, and `include_fields=["id","isActive"]` against a running BossTerm to confirm the projections wire end-to-end.

## Out of scope

- The plan's PR-3 (`include_fields` on more endpoints) — no other endpoint has the same shape problem yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)