### PR TITLE
feat(mcp): port fallback when configured port is busy

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -188,12 +188,50 @@ class BossTermMcpManager(
         }
     }
 
-    private fun startEngineLocked(port: Int) {
+    private fun startEngineLocked(desiredPort: Int) {
+        // Try the user's configured port first, then walk sequential ports up to
+        // MAX_PORT_FALLBACK_ATTEMPTS - 1 more. Only `BindException` (port in use)
+        // triggers fallback; other failures stay hard errors so config bugs aren't
+        // silently masked. The persisted `mcpPort` is NOT updated — the next
+        // restart still tries the original first in case the conflicting process
+        // exited.
+        for (offset in 0 until MAX_PORT_FALLBACK_ATTEMPTS) {
+            val port = desiredPort + offset
+            if (port > MAX_TCP_PORT) {
+                log.error(
+                    "BossTerm MCP port fallback exhausted (last tried {} > {}); giving up",
+                    port, MAX_TCP_PORT
+                )
+                return
+            }
+            if (tryStartOnPort(port, desiredPort)) return
+        }
+        log.error(
+            "BossTerm MCP server failed to bind any port in [{},{}]; giving up",
+            desiredPort, desiredPort + MAX_PORT_FALLBACK_ATTEMPTS - 1
+        )
+    }
+
+    /**
+     * One bind attempt. Returns true on success (state fields are set), false
+     * if [port] was busy (caller should try the next port). Hard failures
+     * (everything other than [BindException]) clear state and return true so
+     * the loop stops — there's no point retrying e.g. an SDK initialization
+     * error on a different port.
+     */
+    private fun tryStartOnPort(port: Int, desiredPort: Int): Boolean {
         val mcpServerWrapper = BossTermMcpServer(registry, config, settingsManager)
         val mcpServer = mcpServerWrapper.createServer()
         val allowedHosts = setOf("127.0.0.1", "localhost", "127.0.0.1:$port", "localhost:$port")
         try {
-            log.info("Starting BossTerm MCP server on http://{}:{}{}", HOST, port, PATH)
+            if (port == desiredPort) {
+                log.info("Starting BossTerm MCP server on http://{}:{}{}", HOST, port, PATH)
+            } else {
+                log.info(
+                    "Starting BossTerm MCP server on http://{}:{}{} (fallback from configured port {})",
+                    HOST, port, PATH, desiredPort
+                )
+            }
             val engine = embeddedServer(CIO, host = HOST, port = port) {
                 install(SSE)
                 // DNS-rebinding defense: only accept Host headers that name a
@@ -232,6 +270,7 @@ class BossTermMcpManager(
                 HOST, port, PATH, registry.stateCount()
             )
             launchAutoReattach(port)
+            return true
         } catch (e: BindException) {
             log.warn(
                 "BossTerm MCP server failed to bind {}:{} (port in use?): {}",
@@ -241,12 +280,15 @@ class BossTermMcpManager(
             runningEngine = null
             runningPort = null
             runningServer = null
+            return false
         } catch (e: Throwable) {
             log.error("BossTerm MCP server failed to start on {}:{}", HOST, port, e)
             mcpServerWrapper.detachServer()
             runningEngine = null
             runningPort = null
             runningServer = null
+            // Stop the loop — this isn't a "try the next port" condition.
+            return true
         }
     }
 
@@ -318,5 +360,18 @@ class BossTermMcpManager(
         private const val PATH = "/"
         private const val STOP_GRACE_MS = 500L
         private const val STOP_TIMEOUT_MS = 1500L
+
+        /**
+         * How many sequential ports to try when the user's configured `mcpPort`
+         * is busy. The first attempt is the configured port; subsequent attempts
+         * walk +1, +2, ... A small range so we don't wander off into ephemeral
+         * port territory or run for too long on each (re)start. Each attempt
+         * is a separate Ktor bind, so this also bounds startup latency in the
+         * worst case (~10 × the bind timeout).
+         */
+        private const val MAX_PORT_FALLBACK_ATTEMPTS = 10
+
+        /** Upper bound on TCP port numbers; we never wrap past this. */
+        private const val MAX_TCP_PORT = 65535
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -188,23 +188,47 @@ class BossTermMcpManager(
         }
     }
 
+    /**
+     * Outcome of a single bind attempt. Distinguishes "port is busy, try the
+     * next one" from "stop trying, something is structurally wrong" so the
+     * caller doesn't have to know which return value means what.
+     */
+    private enum class StartOutcome {
+        /** Bound successfully; manager state fields are set. */
+        Started,
+
+        /** Port was in use (EADDRINUSE). State is cleared; caller should try the next port. */
+        PortBusy,
+
+        /**
+         * Bind failed for a reason that won't be fixed by trying another port —
+         * EACCES on a privileged port, an SDK initialization error, etc. State is
+         * cleared; caller should stop the fallback loop.
+         */
+        HardFailed,
+    }
+
     private fun startEngineLocked(desiredPort: Int) {
         // Try the user's configured port first, then walk sequential ports up to
-        // MAX_PORT_FALLBACK_ATTEMPTS - 1 more. Only `BindException` (port in use)
-        // triggers fallback; other failures stay hard errors so config bugs aren't
-        // silently masked. The persisted `mcpPort` is NOT updated — the next
-        // restart still tries the original first in case the conflicting process
-        // exited.
+        // MAX_PORT_FALLBACK_ATTEMPTS - 1 more. EADDRINUSE triggers fallback;
+        // EACCES (permission denied — privileged ports on Linux/macOS), other
+        // BindException causes, and unrelated Throwables stay hard failures so
+        // config bugs aren't silently masked by walking up a privileged range.
+        // The persisted `mcpPort` is NOT updated — the next restart still
+        // tries the original first in case the conflicting process exited.
         for (offset in 0 until MAX_PORT_FALLBACK_ATTEMPTS) {
             val port = desiredPort + offset
             if (port > MAX_TCP_PORT) {
                 log.error(
-                    "BossTerm MCP port fallback exhausted (last tried {} > {}); giving up",
+                    "BossTerm MCP port fallback exhausted (would-be next port {} exceeds {}); giving up",
                     port, MAX_TCP_PORT
                 )
                 return
             }
-            if (tryStartOnPort(port, desiredPort)) return
+            when (tryStartOnPort(port, desiredPort)) {
+                StartOutcome.Started, StartOutcome.HardFailed -> return
+                StartOutcome.PortBusy -> continue
+            }
         }
         log.error(
             "BossTerm MCP server failed to bind any port in [{},{}]; giving up",
@@ -213,13 +237,17 @@ class BossTermMcpManager(
     }
 
     /**
-     * One bind attempt. Returns true on success (state fields are set), false
-     * if [port] was busy (caller should try the next port). Hard failures
-     * (everything other than [BindException]) clear state and return true so
-     * the loop stops — there's no point retrying e.g. an SDK initialization
-     * error on a different port.
+     * One bind attempt. See [StartOutcome] for the return semantics.
+     *
+     * The EACCES detection inspects [BindException.message] rather than a more
+     * specific exception type because OpenJDK throws plain `BindException` for
+     * both EADDRINUSE and EACCES; only the message string distinguishes them
+     * (see `sun.nio.ch.Net.bind0` → `handleSocketError`). It's brittle — a
+     * non-English locale or a future JDK could rephrase the text — but the
+     * worst-case failure is "fall back through a privileged range and waste
+     * ~10 quick binds before giving up," which is the pre-fix behavior.
      */
-    private fun tryStartOnPort(port: Int, desiredPort: Int): Boolean {
+    private fun tryStartOnPort(port: Int, desiredPort: Int): StartOutcome {
         val mcpServerWrapper = BossTermMcpServer(registry, config, settingsManager)
         val mcpServer = mcpServerWrapper.createServer()
         val allowedHosts = setOf("127.0.0.1", "localhost", "127.0.0.1:$port", "localhost:$port")
@@ -270,25 +298,40 @@ class BossTermMcpManager(
                 HOST, port, PATH, registry.stateCount()
             )
             launchAutoReattach(port)
-            return true
+            return StartOutcome.Started
         } catch (e: BindException) {
-            log.warn(
-                "BossTerm MCP server failed to bind {}:{} (port in use?): {}",
-                HOST, port, e.message
-            )
             mcpServerWrapper.detachServer()
             runningEngine = null
             runningPort = null
             runningServer = null
-            return false
+            val msg = e.message.orEmpty()
+            // Heuristic: if the JDK distinguished EACCES from EADDRINUSE only
+            // via message text, "permission" / "denied" / "not permitted" /
+            // "access" is the signature. Treat as hard failure to avoid
+            // walking up a privileged range (e.g. configured 80 → 81..89).
+            val looksLikePermissionDenied = msg.contains("permission", ignoreCase = true) ||
+                    msg.contains("denied", ignoreCase = true) ||
+                    msg.contains("not permitted", ignoreCase = true)
+            return if (looksLikePermissionDenied) {
+                log.error(
+                    "BossTerm MCP server cannot bind {}:{} (permission denied); giving up: {}",
+                    HOST, port, msg
+                )
+                StartOutcome.HardFailed
+            } else {
+                log.warn(
+                    "BossTerm MCP server failed to bind {}:{} (port in use?): {}",
+                    HOST, port, msg
+                )
+                StartOutcome.PortBusy
+            }
         } catch (e: Throwable) {
             log.error("BossTerm MCP server failed to start on {}:{}", HOST, port, e)
             mcpServerWrapper.detachServer()
             runningEngine = null
             runningPort = null
             runningServer = null
-            // Stop the loop — this isn't a "try the next port" condition.
-            return true
+            return StartOutcome.HardFailed
         }
     }
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -535,7 +535,7 @@ tool registry.
 
 **The server bound to a different port than I configured.** Another process
 is already on the configured port. The manager automatically walks up to
-the next 9 sequential ports on `BindException` (so configured `7676` may end
+the next 9 sequential ports on `EADDRINUSE` (so configured `7676` may end
 up bound on `7677` if `7676` is busy). Look for one of these in the
 startup logs:
 
@@ -550,10 +550,28 @@ exited. The status pill's hover tooltip and the silent CLI auto-reattach
 both use the actual running port, so registered AI CLIs follow along
 automatically.
 
-**The server won't bind any port at all.** All 10 attempted ports were busy,
-or the very first attempt hit a non-bind error (config bug, permission
-denied, etc.). Check the startup logs for `BossTerm MCP server failed to
-bind any port in [...]` or `BossTerm MCP server failed to start on ...`.
+> **Heads-up: CLI auto-reattach runs on every successful bind, not just on
+> port changes.** If your configured port flaps (7676 busy → 7677 → 7676
+> next launch), the persisted CLI configs (`claude mcp add …`,
+> `gemini mcp add …`, etc.) get silently rewritten to follow each launch's
+> actual port. This is intentional, but it does mean any out-of-band edit
+> you make to those CLI configs while BossTerm is running is liable to be
+> clobbered on the next start.
+
+**The server won't bind any port at all.** Either (a) all 10 attempted ports
+were busy, (b) the configured port was rejected for a reason other than
+"address in use" — e.g. permission denied on a privileged port (`<1024` on
+Linux/macOS when not running as root), or (c) the very first attempt hit a
+non-bind error. The manager treats permission-denied as a hard failure
+(not a "try the next port" condition) so it doesn't walk up a privileged
+range futilely. Check the startup logs for one of:
+
+```
+ERROR BossTermMcpManager - BossTerm MCP server cannot bind 127.0.0.1:80 (permission denied); giving up: ...
+ERROR BossTermMcpManager - BossTerm MCP server failed to bind any port in [7676,7685]; giving up
+ERROR BossTermMcpManager - BossTerm MCP server failed to start on 127.0.0.1:7676: ...
+```
+
 Pick a different starting port in Settings.
 
 **The status pill says "BossTerm MCP on" but clients see no tabs.** The

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -45,7 +45,10 @@ The server is constructed in
 and binds via Ktor:
 
 - Host: `127.0.0.1` (never `0.0.0.0`).
-- Port: `settings.mcpPort` (default `7676`).
+- Port: `settings.mcpPort` (default `7676`). If that port is busy, the
+  manager automatically falls back to the next free port in a 10-port
+  window. The configured setting is not modified; the next restart still
+  tries the original first. See [Troubleshooting](#troubleshooting).
 - Path: `/` (root). The SDK 0.8.3 quirk re-mounts SSE/POST at the application
   root regardless of any wrapping path, so the endpoint URL is the
   authoritative pointer.
@@ -530,10 +533,28 @@ tool registry.
 
 ## Troubleshooting
 
-**The server won't bind on the chosen port.** Another process is already on
-that port. The startup logs surface `BossTerm MCP server failed to bind
-127.0.0.1:7676 (port in use?)`. Pick a different port in Settings; the
-manager rebinds automatically.
+**The server bound to a different port than I configured.** Another process
+is already on the configured port. The manager automatically walks up to
+the next 9 sequential ports on `BindException` (so configured `7676` may end
+up bound on `7677` if `7676` is busy). Look for one of these in the
+startup logs:
+
+```
+INFO  BossTermMcpManager - Starting BossTerm MCP server on http://127.0.0.1:7677/ (fallback from configured port 7676)
+INFO  BossTermMcpManager - BossTerm MCP server ready: http://127.0.0.1:7677/ ...
+```
+
+The user-configured `mcpPort` setting is NOT updated by fallback — the next
+restart still tries the original first, in case the conflicting process has
+exited. The status pill's hover tooltip and the silent CLI auto-reattach
+both use the actual running port, so registered AI CLIs follow along
+automatically.
+
+**The server won't bind any port at all.** All 10 attempted ports were busy,
+or the very first attempt hit a non-bind error (config bug, permission
+denied, etc.). Check the startup logs for `BossTerm MCP server failed to
+bind any port in [...]` or `BossTerm MCP server failed to start on ...`.
+Pick a different starting port in Settings.
 
 **The status pill says "BossTerm MCP on" but clients see no tabs.** The
 window's `TabbedTerminalState` / `EmbeddableTerminalState` isn't registered

--- a/docs/wiki/MCP-Server.md
+++ b/docs/wiki/MCP-Server.md
@@ -551,11 +551,11 @@ the UI and a `manage_tools` call don't corrupt the tool registry.
 
 ## Troubleshooting
 
-**The server bound to a different port than I configured.** Another process
-is already on the configured port. The manager automatically walks up to
-the next 9 sequential ports on `BindException` (so configured `7676` may
-end up bound on `7677` if `7676` is busy). Look for one of these in the
-startup logs:
+**The server bound to a different port than I configured.** Another
+process is already on the configured port. The manager automatically
+walks up to the next 9 sequential ports on `EADDRINUSE` (so configured
+`7676` may end up bound on `7677` if `7676` is busy). Look for one of
+these in the startup logs:
 
 ```
 INFO  BossTermMcpManager - Starting BossTerm MCP server on http://127.0.0.1:7677/ (fallback from configured port 7676)
@@ -568,11 +568,29 @@ process has exited. The status pill's hover tooltip and the silent CLI
 auto-reattach both use the actual running port, so registered AI CLIs
 follow along automatically.
 
-**The server won't bind any port at all.** All 10 attempted ports were
-busy, or the very first attempt hit a non-bind error (config bug,
-permission denied, etc.). Check the startup logs for `BossTerm MCP server
-failed to bind any port in [...]` or `BossTerm MCP server failed to start
-on ...`. Pick a different starting port in Settings.
+> **Heads-up: CLI auto-reattach runs on every successful bind, not just
+> on port changes.** If your configured port flaps (7676 busy → 7677 →
+> 7676 next launch), the persisted CLI configs (`claude mcp add …`,
+> `gemini mcp add …`, etc.) get silently rewritten to follow each
+> launch's actual port. This is intentional, but it does mean any
+> out-of-band edit you make to those CLI configs while BossTerm is
+> running is liable to be clobbered on the next start.
+
+**The server won't bind any port at all.** Either (a) all 10 attempted
+ports were busy, (b) the configured port was rejected for a reason other
+than "address in use" — e.g. permission denied on a privileged port
+(`<1024` on Linux/macOS when not running as root), or (c) the very first
+attempt hit a non-bind error. The manager treats permission-denied as a
+hard failure (not a "try the next port" condition) so it doesn't walk up
+a privileged range futilely. Check the startup logs for one of:
+
+```
+ERROR BossTermMcpManager - BossTerm MCP server cannot bind 127.0.0.1:80 (permission denied); giving up: ...
+ERROR BossTermMcpManager - BossTerm MCP server failed to bind any port in [7676,7685]; giving up
+ERROR BossTermMcpManager - BossTerm MCP server failed to start on 127.0.0.1:7676: ...
+```
+
+Pick a different starting port in Settings.
 
 **The status pill says "BossTerm MCP on" but clients see no tabs.** The
 window's `TabbedTerminalState` / `EmbeddableTerminalState` isn't registered

--- a/docs/wiki/MCP-Server.md
+++ b/docs/wiki/MCP-Server.md
@@ -49,7 +49,10 @@ samples, see the `embedded-example/` and `tabbed-example/` modules in the
 The server is constructed in `BossTermMcpManager` and binds via Ktor:
 
 - Host: `127.0.0.1` (never `0.0.0.0`).
-- Port: `settings.mcpPort` (default `7676`).
+- Port: `settings.mcpPort` (default `7676`). If that port is busy, the
+  manager automatically falls back to the next free port in a 10-port
+  window. The configured setting is not modified; the next restart still
+  tries the original first. See [Troubleshooting](#troubleshooting).
 - Path: `/` (root). The MCP SDK 0.8.3 quirk re-mounts SSE/POST at the
   application root regardless of any wrapping path, so the endpoint URL is
   the authoritative pointer.
@@ -548,10 +551,28 @@ the UI and a `manage_tools` call don't corrupt the tool registry.
 
 ## Troubleshooting
 
-**The server won't bind on the chosen port.** Another process is already on
-that port. The startup logs surface `BossTerm MCP server failed to bind
-127.0.0.1:7676 (port in use?)`. Pick a different port in Settings; the
-manager rebinds automatically.
+**The server bound to a different port than I configured.** Another process
+is already on the configured port. The manager automatically walks up to
+the next 9 sequential ports on `BindException` (so configured `7676` may
+end up bound on `7677` if `7676` is busy). Look for one of these in the
+startup logs:
+
+```
+INFO  BossTermMcpManager - Starting BossTerm MCP server on http://127.0.0.1:7677/ (fallback from configured port 7676)
+INFO  BossTermMcpManager - BossTerm MCP server ready: http://127.0.0.1:7677/ ...
+```
+
+The user-configured `mcpPort` setting is NOT updated by fallback — the
+next restart still tries the original first, in case the conflicting
+process has exited. The status pill's hover tooltip and the silent CLI
+auto-reattach both use the actual running port, so registered AI CLIs
+follow along automatically.
+
+**The server won't bind any port at all.** All 10 attempted ports were
+busy, or the very first attempt hit a non-bind error (config bug,
+permission denied, etc.). Check the startup logs for `BossTerm MCP server
+failed to bind any port in [...]` or `BossTerm MCP server failed to start
+on ...`. Pick a different starting port in Settings.
 
 **The status pill says "BossTerm MCP on" but clients see no tabs.** The
 window's `TabbedTerminalState` / `EmbeddableTerminalState` isn't registered


### PR DESCRIPTION
## Summary

When BossTerm's configured `mcpPort` is already bound (another BossTerm instance, a stale TIME_WAIT socket, a colliding service), the manager now walks up to 10 sequential ports on `EADDRINUSE` instead of giving up. The configured setting is never overwritten — restart still tries the original first, in case the conflict has cleared.

Why fallback rather than "step aside if another BossTerm owns the port": each BossTerm JVM has its own `McpTerminalRegistry` singleton, so a quiet instance would have invisible tabs (the *other* instance's MCP only knows its *own* windows). Two instances need two MCP servers on two ports.

## Behavior

- First attempt is the configured `mcpPort`.
- On `EADDRINUSE` (port in use), try `port+1`, `port+2`, … up to 9 more times.
- On **`EACCES`** (permission denied — privileged ports `<1024` on Linux/macOS when not running as root), **fail hard** without walking up the privileged range.
- Any other failure (SDK init bug, etc.) stays a hard failure — we don't try other ports for it.
- `runningPort` reflects the actual bound port; `mcpPort` setting is untouched.
- `launchAutoReattach` already uses the bound port, so the four AI-CLI registrations get their URLs updated to the fallback port automatically.

EADDRINUSE vs EACCES detection is by `BindException.message` substring match ("permission" / "denied" / "not permitted"), because OpenJDK throws plain `BindException` for both — only the message distinguishes them. Brittle, but the worst-case heuristic failure is the pre-fix behavior (10 quick failed binds, then give up).

Sample logs:

```
INFO BossTermMcpManager - Starting BossTerm MCP server on http://127.0.0.1:7676/
WARN BossTermMcpManager - BossTerm MCP server failed to bind 127.0.0.1:7676 (port in use?): ...
INFO BossTermMcpManager - Starting BossTerm MCP server on http://127.0.0.1:7677/ (fallback from configured port 7676)
INFO BossTermMcpManager - BossTerm MCP server ready: http://127.0.0.1:7677/ ...

# Privileged port (won't fall back):
ERROR BossTermMcpManager - BossTerm MCP server cannot bind 127.0.0.1:80 (permission denied); giving up: ...
```

## Implementation notes

- `tryStartOnPort` returns a `StartOutcome { Started, PortBusy, HardFailed }` enum so the loop reads `when (...) { Started, HardFailed -> return; PortBusy -> continue }` instead of overloading a boolean.
- The MAX_TCP_PORT overflow log says "would-be next port {} exceeds {}" rather than "last tried" since we never actually tried it.
- Docs updated in `docs/mcp-server.md` + wiki mirror with the new troubleshooting flow.

## Known caveat (out of scope)

When two BossTerm instances run with the same `BossTermMcpConfig.serverName` (the default `"bossterm"`), their CLI auto-reattach can clobber each other's registrations: each silent reattach rewrites e.g. Claude Code's `bossterm` entry to point at the *latest* instance to start. Port fallback doesn't fix that, but it doesn't worsen it either — it would happen any time two BossTerms run regardless. A follow-up could PID-suffix the serverName for fallback ports, or restrict auto-reattach to canonical-port instances.

Additionally, **auto-reattach runs on every successful bind, not just on user-initiated port changes** — with fallback active, a flapping port (7676 busy → 7677, next launch claims 7676 again) means each launch silently rewrites the persisted CLI configs to follow that launch's port. Documented in the new heads-up callout in `docs/mcp-server.md`.

## Test plan

- [x] `./gradlew :compose-ui:compileKotlinDesktop :bossterm-app :compileKotlinDesktop` — clean.
- [ ] Start a BossTerm with MCP on 7676. Start a second instance from `./gradlew :bossterm-app:run`. Confirm the second logs `(fallback from configured port 7676)` and the status pill's tooltip shows the fallback URL.
- [ ] Kill the first BossTerm; restart the second. Confirm it now claims 7676 on next bind (because `mcpPort` setting was not modified).
- [ ] On Linux/macOS as an unprivileged user, set `mcpPort = 80` in settings.json. Confirm startup logs the `permission denied` hard failure and does **not** walk through 81–89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)