### PR TITLE
feat(mcp): list_panes tool so clients can address splits they didn't create

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -769,6 +769,43 @@ class TabbedTerminalState {
      * `run_in_panel` and wants to address that specific pane in a
      * follow-up tool call (send_input, read_scrollback, etc).
      */
+    /**
+     * Snapshot of every pane in [tabId], suitable for MCP exposure. A tab
+     * without splits returns a single entry whose `id` and `sessionId` both
+     * equal the tab's id and whose `isFocused` is `true`. For a split tab,
+     * each entry carries the wrapping `SplitNode.Pane.id` (what
+     * `splitHorizontal`/`splitVertical`/`run_in_panel` return), the
+     * underlying `TerminalSession.id`, the session's current title/cwd, and
+     * the focus state derived from `SplitViewState.focusedPaneId`.
+     *
+     * Returns an empty list if the tab id is unknown.
+     */
+    fun getPaneSnapshots(tabId: String): List<PaneSnapshot> {
+        val tab = getTabById(tabId) ?: return emptyList()
+        val splitState = splitStates[tabId]
+        if (splitState == null) {
+            return listOf(
+                PaneSnapshot(
+                    id = tab.id,
+                    sessionId = tab.id,
+                    title = tab.title.value,
+                    cwd = tab.workingDirectory.value,
+                    isFocused = true
+                )
+            )
+        }
+        val focusedId = splitState.focusedPaneId
+        return splitState.getAllPanes().map { pane ->
+            PaneSnapshot(
+                id = pane.id,
+                sessionId = pane.session.id,
+                title = pane.session.title.value,
+                cwd = pane.session.workingDirectory.value,
+                isFocused = pane.id == focusedId
+            )
+        }
+    }
+
     fun findSession(tabId: String, paneId: String? = null): TerminalSession? {
         val tab = getTabById(tabId) ?: return null
         val splitState = splitStates[tabId]
@@ -1101,6 +1138,29 @@ data class TerminalTabInfo(
     val isConnected: Boolean,
     val workingDirectory: String?,
     val paneCount: Int
+)
+
+/**
+ * Snapshot of a single pane within a tab. Returned by
+ * [TabbedTerminalState.getPaneSnapshots], exposed by the MCP `list_panes` tool.
+ *
+ * @property id The wrapping `SplitNode.Pane.id` — the value `run_in_panel`,
+ *   `splitHorizontal`, and `splitVertical` return, and the one accepted as
+ *   `pane_id` by other MCP tools. For a tab without splits, equals [sessionId].
+ * @property sessionId The underlying `TerminalSession.id`. Distinct from [id]
+ *   for split panes — preserved here so callers can correlate against any
+ *   API that surfaces session ids directly.
+ * @property title Current pane title (mutates with OSC 0/2; snapshotted at call time).
+ * @property cwd Current working directory (from OSC 7), or null if not reported.
+ * @property isFocused True for the pane that currently has keyboard focus.
+ */
+@Immutable
+data class PaneSnapshot(
+    val id: String,
+    val sessionId: String,
+    val title: String,
+    val cwd: String?,
+    val isFocused: Boolean
 )
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -91,6 +91,7 @@ class BossTermMcpServer(
     private val readToolRegistrations: Map<String, (Server) -> Unit> = mapOf(
         "list_tabs" to ::registerListTabs,
         "get_active_tab" to ::registerGetActiveTab,
+        "list_panes" to ::registerListPanes,
         "read_scrollback" to ::registerReadScrollback,
         "search_output" to ::registerSearchOutput,
         "get_last_command" to ::registerGetLastCommand,
@@ -253,6 +254,54 @@ class BossTermMcpServer(
             // JSON.parse get a real null. Cheaper than wrapping in `{tab: null}`.
             val text = if (info == null) "null" else json.encodeToString(TabInfo.serializer(), info)
             successJson(text)
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Tool: list_panes
+    // -----------------------------------------------------------------
+
+    private fun registerListPanes(server: Server) {
+        server.addTool(
+            name = toolName("list_panes"),
+            description = describe(
+                "list_panes",
+                "Enumerate the panes inside a tab. A tab without splits returns " +
+                        "a single entry whose id equals the tab id. For a split tab, each " +
+                        "entry carries the pane id (the value to pass back as `pane_id` to " +
+                        "other tools), the underlying session id, the pane's current title " +
+                        "and cwd, and whether it currently has keyboard focus. Use this " +
+                        "before send_input / send_signal / read_scrollback when you need to " +
+                        "target a specific split pane and didn't create it via run_in_panel."
+            ),
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("tab_id") {
+                        put("type", "string")
+                        put("description", "Stable tab id (see list_tabs).")
+                    }
+                },
+                required = listOf("tab_id")
+            )
+        ) { request ->
+            val args = request.arguments
+            val tabId = args.requireString("tab_id")
+                ?: return@addTool errorResult("Missing required argument: tab_id")
+            val state = registry.findState(tabId)
+                ?: return@addTool errorResult("Unknown tab_id: $tabId")
+            val snapshots = state.getPaneSnapshots(tabId)
+            val panes = snapshots.map { s ->
+                PaneInfo(
+                    id = s.id,
+                    sessionId = s.sessionId,
+                    title = s.title,
+                    cwd = s.cwd,
+                    isFocused = s.isFocused
+                )
+            }
+            val focusedId = snapshots.firstOrNull { it.isFocused }?.id
+            val payload = ListPanesResult(panes = panes, focusedPaneId = focusedId)
+            successJson(json.encodeToString(ListPanesResult.serializer(), payload))
         }
     }
 
@@ -1000,6 +1049,21 @@ class BossTermMcpServer(
     )
 
     @Serializable
+    data class PaneInfo(
+        val id: String,
+        val sessionId: String,
+        val title: String,
+        val cwd: String?,
+        val isFocused: Boolean
+    )
+
+    @Serializable
+    data class ListPanesResult(
+        val panes: List<PaneInfo>,
+        val focusedPaneId: String?
+    )
+
+    @Serializable
     data class ReadScrollbackResult(
         val lines: List<String>,
         val totalAvailable: Int
@@ -1087,6 +1151,7 @@ class BossTermMcpServer(
         val BUILT_IN_READ_TOOLS: List<String> = listOf(
             "list_tabs",
             "get_active_tab",
+            "list_panes",
             "read_scrollback",
             "search_output",
             "get_last_command",

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -101,6 +101,37 @@ tab is active.
 - Arguments: none.
 - Returns: a `TabInfo` object (same shape as in `list_tabs`) or `null`.
 
+### `list_panes`
+
+Enumerate the panes inside a tab. Call this when you need to address a split
+you didn't create yourself (any split the user opened with the keyboard or via
+the UI), or when you've lost track of a pane id returned by an earlier
+`run_in_panel` call.
+
+- Required: `tab_id` (string).
+- Returns:
+  ```json
+  {
+    "panes": [
+      {
+        "id": "<paneId>",
+        "sessionId": "<sessionId>",
+        "title": "<string>",
+        "cwd": "<string>",
+        "isFocused": true
+      }
+    ],
+    "focusedPaneId": "<paneId>"
+  }
+  ```
+- A tab without splits returns a single entry whose `id` equals the
+  `tab_id`. For a split tab, `id` is the wrapping `SplitNode.Pane.id` — the
+  value to pass back as `pane_id` to `send_input`, `send_signal`,
+  `read_scrollback`, etc. `sessionId` is preserved separately so callers
+  can correlate against APIs that surface session ids directly. Closing a
+  pane is `send_signal` with `signal=ctrl_d` and the pane's `id` —
+  the shell exits and the pane disposes itself.
+
 ### `read_scrollback`
 
 Read the last N lines from a tab or split pane's buffer (history + visible

--- a/docs/wiki/MCP-Server.md
+++ b/docs/wiki/MCP-Server.md
@@ -108,6 +108,37 @@ no tab is active.
 - Arguments: none.
 - Returns: a `TabInfo` object (same shape as in `list_tabs`) or `null`.
 
+### `list_panes`
+
+Enumerate the panes inside a tab. Call this when you need to address a
+split you didn't create yourself (any split the user opened with the
+keyboard or via the UI), or when you've lost track of a pane id returned
+by an earlier `run_in_panel` call.
+
+- Required: `tab_id` (string).
+- Returns:
+  ```json
+  {
+    "panes": [
+      {
+        "id": "<paneId>",
+        "sessionId": "<sessionId>",
+        "title": "<string>",
+        "cwd": "<string>",
+        "isFocused": true
+      }
+    ],
+    "focusedPaneId": "<paneId>"
+  }
+  ```
+- A tab without splits returns a single entry whose `id` equals the
+  `tab_id`. For a split tab, `id` is the wrapping `SplitNode.Pane.id` —
+  the value to pass back as `pane_id` to `send_input`, `send_signal`,
+  `read_scrollback`, etc. `sessionId` is preserved separately so callers
+  can correlate against APIs that surface session ids directly. Closing a
+  pane is `send_signal` with `signal=ctrl_d` and the pane's `id` —
+  the shell exits and the pane disposes itself.
+
 ### `read_scrollback`
 
 Read the last N lines from a tab or split pane's buffer (history + visible


### PR DESCRIPTION
## Summary

Before this PR, the MCP tools that take a `pane_id` (`send_input`, `send_signal`, `read_scrollback`, `search_output`) only worked against panes the same client received from `run_in_panel`. Splits the user opened via keyboard shortcut — or splits from a different MCP client — were unreachable: no call surfaced their ids. Asking "close the right split" had no answer.

`list_panes(tab_id)` fills the gap.

## Tool

```json
list_panes { "tab_id": "<uuid>" }
→
{
  "panes": [
    {
      "id": "<paneId>",           // pass back as pane_id to other tools
      "sessionId": "<sessionId>",
      "title": "Shell 1",
      "cwd": "/Users/me",
      "isFocused": true
    }
  ],
  "focusedPaneId": "<paneId>"
}
```

A tab without splits returns one entry whose `id` equals the `tab_id`. The focused pane is flagged.

Combined with `send_signal ctrl_d <pane_id>`, agents can now close arbitrary splits cleanly.

## Implementation

- New `TabbedTerminalState.getPaneSnapshots(tabId): List<PaneSnapshot>` walks `splitStates[tabId].getAllPanes()` and uses `focusedPaneId` for the focus flag. Falls back to a synthetic single entry when the tab has no splits.
- New `PaneSnapshot` data class alongside `TerminalTabInfo`.
- `BossTermMcpServer` gains `registerListPanes` wired into `readToolRegistrations` and `BUILT_IN_READ_TOOLS` — so the new tool shows up in `manage_tools` and the Settings UI's per-tool toggle list.
- New `PaneInfo` / `ListPanesResult` DTOs.
- Docs section added between `get_active_tab` and `read_scrollback` in both `docs/mcp-server.md` and `docs/wiki/MCP-Server.md`, with the "close a pane" recipe.

## Test plan

- [x] `./gradlew :compose-ui:compileKotlinDesktop :bossterm-app :embedded-example :tabbed-example :compileKotlinDesktop` — clean.
- [ ] Start a BossTerm, open a horizontal split with the keyboard, call `list_panes` from an MCP client — should return two entries with `isFocused: true` on the freshly-focused pane.
- [ ] Call `manage_tools list` and confirm `list_panes` appears with `enabled: true`.
- [ ] Verify in Settings → BossTerm MCP → Exposed Tools that `list_panes` shows up as a togglable checkbox.
- [ ] Round-trip: `list_panes` → pick a non-focused pane id → `send_signal { signal: "ctrl_d", pane_id: <that id> }` → the pane closes; subsequent `list_panes` reflects the new state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)