### PR TITLE
fix(mcp): port fallback was a no-op (Ktor wraps the async BindException)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -216,6 +216,14 @@ class BossTermMcpManager(
         // config bugs aren't silently masked by walking up a privileged range.
         // The persisted `mcpPort` is NOT updated — the next restart still
         // tries the original first in case the conflicting process exited.
+        //
+        // Each iteration pre-flights the port with a synchronous ServerSocket
+        // bind. Ktor CIO's `engine.start(wait = false)` returns immediately
+        // (success) and the real accept-loop bind runs asynchronously — when
+        // that async bind fails it wraps the BindException in a
+        // JobCancellationException which our synchronous try/catch can't see
+        // reliably. Pre-flighting moves the fallback decision out of the async
+        // path and avoids the wrap-in-coroutine problem entirely.
         for (offset in 0 until MAX_PORT_FALLBACK_ATTEMPTS) {
             val port = desiredPort + offset
             if (port > MAX_TCP_PORT) {
@@ -224,6 +232,24 @@ class BossTermMcpManager(
                     port, MAX_TCP_PORT
                 )
                 return
+            }
+            val probe = preflightPort(port)
+            when (probe) {
+                PortProbe.Available -> { /* fall through to tryStartOnPort */ }
+                PortProbe.InUse -> {
+                    log.warn(
+                        "Port {}:{} appears in use (pre-flight); trying next",
+                        HOST, port
+                    )
+                    continue
+                }
+                PortProbe.PermissionDenied -> {
+                    log.error(
+                        "BossTerm MCP server cannot bind {}:{} (permission denied at pre-flight); giving up",
+                        HOST, port
+                    )
+                    return
+                }
             }
             when (tryStartOnPort(port, desiredPort)) {
                 StartOutcome.Started, StartOutcome.HardFailed -> return
@@ -235,6 +261,44 @@ class BossTermMcpManager(
             desiredPort, desiredPort + MAX_PORT_FALLBACK_ATTEMPTS - 1
         )
     }
+
+    /**
+     * Synchronous pre-flight: try to bind a ServerSocket on the loopback
+     * address and immediately close it. Lets us classify the port before
+     * handing it to Ktor's async accept loop, where a real bind failure
+     * gets wrapped in a JobCancellationException and is awkward to catch.
+     *
+     * Has a small TOCTOU window (the port could become busy between the
+     * probe close and Ktor's bind). Acceptable: we're talking about
+     * loopback in a single-user session, and `tryStartOnPort`'s catch
+     * still handles whatever Ktor surfaces.
+     */
+    private fun preflightPort(port: Int): PortProbe {
+        return try {
+            java.net.ServerSocket().use { sock ->
+                sock.reuseAddress = false  // mirror Ktor; don't quietly steal a TIME_WAIT
+                sock.bind(java.net.InetSocketAddress(HOST, port))
+                PortProbe.Available
+            }
+        } catch (e: BindException) {
+            val msg = e.message.orEmpty()
+            if (looksLikePermissionDenied(msg)) PortProbe.PermissionDenied
+            else PortProbe.InUse
+        } catch (e: java.io.IOException) {
+            // Other I/O — treat as "in use" so the loop tries the next port.
+            // If it's a config-level problem (e.g. binding outside loopback),
+            // the user will hit the same error on every port and we'll
+            // eventually run out and give up cleanly.
+            PortProbe.InUse
+        }
+    }
+
+    private enum class PortProbe { Available, InUse, PermissionDenied }
+
+    private fun looksLikePermissionDenied(msg: String): Boolean =
+        msg.contains("permission", ignoreCase = true) ||
+            msg.contains("denied", ignoreCase = true) ||
+            msg.contains("not permitted", ignoreCase = true)
 
     /**
      * One bind attempt. See [StartOutcome] for the return semantics.
@@ -299,38 +363,40 @@ class BossTermMcpManager(
             )
             launchAutoReattach(port)
             return StartOutcome.Started
-        } catch (e: BindException) {
-            mcpServerWrapper.detachServer()
-            runningEngine = null
-            runningPort = null
-            runningServer = null
-            val msg = e.message.orEmpty()
-            // Heuristic: if the JDK distinguished EACCES from EADDRINUSE only
-            // via message text, "permission" / "denied" / "not permitted" /
-            // "access" is the signature. Treat as hard failure to avoid
-            // walking up a privileged range (e.g. configured 80 → 81..89).
-            val looksLikePermissionDenied = msg.contains("permission", ignoreCase = true) ||
-                    msg.contains("denied", ignoreCase = true) ||
-                    msg.contains("not permitted", ignoreCase = true)
-            return if (looksLikePermissionDenied) {
-                log.error(
-                    "BossTerm MCP server cannot bind {}:{} (permission denied); giving up: {}",
-                    HOST, port, msg
-                )
-                StartOutcome.HardFailed
-            } else {
-                log.warn(
-                    "BossTerm MCP server failed to bind {}:{} (port in use?): {}",
-                    HOST, port, msg
-                )
-                StartOutcome.PortBusy
-            }
         } catch (e: Throwable) {
-            log.error("BossTerm MCP server failed to start on {}:{}", HOST, port, e)
             mcpServerWrapper.detachServer()
             runningEngine = null
             runningPort = null
             runningServer = null
+
+            // Ktor CIO wraps the bind-time BindException in a
+            // JobCancellationException (the async accept loop's parent
+            // coroutine gets cancelled). Unwrap the cause chain so the
+            // fallback decision is right whether the JDK threw bind directly
+            // or it bubbled through a coroutine. The pre-flight in
+            // startEngineLocked usually catches this earlier, but a TOCTOU
+            // window remains.
+            val bind = generateSequence(e as Throwable?) { it.cause }
+                .filterIsInstance<BindException>()
+                .firstOrNull()
+            if (bind != null) {
+                val msg = bind.message.orEmpty()
+                return if (looksLikePermissionDenied(msg)) {
+                    log.error(
+                        "BossTerm MCP server cannot bind {}:{} (permission denied); giving up: {}",
+                        HOST, port, msg
+                    )
+                    StartOutcome.HardFailed
+                } else {
+                    log.warn(
+                        "BossTerm MCP server failed to bind {}:{} (port in use?): {}",
+                        HOST, port, msg
+                    )
+                    StartOutcome.PortBusy
+                }
+            }
+
+            log.error("BossTerm MCP server failed to start on {}:{}", HOST, port, e)
             return StartOutcome.HardFailed
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -28,7 +28,10 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
+import java.io.IOException
 import java.net.BindException
+import java.net.InetSocketAddress
+import java.net.ServerSocket
 
 /**
  * Lifecycle wrapper that brings up the BossTerm in-process MCP server on a
@@ -275,16 +278,16 @@ class BossTermMcpManager(
      */
     private fun preflightPort(port: Int): PortProbe {
         return try {
-            java.net.ServerSocket().use { sock ->
+            ServerSocket().use { sock ->
                 sock.reuseAddress = false  // mirror Ktor; don't quietly steal a TIME_WAIT
-                sock.bind(java.net.InetSocketAddress(HOST, port))
+                sock.bind(InetSocketAddress(HOST, port))
                 PortProbe.Available
             }
         } catch (e: BindException) {
             val msg = e.message.orEmpty()
             if (looksLikePermissionDenied(msg)) PortProbe.PermissionDenied
             else PortProbe.InUse
-        } catch (e: java.io.IOException) {
+        } catch (e: IOException) {
             // Other I/O — treat as "in use" so the loop tries the next port.
             // If it's a config-level problem (e.g. binding outside loopback),
             // the user will hit the same error on every port and we'll


### PR DESCRIPTION
## Summary

PR #255's port fallback has been broken since it merged. With a BossTerm already on 7676, starting a second instance reproduces:

```
INFO  BossTermMcpManager - Starting BossTerm MCP server on http://127.0.0.1:7676/
INFO  io.ktor.server.Application - Application started in 0.115 seconds.
ERROR BossTermMcpManager - BossTerm MCP server failed to start on 127.0.0.1:7676
        kotlinx.coroutines.JobCancellationException: LazyStandaloneCoroutine is cancelling
        Caused by: java.net.BindException: Address already in use
```

No "fallback from configured port" log. The loop exited; the second instance just runs with MCP disabled.

## Root cause

Ktor CIO's `engine.start(wait = false)` is non-blocking. The real `tcpBind` runs asynchronously in the accept-loop coroutine; when it fails, the parent `LazyStandaloneCoroutine` cancels and propagates a `JobCancellationException` whose `cause` is the `BindException`. Our synchronous `catch (e: BindException)` in `tryStartOnPort` never saw the wrapped form — it landed in `catch (e: Throwable)` and became `StartOutcome.HardFailed`. Loop stopped.

## Fix

Two layers:

**1. Synchronous pre-flight** in `startEngineLocked`. Before handing the port to Ktor, do a one-shot `ServerSocket().bind(...)`. Classify the result:
- `Available` → start Ktor.
- `InUse` → continue the loop.
- `PermissionDenied` → hard fail.

This moves the fallback decision out of Ktor's async path entirely. A small TOCTOU window remains between the probe's close and Ktor's bind; that's the point of fix #2.

**2. Cause-chain unwrap** in `tryStartOnPort`'s catch. Walk `e.cause` looking for a `BindException`; if found, treat just like the direct form (EADDRINUSE → `PortBusy`, EACCES → `HardFailed`). Covers the TOCTOU and any other async-wrap paths Ktor might introduce.

Both are needed. The pre-flight is the dominant case (clean, no Ktor-internals dependency); the unwrap is the safety net.

Also extracted `looksLikePermissionDenied(msg)` so the pre-flight and post-catch paths share the EACCES heuristic.

## Test plan

CI can't simulate this scenario without a live BossTerm. Manual verification:

- [ ] Start BossTerm A (`mcp_port = 7676`, MCP enabled). Confirm `bossterm mcp status` reports it on 7676.
- [ ] Start BossTerm B via `./gradlew :bossterm-app:run --no-daemon`. Expect logs:
  ```
  WARN  Port 127.0.0.1:7676 appears in use (pre-flight); trying next
  INFO  Starting BossTerm MCP server on http://127.0.0.1:7677/ (fallback from configured port 7676)
  INFO  BossTerm MCP server ready: http://127.0.0.1:7677/ ...
  ```
- [ ] From a fresh MCP client, query both ports (`curl /sse`) and confirm both respond.
- [ ] On Linux, set `mcp_port = 80` as an unprivileged user. Expect the pre-flight to classify as `PermissionDenied` and the loop to abort cleanly — no walk through 81..89.
- [ ] Toggle BossTerm A off and on; confirm B keeps 7677 and A reclaims 7676 (mcpPort setting unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)