### PR TITLE
feat(cli): post-#257 follow-ups — port targeting, signal/close/panes, probe fixes

### DIFF
--- a/cli-resources/bossterm
+++ b/cli-resources/bossterm
@@ -527,6 +527,63 @@ cmd_close() {
     cmd_signal ctrl_d "$@"
 }
 
+# List panes in a tab. Default: active tab, tabular human-readable output.
+# `--tab <id>` overrides; `--json` prints the raw MCP response. The PANE ID
+# column is the value to pass back as `--pane <id>` to send/signal/close.
+cmd_panes() {
+    local tab_id=""
+    local json_out=false
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --tab)    tab_id="$2"; shift 2 ;;
+            --tab=*)  tab_id="${1#--tab=}"; shift ;;
+            --json)   json_out=true; shift ;;
+            *)        echo "Usage: bossterm panes [--tab <id>] [--json]" >&2; exit 1 ;;
+        esac
+    done
+    require_python3
+    local port; port="$(mcp_resolve_port_or_die)" || exit $?
+    if [ -z "$tab_id" ]; then
+        tab_id="$(mcp_call_with_port "$port" list_tabs '{}' \
+                  | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("activeTabId",""))')"
+    fi
+    if [ -z "$tab_id" ]; then
+        echo "Error: no active tab; pass --tab <id>" >&2
+        exit 2
+    fi
+    local args
+    args="$(python3 -c 'import json,sys; print(json.dumps({"tab_id":sys.argv[1]}))' "$tab_id")"
+    local raw rc
+    raw="$(mcp_call_with_port "$port" list_panes "$args")"; rc=$?
+    if [ $rc -ne 0 ]; then
+        # The Python helper prints the server's error text on stdout when a
+        # tool call fails. Surface that to the user instead of letting the
+        # JSON parser choke on it below.
+        echo "Error: list_panes failed${raw:+: $raw}" >&2
+        exit $rc
+    fi
+    if [ "$json_out" = true ]; then
+        echo "$raw"
+        return 0
+    fi
+    echo "$raw" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+panes = data.get("panes", [])
+if not panes:
+    print("(no panes)")
+    sys.exit(0)
+# Plain %-formatting — f-strings disallow backslashes, and the header
+# row needed escaped quotes which was tripping the parser.
+print("%-37s %-3s %-24s %s" % ("PANE ID", "FOC", "TITLE", "CWD"))
+for p in panes:
+    foc = "*" if p.get("isFocused") else ""
+    title = (p.get("title") or "")[:24]
+    cwd = p.get("cwd") or ""
+    print("%-37s %-3s %-24s %s" % (p["id"], foc, title, cwd))
+'
+}
+
 cmd_attach() {
     local target="${1:-}"
     if [ -z "$target" ]; then
@@ -668,6 +725,8 @@ USAGE
   bossterm signal <ctrl_c|ctrl_d|ctrl_z> [--pane id]
                                     Send a control signal                  (MCP)
   bossterm close [--pane id]        Close a pane (Ctrl-D to its shell)     (MCP)
+  bossterm panes [--tab id] [--json]
+                                    List panes in a tab                    (MCP)
   bossterm logs [--tab id] [--lines N]
                                     Dump recent scrollback                 (MCP)
 
@@ -758,6 +817,7 @@ main() {
         send)                   shift; cmd_send "$@" ;;
         signal)                 shift; cmd_signal "$@" ;;
         close)                  shift; cmd_close "$@" ;;
+        panes)                  shift; cmd_panes "$@" ;;
         attach)                 shift; cmd_attach "$@" ;;
         mcp)                    shift; cmd_mcp "$@" ;;
         config)                 shift; cmd_config "$@" ;;

--- a/cli-resources/bossterm
+++ b/cli-resources/bossterm
@@ -69,7 +69,20 @@ VERSION="$(resolve_version)"
 # Co-located Python helper. `install.sh` and `CLIInstaller.kt` drop both
 # files in the same directory (`/usr/local/bin` or `~/.local/bin`) so this
 # resolves cleanly via the script's own location.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#
+# Resolve symlinks so a wrapper symlink (the repo-root `./bossterm` →
+# `cli-resources/bossterm`, or `/usr/local/bin/bossterm` if a packager set
+# it up that way) doesn't make us look for the helper alongside the link
+# instead of alongside the real file. Plain `dirname "${BASH_SOURCE[0]}"`
+# would; this loop walks the chain. Portable; no `readlink -f` (macOS
+# lacks it).
+_BT_SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [ -L "$_BT_SCRIPT_PATH" ]; do
+    _BT_LINK_DIR="$(cd "$(dirname "$_BT_SCRIPT_PATH")" && pwd)"
+    _BT_SCRIPT_PATH="$(readlink "$_BT_SCRIPT_PATH")"
+    [[ "$_BT_SCRIPT_PATH" != /* ]] && _BT_SCRIPT_PATH="$_BT_LINK_DIR/$_BT_SCRIPT_PATH"
+done
+SCRIPT_DIR="$(cd "$(dirname "$_BT_SCRIPT_PATH")" && pwd)"
 MCP_HELPER="$SCRIPT_DIR/bossterm-mcp.py"
 
 SETTINGS_PATH="$HOME/.bossterm/settings.json"
@@ -235,23 +248,28 @@ mcp_configured_port() {
     echo "${p:-7676}"
 }
 
-# Probe whether port responds as a BossTerm MCP server (not just any HTTP
-# server). Returns 0/1. We check `/sse` with `Accept: text/event-stream` and
-# require both 200 status AND `text/event-stream` Content-Type — Ktor's MCP
-# SDK 0.8.3 answers GET /sse exactly that way; a wayward web service on the
-# same port almost never will.
+# Probe whether port responds as a BossTerm MCP server. Returns 0/1.
 #
-# Loopback is fast, so the connect + max time are tight. Each probe caps at
-# ~0.5s, which keeps `bossterm mcp status` snappy even in the fallback walk.
+# Two earlier attempts didn't work:
+#   - `curl GET /` 2xx-any-response was too loose (any HTTP server matched).
+#   - `curl GET /sse` was wrong (the Kotlin MCP SDK 0.8.3 mounts the SSE
+#     endpoint at root, not /sse) and also `curl … -o /dev/null` on an
+#     infinite SSE stream doesn't emit the -w format before the timeout.
+#
+# Now: delegate to the bundled Python helper's `ping` subcommand, which
+# does a real MCP handshake (open SSE → wait for `endpoint` event →
+# initialize). Exit 0 ⇔ MCP is up. Each probe is ~150ms on loopback so
+# the worst-case 10-port walk caps around ~1.5s.
 mcp_probe_port() {
     local port="$1"
-    local meta
-    meta="$(curl --connect-timeout 1 --max-time 1 -sS -o /dev/null \
-        -H "Host: 127.0.0.1" \
-        -H "Accept: text/event-stream" \
-        -w "%{http_code} %{content_type}" \
-        "http://127.0.0.1:$port/sse" 2>/dev/null)" || return 1
-    [[ "$meta" == 200\ text/event-stream* ]]
+    # If Python or the helper is missing, fall back to a connect-only
+    # probe — better than no probe at all. Won't distinguish BossTerm MCP
+    # from a random HTTP server, but the next real call will fail clearly.
+    if ! command -v python3 >/dev/null 2>&1 || [ ! -f "$MCP_HELPER" ]; then
+        nc -z -G 1 127.0.0.1 "$port" >/dev/null 2>&1
+        return $?
+    fi
+    python3 "$MCP_HELPER" ping "$port" >/dev/null 2>&1
 }
 
 # Resolve the actual running port (configured first, then the +0..+9

--- a/cli-resources/bossterm
+++ b/cli-resources/bossterm
@@ -482,6 +482,51 @@ cmd_send() {
     mcp_call_with_port "$port" send_input "$args" >/dev/null
 }
 
+cmd_signal() {
+    local sig="${1:-}"
+    case "$sig" in
+        ctrl_c|ctrl_d|ctrl_z) ;;
+        *)
+            echo "Usage: bossterm signal <ctrl_c|ctrl_d|ctrl_z> [--pane <id>]" >&2
+            exit 1
+            ;;
+    esac
+    shift
+    local pane_id=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --pane)   pane_id="$2"; shift 2 ;;
+            --pane=*) pane_id="${1#--pane=}"; shift ;;
+            *)        echo "Unknown arg: $1" >&2; exit 1 ;;
+        esac
+    done
+    require_python3
+    local port; port="$(mcp_resolve_port_or_die)" || exit $?
+    local tab_id
+    tab_id="$(mcp_call_with_port "$port" list_tabs '{}' \
+              | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("activeTabId",""))')"
+    if [ -z "$tab_id" ]; then
+        echo "Error: no active tab" >&2
+        exit 2
+    fi
+    local args
+    if [ -n "$pane_id" ]; then
+        args="$(python3 -c 'import json,sys; print(json.dumps({"tab_id":sys.argv[1],"pane_id":sys.argv[2],"signal":sys.argv[3]}))' \
+                "$tab_id" "$pane_id" "$sig")"
+    else
+        args="$(python3 -c 'import json,sys; print(json.dumps({"tab_id":sys.argv[1],"signal":sys.argv[2]}))' \
+                "$tab_id" "$sig")"
+    fi
+    mcp_call_with_port "$port" send_signal "$args" >/dev/null
+}
+
+# Close the focused pane (or a specific one) by sending EOF to its shell.
+# Once the shell exits, the pane disposes itself via onProcessExit. Killing
+# the last pane of a tab closes the tab (and the window, if it was the last).
+cmd_close() {
+    cmd_signal ctrl_d "$@"
+}
+
 cmd_attach() {
     local target="${1:-}"
     if [ -z "$target" ]; then
@@ -620,6 +665,9 @@ USAGE
   bossterm new-tab                  Open a new tab in a running BossTerm (MCP)
   bossterm run [--split=h|v] <cmd>  Open a new tab/split and run <cmd>     (MCP)
   bossterm send <text>              Send text to the focused pane          (MCP)
+  bossterm signal <ctrl_c|ctrl_d|ctrl_z> [--pane id]
+                                    Send a control signal                  (MCP)
+  bossterm close [--pane id]        Close a pane (Ctrl-D to its shell)     (MCP)
   bossterm logs [--tab id] [--lines N]
                                     Dump recent scrollback                 (MCP)
 
@@ -708,6 +756,8 @@ main() {
         new-tab)                shift; cmd_new_tab "$@" ;;
         run)                    shift; cmd_run "$@" ;;
         send)                   shift; cmd_send "$@" ;;
+        signal)                 shift; cmd_signal "$@" ;;
+        close)                  shift; cmd_close "$@" ;;
         attach)                 shift; cmd_attach "$@" ;;
         mcp)                    shift; cmd_mcp "$@" ;;
         config)                 shift; cmd_config "$@" ;;

--- a/cli-resources/bossterm
+++ b/cli-resources/bossterm
@@ -272,9 +272,21 @@ mcp_probe_port() {
     python3 "$MCP_HELPER" ping "$port" >/dev/null 2>&1
 }
 
-# Resolve the actual running port (configured first, then the +0..+9
-# fallback range introduced by PR #255).
+# Resolve the actual running port. Order:
+#   1. `$BOSSTERM_MCP_PORT` if set — explicit override; probe that single
+#      port and either return it or fail. Useful when multiple BossTerms
+#      are running (e.g. a packaged install + an IDE debug session) and
+#      you need to address a specific one.
+#   2. Configured port from settings.json (default 7676).
+#   3. Configured+1 .. configured+9 (the fallback range PR #255 walks).
 mcp_running_port() {
+    if [ -n "${BOSSTERM_MCP_PORT:-}" ]; then
+        if mcp_probe_port "$BOSSTERM_MCP_PORT"; then
+            echo "$BOSSTERM_MCP_PORT"
+            return 0
+        fi
+        return 1
+    fi
     local configured base
     configured="$(mcp_configured_port)"
     base="$configured"
@@ -624,6 +636,18 @@ USAGE
   bossterm --version | -v           Print version
   bossterm --help    | -h           Print this help
 
+GLOBAL FLAGS
+  --port <N>                        Target the MCP server on port <N> instead of
+                                    auto-discovering. Useful when multiple
+                                    BossTerm instances are running (e.g. a
+                                    packaged install + an IDE debug session).
+                                    Equivalent to setting BOSSTERM_MCP_PORT.
+
+ENVIRONMENT
+  BOSSTERM_MCP_PORT                 Same as --port. The CLI probes only this
+                                    port instead of walking the configured
+                                    port + the +1..+9 fallback range.
+
 NOTES
   MCP-backed subcommands (new-tab, run, send, logs, mcp tools) require a
   running BossTerm with MCP enabled. Run 'bossterm mcp on' once if needed.
@@ -642,6 +666,34 @@ show_version() {
 # ---------------------------------------------------------------------------
 
 main() {
+    # Pre-pass: extract global `--port=N` / `--port N` and export it as
+    # BOSSTERM_MCP_PORT so the MCP plumbing picks it up. Done before the
+    # subcommand dispatch so the flag works in any position (and so the
+    # subcommands' own arg parsers don't have to know about it). Sets
+    # BOSSTERM_MCP_PORT only when the flag was supplied — env-var sets
+    # from the user's shell continue to work unchanged.
+    local _bt_argv=()
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --port=*)
+                export BOSSTERM_MCP_PORT="${1#--port=}"
+                shift
+                ;;
+            --port)
+                if [ -z "${2:-}" ]; then
+                    echo "Error: --port requires a value" >&2; exit 1
+                fi
+                export BOSSTERM_MCP_PORT="$2"
+                shift 2
+                ;;
+            *)
+                _bt_argv+=("$1")
+                shift
+                ;;
+        esac
+    done
+    set -- "${_bt_argv[@]+"${_bt_argv[@]}"}"
+
     # No args → launch GUI.
     if [ $# -eq 0 ]; then
         check_app

--- a/cli-resources/bossterm-mcp.py
+++ b/cli-resources/bossterm-mcp.py
@@ -16,8 +16,10 @@ Subcommands:
       port (initialize handshake completes), 1 otherwise.
 
 Transport summary (SDK 0.8.3 quirk):
-  - GET /sse with Accept: text/event-stream → server emits an `endpoint`
-    SSE event whose data line is the session-scoped POST URL.
+  - GET / with Accept: text/event-stream → server emits an `endpoint`
+    SSE event whose data line is the session-scoped POST URL. (The Kotlin
+    MCP SDK 0.8.3 mounts the SSE endpoint at the application root, not
+    `/sse`, due to a path-overload quirk in the SDK.)
   - POST that URL with JSON-RPC `initialize` → response arrives on the SSE
     stream as a `message` event.
   - POST `notifications/initialized` (no response expected).
@@ -178,7 +180,8 @@ def wait_for_response(
 
 def open_session(port: int) -> tuple[SseReader, str]:
     """Open the SSE stream and grab the session-scoped POST endpoint URL."""
-    sse_url = f"http://127.0.0.1:{port}/sse"
+    # SDK 0.8.3 mounts the SSE endpoint at root, not /sse.
+    sse_url = f"http://127.0.0.1:{port}/"
     reader = SseReader(sse_url)
     reader.start()
     try:

--- a/cli-resources/man/man1/bossterm.1
+++ b/cli-resources/man/man1/bossterm.1
@@ -90,6 +90,18 @@ Close a pane. Equivalent to
 in a tab closes the tab (and the window, if it was the last). Requires
 MCP.
 .TP
+.B "panes [--tab <id>] [--json]"
+List the panes inside a tab. Default: the active tab.
+.B \-\-tab
+overrides;
+.B \-\-json
+prints the raw MCP \fIlist_panes\fR response instead of a human-readable
+table. The PANE ID column is the value to pass back as
+.B \-\-pane <id>
+to
+.BR send ", " signal ", or " close .
+Requires MCP.
+.TP
 .B "logs [--tab <id>] [--lines <N>]"
 Dump scrollback lines from a tab (default: the active tab; default N: 200).
 Requires MCP.

--- a/cli-resources/man/man1/bossterm.1
+++ b/cli-resources/man/man1/bossterm.1
@@ -142,6 +142,15 @@ Equivalent to
 .BR "bossterm new" .
 .SH ENVIRONMENT
 .TP
+.B BOSSTERM_MCP_PORT
+Override the MCP server port the CLI talks to. When set, the CLI probes
+this single port instead of walking the configured port + the +1..+9
+fallback range. Useful when multiple BossTerm instances are running and
+you want to target a specific one (e.g. a packaged install on 7676 and
+an IDE debug session on 7677). The global
+.B \-\-port \fI<N>\fR
+flag sets the same variable for one invocation.
+.TP
 .B BOSSTERM_CWD
 Set by the script when launching with a positional path. The app does not
 currently consume this variable at startup — it remains exported so that

--- a/cli-resources/man/man1/bossterm.1
+++ b/cli-resources/man/man1/bossterm.1
@@ -72,6 +72,24 @@ real newline character; bash's ANSI-C quoting works:
 \&. A regular double-quoted backslash-n is two literal characters and does
 not submit. Requires MCP.
 .TP
+.BI "signal " "<ctrl_c|ctrl_d|ctrl_z> " "[--pane <id>]"
+Send a control signal to a pane's shell. Defaults to the focused pane of
+the active tab;
+.B \-\-pane
+targets a specific split (see
+.BR "list_panes" ).
+\fBctrl_c\fR sends SIGINT (interrupt the running command), \fBctrl_d\fR
+sends EOF (the shell exits and the pane disposes itself), \fBctrl_z\fR
+sends SIGTSTP (suspend). Requires MCP.
+.TP
+.B "close [--pane <id>]"
+Close a pane. Equivalent to
+.BR "signal ctrl_d"
+— sends EOF to the shell which then exits, after which the pane's
+\fIonProcessExit\fR callback disposes the pane. Closing the only pane
+in a tab closes the tab (and the window, if it was the last). Requires
+MCP.
+.TP
 .B "logs [--tab <id>] [--lines <N>]"
 Dump scrollback lines from a tab (default: the active tab; default N: 200).
 Requires MCP.


### PR DESCRIPTION
## Summary

Follow-up commits on top of the merged #257. Adds multi-instance addressing and a few more MCP-backed subcommands.

- `bossterm --port <N>` / `BOSSTERM_MCP_PORT` — target a specific instance instead of walking the configured port + 1..9 fallback range. Useful when a packaged install and an IDE debug session both have MCP running.
- `bossterm signal <ctrl_c|ctrl_d|ctrl_z> [--pane <id>]` — send a control signal to a pane's shell.
- `bossterm close [--pane <id>]` — close a pane (sends EOF; pane disposes itself).
- `bossterm panes [--tab <id>] [--json]` — list panes in a tab; PANE ID column is what you pass back as `--pane <id>`.
- Fix: MCP probe was hitting `/sse` but SDK 0.8.3 mounts at `/` — moved probe to the Python helper's `ping` subcommand so the signature check matches the real transport.
- Fix: `SCRIPT_DIR` didn't follow symlinks, so a `~/bin/bossterm` symlink resolved to the wrong dir. Added a portable symlink-resolution loop.
- CI: split decl-and-assign in `install_file_versioned` to satisfy shellcheck SC2155.

## Test plan

- [x] `./bossterm --port=7677 panes` against a live instance — tabular output
- [x] `./bossterm --port=7677 panes --json` — raw MCP response
- [x] `./bossterm panes` against an instance without `list_panes` — surfaces `Error: list_panes failed: Tool list_panes not found` (not a JSON traceback)
- [x] `./bossterm --port=7678 panes` (no instance) — clean "not reachable" message
- [x] Bash `bash -n cli-resources/bossterm` parses
- [ ] `bossterm signal ctrl_c` interrupts the focused pane's running command
- [ ] `bossterm close` closes the focused pane (and tab/window when last)
- [ ] CI shellcheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)