### PR TITLE
fix(ui): restore terminal focus on click into mouse-reporting TUIs

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -802,6 +802,20 @@ fun ProperTerminal(
             // forwarded to terminal applications (like nvim with mouse reporting)
             onPaneFocus()
 
+            // Restore keyboard focus on every press. Required when the press is
+            // forwarded to a mouse-reporting TUI (claude, vim, htop, nvim, ...)
+            // via the early-return below and the previous focus owner was a
+            // sibling Compose element (e.g. a Button in an embedder's sidebar).
+            // Without this the cursor looks focused but PTY input is dropped.
+            // Mirrors the delay(50) pattern at the LaunchedEffect above and the
+            // search-close handler — lets recomposition / focus release settle
+            // before requesting. Idempotent with the requestFocus() calls in
+            // the click branches further down.
+            scope.launch {
+              delay(50)
+              focusRequester.requestFocus()
+            }
+
             // Check if mouse event should be forwarded to terminal application
             // NOTE: Exclude right-click (Secondary) from forwarding so context menu always works
             val shiftPressed = event.isShiftPressed()


### PR DESCRIPTION
## Summary

- Clicking back into a pane running a mouse-reporting TUI (claude, vim with `set mouse=a`, htop, nvim, …) after focus went to a sibling Compose element (e.g. a sidebar Button in an embedder) left the cursor visually focused but dropped PTY input. Switching tabs/panes was the only recovery.
- Root cause: `ProperTerminal`'s press handler forwards mouse events to the TUI via an early return; the `focusRequester.requestFocus()` calls in the selection branches below it were never reached on that path. Tabbed mode masked the bug because `onPaneFocus()` flips `isActiveTab` via `SplitContainer`, re-firing the existing `LaunchedEffect(tab.id, isActiveTab) { delay(50); requestFocus() }`. `EmbeddableTerminal` hardcodes `isActiveTab=true` with a no-op `onPaneFocus`, so the bug surfaced first in `embedded-example`.
- Fix: hoist a `scope.launch { delay(50); focusRequester.requestFocus() }` (matching the proven LaunchedEffect / search-close pattern in the same file) to run unconditionally on every press, before the mouse-reporting early-return. Idempotent with the existing `requestFocus()` calls in the non-mouse-reporting click branches.

## Test plan

- [x] `./gradlew :compose-ui:compileKotlinDesktop` — clean (only pre-existing warnings).
- [x] `./gradlew :embedded-example:run` → run `claude` in the embedded terminal → click a sidebar button → click back into the Claude pane → typing reaches Claude's input field on the first click, no tab/pane switch needed.
- [ ] Regression in tabbed mode (`./gradlew :bossterm-app:run`): two panes via `Cmd+D`, run a mouse-reporting TUI (`vim`, `htop`, `claude`) in one pane, click the other pane, click back — input still goes to the TUI.
- [ ] Non-mouse-reporting shells (`bash`/`zsh`): verify single/double/triple click + drag-select still work as before.
- [ ] Mouse interactions inside the TUI (e.g. clicking to position cursor in vim) still reach the TUI — the focus request runs in a coroutine and does not reorder the synchronous `terminal.mousePressed(...)` forward.

Generated with [Claude Code](https://claude.com/claude-code)