### PR TITLE
fix(ui): treat Cmd/Ctrl-held mouse events as BossTerm UI, not TUI

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/input/ComposeMouseEvent.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/input/ComposeMouseEvent.kt
@@ -81,6 +81,19 @@ fun PointerEvent.isAltPressed(): Boolean {
 }
 
 /**
+ * Checks if Ctrl OR Cmd/Meta key is pressed in a PointerEvent — the hyperlink
+ * interaction modifier (Cmd on macOS, Ctrl elsewhere). Reads directly off the
+ * AWT event so it stays correct regardless of which Compose element currently
+ * holds keyboard focus (unlike state tracked via onPreviewKeyEvent, which only
+ * updates while the canvas is focused).
+ */
+fun PointerEvent.isCtrlOrMetaPressed(): Boolean {
+    val flags = toMouseModifierFlags()
+    return (flags and MouseButtonModifierFlags.MOUSE_BUTTON_CTRL_FLAG) != 0 ||
+        (flags and MouseButtonModifierFlags.MOUSE_BUTTON_META_FLAG) != 0
+}
+
+/**
  * Creates a BossTerm MouseEvent from a Compose PointerEvent.
  *
  * @param event The Compose pointer event

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -1064,6 +1064,15 @@ fun ProperTerminal(
               if (!handled) {
                 HyperlinkDetector.openUrl(link.url)
               }
+              // Opening the URL hands focus to the browser, so the canvas never
+              // sees the Cmd/Ctrl KeyUp — isModifierPressed would stay true and
+              // the renderer would keep the link underlined indefinitely. Clear
+              // both flags and force a redraw so the underline drops now; the
+              // next Move event after the user re-engages will reset them
+              // naturally based on the actual cursor + modifier state.
+              isModifierPressed = false
+              hoveredHyperlink = null
+              display.requestImmediateRedraw()
               change.consume()
               return@onPointerEvent
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -94,6 +94,7 @@ import ai.rever.bossterm.compose.input.createMouseEvent
 import ai.rever.bossterm.compose.input.toMouseModifierFlags
 import ai.rever.bossterm.compose.input.isShiftPressed
 import ai.rever.bossterm.compose.input.isAltPressed
+import ai.rever.bossterm.compose.input.isCtrlOrMetaPressed
 import ai.rever.bossterm.core.typeahead.TerminalTypeAheadManager
 import org.jetbrains.skia.FontMgr
 import ai.rever.bossterm.terminal.TextStyle as BossTextStyle
@@ -158,6 +159,11 @@ fun ProperTerminal(
   val scope = rememberCoroutineScope()
   var hasPerformedInitialResize by remember { mutableStateOf(false) }  // Track initial resize
   var isModifierPressed by remember { mutableStateOf(false) }  // Track Ctrl/Cmd for hyperlink clicks
+  // Remember whether the last press was forwarded to the TUI so Release can
+  // mirror that exact decision (instead of re-reading the modifier on release,
+  // which would mishandle the case where the user toggles Cmd/Ctrl between
+  // press and release and leave the TUI with an unpaired button-down/up).
+  var lastPressForwardedToTui by remember { mutableStateOf(false) }
   val focusRequester = remember { FocusRequester() }
   val textMeasurer = rememberTextMeasurer()
   val clipboardManager = LocalClipboardManager.current
@@ -822,15 +828,22 @@ fun ProperTerminal(
             // hyperlink (open via line ~1042) or otherwise driving the BossTerm UI, not
             // the TUI. Symmetric with the Move-handler bypass and how shift bypasses
             // for text selection. Without this, Cmd+click on a URL in mouse-reporting
-            // TUIs (claude, vim with mouse=a, ...) gets eaten by the TUI.
+            // TUIs (claude, vim with mouse=a, ...) gets eaten by the TUI. Modifier is
+            // read straight off the AWT event (focus-independent) rather than the
+            // canvas-focus-gated isModifierPressed flag.
             val shiftPressed = event.isShiftPressed()
-            if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed) && event.button != PointerButton.Secondary && !isModifierPressed) {
+            val cmdOrCtrlHeld = event.isCtrlOrMetaPressed()
+            // Reset eagerly; flip true below only if we actually forward this press.
+            // Ensures Release pairs with the correct Press decision.
+            lastPressForwardedToTui = false
+            if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed) && event.button != PointerButton.Secondary && !cmdOrCtrlHeld) {
               // If button is null, skip remote forwarding and fall through to local handling
               // Button can be null for touch events, stylus input, or exotic input devices
               event.button?.let { button ->
                 val (col, row) = pixelToCharCoords(change.position)
                 val mouseEvent = createComposeMouseEvent(event, button)
                 terminal.mousePressed(col, row, mouseEvent)
+                lastPressForwardedToTui = true
                 change.consume()
                 return@onPointerEvent
               } ?: run {
@@ -1142,15 +1155,25 @@ fun ProperTerminal(
           val pos = change.position
           val startPos = dragStartPos
 
-          // Check if mouse event should be forwarded to terminal application
-          val shiftPressed = event.isShiftPressed()
+          // Check if mouse event should be forwarded to terminal application.
           // When the user is holding Cmd/Ctrl for hyperlink interaction, bypass
           // the mouse-reporting forward (same as shift bypasses for selection)
           // so the hover-detection block below can set hoveredHyperlink and the
           // renderer can draw the link underline. Press/Release apply the same
           // bypass — see those handlers. Scroll keeps current forwarding so
           // Ctrl+wheel (TUI font zoom / pager input) still reaches the TUI.
-          if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed) && !isModifierPressed) {
+          //
+          // Drag (button held): mirror the Press decision via lastPressForwardedToTui
+          // so toggling Cmd mid-drag does not strand half a sequence at the TUI.
+          // Pure motion (no button): each event is independent — read the modifier
+          // straight off the AWT event (focus-independent).
+          val shiftPressed = event.isShiftPressed()
+          val forwardThisMove = if (change.pressed) {
+            lastPressForwardedToTui
+          } else {
+            !event.isCtrlOrMetaPressed()
+          }
+          if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed) && forwardThisMove) {
             val (col, row) = pixelToCharCoords(pos)
             if (change.pressed) {
               // Button is held - this is a drag event (BUTTON_MOTION or ALL_MOTION modes)
@@ -1292,18 +1315,19 @@ fun ProperTerminal(
           // Skip if event was already consumed by an overlay
           if (change.isConsumed) return@onPointerEvent
 
-          // Check if mouse event should be forwarded to terminal application
-          // NOTE: Mirror the Press handler — bypass when Cmd/Ctrl is held so the
-          // TUI never sees an unpaired button-up after a Cmd+click that we handled
-          // locally (e.g. a hyperlink open).
+          // Check if mouse event should be forwarded to terminal application.
+          // Mirror the exact Press decision via lastPressForwardedToTui rather
+          // than re-reading the modifier here — toggling Cmd/Ctrl between press
+          // and release would otherwise leave the TUI with an unpaired event.
           val shiftPressed = event.isShiftPressed()
-          if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed) && !isModifierPressed) {
+          if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed) && lastPressForwardedToTui) {
             // If button is null, skip remote forwarding and fall through to local handling
             // Button can be null for touch events, stylus input, or exotic input devices
             event.button?.let { button ->
               val (col, row) = pixelToCharCoords(change.position)
               val mouseEvent = createComposeMouseEvent(event, button)
               terminal.mouseReleased(col, row, mouseEvent)
+              lastPressForwardedToTui = false
               change.consume()
               return@onPointerEvent
             } ?: run {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -818,8 +818,13 @@ fun ProperTerminal(
 
             // Check if mouse event should be forwarded to terminal application
             // NOTE: Exclude right-click (Secondary) from forwarding so context menu always works
+            // NOTE: Also bypass when Cmd/Ctrl is held — the user is interacting with a
+            // hyperlink (open via line ~1042) or otherwise driving the BossTerm UI, not
+            // the TUI. Symmetric with the Move-handler bypass and how shift bypasses
+            // for text selection. Without this, Cmd+click on a URL in mouse-reporting
+            // TUIs (claude, vim with mouse=a, ...) gets eaten by the TUI.
             val shiftPressed = event.isShiftPressed()
-            if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed) && event.button != PointerButton.Secondary) {
+            if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed) && event.button != PointerButton.Secondary && !isModifierPressed) {
               // If button is null, skip remote forwarding and fall through to local handling
               // Button can be null for touch events, stylus input, or exotic input devices
               event.button?.let { button ->
@@ -1139,7 +1144,13 @@ fun ProperTerminal(
 
           // Check if mouse event should be forwarded to terminal application
           val shiftPressed = event.isShiftPressed()
-          if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed)) {
+          // When the user is holding Cmd/Ctrl for hyperlink interaction, bypass
+          // the mouse-reporting forward (same as shift bypasses for selection)
+          // so the hover-detection block below can set hoveredHyperlink and the
+          // renderer can draw the link underline. Press/Release apply the same
+          // bypass — see those handlers. Scroll keeps current forwarding so
+          // Ctrl+wheel (TUI font zoom / pager input) still reaches the TUI.
+          if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed) && !isModifierPressed) {
             val (col, row) = pixelToCharCoords(pos)
             if (change.pressed) {
               // Button is held - this is a drag event (BUTTON_MOTION or ALL_MOTION modes)
@@ -1282,8 +1293,11 @@ fun ProperTerminal(
           if (change.isConsumed) return@onPointerEvent
 
           // Check if mouse event should be forwarded to terminal application
+          // NOTE: Mirror the Press handler — bypass when Cmd/Ctrl is held so the
+          // TUI never sees an unpaired button-up after a Cmd+click that we handled
+          // locally (e.g. a hyperlink open).
           val shiftPressed = event.isShiftPressed()
-          if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed)) {
+          if (settings.enableMouseReporting && isRemoteMouseAction(shiftPressed) && !isModifierPressed) {
             // If button is null, skip remote forwarding and fall through to local handling
             // Button can be null for touch events, stylus input, or exotic input devices
             event.button?.let { button ->


### PR DESCRIPTION
## Summary

Sibling fix to #260 — same file, same mouse-reporting early-return pattern, different handlers.

In a pane running a TUI that enables mouse reporting (`claude`, `vim` with `set mouse=a`, `htop`, `nvim`, …):
- **Cmd-hover** on a URL did not draw the underline. Move handler short-circuits to the TUI forward at `ProperTerminal.kt:1142`, so `hoveredHyperlink` never gets set — and the renderer at `TerminalCanvasRenderer.kt:833` requires `hoveredHyperlink != null && isModifierPressed`.
- **Cmd-click** on a URL did not open it via BossTerm. Press handler at `:808` forwards the click to the TUI, so the Cmd-click branch at `:1042` is never reached. Some TUIs implement their own URL opener on the forwarded click; many — including some Claude Code surfaces — do not.

Fix mirrors the existing shift bypass for text selection: when the user is holding Cmd/Ctrl (tracked via `isModifierPressed`, updated by the `.onPreviewKeyEvent` at `:1382-1395`), skip the mouse-reporting forward in Press/Move/Release so the hyperlink hover/click handlers run locally. Scroll keeps current forwarding so Ctrl+wheel (TUI font-zoom, pager input) still works.

## Test plan

- [x] `./gradlew :compose-ui:compileKotlinDesktop` — clean.
- [x] `./gradlew :embedded-example:run` → run `claude` → Cmd-hover a URL → underline appears → Cmd-click → browser opens.
- [ ] Plain shell in same pane: Cmd-hover/click on URL still works (regression check).
- [ ] Tabbed mode (`:bossterm-app:run`): `vim` with `set mouse=a`, hover/click URLs in a buffer — same behavior.
- [ ] Non-link Cmd-click in mouse-reporting TUI: doesn't reach the TUI (acceptable — Cmd isn't normally a TUI mouse modifier; this is symmetric with how shift is already treated).
- [ ] Ctrl+wheel still reaches the TUI (no change to Scroll handler).

## Note

Lightly depends on #260's focus-restore for the keyboard-canvas-focused state that updates `isModifierPressed`. If #260 lands first, this is mergeable as-is. If this lands first, both still work because clicking into a TUI pane will focus the canvas via the existing (un-fixed) path most of the time.

Generated with [Claude Code](https://claude.com/claude-code)