### PR TITLE
feat(mcp): embedder settings relocation + custom MCP status-pill label

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1144,7 +1144,8 @@ fun TabbedTerminal(
                                 copy(mcpEnabled = true)
                             }
                         },
-                        isUserEnabled = settings.mcpEnabled
+                        isUserEnabled = settings.mcpEnabled,
+                        serverLabel = LocalBossTermMcpConfig.current?.displayName ?: "BossTerm"
                     )
                 }
                 attachStatus?.let { status ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpConfig.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpConfig.kt
@@ -56,6 +56,12 @@ typealias ServerToolRegistrar = (Server) -> Unit
 data class BossTermMcpConfig(
     /** Reported as `Implementation.name`. MCP clients see this string. */
     val serverName: String = "bossterm",
+    /**
+     * Friendly label for the in-app MCP status pill / menus (e.g. "Boss",
+     * "BossConsole"). When null, the UI falls back to "BossTerm". This is purely
+     * cosmetic and independent of [serverName] (which clients/auto-attach use).
+     */
+    val displayName: String? = null,
     /** Reported as `Implementation.version`. */
     val serverVersion: String = "1.0",
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -79,6 +79,8 @@ fun McpStatusIndicator(
     onTurnOnRequest: () -> Unit = {},
     /** User's `settings.mcpEnabled` (intent) — drives the toggle menu label. */
     isUserEnabled: Boolean = true,
+    /** Brand shown in the pill / menus / tooltip (e.g. "Boss"). Defaults to "BossTerm". */
+    serverLabel: String = "BossTerm",
     modifier: Modifier = Modifier
 ) {
     if (!enabled) return
@@ -101,6 +103,7 @@ fun McpStatusIndicator(
             attached = attached,
             isRunning = isRunning,
             isUserEnabled = isUserEnabled,
+            serverLabel = serverLabel,
             onAttachRequest = onAttachRequest,
             onShowSettings = onShowSettings,
             onTurnOffRequest = onTurnOffRequest,
@@ -110,7 +113,7 @@ fun McpStatusIndicator(
     }
 
     TooltipArea(
-        tooltip = { McpStatusTooltip(runningPort = runningPort, attached = attached) },
+        tooltip = { McpStatusTooltip(runningPort = runningPort, attached = attached, serverLabel = serverLabel) },
         delayMillis = 350,
         tooltipPlacement = TooltipPlacement.CursorPoint(
             offset = DpOffset(0.dp, 16.dp)
@@ -149,7 +152,7 @@ fun McpStatusIndicator(
                 )
             }
             Text(
-                text = if (isRunning) "BossTerm MCP on" else "BossTerm MCP off",
+                text = if (isRunning) "$serverLabel MCP on" else "$serverLabel MCP off",
                 color = labelColor,
                 fontSize = 11.sp
             )
@@ -180,6 +183,7 @@ private fun buildIndicatorMenuItems(
     attached: Set<McpAttachTarget>,
     isRunning: Boolean,
     isUserEnabled: Boolean,
+    serverLabel: String,
     onAttachRequest: (McpAttachTarget) -> Unit,
     onShowSettings: () -> Unit,
     onTurnOffRequest: () -> Unit,
@@ -202,7 +206,7 @@ private fun buildIndicatorMenuItems(
     )
     val settings = ContextMenuController.MenuItem(
         id = "mcp_settings",
-        label = "BossTerm MCP Settings…",
+        label = "$serverLabel MCP Settings…",
         enabled = true,
         action = onShowSettings
     )
@@ -210,14 +214,14 @@ private fun buildIndicatorMenuItems(
     val toggle = if (isUserEnabled) {
         ContextMenuController.MenuItem(
             id = "mcp_turn_off",
-            label = "Turn BossTerm MCP off",
+            label = "Turn $serverLabel MCP off",
             enabled = true,
             action = onTurnOffRequest
         )
     } else {
         ContextMenuController.MenuItem(
             id = "mcp_turn_on",
-            label = "Turn BossTerm MCP on",
+            label = "Turn $serverLabel MCP on",
             enabled = true,
             action = onTurnOnRequest
         )
@@ -233,7 +237,8 @@ private fun buildIndicatorMenuItems(
 @Composable
 private fun McpStatusTooltip(
     runningPort: Int?,
-    attached: Set<McpAttachTarget>
+    attached: Set<McpAttachTarget>,
+    serverLabel: String = "BossTerm"
 ) {
     Column(
         modifier = Modifier
@@ -245,20 +250,20 @@ private fun McpStatusTooltip(
     ) {
         if (runningPort == null) {
             Text(
-                text = "BossTerm MCP server is off",
+                text = "$serverLabel MCP server is off",
                 color = McpOffLabelColor,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.SemiBold
             )
             Text(
-                text = "Click the pill to turn it on, or open BossTerm MCP Settings…",
+                text = "Click the pill to turn it on, or open $serverLabel MCP Settings…",
                 color = McpToastTextColor,
                 fontSize = 11.sp
             )
             return@Column
         }
         Text(
-            text = "BossTerm MCP server running",
+            text = "$serverLabel MCP server running",
             color = McpToastSuccessColor,
             fontSize = 12.sp,
             fontWeight = FontWeight.SemiBold

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
@@ -48,14 +48,25 @@ class SettingsManager(private val customSettingsPath: String? = null) {
         if (customSettingsPath != null) {
             File(customSettingsPath).parentFile?.apply {
                 if (!exists()) mkdirs()
-            } ?: File(System.getProperty("user.home"), ".bossterm").apply {
-                if (!exists()) mkdirs()
-            }
+            } ?: defaultSettingsDir()
         } else {
-            File(System.getProperty("user.home"), ".bossterm").apply {
-                if (!exists()) mkdirs()
-            }
+            defaultSettingsDir()
         }
+    }
+
+    /**
+     * Default directory for the settings file when no [customSettingsPath] is
+     * given. Honors the `bossterm.settings.dir` system property so an embedder
+     * (e.g. BossConsole's terminal plugin) can relocate the entire settings
+     * store off the shared `~/.bossterm` — letting multiple BossTerm-based apps
+     * on one machine keep independent settings, including independent MCP
+     * `mcpEnabled`/`mcpPort` state. When the property is unset or blank, falls
+     * back to the historical `~/.bossterm` so standalone BossTerm is unchanged.
+     */
+    private fun defaultSettingsDir(): File {
+        val override = System.getProperty("bossterm.settings.dir")?.takeIf { it.isNotBlank() }
+        val dir = if (override != null) File(override) else File(System.getProperty("user.home"), ".bossterm")
+        return dir.apply { if (!exists()) mkdirs() }
     }
 
     private val settingsFile: File by lazy {

--- a/embedded-example/src/desktopMain/kotlin/ai/rever/bossterm/embedded/Main.kt
+++ b/embedded-example/src/desktopMain/kotlin/ai/rever/bossterm/embedded/Main.kt
@@ -80,6 +80,9 @@ fun main() {
     val mcpScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     val mcpConfig = BossTermMcpConfig(
         serverName = "bossterm-embedded-example",
+        // Friendly brand for the in-app MCP status pill / menus. With this set the
+        // pill reads "Embedded Example MCP on" instead of the default "BossTerm MCP on".
+        displayName = "Embedded Example",
         // `defaultEnabled` is honored only on the very first BossTerm launch on this
         // machine (gated by the global `mcpConfigured` flag in ~/.bossterm/settings.json).
         // If you've already run another BossTerm-based app on this machine, the setting

--- a/tabbed-example/src/desktopMain/kotlin/ai/rever/bossterm/tabbed/Main.kt
+++ b/tabbed-example/src/desktopMain/kotlin/ai/rever/bossterm/tabbed/Main.kt
@@ -75,6 +75,9 @@ fun main() {
     val mcpScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     val mcpConfig = BossTermMcpConfig(
         serverName = "bossterm-tabbed-example",
+        // Friendly brand for the in-app MCP status pill / menus. With this set the
+        // pill reads "Tabbed Example MCP on" instead of the default "BossTerm MCP on".
+        displayName = "Tabbed Example",
         // `defaultEnabled` is honored only on the very first BossTerm launch on this
         // machine (gated by the global `mcpConfigured` flag in ~/.bossterm/settings.json).
         // If you've already run another BossTerm-based app on this machine, the setting


### PR DESCRIPTION
## Summary

Adds an embedder API so apps embedding `compose-ui` (e.g. BossConsole) can **brand the in-app MCP status pill** and **relocate the settings store**. Also carries the work already merged to `dev` since v1.1.98.

### MCP embedder API (headline of this PR)
- **`SettingsManager`** — honors a `bossterm.settings.dir` system property; embedders point the settings store off the shared `~/.bossterm` so multiple BossTerm-based apps on one machine keep independent settings + MCP `mcpEnabled`/`mcpPort`. Unset/blank → the historical `~/.bossterm` (standalone unchanged).
- **`BossTermMcpConfig.displayName`** — friendly label for the MCP status pill / menus (null → "BossTerm").
- **`McpStatusIndicator`** — new `serverLabel` param drives the pill text, right-click menu, and tooltip (was hardcoded "BossTerm").
- **`TabbedTerminal`** — passes the label from `LocalBossTermMcpConfig.displayName`.
- **Examples** — `tabbed-example` / `embedded-example` set `displayName` to demo it.

### Also included (already on `dev`)
streamed auto-update download (#267), `run_command` MCP tool (#262), MCP indicator overlap fix (#264), and v1.1.96–v1.1.98 release notes.

## Test plan
- `./gradlew :tabbed-example:run` → pill reads **"Tabbed Example MCP on"** ✅ (verified)
- `./gradlew :embedded-example:run` → **"Embedded Example MCP on"**
- Run any app with `-Dbossterm.settings.dir=/tmp/bt-test` → `settings.json` lands there; unset → `~/.bossterm`.
- Standalone BossTerm unaffected (no `displayName`/property → "BossTerm MCP", `~/.bossterm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
