### PR TITLE
🛡️ Compile compose-ui with -Xjvm-default=all (no $DefaultImpls bridges)

### DIFF
--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -50,6 +50,14 @@ kotlin {
             compileTaskProvider.configure {
                 compilerOptions {
                     jvmTarget.set(JvmTarget.JVM_17)
+                    // Compile Kotlin interface default methods as real JVM default
+                    // methods instead of generating a $DefaultImpls bridge class. The
+                    // bridge is resolved lazily on first call; for a listener like
+                    // TerminalSessionListener that fires during teardown, that lazy load
+                    // can happen after a consuming plugin's classloader is closed,
+                    // throwing NoClassDefFoundError. JVM default methods resolve with the
+                    // interface at link time. See risa-labs-inc/BossConsole#764.
+                    freeCompilerArgs.add("-Xjvm-default=all")
                 }
             }
         }


### PR DESCRIPTION
## Why

A consumer crash (risa-labs-inc/BossConsole#764) traced to `TerminalSessionListener`:

```
java.lang.NoClassDefFoundError: ai/rever/bossterm/compose/tabs/TerminalSessionListener$DefaultImpls
  ... onSessionClosed(...) ... TabController.disposeAll ... (window close / teardown)
Caused by: ClassNotFoundException: ...TerminalSessionListener$DefaultImpls (plugin classloader)
```

`compose-ui` builds with the Kotlin default `-Xjvm-default=disable`, so interface default methods are compiled into a `…$DefaultImpls` class and implementors that don't override a default get a synthetic bridge calling it. That bridge class is resolved **lazily on first call**. For a listener whose callbacks fire during teardown (e.g. `onSessionClosed` on `disposeAll` at window close), the lazy load can happen **after** a consuming plugin's classloader has been closed → `NoClassDefFoundError`.

## Change

Build the `desktop` JVM target with `-Xjvm-default=all`, so interface default methods are emitted as **real JVM default methods** — resolved with the interface at link time, no `$DefaultImpls` bridge to lazily load. This removes the whole class of teardown crash for every interface in the module, not just `TerminalSessionListener`.

One-line compiler-option change; `./gradlew :compose-ui:compileKotlinDesktop` → BUILD SUCCESSFUL.

## ABI note

`-Xjvm-default=all` changes the binary shape of interface defaults in `compose-ui`. Consumers should recompile against the new artifact (the bundling consumer, the `terminal-tab` plugin, recompiles against the bundled jar). Already-compiled callers that relied on `$DefaultImpls` would need a rebuild.

A complementary plugin-side fix (overriding the listener's default methods) ships in terminal-tab `2.3.2`; this PR is the durable upstream fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)