### PR TITLE
Phase 2: Command Palette (fuzzy, Cmd/Ctrl+Shift+P)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/CommandPalette.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/CommandPalette.kt
@@ -1,0 +1,169 @@
+package ai.rever.bossterm.compose.palette
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Fuzzy command palette overlay (Phase 2). Renders nothing when [visible] is
+ * false. Type to fuzzy-filter [commands], ↑/↓ to move, Enter to run, Esc or a
+ * click on the scrim to dismiss.
+ */
+@Composable
+fun CommandPalette(
+    visible: Boolean,
+    commands: List<PaletteCommand>,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (!visible) return
+
+    var query by remember { mutableStateOf("") }
+    var selected by remember { mutableStateOf(0) }
+    val focusRequester = remember { FocusRequester() }
+
+    val filtered = remember(query, commands) {
+        if (query.isBlank()) {
+            commands.take(100)
+        } else {
+            commands.mapNotNull { c -> FuzzyMatch.score(c.title, query)?.let { it.score to c } }
+                .sortedByDescending { it.first }
+                .map { it.second }
+                .take(100)
+        }
+    }
+    LaunchedEffect(filtered.size) {
+        selected = selected.coerceIn(0, (filtered.size - 1).coerceAtLeast(0))
+    }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    fun choose() {
+        val cmd = filtered.getOrNull(selected) ?: return
+        onDismiss()
+        cmd.run()
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color(0x88000000))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) { onDismiss() }
+    ) {
+        Surface(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 80.dp)
+                .width(560.dp)
+                // Swallow clicks inside the palette so they don't hit the scrim.
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) { },
+            color = Color(0xFF2A2A2A),
+            shape = RoundedCornerShape(8.dp),
+            shadowElevation = 8.dp,
+        ) {
+            Column {
+                BasicTextField(
+                    value = query,
+                    onValueChange = { query = it; selected = 0 },
+                    singleLine = true,
+                    textStyle = TextStyle(color = Color.White, fontSize = 14.sp),
+                    cursorBrush = SolidColor(Color.White),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp)
+                        .focusRequester(focusRequester)
+                        .onPreviewKeyEvent { e ->
+                            if (e.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                            when (e.key) {
+                                Key.DirectionDown -> {
+                                    if (filtered.isNotEmpty()) selected = (selected + 1) % filtered.size
+                                    true
+                                }
+                                Key.DirectionUp -> {
+                                    if (filtered.isNotEmpty()) selected = (selected - 1 + filtered.size) % filtered.size
+                                    true
+                                }
+                                Key.Enter -> { choose(); true }
+                                Key.Escape -> { onDismiss(); true }
+                                else -> false
+                            }
+                        },
+                    decorationBox = { inner ->
+                        if (query.isEmpty()) {
+                            Text("Run a command…", color = Color(0xFF808080), fontSize = 14.sp)
+                        }
+                        inner()
+                    },
+                )
+
+                Box(Modifier.fillMaxWidth().height(1.dp).background(Color(0xFF3A3A3A)))
+
+                LazyColumn(Modifier.heightIn(max = 360.dp)) {
+                    itemsIndexed(filtered) { i, c ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(if (i == selected) Color(0xFF094771) else Color.Transparent)
+                                .clickable { onDismiss(); c.run() }
+                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                c.group,
+                                color = Color(0xFF888888),
+                                fontSize = 11.sp,
+                                modifier = Modifier.width(64.dp),
+                            )
+                            Column(Modifier.weight(1f)) {
+                                Text(c.title, color = Color.White, fontSize = 13.sp, maxLines = 1)
+                                c.subtitle?.let {
+                                    Text(it, color = Color(0xFFAAAAAA), fontSize = 11.sp, maxLines = 1)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/FuzzyMatch.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/FuzzyMatch.kt
@@ -1,0 +1,39 @@
+package ai.rever.bossterm.compose.palette
+
+/**
+ * Tiny subsequence fuzzy matcher (skim-style) for ranking command-palette
+ * entries. Case-smart (a lowercase query char matches either case; an uppercase
+ * query char must match exactly), rewards contiguous runs and word-boundary
+ * hits, and prefers earlier first matches. Roughly O(text length) per candidate.
+ */
+object FuzzyMatch {
+
+    data class Result(val score: Int, val matchedIndices: List<Int>)
+
+    /** Returns null when [query] is not a subsequence of [text]; higher score = better. */
+    fun score(text: String, query: String): Result? {
+        if (query.isEmpty()) return Result(0, emptyList())
+        var ti = 0
+        var prev = -2
+        var score = 0
+        val idx = ArrayList<Int>(query.length)
+        for (qc in query) {
+            var found = -1
+            while (ti < text.length) {
+                val c = text[ti]
+                val hit = if (qc.isUpperCase()) c == qc else c.lowercaseChar() == qc.lowercaseChar()
+                if (hit) { found = ti; ti++; break }
+                ti++
+            }
+            if (found < 0) return null
+            idx += found
+            score += 10
+            if (found == prev + 1) score += 15                               // contiguous run
+            if (found == 0 || !text[found - 1].isLetterOrDigit()) score += 8  // word boundary
+            if (text[found] == qc) score += 4                                 // exact case
+            score -= minOf(found, 20)                                         // earlier is better
+            prev = found
+        }
+        return Result(score, idx)
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/PaletteCommand.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/PaletteCommand.kt
@@ -1,0 +1,15 @@
+package ai.rever.bossterm.compose.palette
+
+/**
+ * One entry in the command palette.
+ *
+ * @property group short category label shown on the left ("Action" | "Recent" | …)
+ * @property run invoked when the entry is chosen (the palette closes first)
+ */
+data class PaletteCommand(
+    val id: String,
+    val title: String,
+    val subtitle: String? = null,
+    val group: String,
+    val run: () -> Unit,
+)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/PaletteSources.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/PaletteSources.kt
@@ -1,0 +1,47 @@
+package ai.rever.bossterm.compose.palette
+
+import ai.rever.bossterm.compose.actions.ActionRegistry
+
+/**
+ * Builds the list of [PaletteCommand]s shown in the command palette.
+ *
+ * Phase 2 covers two sources: every registered [ai.rever.bossterm.compose.actions.TerminalAction]
+ * (run immediately via `executeFromMenu`) and recent commands captured by the
+ * command-block tracker (inserted at the prompt, not auto-run, so the user can
+ * review before pressing Enter). Git / AI / workflow sources are planned follow-ups.
+ */
+object PaletteSources {
+
+    fun collect(
+        actions: ActionRegistry,
+        recentCommands: List<String>,
+        insertCommand: (String) -> Unit,
+    ): List<PaletteCommand> = buildList {
+        actions.getAllActions()
+            .filter { it.name.isNotBlank() }
+            .sortedBy { it.name.lowercase() }
+            .forEach { action ->
+                add(
+                    PaletteCommand(
+                        id = "action:${action.id}",
+                        title = action.name,
+                        group = "Action",
+                        run = { action.executeFromMenu() },
+                    )
+                )
+            }
+
+        // recentCommands arrive oldest-first; show newest first, de-duplicated.
+        recentCommands.asReversed().distinct().take(50).forEach { cmd ->
+            add(
+                PaletteCommand(
+                    id = "recent:$cmd",
+                    title = cmd,
+                    subtitle = "Recent command — inserts at prompt",
+                    group = "Recent",
+                    run = { insertCommand(cmd) },
+                )
+            )
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsCategory.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsCategory.kt
@@ -38,6 +38,11 @@ enum class SettingsCategory(
         icon = Icons.Default.List,
         description = "Per-command output blocks, gutter bars, and markers"
     ),
+    COMMAND_PALETTE(
+        displayName = "Command Palette",
+        icon = Icons.Default.PlayArrow,
+        description = "Fuzzy command palette (Cmd/Ctrl+Shift+P)"
+    ),
     PERFORMANCE(
         displayName = "Performance",
         icon = Icons.Default.Refresh,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
@@ -320,6 +320,10 @@ private fun SettingsContent(
                 onSettingsChange = onSettingsChange,
                 onSettingsSave = onSettingsSave
             )
+            SettingsCategory.COMMAND_PALETTE -> CommandPaletteSettingsSection(
+                settings = settings,
+                onSettingsChange = onSettingsChange
+            )
             SettingsCategory.PERFORMANCE -> PerformanceSettingsSection(
                 settings = settings,
                 onSettingsChange = onSettingsChange,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -401,6 +401,14 @@ data class TerminalSettings(
      */
     val commandBlockShowScrollbarMarkers: Boolean = true,
 
+    // ===== Command Palette =====
+
+    /**
+     * Enable the fuzzy command palette (Cmd/Ctrl+Shift+P). When false the hotkey
+     * is not intercepted and the palette never opens.
+     */
+    val commandPaletteEnabled: Boolean = true,
+
     // ===== GPU Rendering Settings =====
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/CommandPaletteSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/CommandPaletteSettingsSection.kt
@@ -1,0 +1,29 @@
+package ai.rever.bossterm.compose.settings.sections
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ai.rever.bossterm.compose.settings.TerminalSettings
+import ai.rever.bossterm.compose.settings.components.*
+
+/**
+ * Command Palette settings. Gated by [TerminalSettings.commandPaletteEnabled];
+ * when off, the Cmd/Ctrl+Shift+P hotkey is not intercepted.
+ */
+@Composable
+fun CommandPaletteSettingsSection(
+    settings: TerminalSettings,
+    onSettingsChange: (TerminalSettings) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        SettingsSection(title = "Command Palette") {
+            SettingsToggle(
+                label = "Enable Command Palette",
+                checked = settings.commandPaletteEnabled,
+                onCheckedChange = { onSettingsChange(settings.copy(commandPaletteEnabled = it)) },
+                description = "Fuzzy-search and run any action or recent command (Cmd/Ctrl+Shift+P)"
+            )
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -189,6 +189,9 @@ fun ProperTerminal(
   }
   val commandBlocks by commandBlockFlow.collectAsState()
 
+  // Command palette overlay visibility (toggled by the command_palette action).
+  var commandPaletteVisible by remember { mutableStateOf(false) }
+
   // Search state from tab
   var searchVisible by tab.searchVisible
   var searchQuery by tab.searchQuery
@@ -512,6 +515,25 @@ fun ProperTerminal(
         clipboardManager = clipboardManager,
         isMacOS = isMacOS
       ).toTypedArray()
+    )
+
+    // Command palette (Phase 2). Cmd/Ctrl+Shift+P. Enabled-gated by
+    // `commandPaletteEnabled`, so the hotkey passes through when disabled.
+    registry.register(
+      ai.rever.bossterm.compose.actions.TerminalAction(
+        id = "command_palette",
+        name = "Command Palette",
+        keyStrokes = if (isMacOS) {
+          listOf(ai.rever.bossterm.compose.actions.KeyStroke(key = Key.P, meta = true, shift = true))
+        } else {
+          listOf(ai.rever.bossterm.compose.actions.KeyStroke(key = Key.P, ctrl = true, shift = true))
+        },
+        enabled = { SettingsManager.instance.settings.value.commandPaletteEnabled },
+        handler = {
+          commandPaletteVisible = true
+          true
+        }
+      )
     )
 
     registry
@@ -1823,6 +1845,28 @@ fun ProperTerminal(
           },
           modifier = Modifier.align(Alignment.TopEnd)
         )
+
+        // Command palette overlay (Phase 2)
+        if (commandPaletteVisible) {
+          val paletteCommands = remember(commandBlocks, actionRegistry) {
+            ai.rever.bossterm.compose.palette.PaletteSources.collect(
+              actions = actionRegistry,
+              recentCommands = commandBlocks.mapNotNull { it.commandText },
+              insertCommand = { cmd -> tab.writeUserInput(cmd) }
+            )
+          }
+          ai.rever.bossterm.compose.palette.CommandPalette(
+            visible = true,
+            commands = paletteCommands,
+            onDismiss = {
+              commandPaletteVisible = false
+              scope.launch {
+                kotlinx.coroutines.delay(50)
+                focusRequester.requestFocus()
+              }
+            }
+          )
+        }
 
         // Restore focus to terminal when debug window closes
         LaunchedEffect(debugPanelVisible) {


### PR DESCRIPTION
Implements **Phase 2 — Command Palette** from #271.

> **Stacked on #272 (Phase 1).** Base branch is `feat/command-blocks`; review/merge #272 first. The diff against `master` will shrink to just this phase once #272 lands.

A fuzzy command palette: **Cmd/Ctrl+Shift+P** opens an overlay to search and run any registered action or recent command.

### Gating
Behind **`commandPaletteEnabled`** (default **on**). When off, the action's `enabled()` is false so the hotkey is never intercepted and falls through to the shell.

### What's included
- **`FuzzyMatch`** — subsequence scorer with contiguity, word-boundary, and case bonuses.
- **`PaletteCommand` + `PaletteSources`** — aggregates every registered `TerminalAction` (run via `executeFromMenu`) and recent commands from the Phase 1 block tracker. Recent commands are **inserted at the prompt, not auto-run** (safe). Git / AI / workflow sources are planned follow-ups.
- **`CommandPalette`** overlay — search field + fuzzy-ranked list, ↑/↓ to move, Enter to run, Esc / scrim-click to dismiss; modeled on the existing `SearchBar` overlay and returns focus to the terminal on close.
- **Trigger action** `command_palette` (Cmd/Ctrl+Shift+P) + new **Command Palette** settings section/category.

### How to test
1. Press **Cmd/Ctrl+Shift+P**.
2. Type a fragment (e.g. `split`, `copy`, `clear`) → fuzzy-ranked actions; Enter runs the selected one.
3. With command blocks enabled and after running a few commands, recent commands appear in the palette and insert at the prompt on Enter.
4. Toggle it off in Settings → Command Palette → the hotkey no longer opens it.

Build: `./gradlew :compose-ui:compileKotlinDesktop` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
