### PR TITLE
Phase 3: Workflows (saved parameterized commands)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/PaletteSources.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/PaletteSources.kt
@@ -1,14 +1,15 @@
 package ai.rever.bossterm.compose.palette
 
 import ai.rever.bossterm.compose.actions.ActionRegistry
+import ai.rever.bossterm.compose.workflows.Workflow
 
 /**
  * Builds the list of [PaletteCommand]s shown in the command palette.
  *
- * Phase 2 covers two sources: every registered [ai.rever.bossterm.compose.actions.TerminalAction]
- * (run immediately via `executeFromMenu`) and recent commands captured by the
- * command-block tracker (inserted at the prompt, not auto-run, so the user can
- * review before pressing Enter). Git / AI / workflow sources are planned follow-ups.
+ * Sources: every registered [ai.rever.bossterm.compose.actions.TerminalAction]
+ * (run immediately via `executeFromMenu`), workflows (open the parameter dialog),
+ * and recent commands captured by the command-block tracker (inserted at the
+ * prompt, not auto-run). Git / AI sources are planned follow-ups.
  */
 object PaletteSources {
 
@@ -16,6 +17,8 @@ object PaletteSources {
         actions: ActionRegistry,
         recentCommands: List<String>,
         insertCommand: (String) -> Unit,
+        workflows: List<Workflow> = emptyList(),
+        onRunWorkflow: (Workflow) -> Unit = {},
     ): List<PaletteCommand> = buildList {
         actions.getAllActions()
             .filter { it.name.isNotBlank() }
@@ -30,6 +33,19 @@ object PaletteSources {
                     )
                 )
             }
+
+        workflows.sortedBy { it.name.lowercase() }.forEach { wf ->
+            add(
+                PaletteCommand(
+                    id = "workflow:${wf.sourcePath ?: wf.name}",
+                    title = wf.name,
+                    subtitle = wf.description?.takeIf { it.isNotBlank() }
+                        ?: "Workflow — ${wf.arguments.size} parameter(s)",
+                    group = "Workflow",
+                    run = { onRunWorkflow(wf) },
+                )
+            )
+        }
 
         // recentCommands arrive oldest-first; show newest first, de-duplicated.
         recentCommands.asReversed().distinct().take(50).forEach { cmd ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsCategory.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsCategory.kt
@@ -43,6 +43,11 @@ enum class SettingsCategory(
         icon = Icons.Default.PlayArrow,
         description = "Fuzzy command palette (Cmd/Ctrl+Shift+P)"
     ),
+    WORKFLOWS(
+        displayName = "Workflows",
+        icon = Icons.Default.Bookmark,
+        description = "Saved parameterized commands"
+    ),
     PERFORMANCE(
         displayName = "Performance",
         icon = Icons.Default.Refresh,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
@@ -324,6 +324,10 @@ private fun SettingsContent(
                 settings = settings,
                 onSettingsChange = onSettingsChange
             )
+            SettingsCategory.WORKFLOWS -> WorkflowsSettingsSection(
+                settings = settings,
+                onSettingsChange = onSettingsChange
+            )
             SettingsCategory.PERFORMANCE -> PerformanceSettingsSection(
                 settings = settings,
                 onSettingsChange = onSettingsChange,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -409,6 +409,26 @@ data class TerminalSettings(
      */
     val commandPaletteEnabled: Boolean = true,
 
+    // ===== Workflows =====
+
+    /**
+     * Enable saved parameterized commands (workflows). When false no workflows
+     * are loaded or surfaced in the palette.
+     */
+    val workflowsEnabled: Boolean = true,
+
+    /**
+     * Run a workflow's command immediately on submit (append newline) instead of
+     * just inserting it at the prompt for review.
+     */
+    val workflowsAutoRun: Boolean = false,
+
+    /**
+     * Additional directories to scan for workflow `*.yaml` files, beyond
+     * `~/.bossterm/workflows` and the project's `.warp/workflows`.
+     */
+    val workflowExtraDirs: List<String> = emptyList(),
+
     // ===== GPU Rendering Settings =====
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/WorkflowsSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/WorkflowsSettingsSection.kt
@@ -1,0 +1,36 @@
+package ai.rever.bossterm.compose.settings.sections
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ai.rever.bossterm.compose.settings.TerminalSettings
+import ai.rever.bossterm.compose.settings.components.*
+
+/**
+ * Workflows settings. Gated by [TerminalSettings.workflowsEnabled]; when off,
+ * no workflows are loaded or shown in the palette.
+ */
+@Composable
+fun WorkflowsSettingsSection(
+    settings: TerminalSettings,
+    onSettingsChange: (TerminalSettings) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        SettingsSection(title = "Workflows") {
+            SettingsToggle(
+                label = "Enable Workflows",
+                checked = settings.workflowsEnabled,
+                onCheckedChange = { onSettingsChange(settings.copy(workflowsEnabled = it)) },
+                description = "Saved parameterized commands from ~/.bossterm/workflows and project .warp/workflows, surfaced in the command palette"
+            )
+            SettingsToggle(
+                label = "Run on Submit",
+                checked = settings.workflowsAutoRun,
+                onCheckedChange = { onSettingsChange(settings.copy(workflowsAutoRun = it)) },
+                description = "Run the workflow command immediately instead of inserting it at the prompt for review",
+                enabled = settings.workflowsEnabled
+            )
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -192,6 +192,19 @@ fun ProperTerminal(
   // Command palette overlay visibility (toggled by the command_palette action).
   var commandPaletteVisible by remember { mutableStateOf(false) }
 
+  // Workflows for this session (Phase 3); reloaded when cwd / settings change.
+  val workflows = remember(tab.workingDirectory.value, settings.workflowsEnabled, settings.workflowExtraDirs) {
+    if (settings.workflowsEnabled) {
+      ai.rever.bossterm.compose.workflows.WorkflowStore(
+        extraDirs = settings.workflowExtraDirs.map { java.io.File(it) }
+      ).load(tab.workingDirectory.value)
+    } else {
+      emptyList()
+    }
+  }
+  // When non-null, the workflow parameter dialog is shown for this workflow.
+  var pendingWorkflow by remember { mutableStateOf<ai.rever.bossterm.compose.workflows.Workflow?>(null) }
+
   // Search state from tab
   var searchVisible by tab.searchVisible
   var searchQuery by tab.searchQuery
@@ -1848,11 +1861,13 @@ fun ProperTerminal(
 
         // Command palette overlay (Phase 2)
         if (commandPaletteVisible) {
-          val paletteCommands = remember(commandBlocks, actionRegistry) {
+          val paletteCommands = remember(commandBlocks, actionRegistry, workflows) {
             ai.rever.bossterm.compose.palette.PaletteSources.collect(
               actions = actionRegistry,
               recentCommands = commandBlocks.mapNotNull { it.commandText },
-              insertCommand = { cmd -> tab.writeUserInput(cmd) }
+              insertCommand = { cmd -> tab.writeUserInput(cmd) },
+              workflows = workflows,
+              onRunWorkflow = { wf -> pendingWorkflow = wf }
             )
           }
           ai.rever.bossterm.compose.palette.CommandPalette(
@@ -1864,6 +1879,24 @@ fun ProperTerminal(
                 kotlinx.coroutines.delay(50)
                 focusRequester.requestFocus()
               }
+            }
+          )
+        }
+
+        // Workflow parameter dialog (Phase 3)
+        pendingWorkflow?.let { wf ->
+          ai.rever.bossterm.compose.workflows.WorkflowRunDialog(
+            workflow = wf,
+            autoRun = settings.workflowsAutoRun,
+            onDismiss = {
+              pendingWorkflow = null
+              scope.launch {
+                kotlinx.coroutines.delay(50)
+                focusRequester.requestFocus()
+              }
+            },
+            onSubmit = { rendered ->
+              tab.writeUserInput(rendered + if (settings.workflowsAutoRun) "\n" else "")
             }
           )
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/workflows/Workflow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/workflows/Workflow.kt
@@ -1,0 +1,41 @@
+package ai.rever.bossterm.compose.workflows
+
+/**
+ * A single parameter of a [Workflow], mirroring Warp's `arguments` schema.
+ */
+data class WorkflowArgument(
+    val name: String,
+    val description: String? = null,
+    val defaultValue: String? = null,
+)
+
+/**
+ * A saved, parameterized command template — Warp-compatible.
+ *
+ * Loaded from `*.yaml` files (see [WorkflowStore]) using the Warp schema:
+ * `name`, `command`, `description`, `arguments: [{name, description, default_value}]`,
+ * `tags`, `shells`. Parameters are referenced in [command] as `{{name}}`.
+ */
+data class Workflow(
+    val name: String,
+    val command: String,
+    val description: String? = null,
+    val arguments: List<WorkflowArgument> = emptyList(),
+    val tags: List<String> = emptyList(),
+    val shells: List<String> = emptyList(),
+    /** Absolute path of the file this workflow was loaded from (for de-duplication). */
+    val sourcePath: String? = null,
+) {
+    /**
+     * Substitute `{{arg}}` placeholders with the supplied [values], falling back
+     * to each argument's default (then empty string) when a value is missing.
+     */
+    fun render(values: Map<String, String>): String {
+        var out = command
+        for (arg in arguments) {
+            val value = values[arg.name] ?: arg.defaultValue ?: ""
+            out = out.replace("{{${arg.name}}}", value)
+        }
+        return out
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/workflows/WorkflowRunDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/workflows/WorkflowRunDialog.kt
@@ -1,0 +1,167 @@
+package ai.rever.bossterm.compose.workflows
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Parameter-entry overlay for running a [Workflow]. Renders one field per
+ * argument (prefilled with its default), a live preview of the substituted
+ * command, and a submit button labeled per [autoRun]. Esc cancels.
+ *
+ * @param onSubmit receives the fully rendered command string.
+ */
+@Composable
+fun WorkflowRunDialog(
+    workflow: Workflow,
+    autoRun: Boolean,
+    onDismiss: () -> Unit,
+    onSubmit: (rendered: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val values = remember(workflow) {
+        mutableStateMapOf<String, String>().apply {
+            workflow.arguments.forEach { put(it.name, it.defaultValue ?: "") }
+        }
+    }
+    val firstFieldFocus = remember { FocusRequester() }
+
+    fun submit() {
+        onDismiss()
+        onSubmit(workflow.render(values))
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color(0x88000000))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) { onDismiss() }
+    ) {
+        Surface(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 80.dp)
+                .width(460.dp)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) { }
+                .onPreviewKeyEvent { e ->
+                    if (e.type == KeyEventType.KeyDown && e.key == Key.Escape) {
+                        onDismiss(); true
+                    } else {
+                        false
+                    }
+                },
+            color = Color(0xFF2A2A2A),
+            shape = RoundedCornerShape(8.dp),
+            shadowElevation = 8.dp,
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Text(workflow.name, color = Color.White, fontSize = 15.sp)
+                workflow.description?.takeIf { it.isNotBlank() }?.let {
+                    Text(it, color = Color(0xFFAAAAAA), fontSize = 12.sp)
+                }
+                Spacer(Modifier.height(12.dp))
+
+                workflow.arguments.forEachIndexed { index, arg ->
+                    Text(arg.name, color = Color(0xFFCCCCCC), fontSize = 12.sp)
+                    arg.description?.takeIf { it.isNotBlank() }?.let {
+                        Text(it, color = Color(0xFF808080), fontSize = 11.sp)
+                    }
+                    BasicTextField(
+                        value = values[arg.name].orEmpty(),
+                        onValueChange = { values[arg.name] = it },
+                        singleLine = true,
+                        textStyle = TextStyle(color = Color.White, fontSize = 13.sp),
+                        cursorBrush = SolidColor(Color.White),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp)
+                            .background(Color(0xFF1E1E1E))
+                            .padding(8.dp)
+                            .then(if (index == 0) Modifier.focusRequester(firstFieldFocus) else Modifier)
+                            .onPreviewKeyEvent { e ->
+                                if (e.type == KeyEventType.KeyDown && e.key == Key.Enter) { submit(); true } else false
+                            },
+                    )
+                    Spacer(Modifier.height(8.dp))
+                }
+
+                // Live preview of the command that will run.
+                Text("Preview", color = Color(0xFF808080), fontSize = 11.sp)
+                Text(workflow.render(values), color = Color(0xFF66D9EF), fontSize = 12.sp)
+                Spacer(Modifier.height(12.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    DialogButton("Cancel", onClick = onDismiss)
+                    Spacer(Modifier.width(8.dp))
+                    DialogButton(if (autoRun) "Run" else "Insert", primary = true, onClick = { submit() })
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(workflow) {
+        if (workflow.arguments.isNotEmpty()) firstFieldFocus.requestFocus()
+    }
+}
+
+@Composable
+private fun DialogButton(label: String, primary: Boolean = false, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .background(
+                if (primary) Color(0xFF094771) else Color(0xFF3A3A3A),
+                RoundedCornerShape(4.dp),
+            )
+            .clickable { onClick() }
+            .padding(horizontal = 14.dp, vertical = 6.dp),
+    ) {
+        Text(label, color = Color.White, fontSize = 13.sp)
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/workflows/WorkflowStore.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/workflows/WorkflowStore.kt
@@ -1,0 +1,44 @@
+package ai.rever.bossterm.compose.workflows
+
+import java.io.File
+
+/**
+ * Discovers and loads [Workflow]s from disk (Warp-compatible).
+ *
+ * Search order (later sources can shadow earlier by name):
+ *  1. `.yaml` files in `~/.bossterm/workflows`
+ *  2. project-local `<cwd>/.warp/workflows`
+ *  3. any [extraDirs] from settings
+ *
+ * Honors the `bossterm.settings.dir` system property for the home location,
+ * matching `SettingsManager`. Files that fail to parse are skipped (logged).
+ */
+class WorkflowStore(
+    private val extraDirs: List<File> = emptyList(),
+) {
+    fun load(projectDir: String?): List<Workflow> {
+        val dirs = buildList {
+            add(File(bosstermHome(), "workflows"))
+            if (!projectDir.isNullOrBlank()) add(File(projectDir, ".warp/workflows"))
+            addAll(extraDirs)
+        }
+        return dirs
+            .filter { it.isDirectory }
+            .flatMap { dir ->
+                dir.listFiles { f -> f.isFile && (f.extension == "yaml" || f.extension == "yml") }
+                    ?.sortedBy { it.name }
+                    ?.toList()
+                    .orEmpty()
+            }
+            .mapNotNull { file ->
+                runCatching { WorkflowYaml.parse(file.readText(), file.absolutePath) }
+                    .onFailure { System.err.println("Skipping workflow ${file.name}: ${it.message}") }
+                    .getOrNull()
+            }
+    }
+
+    private fun bosstermHome(): File {
+        val override = System.getProperty("bossterm.settings.dir")?.takeIf { it.isNotBlank() }
+        return if (override != null) File(override) else File(System.getProperty("user.home"), ".bossterm")
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/workflows/WorkflowYaml.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/workflows/WorkflowYaml.kt
@@ -1,0 +1,177 @@
+package ai.rever.bossterm.compose.workflows
+
+/**
+ * Minimal, dependency-free YAML reader for the Warp **workflow** schema only —
+ * NOT a general YAML parser. It deliberately supports just the shapes that
+ * appear in workflow files:
+ *
+ * - top-level scalars `name` / `command` / `description` (plain, quoted, or a
+ *   `|` literal / `>` folded block scalar),
+ * - `arguments:` as a block list of `{name, description, default_value}` maps,
+ * - `tags:` / `shells:` as an inline `[a, b]` list or a block `- item` list.
+ *
+ * Anchors, flow maps, multi-document streams, and inline comments are not
+ * supported; unparseable files are skipped by [WorkflowStore].
+ */
+object WorkflowYaml {
+
+    fun parse(text: String, sourcePath: String? = null): Workflow? {
+        val lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+        var name: String? = null
+        var command: String? = null
+        var description: String? = null
+        var arguments: List<WorkflowArgument> = emptyList()
+        var tags: List<String> = emptyList()
+        var shells: List<String> = emptyList()
+
+        var i = 0
+        while (i < lines.size) {
+            val raw = lines[i]
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty() || trimmed.startsWith("#") || indentOf(raw) != 0 || !trimmed.contains(":")) {
+                i++
+                continue
+            }
+            val key = trimmed.substringBefore(":").trim()
+            val rest = trimmed.substringAfter(":").trim()
+            when (key) {
+                "name", "command", "description" -> {
+                    val value: String
+                    if (rest.startsWith("|") || rest.startsWith(">")) {
+                        val (block, next) = readBlockScalar(lines, i + 1, fold = rest.startsWith(">"))
+                        value = block
+                        i = next
+                    } else {
+                        value = unquote(rest)
+                        i++
+                    }
+                    when (key) {
+                        "name" -> name = value
+                        "command" -> command = value
+                        "description" -> description = value
+                    }
+                }
+                "arguments" -> {
+                    val (args, next) = readArguments(lines, i + 1)
+                    arguments = args
+                    i = next
+                }
+                "tags", "shells" -> {
+                    val list: List<String>
+                    if (rest.startsWith("[")) {
+                        list = parseInlineList(rest)
+                        i++
+                    } else if (rest.isEmpty()) {
+                        val (block, next) = readBlockList(lines, i + 1)
+                        list = block
+                        i = next
+                    } else {
+                        list = emptyList()
+                        i++
+                    }
+                    if (key == "tags") tags = list else shells = list
+                }
+                else -> i++
+            }
+        }
+
+        val resolvedName = name?.takeIf { it.isNotBlank() } ?: return null
+        val resolvedCommand = command?.takeIf { it.isNotBlank() } ?: return null
+        return Workflow(resolvedName, resolvedCommand, description, arguments, tags, shells, sourcePath)
+    }
+
+    private fun indentOf(line: String): Int = line.takeWhile { it == ' ' }.length
+
+    private fun unquote(s: String): String {
+        if (s.length >= 2) {
+            if (s.first() == '"' && s.last() == '"') {
+                return s.substring(1, s.length - 1)
+                    .replace("\\n", "\n").replace("\\t", "\t")
+                    .replace("\\\"", "\"").replace("\\\\", "\\")
+            }
+            if (s.first() == '\'' && s.last() == '\'') {
+                return s.substring(1, s.length - 1).replace("''", "'")
+            }
+        }
+        return s
+    }
+
+    /** Read an indented block scalar; `fold` joins lines with spaces (`>`) vs newlines (`|`). */
+    private fun readBlockScalar(lines: List<String>, start: Int, fold: Boolean): Pair<String, Int> {
+        val content = mutableListOf<String>()
+        var i = start
+        var baseIndent = -1
+        while (i < lines.size) {
+            val raw = lines[i]
+            if (raw.isBlank()) { content.add(""); i++; continue }
+            if (indentOf(raw) == 0) break
+            if (baseIndent < 0) baseIndent = indentOf(raw)
+            content.add(raw.drop(baseIndent))
+            i++
+        }
+        while (content.isNotEmpty() && content.last().isBlank()) content.removeAt(content.size - 1)
+        val joined = if (fold) content.joinToString(" ") { it.trim() }.trim() else content.joinToString("\n")
+        return joined to i
+    }
+
+    private fun readArguments(lines: List<String>, start: Int): Pair<List<WorkflowArgument>, Int> {
+        val args = mutableListOf<WorkflowArgument>()
+        var i = start
+        var curName: String? = null
+        var curDesc: String? = null
+        var curDef: String? = null
+
+        fun flush() {
+            curName?.let { args.add(WorkflowArgument(it, curDesc, curDef)) }
+            curName = null; curDesc = null; curDef = null
+        }
+
+        fun applyKey(k: String, v: String) {
+            when (k) {
+                "name" -> curName = v
+                "description" -> curDesc = v
+                "default_value" -> curDef = v
+            }
+        }
+
+        while (i < lines.size) {
+            val raw = lines[i]
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) { i++; continue }
+            if (indentOf(raw) == 0) break
+            if (trimmed.startsWith("-")) {
+                flush()
+                val afterDash = trimmed.removePrefix("-").trim()
+                if (afterDash.contains(":")) {
+                    applyKey(afterDash.substringBefore(":").trim(), unquote(afterDash.substringAfter(":").trim()))
+                }
+            } else if (trimmed.contains(":")) {
+                applyKey(trimmed.substringBefore(":").trim(), unquote(trimmed.substringAfter(":").trim()))
+            }
+            i++
+        }
+        flush()
+        return args to i
+    }
+
+    private fun readBlockList(lines: List<String>, start: Int): Pair<List<String>, Int> {
+        val out = mutableListOf<String>()
+        var i = start
+        while (i < lines.size) {
+            val raw = lines[i]
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) { i++; continue }
+            if (indentOf(raw) == 0) break
+            if (trimmed.startsWith("-")) out.add(unquote(trimmed.removePrefix("-").trim()))
+            i++
+        }
+        return out to i
+    }
+
+    private fun parseInlineList(s: String): List<String> {
+        val inner = s.trim().removePrefix("[").substringBeforeLast("]")
+        if (inner.isBlank()) return emptyList()
+        return inner.split(",").map { unquote(it.trim()) }.filter { it.isNotEmpty() }
+    }
+}


### PR DESCRIPTION
Implements **Phase 3 — Workflows** from #271.

> **Stacked on #273 (Phase 2), which is stacked on #272 (Phase 1).** Base branch is `feat/command-palette`; merge #272 then #273 first.

Warp-compatible saved, parameterized commands. Discover them in the command palette; running one prompts for parameter values, substitutes `{{param}}`, then inserts (or runs) the command.

### Gating
Behind **`workflowsEnabled`** (default on). When off, no workflows are loaded or shown.

### What's included
- **`Workflow` / `WorkflowArgument`** — the Warp schema, with `render(values)` doing `{{param}}` substitution (falling back to defaults).
- **`WorkflowYaml`** — a small, **dependency-free** reader for the workflow schema *only* (not general YAML). Supports plain/quoted scalars, `|`/`>` block scalars for `command`, an `arguments` block-list of maps, and inline `[a,b]` or block `- item` lists for `tags`/`shells`. This avoids adding a YAML library whose runtime behavior I couldn't verify here (you run the app).
- **`WorkflowStore`** — loads `.yaml` from `~/.bossterm/workflows`, the project's `.warp/workflows`, and configured extra dirs; bad files are skipped.
- **`WorkflowRunDialog`** — parameter-entry overlay (a field per argument, prefilled with its default) + live command preview; **Insert** (default, safe) or **Run** on submit per the `workflowsAutoRun` setting.
- Palette integration (group **Workflow**) + a new **Workflows** settings section.

### How to test
1. Create `~/.bossterm/workflows/greet.yaml`:
   ```yaml
   name: Greet
   command: echo "hello {{who}}"
   description: Say hello
   arguments:
     - name: who
       default_value: world
   ```
2. Open the palette (Cmd/Ctrl+Shift+P), type `greet`, Enter → the dialog opens prefilled with `world`.
3. Insert → `echo "hello world"` appears at the prompt (or runs, if "Run on Submit" is enabled).

Build: `./gradlew :compose-ui:compileKotlinDesktop` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
