### PR TITLE
Share-window polish, window focus, and clean port fallback

### DIFF
--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -128,6 +128,9 @@ fun main() {
                 val windowState = rememberWindowState()
                 // Settings dialog state (declared before Window for onPreviewKeyEvent access)
                 var showSettingsDialog by remember { mutableStateOf(false) }
+                // Bumped on every settings-open request so an already-open settings window
+                // is raised to the front instead of staying behind. See SettingsWindow.focusTick.
+                var settingsFocusTick by remember { mutableStateOf(0) }
                 // Optional initial category — set by deep links (e.g. MCP status indicator).
                 // Cleared on dismiss so the next open falls back to the default category.
                 var initialSettingsCategory by remember {
@@ -202,7 +205,7 @@ fun main() {
                             keyEvent.key == Key.Comma &&
                             ((isMacOS && keyEvent.isMetaPressed) || (!isMacOS && keyEvent.isCtrlPressed))
                         ) {
-                            showSettingsDialog = true
+                            showSettingsDialog = true; settingsFocusTick++
                             true // Consume event
                         } else {
                             false
@@ -353,7 +356,7 @@ fun main() {
                             Separator()
                             Item(
                                 "Settings...",
-                                onClick = { showSettingsDialog = true },
+                                onClick = { showSettingsDialog = true; settingsFocusTick++ },
                                 shortcut = KeyShortcut(Key.Comma, meta = isMacOS, ctrl = !isMacOS)
                             )
                             Separator()
@@ -498,7 +501,7 @@ fun main() {
                                         onClick = {
                                             initialSettingsCategory =
                                                 ai.rever.bossterm.compose.settings.SettingsCategory.MCP
-                                            showSettingsDialog = true
+                                            showSettingsDialog = true; settingsFocusTick++
                                         }
                                     )
                                 }
@@ -782,11 +785,11 @@ fun main() {
                                     onNewWindow = {
                                         WindowManager.createWindow()
                                     },
-                                    onShowSettings = { showSettingsDialog = true },
+                                    onShowSettings = { showSettingsDialog = true; settingsFocusTick++ },
                                     onShowMcpSettings = {
                                         initialSettingsCategory =
                                             ai.rever.bossterm.compose.settings.SettingsCategory.MCP
-                                        showSettingsDialog = true
+                                        showSettingsDialog = true; settingsFocusTick++
                                     },
                                     onShowWelcomeWizard = { showOnboardingWizard = true },
                                     menuActions = window.menuActions,
@@ -828,7 +831,8 @@ fun main() {
                             WindowManager.closeWindow(window.id)
                             WindowManager.createWindow()
                         },
-                        initialCategory = initialSettingsCategory
+                        initialCategory = initialSettingsCategory,
+                        focusTick = settingsFocusTick
                     )
 
                     // CLI install dialog

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -794,11 +794,11 @@ fun TabbedTerminal(
     // Devices awaiting host approval to connect (issue #276) — drives the approval toast
     // and the share dialog's pending list.
     val pendingShareRequests by ai.rever.bossterm.compose.share.SessionShareManager.pendingRequests.collectAsState()
-    // Tailscale exposure resolves asynchronously (off the UI thread), so a share dialog
-    // opens with the LAN URL first; when the https://<host>.ts.net link becomes available
-    // (or is torn down), rebuild the open dialog so it shows the current best URL.
-    val shareTailscaleUrl by ai.rever.bossterm.compose.share.SessionShareManager.tailscaleUrlFlow.collectAsState()
-    LaunchedEffect(shareTailscaleUrl) {
+    // Remote-access exposure (Tailscale/Cloudflare) resolves asynchronously (off the UI
+    // thread), so a share dialog opens with the LAN URL first; when the public link becomes
+    // available (or is torn down), rebuild the open dialog so it shows the current best URL.
+    val shareRemoteUrl by ai.rever.bossterm.compose.share.SessionShareManager.remoteUrlFlow.collectAsState()
+    LaunchedEffect(shareRemoteUrl) {
         val info = shareDialog ?: return@LaunchedEffect
         ai.rever.bossterm.compose.share.SessionShareManager.infoFor(info.tabId)?.let { shareDialog = it }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -786,12 +786,22 @@ fun TabbedTerminal(
     var mcpAttaching by remember { mutableStateOf(false) }
     // Session sharing (issue #276): dialog state + live set of shared tab ids.
     var shareDialog by remember { mutableStateOf<ai.rever.bossterm.compose.share.SessionShareManager.ShareInfo?>(null) }
+    // Bumped every time the share window is opened/reopened; ShareWindow brings its OS
+    // window to the front when this changes, so clicking the share button while a share
+    // window is already open raises that window instead of leaving it behind.
+    var shareFocusTick by remember { mutableStateOf(0) }
     val sharedTabIds by ai.rever.bossterm.compose.share.SessionShareManager.sharedTabIds.collectAsState()
+    // Show (and focus) the share window for [info]. No-op when info is null.
+    fun openShareWindow(info: ai.rever.bossterm.compose.share.SessionShareManager.ShareInfo?) {
+        if (info == null) return
+        shareDialog = info
+        shareFocusTick++
+    }
     // Start (or reopen) a share for a tab. TAB = this tab + its splits; WINDOW = all tabs.
     // First use auto-enables the feature; the server binds on demand.
     fun startShare(tabId: String, scope: ai.rever.bossterm.compose.share.ShareScope) {
         if (sharedTabIds.contains(tabId)) {
-            shareDialog = ai.rever.bossterm.compose.share.SessionShareManager.infoFor(tabId)
+            openShareWindow(ai.rever.bossterm.compose.share.SessionShareManager.infoFor(tabId))
             return
         }
         if (!settings.sessionSharingEnabled) {
@@ -799,7 +809,7 @@ fun TabbedTerminal(
         }
         mcpScope.launch {
             val info = ai.rever.bossterm.compose.share.SessionShareManager.share(tabId, scope)
-            if (info != null) shareDialog = info
+            openShareWindow(info)
         }
     }
     // Split the active tab's focused pane (used by the left bar's split buttons). Mirrors
@@ -1262,14 +1272,21 @@ fun TabbedTerminal(
                                 action = { ai.rever.bossterm.compose.share.SessionShareManager.unshare(activeTab.id) }
                             )
                         } else {
-                            items + ContextMenuItem(
-                                id = "share_tab",
-                                label = "Share Tab…",
-                                action = { startShare(activeTab.id, ai.rever.bossterm.compose.share.ShareScope.TAB) }
-                            ) + ContextMenuItem(
-                                id = "share_window",
-                                label = "Share Window…",
-                                action = { startShare(activeTab.id, ai.rever.bossterm.compose.share.ShareScope.WINDOW) }
+                            items + ContextMenuSubmenu(
+                                id = "share_submenu",
+                                label = "Share",
+                                items = listOf(
+                                    ContextMenuItem(
+                                        id = "share_tab",
+                                        label = "Tab…",
+                                        action = { startShare(activeTab.id, ai.rever.bossterm.compose.share.ShareScope.TAB) }
+                                    ),
+                                    ContextMenuItem(
+                                        id = "share_window",
+                                        label = "Window…",
+                                        action = { startShare(activeTab.id, ai.rever.bossterm.compose.share.ShareScope.WINDOW) }
+                                    )
+                                )
                             )
                         }
                     }
@@ -1439,7 +1456,7 @@ fun TabbedTerminal(
                         val sharedId = sharedTabIds.firstOrNull { tabController.tabs.any { t -> t.id == it } }
                             ?: sharedTabIds.firstOrNull()
                         if (sharedId != null) {
-                            shareDialog = ai.rever.bossterm.compose.share.SessionShareManager.infoFor(sharedId)
+                            openShareWindow(ai.rever.bossterm.compose.share.SessionShareManager.infoFor(sharedId))
                         } else {
                             tabController.activeTab?.let { active ->
                                 shareScopeMenu.showMenu(0f, 0f, listOf(
@@ -1476,7 +1493,8 @@ fun TabbedTerminal(
             onScopeChange = { scope ->
                 // Re-scope in place (same tokens/links/viewers) and refresh the dialog.
                 ai.rever.bossterm.compose.share.SessionShareManager.reshare(info.tabId, scope)?.let { shareDialog = it }
-            }
+            },
+            focusTick = shareFocusTick
         )
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1517,6 +1517,8 @@ fun TabbedTerminal(
             pendingRequests = pendingShareRequests,
             onApproveRequest = { ai.rever.bossterm.compose.share.SessionShareManager.approveRequest(it) },
             onDenyRequest = { ai.rever.bossterm.compose.share.SessionShareManager.denyRequest(it) },
+            tailscaleMode = settings.shareTailscaleMode,
+            onTailscaleModeChange = { SettingsManager.instance.updateSetting { copy(shareTailscaleMode = it) } },
         )
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1519,6 +1519,7 @@ fun TabbedTerminal(
             onDenyRequest = { ai.rever.bossterm.compose.share.SessionShareManager.denyRequest(it) },
             tailscaleMode = settings.shareTailscaleMode,
             onTailscaleModeChange = { SettingsManager.instance.updateSetting { copy(shareTailscaleMode = it) } },
+            onRefreshLink = { ai.rever.bossterm.compose.share.SessionShareManager.refreshRemoteLink() },
         )
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -791,6 +791,9 @@ fun TabbedTerminal(
     // window is already open raises that window instead of leaving it behind.
     var shareFocusTick by remember { mutableStateOf(0) }
     val sharedTabIds by ai.rever.bossterm.compose.share.SessionShareManager.sharedTabIds.collectAsState()
+    // Devices awaiting host approval to connect (issue #276) — drives the approval toast
+    // and the share dialog's pending list.
+    val pendingShareRequests by ai.rever.bossterm.compose.share.SessionShareManager.pendingRequests.collectAsState()
     // Show (and focus) the share window for [info]. No-op when info is null.
     fun openShareWindow(info: ai.rever.bossterm.compose.share.SessionShareManager.ShareInfo?) {
         if (info == null) return
@@ -1418,7 +1421,7 @@ fun TabbedTerminal(
         // QR/links dialog if already shared). Shown per its own toggle.
         val showMcpStatus = settings.mcpShowStatusIndicator
         val showSharingStatus = settings.sessionSharingShowIndicator
-        if (showMcpStatus || showSharingStatus || attachStatus != null) {
+        if (showMcpStatus || showSharingStatus || attachStatus != null || pendingShareRequests.isNotEmpty()) {
             Column(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
@@ -1476,6 +1479,14 @@ fun TabbedTerminal(
                 attachStatus?.let { status ->
                     AttachToast(status = status)
                 }
+                // Approval prompts (issue #276): one banner per waiting device.
+                pendingShareRequests.forEach { req ->
+                    ai.rever.bossterm.compose.share.ShareRequestToast(
+                        request = req,
+                        onApprove = { ai.rever.bossterm.compose.share.SessionShareManager.approveRequest(req.id) },
+                        onDeny = { ai.rever.bossterm.compose.share.SessionShareManager.denyRequest(req.id) },
+                    )
+                }
             }
         }
     }
@@ -1494,7 +1505,10 @@ fun TabbedTerminal(
                 // Re-scope in place (same tokens/links/viewers) and refresh the dialog.
                 ai.rever.bossterm.compose.share.SessionShareManager.reshare(info.tabId, scope)?.let { shareDialog = it }
             },
-            focusTick = shareFocusTick
+            focusTick = shareFocusTick,
+            pendingRequests = pendingShareRequests,
+            onApproveRequest = { ai.rever.bossterm.compose.share.SessionShareManager.approveRequest(it) },
+            onDenyRequest = { ai.rever.bossterm.compose.share.SessionShareManager.denyRequest(it) },
         )
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -794,6 +794,14 @@ fun TabbedTerminal(
     // Devices awaiting host approval to connect (issue #276) — drives the approval toast
     // and the share dialog's pending list.
     val pendingShareRequests by ai.rever.bossterm.compose.share.SessionShareManager.pendingRequests.collectAsState()
+    // Tailscale exposure resolves asynchronously (off the UI thread), so a share dialog
+    // opens with the LAN URL first; when the https://<host>.ts.net link becomes available
+    // (or is torn down), rebuild the open dialog so it shows the current best URL.
+    val shareTailscaleUrl by ai.rever.bossterm.compose.share.SessionShareManager.tailscaleUrlFlow.collectAsState()
+    LaunchedEffect(shareTailscaleUrl) {
+        val info = shareDialog ?: return@LaunchedEffect
+        ai.rever.bossterm.compose.share.SessionShareManager.infoFor(info.tabId)?.let { shareDialog = it }
+    }
     // Show (and focus) the share window for [info]. No-op when info is null.
     fun openShareWindow(info: ai.rever.bossterm.compose.share.SessionShareManager.ShareInfo?) {
         if (info == null) return

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -638,6 +638,24 @@ class TabbedTerminalState {
     )
 
     /**
+     * Split a specific pane (by id) horizontally — the new pane appears below
+     * [anchorPaneId]. Horizontal twin of [splitVerticalFromPane]: focuses the
+     * anchor, splits it, then restores the caller's prior focus (so it doesn't
+     * yank focus from the pane a local user is typing in). Falls back to the
+     * focused pane if the anchor doesn't exist.
+     *
+     * @return The session id of the new pane, or null if the split failed.
+     */
+    fun splitHorizontalFromPane(
+        tabId: String,
+        anchorPaneId: String,
+        ratio: Float? = null,
+        initialCommand: String? = null
+    ): String? = performSplit(
+        SplitOrientation.HORIZONTAL, tabId, ratio, initialCommand, anchorPaneId
+    )
+
+    /**
      * Internal helper to perform a split in the given orientation.
      *
      * @param initialCommand Optional command to run in the new pane once its shell is ready

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -264,6 +264,47 @@ class TabbedTerminalState {
         return tabController?.closeTabById(tabId) ?: false
     }
 
+    /** Close every tab except [tabId] (mirrors the chip menu's "Close Other Tabs"). */
+    fun closeOtherTabs(tabId: String) {
+        val i = tabs.indexOfFirst { it.id == tabId }
+        if (i >= 0) tabController?.closeOtherTabs(i)
+    }
+
+    /** Close all tabs ordered after [tabId] (mirrors "Close Tabs Below"). */
+    fun closeTabsBelow(tabId: String) {
+        val i = tabs.indexOfFirst { it.id == tabId }
+        if (i >= 0) tabController?.closeTabsBelow(i)
+    }
+
+    /** Duplicate [tabId] into a new tab starting in the same cwd (mirrors "Duplicate Tab"). */
+    fun duplicateTab(tabId: String) {
+        val wd = tabs.firstOrNull { it.id == tabId }?.workingDirectory?.value
+        createTab(workingDir = wd)
+    }
+
+    /** The session a chip refers to: a split pane by id, else the tab itself (summary/unsplit). */
+    private fun chipSession(tabId: String, paneId: String): TerminalSession? =
+        splitStates[tabId]?.getAllPanes()?.firstOrNull { it.id == paneId }?.session
+            ?: tabs.firstOrNull { it.id == tabId }
+
+    /** Rename a tab/pane chip; a blank [title] clears the custom title (reverts to cwd). */
+    fun renameChip(tabId: String, paneId: String, title: String) {
+        val s = chipSession(tabId, paneId) ?: return
+        val t = title.trim()
+        if (t.isBlank()) {
+            s.customTitle.value = null
+        } else {
+            s.customTitle.value = t
+            s.title.value = t
+        }
+    }
+
+    /** Set ("#RRGGBB") or clear (null) a tab/pane chip's accent color. */
+    fun setChipColor(tabId: String, paneId: String, cssHex: String?) {
+        val s = chipSession(tabId, paneId) ?: return
+        s.tabColor.value = cssHex?.removePrefix("#")?.uppercase()?.let { "0xFF$it" }
+    }
+
     /**
      * Close the currently active tab.
      */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsWindow.kt
@@ -28,7 +28,9 @@ fun SettingsWindow(
     onDismiss: () -> Unit,
     onRestartApp: (() -> Unit)? = null,
     /** Optional category to open the panel at. Null falls back to [SettingsCategory.default]. */
-    initialCategory: SettingsCategory? = null
+    initialCategory: SettingsCategory? = null,
+    /** Bumped each time settings is requested; raises the window to the front when it changes. */
+    focusTick: Int = 0
 ) {
     if (!visible) return
 
@@ -66,6 +68,11 @@ fun SettingsWindow(
             size = DpSize(750.dp, 580.dp)
         )
     ) {
+        // Raise an already-open settings window to the front when settings is requested again.
+        LaunchedEffect(focusTick) {
+            window.toFront()
+            window.requestFocus()
+        }
         SettingsPanel(
             settings = pendingSettings,
             onSettingsChange = { newSettings ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -920,15 +920,19 @@ data class TerminalSettings(
 
     /**
      * Remote-access mode for sharing (which tunnel provider exposes the share server):
-     *  - "off" (default): no tunnel — reach is loopback/LAN only.
+     *  - "off": no tunnel — reach is loopback/LAN only.
      *  - "serve": Tailscale Serve — your tailnet only (private, TLS). Requires `tailscale`.
      *  - "funnel": Tailscale Funnel — public internet via Tailscale's edge (TLS).
-     *  - "cloudflare": Cloudflare Quick Tunnel — instant public https link via `cloudflared`,
-     *    no account/config (ephemeral URL). See [ai.rever.bossterm.compose.share.CloudflaredExposer].
+     *  - "cloudflare" (default): Cloudflare Quick Tunnel — instant public https link via
+     *    `cloudflared`, no account/config (ephemeral URL); auto-installable via Homebrew.
+     *    The zero-config option, so it's the default. Falls back to the LAN URL if
+     *    `cloudflared` isn't present. See [ai.rever.bossterm.compose.share.CloudflaredExposer].
      * When active, the share URL becomes the published https link (…ts.net or …trycloudflare.com).
+     * Note: sharing is still gated by [sessionSharingEnabled] (off by default) and, for public
+     * modes, [sessionSharingApprovalScope] — so a public tunnel only opens once the user shares.
      * (Field name is historical — it's the general remote-access mode, not Tailscale-only.)
      */
-    val shareTailscaleMode: String = "off",
+    val shareTailscaleMode: String = "cloudflare",
 
     /**
      * Explicit public base URL to advertise instead of the bound host — for when the

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -936,6 +936,17 @@ data class TerminalSettings(
     val sessionSharingPublicUrl: String = "",
 
     /**
+     * When a new device connects to a share, whether the host must approve it before
+     * it can view/control. On approval the device gets a 24h rolling access key so it
+     * isn't re-prompted on every reconnect. Values:
+     *  - "off":    no approval — the share link alone grants access (original behavior).
+     *  - "funnel": require approval only for public reach (Tailscale Funnel or a custom
+     *              public URL); LAN and Tailscale Serve stay link-only. (default)
+     *  - "all":    require approval for every connection, including LAN.
+     */
+    val sessionSharingApprovalScope: String = "funnel",
+
+    /**
      * Show the small status indicator while a tab is being shared. Mirrors
      * [mcpShowStatusIndicator] for the share server.
      */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -919,11 +919,14 @@ data class TerminalSettings(
     val sessionSharingBindHost: String = "",
 
     /**
-     * Remote-reach via Tailscale (OpenClaw-style; requires the `tailscale` CLI):
+     * Remote-access mode for sharing (which tunnel provider exposes the share server):
      *  - "off" (default): no tunnel — reach is loopback/LAN only.
-     *  - "serve": expose to your tailnet only (private, TLS via Tailscale).
-     *  - "funnel": expose to the public internet via Tailscale's edge (TLS).
-     * When active, the share URL becomes the published https://<host>.ts.net link.
+     *  - "serve": Tailscale Serve — your tailnet only (private, TLS). Requires `tailscale`.
+     *  - "funnel": Tailscale Funnel — public internet via Tailscale's edge (TLS).
+     *  - "cloudflare": Cloudflare Quick Tunnel — instant public https link via `cloudflared`,
+     *    no account/config (ephemeral URL). See [ai.rever.bossterm.compose.share.CloudflaredExposer].
+     * When active, the share URL becomes the published https link (…ts.net or …trycloudflare.com).
+     * (Field name is historical — it's the general remote-access mode, not Tailscale-only.)
      */
     val shareTailscaleMode: String = "off",
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/SessionSharingSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/SessionSharingSettingsSection.kt
@@ -59,12 +59,14 @@ fun SessionSharingSettingsSection(
 
         SettingsSection(title = "Remote Access (advanced)") {
             SettingsDropdown(
-                label = "Tailscale",
-                options = listOf("off", "serve", "funnel"),
+                label = "Remote access",
+                options = listOf("off", "serve", "funnel", "cloudflare"),
                 selectedOption = settings.shareTailscaleMode,
                 onOptionSelected = { onSettingsChange(settings.copy(shareTailscaleMode = it)) },
-                description = "Reach the share from anywhere via the Tailscale CLI (no port-forwarding): " +
-                        "serve = your tailnet only; funnel = public internet (TLS). off = LAN/loopback only."
+                description = "Reach the share from other networks (no port-forwarding). " +
+                        "serve = your Tailscale tailnet only; funnel = public via Tailscale (TLS); " +
+                        "cloudflare = instant public link via cloudflared, no account (ephemeral URL); " +
+                        "off = LAN/loopback only."
             )
             SettingsTextField(
                 label = "Public URL override",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/SessionSharingSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/SessionSharingSettingsSection.kt
@@ -74,6 +74,15 @@ fun SessionSharingSettingsSection(
                 description = "If you front the server with your own reverse proxy / cloudflared / SSH " +
                         "reverse tunnel, set the public base URL here (use https for internet access)."
             )
+            SettingsDropdown(
+                label = "Require device approval",
+                options = listOf("off", "funnel", "all"),
+                selectedOption = settings.sessionSharingApprovalScope,
+                onOptionSelected = { onSettingsChange(settings.copy(sessionSharingApprovalScope = it)) },
+                description = "Ask before a new device may view/control. funnel (default) = only for " +
+                        "public reach (Funnel or a custom URL); all = every device incl. LAN; off = the " +
+                        "link alone grants access. Approved devices get a 24h key so they aren't re-prompted."
+            )
         }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/CloudflaredExposer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/CloudflaredExposer.kt
@@ -62,7 +62,10 @@ object CloudflaredExposer {
     fun start(port: Int): Process? {
         val b = bin() ?: run { log.warn("cloudflared not found; cannot start quick tunnel"); return null }
         return try {
-            ProcessBuilder(b, "tunnel", "--no-autoupdate", "--url", "http://127.0.0.1:$port")
+            // `--no-autoupdate` is a GLOBAL flag — it must precede the `tunnel` subcommand,
+            // or cloudflared rejects/ignores it (and an auto-update mid-session would restart
+            // the process and drop the tunnel).
+            ProcessBuilder(b, "--no-autoupdate", "tunnel", "--url", "http://127.0.0.1:$port")
                 .redirectErrorStream(true)
                 .start()
                 .also { runCatching { it.outputStream.close() } } // no stdin needed

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/CloudflaredExposer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/CloudflaredExposer.kt
@@ -1,0 +1,112 @@
+package ai.rever.bossterm.compose.share
+
+import org.slf4j.LoggerFactory
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+/**
+ * Remote-reach via **Cloudflare Quick Tunnel** (issue #276) — the zero-config public
+ * sharing option, an alternative to Tailscale. Shells out to the `cloudflared` CLI:
+ *
+ *     cloudflared tunnel --no-autoupdate --url http://127.0.0.1:<port>
+ *
+ * This opens an *outbound* connection to Cloudflare's edge (so it traverses NAT with
+ * no port-forwarding) and Cloudflare hands back a public `https://<random>.trycloudflare.com`
+ * URL with **no account, no DNS, no config** and TLS included. We operate nothing.
+ *
+ * Unlike `tailscale serve` (which configures the daemon and exits), `cloudflared` is a
+ * **long-lived process**: the tunnel lives only as long as the process. So [start]
+ * returns the [Process] for the caller to hold and kill on teardown, and [awaitUrl]
+ * parses the assigned URL from its output.
+ *
+ * Caveats (inherent to quick tunnels): the URL is ephemeral (new one each run) and
+ * best-effort (no uptime SLA — Cloudflare positions it for testing/dev).
+ */
+object CloudflaredExposer {
+
+    private val log = LoggerFactory.getLogger(CloudflaredExposer::class.java)
+
+    // "cloudflared" first (honors PATH), then typical Homebrew locations.
+    private val candidates = listOf("cloudflared", "/opt/homebrew/bin/cloudflared", "/usr/local/bin/cloudflared")
+    private fun bin(): String? = candidates.firstOrNull { runCmd(listOf(it, "--version"), 5) != null }
+
+    /** True if a working `cloudflared` CLI is present. Blocking — call off the UI thread. */
+    fun isInstalled(): Boolean = bin() != null
+
+    // Common Homebrew locations (Apple-silicon, Intel, then PATH).
+    private val brewCandidates = listOf("/opt/homebrew/bin/brew", "/usr/local/bin/brew", "brew")
+    private fun brewBin(): String? = brewCandidates.firstOrNull { runCmd(listOf(it, "--version"), 5) != null }
+
+    /** True if Homebrew is available to auto-install cloudflared. Blocking. */
+    fun brewAvailable(): Boolean = brewBin() != null
+
+    /**
+     * Install cloudflared via `brew install cloudflared`. Blocking and slow (downloads) —
+     * call off the UI thread. Returns true on success (or if it's already installed).
+     */
+    fun brewInstall(): Boolean {
+        val brew = brewBin() ?: run { log.warn("Homebrew not found; cannot install cloudflared"); return false }
+        log.info("Installing cloudflared: {} install cloudflared …", brew)
+        val ok = runCmd(listOf(brew, "install", "cloudflared"), 600) != null
+        log.info("`brew install cloudflared` {}", if (ok) "succeeded" else "failed")
+        return ok || isInstalled()
+    }
+
+    private val URL_RE = Regex("""https://[a-z0-9-]+\.trycloudflare\.com""")
+
+    /**
+     * Start a quick tunnel to `127.0.0.1:`[port]. Returns the **long-lived** [Process]
+     * (caller must keep it and [Process.destroyForcibly] it on teardown), or null if the
+     * CLI is missing / failed to spawn. Pair with [awaitUrl] to get the public URL.
+     */
+    fun start(port: Int): Process? {
+        val b = bin() ?: run { log.warn("cloudflared not found; cannot start quick tunnel"); return null }
+        return try {
+            ProcessBuilder(b, "tunnel", "--no-autoupdate", "--url", "http://127.0.0.1:$port")
+                .redirectErrorStream(true)
+                .start()
+                .also { runCatching { it.outputStream.close() } } // no stdin needed
+        } catch (e: Exception) {
+            log.warn("failed to start cloudflared: {}", e.message)
+            null
+        }
+    }
+
+    /**
+     * Read [process] output until the assigned `*.trycloudflare.com` URL appears (or
+     * [timeoutMs] elapses). The reader keeps draining the pipe afterwards so the process
+     * doesn't stall on a full output buffer. Returns the URL, or null on timeout / early exit.
+     */
+    fun awaitUrl(process: Process, timeoutMs: Long = 30_000): String? {
+        val result = CompletableFuture<String?>()
+        Thread {
+            runCatching {
+                process.inputStream.bufferedReader().forEachLine { line ->
+                    URL_RE.find(line)?.value?.let { result.complete(it) } // first match wins; keep draining
+                }
+            }
+            result.complete(null) // EOF without a URL
+        }.apply { isDaemon = true; start() }
+        return runCatching { result.get(timeoutMs, TimeUnit.MILLISECONDS) }.getOrNull()
+    }
+
+    /** Run a short-lived command; return stdout on exit 0, else null. Bounded by [timeoutSec]. */
+    private fun runCmd(cmd: List<String>, timeoutSec: Long): String? {
+        return try {
+            val p = ProcessBuilder(cmd).redirectErrorStream(true).start()
+            runCatching { p.outputStream.close() }
+            val sb = StringBuilder()
+            val reader = Thread {
+                runCatching { p.inputStream.bufferedReader().forEachLine { sb.append(it).append('\n') } }
+            }.apply { isDaemon = true; start() }
+            if (!p.waitFor(timeoutSec, TimeUnit.SECONDS)) {
+                p.destroyForcibly()
+                return null
+            }
+            reader.join(500)
+            if (p.exitValue() == 0) sb.toString() else null
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -115,7 +115,7 @@ class MirrorShare(
         val sig = computeSignature()
         val out = ArrayList<ServerMessage>()
         out.add(themeMessage())
-        out.add(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft))
+        out.add(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft, sig.summaryMode))
         for ((id, tab) in paneTabMap()) {
             val sz = sig.sizes[id] ?: listOf(80, 24)
             out.add(ServerMessage.PaneSnapshot(id, snapshotText(tab), sz[0], sz[1]))
@@ -176,7 +176,7 @@ class MirrorShare(
                 }
             }
         }
-        broadcast(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft))
+        broadcast(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft, sig.summaryMode))
         sig.sizes.forEach { (id, sz) -> broadcast(ServerMessage.PaneResize(id, sz[0], sz[1])) }
     }
 
@@ -186,6 +186,7 @@ class MirrorShare(
         val activeTabId: String?,
         val sizes: Map<String, List<Int>>,
         val tabBarOnLeft: Boolean,
+        val summaryMode: Boolean,
     )
 
     private fun inScopeTabs(state: TabbedTerminalState): List<TerminalTab> = when (scope) {
@@ -194,11 +195,13 @@ class MirrorShare(
     }
 
     private fun computeSignature(): WindowSig {
-        val state = McpTerminalRegistry.findState(tabId) ?: return WindowSig(emptyList(), null, emptyMap(), false)
+        val state = McpTerminalRegistry.findState(tabId) ?: return WindowSig(emptyList(), null, emptyMap(), false, false)
         val tabNodes = ArrayList<TabNode>()
         val sizes = HashMap<String, List<Int>>()
         val activeId = if (scope == ShareScope.TAB) tabId else state.activeTabId
-        val onLeft = SettingsManager.instance.settings.value.tabBarPosition == "left"
+        val settings = SettingsManager.instance.settings.value
+        val onLeft = settings.tabBarPosition == "left"
+        val summary = settings.tabBarSummaryMode
         for (tab in inScopeTabs(state)) {
             val ss = state.splitStates[tab.id]
             val tree: PaneTreeNode = if (ss != null) {
@@ -206,7 +209,10 @@ class MirrorShare(
             } else {
                 val s = tab.display.termSize.value
                 sizes[tab.id] = listOf(s.columns, s.rows)
-                PaneTreeNode.Pane(tab.id, tab.title.value, tab.workingDirectory.value, true)
+                PaneTreeNode.Pane(
+                    tab.id, tab.title.value, tab.workingDirectory.value, true,
+                    color = tabColorCss(tab), branch = tab.gitBranch.value
+                )
             }
             tabNodes.add(
                 TabNode(
@@ -215,7 +221,7 @@ class MirrorShare(
                 )
             )
         }
-        return WindowSig(tabNodes, activeId, sizes, onLeft)
+        return WindowSig(tabNodes, activeId, sizes, onLeft, summary)
     }
 
     /** Resolve a tab's accent as CSS (#RRGGBB), mirroring the host's chip color (manual or auto). */
@@ -237,7 +243,10 @@ class MirrorShare(
             val tab = node.session as TerminalTab
             val s = tab.display.termSize.value
             sizes[node.id] = listOf(s.columns, s.rows)
-            PaneTreeNode.Pane(node.id, tab.title.value, tab.workingDirectory.value, node.id == focusedId)
+            PaneTreeNode.Pane(
+                node.id, tab.title.value, tab.workingDirectory.value, node.id == focusedId,
+                color = tabColorCss(tab), branch = tab.gitBranch.value
+            )
         }
         is SplitNode.VerticalSplit ->
             PaneTreeNode.Split("v", node.ratio, sigNode(node.left, focusedId, sizes), sigNode(node.right, focusedId, sizes))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -133,9 +133,9 @@ class MirrorShare(
                 McpTerminalRegistry.findState(tabId)?.closeTab(msg.tabId)
             is ClientMessage.NewTab ->
                 McpTerminalRegistry.findState(tabId)?.createTab()
-            is ClientMessage.SplitRight ->
+            is ClientMessage.SplitVertical ->
                 McpTerminalRegistry.findState(tabId)?.splitVerticalFromPane(msg.tabId, msg.paneId)
-            is ClientMessage.SplitDown ->
+            is ClientMessage.SplitHorizontal ->
                 McpTerminalRegistry.findState(tabId)?.splitHorizontalFromPane(msg.tabId, msg.paneId)
             is ClientMessage.ClosePane -> {
                 // Target the clicked pane (focus it), then close; closeFocusedPane closes

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -219,6 +219,11 @@ class MirrorShare(
             row++
         }
         sb.append("[0m") // reset trailing style
+        // Park the cursor at its real screen position (1-based row;col) — otherwise xterm.js
+        // leaves it on the bottom row after we write the full-height blob (scrollback + screen).
+        val cy = tab.terminal.cursorY.coerceIn(1, snap.height)
+        val cx = tab.terminal.cursorX.coerceAtLeast(1)
+        sb.append("[$cy;${cx}H")
         return sb.toString()
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -8,6 +8,9 @@ import ai.rever.bossterm.compose.settings.theme.ColorPaletteManager
 import ai.rever.bossterm.compose.settings.theme.ThemeManager
 import ai.rever.bossterm.compose.splits.SplitNode
 import ai.rever.bossterm.compose.tabs.TerminalTab
+import ai.rever.bossterm.terminal.TerminalColor
+import ai.rever.bossterm.terminal.TextStyle
+import ai.rever.bossterm.terminal.model.TerminalLine
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -200,16 +203,63 @@ class MirrorShare(
         return m
     }
 
+    /**
+     * Build the initial-paint blob for a pane as **styled** text: each cell run is
+     * prefixed with its SGR escape so the viewer's xterm.js paints the scrollback in
+     * color, exactly like live output. (Previously this sent `line.text` — plain chars
+     * with no styling — so the very first render was monochrome until new output arrived.)
+     */
     private fun snapshotText(tab: TerminalTab): String {
         val snap = tab.textBuffer.createSnapshot()
         val sb = StringBuilder()
         var row = -snap.historyLinesCount
         while (row < snap.height) {
-            sb.append(snap.getLine(row).text.trimEnd())
+            appendStyledLine(sb, snap.getLine(row))
             if (row < snap.height - 1) sb.append("\r\n")
             row++
         }
+        sb.append("[0m") // reset trailing style
         return sb.toString()
+    }
+
+    /** Append one buffer line as SGR-prefixed styled runs, trimming invisible trailing padding. */
+    private fun appendStyledLine(sb: StringBuilder, line: TerminalLine) {
+        // Collect runs, stopping at the first NUL entry (trailing unfilled cells), like TerminalLine.text.
+        val runs = ArrayList<TerminalLine.TextEntry>()
+        for (e in line.entries) {
+            if (e == null) continue
+            if (e.isNul) break
+            runs.add(e)
+        }
+        // Drop trailing runs that are blank with no background — invisible padding (old .trimEnd()).
+        var end = runs.size
+        while (end > 0 && runs[end - 1].let { it.text.toString().isBlank() && it.style.background == null }) end--
+        for (i in 0 until end) {
+            sb.append(ansiForStyle(runs[i].style)).append(runs[i].text.toString())
+        }
+    }
+
+    /** SGR escape that resets then applies [style]'s colors + attributes (256-color / truecolor). */
+    private fun ansiForStyle(style: TextStyle): String {
+        val codes = ArrayList<String>()
+        codes.add("0") // reset first so each run is self-contained
+        if (style.hasOption(TextStyle.Option.BOLD)) codes.add("1")
+        if (style.hasOption(TextStyle.Option.DIM)) codes.add("2")
+        if (style.hasOption(TextStyle.Option.ITALIC)) codes.add("3")
+        if (style.hasOption(TextStyle.Option.UNDERLINED)) codes.add("4")
+        if (style.hasOption(TextStyle.Option.SLOW_BLINK)) codes.add("5")
+        if (style.hasOption(TextStyle.Option.RAPID_BLINK)) codes.add("6")
+        if (style.hasOption(TextStyle.Option.INVERSE)) codes.add("7")
+        if (style.hasOption(TextStyle.Option.HIDDEN)) codes.add("8")
+        style.foreground?.let { codes.add(sgrColor(it, fg = true)) }
+        style.background?.let { codes.add(sgrColor(it, fg = false)) }
+        return "[" + codes.joinToString(";") + "m"
+    }
+
+    private fun sgrColor(c: TerminalColor, fg: Boolean): String {
+        val base = if (fg) "38" else "48"
+        return if (c.isIndexed) "$base;5;${c.colorIndex}"
+        else c.toColor().let { "$base;2;${it.red};${it.green};${it.blue}" }
     }
 
     // ---- theme (host palette → CSS) ----

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -113,7 +113,7 @@ class MirrorShare(
         val sig = computeSignature()
         val out = ArrayList<ServerMessage>()
         out.add(themeMessage())
-        out.add(ServerMessage.Layout(sig.tabs, sig.activeTabId))
+        out.add(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft))
         for ((id, tab) in paneTabMap()) {
             val sz = sig.sizes[id] ?: listOf(80, 24)
             out.add(ServerMessage.PaneSnapshot(id, snapshotText(tab), sz[0], sz[1]))
@@ -121,12 +121,18 @@ class MirrorShare(
         return out
     }
 
-    /** Route viewer input to the addressed pane (controller role only). */
+    /** Route viewer messages — input + tab close/new — to the host (controller role only). */
     fun handleClient(vc: ViewerConnection, msg: ClientMessage) {
-        if (msg is ClientMessage.Input && vc.canControl) {
-            (taps[msg.paneId]?.tab ?: paneTabMap()[msg.paneId])?.writeUserInput(msg.data)
+        if (!vc.canControl) return // all mutating actions require the control role
+        when (msg) {
+            is ClientMessage.Input ->
+                (taps[msg.paneId]?.tab ?: paneTabMap()[msg.paneId])?.writeUserInput(msg.data)
+            is ClientMessage.CloseTab ->
+                McpTerminalRegistry.findState(tabId)?.closeTab(msg.tabId)
+            is ClientMessage.NewTab ->
+                McpTerminalRegistry.findState(tabId)?.createTab()
+            else -> {} // Hello / Focus / RequestControl: no-op (focus is viewer-side; control via token)
         }
-        // Hello / Focus / RequestControl: no-op in v1 (focus is viewer-side; control via token).
     }
 
     // ---- reconcile on structural change ----
@@ -147,12 +153,17 @@ class MirrorShare(
                 }
             }
         }
-        broadcast(ServerMessage.Layout(sig.tabs, sig.activeTabId))
+        broadcast(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft))
         sig.sizes.forEach { (id, sz) -> broadcast(ServerMessage.PaneResize(id, sz[0], sz[1])) }
     }
 
     // ---- window-state signature (pure-serializable; drives distinctUntilChanged) ----
-    private data class WindowSig(val tabs: List<TabNode>, val activeTabId: String?, val sizes: Map<String, List<Int>>)
+    private data class WindowSig(
+        val tabs: List<TabNode>,
+        val activeTabId: String?,
+        val sizes: Map<String, List<Int>>,
+        val tabBarOnLeft: Boolean,
+    )
 
     private fun inScopeTabs(state: TabbedTerminalState): List<TerminalTab> = when (scope) {
         ShareScope.WINDOW -> state.tabs
@@ -160,10 +171,11 @@ class MirrorShare(
     }
 
     private fun computeSignature(): WindowSig {
-        val state = McpTerminalRegistry.findState(tabId) ?: return WindowSig(emptyList(), null, emptyMap())
+        val state = McpTerminalRegistry.findState(tabId) ?: return WindowSig(emptyList(), null, emptyMap(), false)
         val tabNodes = ArrayList<TabNode>()
         val sizes = HashMap<String, List<Int>>()
         val activeId = if (scope == ShareScope.TAB) tabId else state.activeTabId
+        val onLeft = SettingsManager.instance.settings.value.tabBarPosition == "left"
         for (tab in inScopeTabs(state)) {
             val ss = state.splitStates[tab.id]
             val tree: PaneTreeNode = if (ss != null) {
@@ -173,9 +185,28 @@ class MirrorShare(
                 sizes[tab.id] = listOf(s.columns, s.rows)
                 PaneTreeNode.Pane(tab.id, tab.title.value, tab.workingDirectory.value, true)
             }
-            tabNodes.add(TabNode(tab.id, tab.title.value, tab.id == activeId, tree))
+            tabNodes.add(
+                TabNode(
+                    id = tab.id, title = tab.title.value, active = tab.id == activeId, tree = tree,
+                    color = tabColorCss(tab), cwd = tab.workingDirectory.value, branch = tab.gitBranch.value
+                )
+            )
         }
-        return WindowSig(tabNodes, activeId, sizes)
+        return WindowSig(tabNodes, activeId, sizes, onLeft)
+    }
+
+    /** Resolve a tab's accent as CSS (#RRGGBB), mirroring the host's chip color (manual or auto). */
+    private fun tabColorCss(tab: TerminalTab): String? {
+        val argb = tab.tabColor.value ?: run {
+            val s = SettingsManager.instance.settings.value
+            if (!s.tabColorByDirectory) return null
+            val cwd = tab.workingDirectory.value
+            if (cwd.isNullOrBlank()) return null
+            val presets = ai.rever.bossterm.compose.tabs.TAB_COLOR_PRESETS
+            presets[cwd.hashCode().mod(presets.size)].second
+        }
+        val h = argb.removePrefix("0x")
+        return if (h.length >= 8) "#" + h.substring(2) else null // drop AA → #RRGGBB
     }
 
     private fun sigNode(node: SplitNode, focusedId: String, sizes: HashMap<String, List<Int>>): PaneTreeNode = when (node) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -154,6 +154,17 @@ class MirrorShare(
                     target.writeUserInput(ToolCommandProvider().getLaunchCommand(assistant, cfg))
                 }
             }
+            // ---- tab-chip context menu (mirrors the host's chip menu) ----
+            is ClientMessage.RenameTab ->
+                McpTerminalRegistry.findState(tabId)?.renameChip(msg.tabId, msg.paneId, msg.title)
+            is ClientMessage.SetTabColor ->
+                McpTerminalRegistry.findState(tabId)?.setChipColor(msg.tabId, msg.paneId, msg.color)
+            is ClientMessage.DuplicateTab ->
+                McpTerminalRegistry.findState(tabId)?.duplicateTab(msg.tabId)
+            is ClientMessage.CloseOtherTabs ->
+                McpTerminalRegistry.findState(tabId)?.closeOtherTabs(msg.tabId)
+            is ClientMessage.CloseTabsBelow ->
+                McpTerminalRegistry.findState(tabId)?.closeTabsBelow(msg.tabId)
             else -> {} // Hello / Focus / RequestControl: no-op (focus is viewer-side; control via token)
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -1,6 +1,8 @@
 package ai.rever.bossterm.compose.share
 
 import ai.rever.bossterm.compose.TabbedTerminalState
+import ai.rever.bossterm.compose.ai.AIAssistants
+import ai.rever.bossterm.compose.ai.ToolCommandProvider
 import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.theme.ColorPalette
@@ -131,6 +133,27 @@ class MirrorShare(
                 McpTerminalRegistry.findState(tabId)?.closeTab(msg.tabId)
             is ClientMessage.NewTab ->
                 McpTerminalRegistry.findState(tabId)?.createTab()
+            is ClientMessage.SplitRight ->
+                McpTerminalRegistry.findState(tabId)?.splitVerticalFromPane(msg.tabId, msg.paneId)
+            is ClientMessage.SplitDown ->
+                McpTerminalRegistry.findState(tabId)?.splitHorizontalFromPane(msg.tabId, msg.paneId)
+            is ClientMessage.ClosePane -> {
+                // Target the clicked pane (focus it), then close; closeFocusedPane closes
+                // the whole tab when it's the only pane (matches the host's behavior).
+                val st = McpTerminalRegistry.findState(tabId)
+                st?.splitStates?.get(msg.tabId)?.setFocusedPane(msg.paneId)
+                st?.closeFocusedPane(msg.tabId)
+            }
+            is ClientMessage.LaunchAI -> {
+                // Run the same launch command the host's AI menu would (honoring the
+                // user's per-assistant YOLO/auto-mode config), in the clicked pane.
+                val target = taps[msg.paneId]?.tab ?: paneTabMap()[msg.paneId]
+                val assistant = AIAssistants.findById(msg.assistantId)
+                if (target != null && assistant != null) {
+                    val cfg = SettingsManager.instance.settings.value.aiAssistantConfigs[msg.assistantId]
+                    target.writeUserInput(ToolCommandProvider().getLaunchCommand(assistant, cfg))
+                }
+            }
             else -> {} // Hello / Focus / RequestControl: no-op (focus is viewer-side; control via token)
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -240,6 +240,21 @@ object SessionShareManager {
         else -> "127.0.0.1"
     }
 
+    /**
+     * True if [port] on [host] can currently be bound. Probes with a plain
+     * [java.net.ServerSocket] (SO_REUSEADDR set to mirror CIO) and releases it
+     * immediately. Used to pick a free port before starting Ktor, since CIO's
+     * own bind failure is asynchronous and would otherwise leak an uncaught
+     * BindException. A tiny TOCTOU window remains but is harmless for a local tool.
+     */
+    private fun portBindable(host: String, port: Int): Boolean = runCatching {
+        java.net.ServerSocket().use { ss ->
+            ss.reuseAddress = true
+            ss.bind(java.net.InetSocketAddress(host, port))
+        }
+        true
+    }.getOrDefault(false)
+
     /** Start the engine if not already running. Returns true if running afterwards. */
     private fun ensureEngineLocked(settings: TerminalSettings): Boolean {
         if (engine != null) return true
@@ -248,6 +263,14 @@ object SessionShareManager {
         for (offset in 0 until MAX_PORT_FALLBACK) {
             val port = desiredPort + offset
             if (port > 65535) break
+            // CIO binds its listening socket asynchronously (in the acceptJob coroutine),
+            // so a port-already-in-use surfaces as an UNCAUGHT BindException instead of
+            // throwing from start(). Probe the port synchronously first and skip it if
+            // taken — e.g. a previous instance still shutting down on relaunch.
+            if (!portBindable(host, port)) {
+                log.warn("Session-sharing port {}:{} in use, trying next", host, port)
+                continue
+            }
             try {
                 val started = embeddedServer(CIO, host = host, port = port) {
                     install(WebSockets)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -249,6 +249,51 @@ object SessionShareManager {
     }
 
     /**
+     * Regenerate the remote-access link in place — get a fresh tunnel and publish it.
+     * Cloudflare quick-tunnel URLs are ephemeral (new one per process, and a tunnel can
+     * drop), so this is the "give me a new link" action in the share dialog. The share
+     * server + viewers keep running; the open dialog updates via [remoteUrlFlow].
+     *
+     * For Cloudflare the new tunnel is brought up and its URL captured *before* the old
+     * process is killed, so the dialog jumps straight from the old link to the new one
+     * (no momentary fallback to the LAN URL). Tailscale serve/funnel URLs are stable, so
+     * this just re-affirms the mapping. No-op when remote access is off (the LAN link
+     * never changes). Runs off the UI thread.
+     */
+    fun refreshRemoteLink() {
+        scope.launch {
+            val port = boundPort ?: return@launch
+            val mode = SettingsManager.instance.settings.value.shareTailscaleMode
+            if (mode == "off") return@launch
+            withContext(Dispatchers.IO) {
+                val newUrl = when (mode) {
+                    "cloudflare" -> {
+                        val newProc = CloudflaredExposer.start(port)
+                        val u = newProc?.let { CloudflaredExposer.awaitUrl(it) }
+                        if (u != null) {
+                            val old = remoteProcess
+                            remoteProcess = newProc
+                            runCatching { old?.destroyForcibly() } // swap, then kill the old tunnel
+                        } else {
+                            runCatching { newProc?.destroyForcibly() } // failed — don't leak it
+                        }
+                        u
+                    }
+                    else -> TailscaleExposer.enable(mode, port) // serve/funnel: URL is stable
+                }
+                activeRemoteMode = mode
+                if (newUrl != null) {
+                    remoteUrl = newUrl
+                    _remoteUrlFlow.value = newUrl
+                    log.info("Session-sharing remote link refreshed via {}: {}", mode, newUrl)
+                } else {
+                    log.warn("Remote link refresh ({}) did not yield a URL; keeping the current link.", mode)
+                }
+            }
+        }
+    }
+
+    /**
      * Window's onTabClose hook: stop only a TAB-scope share keyed by the closed tab.
      * WINDOW shares clean up via [MirrorShare]'s own observer when their window empties.
      */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -66,6 +66,13 @@ object SessionShareManager {
     // Tailscale (Phase 3): published https://<host>.ts.net URL while a tunnel is up.
     private var tailscaleUrl: String? = null
     private var tailscaleMode: String = "off"
+    private val _tailscaleUrlFlow = MutableStateFlow<String?>(null)
+    /**
+     * The published Tailscale https URL once exposure resolves, else null. Exposure runs
+     * asynchronously (off the UI thread), so the share dialog opens with the LAN URL first;
+     * the UI observes this to refresh the dialog to the https://<host>.ts.net link when ready.
+     */
+    val tailscaleUrlFlow: StateFlow<String?> = _tailscaleUrlFlow.asStateFlow()
 
     /** A token resolves to a share and whether that token grants control. */
     private data class TokenRef(val share: MirrorShare, val canControl: Boolean)
@@ -311,6 +318,7 @@ object SessionShareManager {
         boundPort = null
         boundHost = null
         tailscaleUrl = null
+        _tailscaleUrlFlow.value = null
         tailscaleMode = "off"
     }
 
@@ -384,6 +392,7 @@ object SessionShareManager {
                         val url = TailscaleExposer.enable(tsMode, tsPort)
                         if (url != null) {
                             tailscaleUrl = url
+                            _tailscaleUrlFlow.value = url  // refresh any open share dialog to the https URL
                             log.info("Session-sharing reachable via Tailscale: {}", url)
                         } else {
                             log.warn("Tailscale {} did not yield a URL; using the LAN link. " +
@@ -424,6 +433,7 @@ object SessionShareManager {
             boundPort = null
             boundHost = null
             tailscaleUrl = null
+            _tailscaleUrlFlow.value = null
             tailscaleMode = "off"
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -15,6 +15,7 @@ import io.ktor.websocket.CloseReason
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -30,10 +31,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
 import java.net.BindException
 import java.net.Inet4Address
 import java.net.NetworkInterface
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -75,6 +78,79 @@ object SessionShareManager {
     val sharedTabIds: StateFlow<Set<String>> = _sharedTabIds.asStateFlow()
 
     private var watcherJob: Job? = null
+
+    // ---- Approval handshake + 24h rolling access keys (issue #276) ----
+
+    private const val GRANT_TTL_MS = 24L * 60 * 60 * 1000
+
+    /** A granted device key: which share it's for, its role, and when it lapses. */
+    private data class Grant(
+        val key: String,
+        val shareId: String,
+        val clientId: String,
+        val canControl: Boolean,
+        @Volatile var expiresAtMs: Long,
+    )
+
+    /** Access key → grant. Lazily expired on use; cleared when the share ends. */
+    private val grants = ConcurrentHashMap<String, Grant>()
+
+    /** A viewer connection awaiting the host's approve/deny decision. */
+    data class PendingShareRequest(
+        val id: String,
+        val tabId: String,
+        val deviceName: String,
+        /** True when the device used the control link (one approve grants control). */
+        val wantsControl: Boolean,
+    ) {
+        internal val decision = CompletableDeferred<Boolean>()
+    }
+
+    private val _pendingRequests = MutableStateFlow<List<PendingShareRequest>>(emptyList())
+    /** Connections waiting for host approval — drives the approval toast + dialog list. */
+    val pendingRequests: StateFlow<List<PendingShareRequest>> = _pendingRequests.asStateFlow()
+
+    /** Host approved a pending request (admits the viewer + mints a 24h key). */
+    fun approveRequest(id: String) = decideRequest(id, true)
+    /** Host denied a pending request (closes the viewer socket). */
+    fun denyRequest(id: String) = decideRequest(id, false)
+    private fun decideRequest(id: String, approve: Boolean) {
+        val req = _pendingRequests.value.firstOrNull { it.id == id } ?: return
+        _pendingRequests.value = _pendingRequests.value.filterNot { it.id == id }
+        req.decision.complete(approve)
+    }
+
+    /** Deny + drop any pending requests for [tabId] (its share is ending). */
+    private fun failPendingFor(tabId: String) {
+        val (drop, keep) = _pendingRequests.value.partition { it.tabId == tabId }
+        if (drop.isEmpty()) return
+        _pendingRequests.value = keep
+        drop.forEach { it.decision.complete(false) }
+    }
+
+    /** Deny + drop all pending requests (sharing is shutting down). */
+    private fun failAllPending() {
+        val all = _pendingRequests.value
+        if (all.isNotEmpty()) _pendingRequests.value = emptyList()
+        all.forEach { it.decision.complete(false) }
+    }
+
+    /**
+     * Whether a newly connecting device must be approved before it can view/control,
+     * per [TerminalSettings.sessionSharingApprovalScope]: "all" = always; "off" = never;
+     * "funnel" (default) = only when the share is publicly reachable (Tailscale Funnel
+     * or a custom public URL), since LAN/Serve reach is already trusted.
+     */
+    private fun requiresApproval(): Boolean {
+        val s = SettingsManager.instance.settings.value
+        return when (s.sessionSharingApprovalScope) {
+            "all" -> true
+            "off" -> false
+            else -> tailscaleMode == "funnel" || s.sessionSharingPublicUrl.isNotBlank()
+        }
+    }
+
+    private fun newKey(): String = UUID.randomUUID().toString().replace("-", "")
 
     /** Public info handed back to the UI when a share starts. */
     data class ShareInfo(
@@ -190,6 +266,8 @@ object SessionShareManager {
                 val share = sharesByTab.remove(tabId) ?: return@withLock
                 sharesByToken.remove(share.viewToken)
                 sharesByToken.remove(share.controlToken)
+                grants.values.removeIf { it.shareId == share.viewToken }
+                failPendingFor(tabId)
                 share.stop()
                 _sharedTabIds.value = sharesByTab.keys.toSet()
                 if (sharesByTab.isEmpty()) stopEngineLocked()
@@ -203,6 +281,8 @@ object SessionShareManager {
                 sharesByTab.values.forEach { it.stop() }
                 sharesByTab.clear()
                 sharesByToken.clear()
+                grants.clear()
+                failAllPending()
                 _sharedTabIds.value = emptySet()
                 stopEngineLocked()
             }
@@ -220,6 +300,8 @@ object SessionShareManager {
         sharesByTab.values.forEach { runCatching { it.stop() } }
         sharesByTab.clear()
         sharesByToken.clear()
+        grants.clear()
+        failAllPending()
         _sharedTabIds.value = emptySet()
         val e = engine ?: return
         val port = boundPort
@@ -346,7 +428,7 @@ object SessionShareManager {
         }
     }
 
-    /** Handle one viewer WebSocket: snapshot, then drain its outbox to the socket. */
+    /** Handle one viewer WebSocket: handshake/approval, snapshot, then drain its outbox. */
     private suspend fun serveViewer(ws: io.ktor.server.websocket.DefaultWebSocketServerSession) {
         val token = ws.call.parameters["token"]
         val ref = token?.let { sharesByToken[it] }
@@ -355,12 +437,52 @@ object SessionShareManager {
             return
         }
         val share = ref.share
-        // Theme + Layout + a PaneSnapshot per pane, THEN register so the outbox only
-        // carries output produced after the snapshot — avoids double-rendering a chunk.
+        val shareId = share.viewToken
+
+        // Handshake: the viewer's first frame carries its clientId + any prior access key.
+        val hello = readHello(ws)
+        val clientId = hello?.clientId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
+        var canControl = ref.canControl
+
+        if (requiresApproval()) {
+            val now = System.currentTimeMillis()
+            val existing = hello?.key?.let { grants[it] }
+            if (existing != null && existing.shareId == shareId && existing.expiresAtMs > now) {
+                // Known device with a live key → slide the 24h window, skip re-approval.
+                existing.expiresAtMs = now + GRANT_TTL_MS
+                canControl = existing.canControl
+                ws.send(Frame.Text(ShareProtocol.encodeServer(
+                    ServerMessage.Grant(existing.key, existing.expiresAtMs, canControl))))
+            } else {
+                hello?.key?.let { grants.remove(it) } // drop a stale/expired key
+                val req = PendingShareRequest(
+                    id = UUID.randomUUID().toString(),
+                    tabId = share.tabId,
+                    deviceName = hello?.name?.takeIf { it.isNotBlank() } ?: "Browser (${clientId.take(6)})",
+                    wantsControl = ref.canControl,
+                )
+                _pendingRequests.value = _pendingRequests.value + req
+                runCatching { ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Pending))) }
+                val approved = withTimeoutOrNull(2 * 60_000L) { req.decision.await() } ?: false
+                _pendingRequests.value = _pendingRequests.value.filterNot { it.id == req.id }
+                if (!approved) {
+                    runCatching { ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Denied("Not approved")))) }
+                    ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "Not approved"))
+                    return
+                }
+                val key = newKey()
+                val exp = System.currentTimeMillis() + GRANT_TTL_MS
+                grants[key] = Grant(key, shareId, clientId, ref.canControl, exp)
+                canControl = ref.canControl
+                ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Grant(key, exp, canControl))))
+            }
+        }
+
+        // Admit: Theme + Layout + a PaneSnapshot per pane, THEN register so the outbox
+        // only carries output produced after the snapshot (avoids double-rendering).
         share.initialMessages().forEach { ws.send(Frame.Text(ShareProtocol.encodeServer(it))) }
-        // Control granted iff this connection used the control token.
-        ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Control(granted = ref.canControl))))
-        val vc = share.addViewer(ref.canControl)
+        ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Control(granted = canControl))))
+        val vc = share.addViewer(canControl)
         val writer = ws.launch {
             for (text in vc.outbox) ws.send(Frame.Text(text))
         }
@@ -377,6 +499,15 @@ object SessionShareManager {
             writer.cancel()
             share.removeViewer(vc)
         }
+    }
+
+    /** Read the first frame as a [ClientMessage.Hello] (best-effort, short timeout). */
+    private suspend fun readHello(
+        ws: io.ktor.server.websocket.DefaultWebSocketServerSession
+    ): ClientMessage.Hello? {
+        val frame = withTimeoutOrNull(10_000L) { runCatching { ws.incoming.receive() }.getOrNull() } ?: return null
+        if (frame !is Frame.Text) return null
+        return runCatching { ShareProtocol.decodeClient(frame.readText()) }.getOrNull() as? ClientMessage.Hello
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -287,14 +287,27 @@ object SessionShareManager {
                 boundHost = host
                 log.info("Session-sharing server bound on {}:{} (bind={})", host, port, settings.sessionSharingBind)
                 // Phase 3: expose remotely via Tailscale if configured. Best-effort —
-                // failure just leaves us on the LAN/loopback URL. Kept inline (under the
-                // mutex) because the share dialog needs the published https URL the moment
-                // share() returns; this only blocks once — on the FIRST share of a server
-                // lifecycle when Tailscale is enabled (the engine is reused thereafter, so
-                // ensureEngineLocked returns early and never re-runs this).
-                if (settings.shareTailscaleMode != "off") {
-                    tailscaleMode = settings.shareTailscaleMode
-                    tailscaleUrl = TailscaleExposer.enable(tailscaleMode, port)
+                // failure just leaves us on the LAN/loopback URL. Run it OFF the share
+                // path (manager scope, Dispatchers.IO): shelling out to the `tailscale`
+                // CLI can be slow or hang, and ensureEngineLocked runs synchronously on
+                // the caller's (UI) thread — doing it inline froze the whole app while a
+                // stuck `tailscale serve` was draining. The dialog opens immediately with
+                // the LAN URL; the Tailscale URL is picked up when the dialog is next
+                // (re)opened. Guarded so it only fires once per server lifecycle.
+                if (settings.shareTailscaleMode != "off" && tailscaleMode == "off") {
+                    val tsMode = settings.shareTailscaleMode
+                    val tsPort = port
+                    tailscaleMode = tsMode
+                    scope.launch {
+                        val url = TailscaleExposer.enable(tsMode, tsPort)
+                        if (url != null) {
+                            tailscaleUrl = url
+                            log.info("Session-sharing reachable via Tailscale: {}", url)
+                        } else {
+                            log.warn("Tailscale {} did not yield a URL; using the LAN link. " +
+                                "Check `tailscale status` and that {} is enabled for your tailnet.", tsMode, tsMode)
+                        }
+                    }
                 }
                 return true
             } catch (e: Throwable) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -63,16 +63,21 @@ object SessionShareManager {
     private var engine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
     private var boundPort: Int? = null
     private var boundHost: String? = null
-    // Tailscale (Phase 3): published https://<host>.ts.net URL while a tunnel is up.
-    private var tailscaleUrl: String? = null
-    private var tailscaleMode: String = "off"
-    private val _tailscaleUrlFlow = MutableStateFlow<String?>(null)
+    // Remote access (Phase 3): the published public/tunnel URL + which provider is live.
+    // [activeRemoteMode] mirrors a TerminalSettings.shareTailscaleMode value:
+    // "off" | "serve" | "funnel" (Tailscale) | "cloudflare" (Cloudflare Quick Tunnel).
+    private var remoteUrl: String? = null
+    private var activeRemoteMode: String = "off"
+    // For long-lived tunnels (cloudflared): the running process to kill on teardown.
+    private var remoteProcess: Process? = null
+    private val _remoteUrlFlow = MutableStateFlow<String?>(null)
     /**
-     * The published Tailscale https URL once exposure resolves, else null. Exposure runs
+     * The published remote-access URL (Tailscale `https://<host>.ts.net` or a Cloudflare
+     * `https://<rand>.trycloudflare.com`) once exposure resolves, else null. Exposure runs
      * asynchronously (off the UI thread), so the share dialog opens with the LAN URL first;
-     * the UI observes this to refresh the dialog to the https://<host>.ts.net link when ready.
+     * the UI observes this to refresh the dialog to the public link when it's ready.
      */
-    val tailscaleUrlFlow: StateFlow<String?> = _tailscaleUrlFlow.asStateFlow()
+    val remoteUrlFlow: StateFlow<String?> = _remoteUrlFlow.asStateFlow()
 
     /** A token resolves to a share and whether that token grants control. */
     private data class TokenRef(val share: MirrorShare, val canControl: Boolean)
@@ -145,15 +150,15 @@ object SessionShareManager {
     /**
      * Whether a newly connecting device must be approved before it can view/control,
      * per [TerminalSettings.sessionSharingApprovalScope]: "all" = always; "off" = never;
-     * "funnel" (default) = only when the share is publicly reachable (Tailscale Funnel
-     * or a custom public URL), since LAN/Serve reach is already trusted.
+     * "funnel" (default) = only when the share is publicly reachable (Tailscale Funnel,
+     * Cloudflare Quick Tunnel, or a custom public URL), since LAN/Serve reach is trusted.
      */
     private fun requiresApproval(): Boolean {
         val s = SettingsManager.instance.settings.value
         return when (s.sessionSharingApprovalScope) {
             "all" -> true
             "off" -> false
-            else -> tailscaleMode == "funnel" || s.sessionSharingPublicUrl.isNotBlank()
+            else -> activeRemoteMode == "funnel" || activeRemoteMode == "cloudflare" || s.sessionSharingPublicUrl.isNotBlank()
         }
     }
 
@@ -310,16 +315,12 @@ object SessionShareManager {
         grants.clear()
         failAllPending()
         _sharedTabIds.value = emptySet()
+        teardownRemoteAccess(boundPort)
         val e = engine ?: return
-        val port = boundPort
-        if (tailscaleMode != "off" && port != null) runCatching { TailscaleExposer.disable(tailscaleMode, port) }
         runCatching { e.stop(200, 800) }
         engine = null
         boundPort = null
         boundHost = null
-        tailscaleUrl = null
-        _tailscaleUrlFlow.value = null
-        tailscaleMode = "off"
     }
 
     // ---- engine lifecycle (mutex-guarded) ----
@@ -388,27 +389,35 @@ object SessionShareManager {
                 boundPort = port
                 boundHost = host
                 log.info("Session-sharing server bound on {}:{} (bind={})", host, port, settings.sessionSharingBind)
-                // Phase 3: expose remotely via Tailscale if configured. Best-effort —
-                // failure just leaves us on the LAN/loopback URL. Run it OFF the share
-                // path (manager scope, Dispatchers.IO): shelling out to the `tailscale`
-                // CLI can be slow or hang, and ensureEngineLocked runs synchronously on
-                // the caller's (UI) thread — doing it inline froze the whole app while a
-                // stuck `tailscale serve` was draining. The dialog opens immediately with
-                // the LAN URL; the Tailscale URL is picked up when the dialog is next
-                // (re)opened. Guarded so it only fires once per server lifecycle.
-                if (settings.shareTailscaleMode != "off" && tailscaleMode == "off") {
-                    val tsMode = settings.shareTailscaleMode
-                    val tsPort = port
-                    tailscaleMode = tsMode
+                // Phase 3: expose remotely via the configured provider, if any. Best-effort —
+                // failure just leaves us on the LAN/loopback URL. Run it OFF the share path
+                // (manager scope, Dispatchers.IO): shelling out to `tailscale`/`cloudflared`
+                // can be slow or hang, and ensureEngineLocked runs synchronously on the
+                // caller's (UI) thread — doing it inline would freeze the app. The dialog
+                // opens immediately with the LAN URL; the public URL is picked up via
+                // remoteUrlFlow when it resolves. Guarded so it only fires once per lifecycle.
+                if (settings.shareTailscaleMode != "off" && activeRemoteMode == "off") {
+                    val mode = settings.shareTailscaleMode
+                    val rPort = port
+                    activeRemoteMode = mode
                     scope.launch {
-                        val url = TailscaleExposer.enable(tsMode, tsPort)
+                        val url = when (mode) {
+                            "cloudflare" -> CloudflaredExposer.start(rPort)?.let { proc ->
+                                remoteProcess = proc
+                                CloudflaredExposer.awaitUrl(proc)
+                            }
+                            else -> TailscaleExposer.enable(mode, rPort) // "serve" / "funnel"
+                        }
                         if (url != null) {
-                            tailscaleUrl = url
-                            _tailscaleUrlFlow.value = url  // refresh any open share dialog to the https URL
-                            log.info("Session-sharing reachable via Tailscale: {}", url)
+                            remoteUrl = url
+                            _remoteUrlFlow.value = url  // refresh any open share dialog to the public URL
+                            log.info("Session-sharing reachable via {}: {}", mode, url)
                         } else {
-                            log.warn("Tailscale {} did not yield a URL; using the LAN link. " +
-                                "Check `tailscale status` and that {} is enabled for your tailnet.", tsMode, tsMode)
+                            log.warn(
+                                "Remote access ({}) did not yield a URL; using the LAN link. " +
+                                    "For tailscale check `tailscale status`; for cloudflare ensure `cloudflared` is installed.",
+                                mode
+                            )
                         }
                     }
                 }
@@ -429,12 +438,8 @@ object SessionShareManager {
 
     private suspend fun stopEngineLocked() {
         val e = engine ?: return
-        // Tear down any Tailscale mapping first (best-effort).
-        if (tailscaleMode != "off") {
-            val port = boundPort
-            val mode = tailscaleMode
-            if (port != null) withContext(Dispatchers.IO) { TailscaleExposer.disable(mode, port) }
-        }
+        // Tear down any active remote-access exposure first (best-effort, off the UI thread).
+        withContext(Dispatchers.IO) { teardownRemoteAccess(boundPort) }
         try {
             withContext(Dispatchers.IO) { e.stop(300, 1000) }
             log.info("Session-sharing server stopped (port {})", boundPort)
@@ -444,10 +449,23 @@ object SessionShareManager {
             engine = null
             boundPort = null
             boundHost = null
-            tailscaleUrl = null
-            _tailscaleUrlFlow.value = null
-            tailscaleMode = "off"
         }
+    }
+
+    /**
+     * Tear down whatever remote-access provider is live and reset the published URL.
+     * Tailscale serve/funnel is unmapped via the CLI; a Cloudflare quick tunnel is a
+     * long-lived process, so it's killed. Idempotent / safe when nothing is active.
+     */
+    private fun teardownRemoteAccess(port: Int?) {
+        when (activeRemoteMode) {
+            "serve", "funnel" -> if (port != null) runCatching { TailscaleExposer.disable(activeRemoteMode, port) }
+            "cloudflare" -> runCatching { remoteProcess?.destroyForcibly() }
+        }
+        remoteProcess = null
+        remoteUrl = null
+        _remoteUrlFlow.value = null
+        activeRemoteMode = "off"
     }
 
     /** Handle one viewer WebSocket: handshake/approval, snapshot, then drain its outbox. */
@@ -533,13 +551,14 @@ object SessionShareManager {
     }
 
     /**
-     * Build the user-facing share URL. Precedence: an active Tailscale tunnel
-     * (https://<host>.ts.net) → a user-set public URL (their own proxy/cloudflared/
-     * SSH tunnel) → the bound host (LAN-resolved when bound wide). https bases yield
-     * wss automatically since the viewer derives the WS scheme from the page.
+     * Build the user-facing share URL. Precedence: an active remote-access tunnel
+     * (Tailscale `https://<host>.ts.net` or Cloudflare `https://<rand>.trycloudflare.com`)
+     * → a user-set public URL (their own proxy/SSH tunnel) → the bound host (LAN-resolved
+     * when bound wide). https bases yield wss automatically since the viewer derives the
+     * WS scheme from the page.
      */
     private fun buildUrl(token: String): String? {
-        tailscaleUrl?.let { return "${it.trimEnd('/')}/?t=$token" }
+        remoteUrl?.let { return "${it.trimEnd('/')}/?t=$token" }
         val publicUrl = SettingsManager.instance.settings.value.sessionSharingPublicUrl
         if (publicUrl.isNotBlank()) return "${publicUrl.trimEnd('/')}/?t=$token"
         val port = boundPort ?: return null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -331,19 +331,31 @@ object SessionShareManager {
     }
 
     /**
-     * True if [port] on [host] can currently be bound. Probes with a plain
-     * [java.net.ServerSocket] (SO_REUSEADDR set to mirror CIO) and releases it
-     * immediately. Used to pick a free port before starting Ktor, since CIO's
-     * own bind failure is asynchronous and would otherwise leak an uncaught
-     * BindException. A tiny TOCTOU window remains but is harmless for a local tool.
+     * True if [port] is free for the share server to take. Probes both the bind
+     * [host] (so we don't double-bind our own wildcard) AND `127.0.0.1` — the latter
+     * because Tailscale Serve proxies to `127.0.0.1:<port>`, so we must OWN the loopback
+     * address, not just the wildcard. With `reuseAddress = false` the probe reports a
+     * port as taken when ANY other process holds it, including a loopback-specific
+     * listener (e.g. BossConsole on 127.0.0.1) that a wildcard bind would otherwise
+     * silently shadow — which is exactly how `serve` ended up hitting the wrong server.
+     * Used to pick a free port before starting Ktor (CIO binds asynchronously, so a
+     * collision would otherwise surface as an uncaught BindException or a mis-proxy).
      */
-    private fun portBindable(host: String, port: Int): Boolean = runCatching {
-        java.net.ServerSocket().use { ss ->
-            ss.reuseAddress = true
-            ss.bind(java.net.InetSocketAddress(host, port))
+    private fun portBindable(host: String, port: Int): Boolean {
+        val probes = buildList {
+            add("127.0.0.1")
+            if (host != "127.0.0.1") add(host)
         }
-        true
-    }.getOrDefault(false)
+        return probes.all { addr ->
+            runCatching {
+                java.net.ServerSocket().use { ss ->
+                    ss.reuseAddress = false
+                    ss.bind(java.net.InetSocketAddress(addr, port))
+                }
+                true
+            }.getOrDefault(false)
+        }
+    }
 
     /** Start the engine if not already running. Returns true if running afterwards. */
     private fun ensureEngineLocked(settings: TerminalSettings): Boolean {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareApprovalUi.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareApprovalUi.kt
@@ -1,0 +1,108 @@
+package ai.rever.bossterm.compose.share
+
+import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+private val ApproveColor = Color(0xFF4CAF50)
+private val DenyColor = Color(0xFFE57373)
+
+private fun verb(wantsControl: Boolean) = if (wantsControl) "control" else "view"
+
+/**
+ * Floating banner (issue #276) prompting the host to approve/deny one device's
+ * request to connect to a share. Shown in the top-right overlay alongside the
+ * status strip; the full queue also appears in the share dialog.
+ */
+@Composable
+fun ShareRequestToast(
+    request: SessionShareManager.PendingShareRequest,
+    onApprove: () -> Unit,
+    onDeny: () -> Unit,
+) {
+    Surface(
+        color = Color(0xFF2B2B2B),
+        shape = RoundedCornerShape(8.dp),
+        border = BorderStroke(1.dp, BorderColor),
+        shadowElevation = 6.dp,
+    ) {
+        Column(Modifier.widthIn(max = 320.dp).padding(horizontal = 12.dp, vertical = 10.dp)) {
+            Text("Session sharing", color = TextMuted, fontSize = 11.sp)
+            Spacer(Modifier.height(2.dp))
+            Text(
+                "${request.deviceName} wants to ${verb(request.wantsControl)} this session",
+                color = Color.White, fontSize = 13.sp
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(onClick = onDeny, colors = ButtonDefaults.textButtonColors(contentColor = DenyColor)) {
+                    Text("Deny")
+                }
+                Button(
+                    onClick = onApprove,
+                    colors = ButtonDefaults.buttonColors(containerColor = ApproveColor, contentColor = Color.White)
+                ) { Text("Approve") }
+            }
+        }
+    }
+}
+
+/**
+ * The pending-request queue rendered inside the share dialog. Each row names the
+ * device and what it asked for, with Approve / Deny. Renders nothing when empty.
+ */
+@Composable
+fun PendingRequestsList(
+    requests: List<SessionShareManager.PendingShareRequest>,
+    onApprove: (String) -> Unit,
+    onDeny: (String) -> Unit,
+) {
+    requests.forEach { req ->
+        Surface(color = SurfaceColor, shape = RoundedCornerShape(6.dp), modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Text(req.deviceName, color = TextPrimary, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    Text("wants to ${verb(req.wantsControl)}", color = TextMuted, fontSize = 11.sp)
+                }
+                TextButton(onClick = { onDeny(req.id) }, colors = ButtonDefaults.textButtonColors(contentColor = DenyColor)) {
+                    Text("Deny")
+                }
+                Button(
+                    onClick = { onApprove(req.id) },
+                    colors = ButtonDefaults.buttonColors(containerColor = ApproveColor, contentColor = Color.White)
+                ) { Text("Approve") }
+            }
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -63,6 +63,25 @@ sealed class ServerMessage {
     @SerialName("control")
     data class Control(val granted: Boolean) : ServerMessage()
 
+    /** Host requires approval and this viewer's request is awaiting the host's decision. */
+    @Serializable
+    @SerialName("pending")
+    data object Pending : ServerMessage()
+
+    /**
+     * The host approved this device: a per-device access [key] valid until [expiresAt]
+     * (epoch ms). The viewer persists it and replays it on reconnect to skip re-approval;
+     * the host slides [expiresAt] forward on each accepted use (24h rolling window).
+     */
+    @Serializable
+    @SerialName("grant")
+    data class Grant(val key: String, val expiresAt: Long, val control: Boolean) : ServerMessage()
+
+    /** The host denied the request (or it timed out / the key expired). */
+    @Serializable
+    @SerialName("denied")
+    data class Denied(val reason: String? = null) : ServerMessage()
+
     /** Host terminal theme (core colors + 16 ANSI + font) so the viewer matches BossTerm. */
     @Serializable
     @SerialName("theme")
@@ -99,10 +118,18 @@ sealed class PaneTreeNode {
 /** Viewer → host messages. */
 @Serializable
 sealed class ClientMessage {
-    /** Handshake with an optional display name. */
+    /**
+     * Handshake. [name] is a display label for the host's approval prompt; [clientId]
+     * is a stable per-browser id (localStorage) so a device is recognized across
+     * reconnects; [key] is a previously granted access key replayed to skip re-approval.
+     */
     @Serializable
     @SerialName("hello")
-    data class Hello(val name: String? = null) : ClientMessage()
+    data class Hello(
+        val name: String? = null,
+        val clientId: String? = null,
+        val key: String? = null,
+    ) : ClientMessage()
 
     /** Keystrokes for a specific pane. Honored only with controller role. */
     @Serializable

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -36,7 +36,12 @@ sealed class ServerMessage {
     /** The window layout: tabs + their split trees + which tab is active. Resent on change. */
     @Serializable
     @SerialName("layout")
-    data class Layout(val tabs: List<TabNode>, val activeTabId: String?) : ServerMessage()
+    data class Layout(
+        val tabs: List<TabNode>,
+        val activeTabId: String?,
+        /** Host's tab-bar orientation, so the viewer mirrors it: true = left (vertical), false = top. */
+        val tabBarOnLeft: Boolean = false,
+    ) : ServerMessage()
 
     /** One-time initial paint for a pane: scrollback+screen as a raw escape/text blob. */
     @Serializable
@@ -97,9 +102,21 @@ sealed class ServerMessage {
     ) : ServerMessage()
 }
 
-/** One tab in the [ServerMessage.Layout]: id, title, whether active, and its split tree. */
+/**
+ * One tab in the [ServerMessage.Layout]: id, title, whether active, and its split tree.
+ * [color] (CSS, e.g. "#E06C75"), [cwd], and [branch] mirror the host's tab-chip styling
+ * (accent stripe + the left bar's cwd/branch lines); all optional.
+ */
 @Serializable
-data class TabNode(val id: String, val title: String, val active: Boolean, val tree: PaneTreeNode)
+data class TabNode(
+    val id: String,
+    val title: String,
+    val active: Boolean,
+    val tree: PaneTreeNode,
+    val color: String? = null,
+    val cwd: String? = null,
+    val branch: String? = null,
+)
 
 /** Recursive split-layout node: either a binary split or a leaf pane. */
 @Serializable
@@ -145,4 +162,14 @@ sealed class ClientMessage {
     @Serializable
     @SerialName("requestControl")
     data object RequestControl : ClientMessage()
+
+    /** Close a tab on the host (controller role only). Mirrors the host tab's close button. */
+    @Serializable
+    @SerialName("closeTab")
+    data class CloseTab(val tabId: String) : ClientMessage()
+
+    /** Open a new tab on the host (controller role only). Mirrors the host's new-tab (+) button. */
+    @Serializable
+    @SerialName("newTab")
+    data object NewTab : ClientMessage()
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -172,4 +172,28 @@ sealed class ClientMessage {
     @Serializable
     @SerialName("newTab")
     data object NewTab : ClientMessage()
+
+    /** Split [paneId] in [tabId] left/right — new pane on the right (controller role only). */
+    @Serializable
+    @SerialName("splitRight")
+    data class SplitRight(val tabId: String, val paneId: String) : ClientMessage()
+
+    /** Split [paneId] in [tabId] top/bottom — new pane below (controller role only). */
+    @Serializable
+    @SerialName("splitDown")
+    data class SplitDown(val tabId: String, val paneId: String) : ClientMessage()
+
+    /** Close [paneId] in [tabId]; closes the tab if it's the last pane (controller role only). */
+    @Serializable
+    @SerialName("closePane")
+    data class ClosePane(val tabId: String, val paneId: String) : ClientMessage()
+
+    /**
+     * Launch an AI assistant (by [assistantId], e.g. "claude-code") in [paneId] of [tabId]
+     * — mirrors the host's AI-assistant menu, running the same configured launch command
+     * (incl. the user's YOLO/auto-mode setting). Controller role only.
+     */
+    @Serializable
+    @SerialName("launchAI")
+    data class LaunchAI(val tabId: String, val paneId: String, val assistantId: String) : ClientMessage()
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -217,4 +217,35 @@ sealed class ClientMessage {
     @Serializable
     @SerialName("launchAI")
     data class LaunchAI(val tabId: String, val paneId: String, val assistantId: String) : ClientMessage()
+
+    /**
+     * Rename a tab/pane chip ([paneId] == [tabId] for a tab-level chip). A blank [title]
+     * clears the custom title (reverts to the cwd-derived one). Controller role only.
+     */
+    @Serializable
+    @SerialName("renameTab")
+    data class RenameTab(val tabId: String, val paneId: String, val title: String) : ClientMessage()
+
+    /**
+     * Set ([color] = CSS "#RRGGBB") or clear ([color] = null) a chip's accent, mirroring
+     * the host chip menu's Color ▸ presets / Clear. Controller role only.
+     */
+    @Serializable
+    @SerialName("setTabColor")
+    data class SetTabColor(val tabId: String, val paneId: String, val color: String? = null) : ClientMessage()
+
+    /** Duplicate [tabId] into a new tab in the same cwd ("Duplicate Tab"). Controller role only. */
+    @Serializable
+    @SerialName("duplicateTab")
+    data class DuplicateTab(val tabId: String) : ClientMessage()
+
+    /** Close every tab except [tabId] ("Close Other Tabs"). Controller role only. */
+    @Serializable
+    @SerialName("closeOtherTabs")
+    data class CloseOtherTabs(val tabId: String) : ClientMessage()
+
+    /** Close all tabs after [tabId] ("Close Tabs Below"). Controller role only. */
+    @Serializable
+    @SerialName("closeTabsBelow")
+    data class CloseTabsBelow(val tabId: String) : ClientMessage()
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -173,15 +173,21 @@ sealed class ClientMessage {
     @SerialName("newTab")
     data object NewTab : ClientMessage()
 
-    /** Split [paneId] in [tabId] left/right — new pane on the right (controller role only). */
+    /**
+     * Split [paneId] in [tabId] into left/right panes (vertical divider) — the host's
+     * "Split Left/Right". Controller role only.
+     */
     @Serializable
-    @SerialName("splitRight")
-    data class SplitRight(val tabId: String, val paneId: String) : ClientMessage()
+    @SerialName("splitVertical")
+    data class SplitVertical(val tabId: String, val paneId: String) : ClientMessage()
 
-    /** Split [paneId] in [tabId] top/bottom — new pane below (controller role only). */
+    /**
+     * Split [paneId] in [tabId] into top/bottom panes (horizontal divider) — the host's
+     * "Split Top/Bottom". Controller role only.
+     */
     @Serializable
-    @SerialName("splitDown")
-    data class SplitDown(val tabId: String, val paneId: String) : ClientMessage()
+    @SerialName("splitHorizontal")
+    data class SplitHorizontal(val tabId: String, val paneId: String) : ClientMessage()
 
     /** Close [paneId] in [tabId]; closes the tab if it's the last pane (controller role only). */
     @Serializable

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -41,6 +41,11 @@ sealed class ServerMessage {
         val activeTabId: String?,
         /** Host's tab-bar orientation, so the viewer mirrors it: true = left (vertical), false = top. */
         val tabBarOnLeft: Boolean = false,
+        /**
+         * Host's `tabBarSummaryMode`: true = one chip per tab (active pane, tab title);
+         * false (default) = one chip per split pane (the viewer shows per-pane sub-tabs).
+         */
+        val summaryMode: Boolean = false,
     ) : ServerMessage()
 
     /** One-time initial paint for a pane: scrollback+screen as a raw escape/text blob. */
@@ -126,10 +131,20 @@ sealed class PaneTreeNode {
     @SerialName("split")
     data class Split(val dir: String, val ratio: Float, val a: PaneTreeNode, val b: PaneTreeNode) : PaneTreeNode()
 
-    /** A leaf terminal pane. */
+    /**
+     * A leaf terminal pane. [color] (CSS accent) and [branch] (git branch) mirror the
+     * host's per-pane chip styling in the left bar's per-split sub-tabs; both optional.
+     */
     @Serializable
     @SerialName("pane")
-    data class Pane(val paneId: String, val title: String, val cwd: String?, val focused: Boolean) : PaneTreeNode()
+    data class Pane(
+        val paneId: String,
+        val title: String,
+        val cwd: String?,
+        val focused: Boolean,
+        val color: String? = null,
+        val branch: String? = null,
+    ) : PaneTreeNode()
 }
 
 /** Viewer → host messages. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareSheet.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareSheet.kt
@@ -1,0 +1,105 @@
+package ai.rever.bossterm.compose.share
+
+import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * Opens the macOS native Share sheet (AirDrop / Messages / Mail / Notes / Copy…) for a
+ * share link, so it can be sent straight to a phone. Implemented out-of-process via a
+ * small JXA (`osascript -l JavaScript`) helper that presents an `NSSharingServicePicker`
+ * anchored at the mouse: keeping it out of our JVM means a failure there can't crash or
+ * hang BossTerm, and AppKit threading stays in the helper's own process. macOS only —
+ * callers fall back to copying the link elsewhere.
+ */
+object ShareSheet {
+    private val log = LoggerFactory.getLogger(ShareSheet::class.java)
+
+    @Volatile private var scriptFile: File? = null
+
+    /** True on macOS, where the native share sheet exists. */
+    fun isSupported(): Boolean = ShellCustomizationUtils.isMacOS()
+
+    /**
+     * Launch the share sheet for [url] (non-blocking). Returns true if the helper was
+     * started; false on non-macOS or any launch failure, so callers can fall back (copy).
+     */
+    fun share(url: String): Boolean {
+        if (!isSupported() || url.isBlank()) return false
+        return try {
+            val script = scriptFile ?: writeScript().also { scriptFile = it }
+            // watchdog (120s) bounds the helper's lifetime even if the user walks away.
+            ProcessBuilder("osascript", "-l", "JavaScript", script.absolutePath, url, "120")
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+            true
+        } catch (t: Throwable) {
+            log.warn("macOS share sheet failed to launch: {}", t.message)
+            false
+        }
+    }
+
+    private fun writeScript(): File {
+        val f = File.createTempFile("bossterm-share", ".js")
+        f.deleteOnExit()
+        f.writeText(JXA)
+        return f
+    }
+
+    // JXA helper. argv[0] = url, argv[1] = watchdog seconds. A transient near-invisible
+    // window at the mouse anchors the popover; a delegate quits the helper shortly after
+    // the user chooses (so the chosen service's own UI takes over) or cancels; a hard
+    // watchdog guarantees it never lingers. ($. / $( ) are literal — not Kotlin templates.)
+    private val JXA = """
+        ObjC.import('AppKit');
+        ObjC.import('Foundation');
+
+        function run(argv) {
+          var urlStr = argv[0];
+          var watchdog = parseFloat(argv[1] || "120");
+          if (!urlStr) return "no-url";
+
+          var app = $.NSApplication.sharedApplication;
+          app.setActivationPolicy($.NSApplicationActivationPolicyAccessory);
+          var term = $.NSSelectorFromString('terminate:');
+
+          var mouse = $.NSEvent.mouseLocation;
+          var rect = $.NSMakeRect(mouse.x, mouse.y, 1, 1);
+          var win = $.NSWindow.alloc.initWithContentRectStyleMaskBackingDefer(
+            rect, 0, $.NSBackingStoreBuffered, false);
+          win.setAlphaValue(0.0);
+          win.makeKeyAndOrderFront(null);
+          app.activateIgnoringOtherApps(true);
+
+          var url = $.NSURL.URLWithString(urlStr);
+          var items = $.NSArray.arrayWithObject(url);
+
+          if (!this.__BT_DELEGATE) {
+            ObjC.registerSubclass({
+              name: 'BTShareDelegate', superclass: 'NSObject',
+              protocols: ['NSSharingServicePickerDelegate'],
+              methods: {
+                'sharingServicePicker:didChooseSharingService:': {
+                  types: ['void', ['id', 'id']],
+                  implementation: function(picker, service) {
+                    var delay = service.isNil() ? 0.0 : 6.0;
+                    $.NSApp.performSelectorWithObjectAfterDelay($.NSSelectorFromString('terminate:'), $(), delay);
+                  }
+                }
+              }
+            });
+            this.__BT_DELEGATE = true;
+          }
+          var del = $.BTShareDelegate.alloc.init;
+
+          var picker = $.NSSharingServicePicker.alloc.initWithItems(items);
+          picker.delegate = del;
+          picker.showRelativeToRectOfViewPreferredEdge($.NSMakeRect(0, 0, 1, 1), win.contentView, 1);
+
+          app.performSelectorWithObjectAfterDelay(term, $(), watchdog);
+          app.run();
+          return "done";
+        }
+    """.trimIndent()
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.DpSize
@@ -78,6 +79,8 @@ fun ShareWindow(
     pendingRequests: List<SessionShareManager.PendingShareRequest> = emptyList(),
     onApproveRequest: (String) -> Unit = {},
     onDenyRequest: (String) -> Unit = {},
+    tailscaleMode: String = "off",
+    onTailscaleModeChange: (String) -> Unit = {},
 ) {
     val clipboard = LocalClipboardManager.current
     val isWindow = info.scope == ShareScope.WINDOW
@@ -184,6 +187,14 @@ fun ShareWindow(
                         )
                     }
                 }
+                Spacer(Modifier.height(20.dp))
+
+                TailscaleSetupSection(
+                    mode = tailscaleMode,
+                    onModeChange = onTailscaleModeChange,
+                    currentUrl = info.url,
+                    clipboard = clipboard,
+                )
 
                 Spacer(Modifier.height(8.dp))
             }
@@ -249,6 +260,114 @@ private fun LinkRow(label: String, url: String, clipboard: ClipboardManager) {
             }
         }
     }
+}
+
+private const val FUNNEL_ACL_SNIPPET =
+    "\"nodeAttrs\": [\n  { \"target\": [\"autogroup:member\"], \"attr\": [\"funnel\"] },\n],"
+
+/**
+ * Collapsible "Remote access (Tailscale)" subsection: pick the mode (Off/Serve/Funnel),
+ * see live status, and the full one-time setup with clickable admin-console links and a
+ * copyable ACL snippet. Surfaces the same steps as Settings → Session Sharing here, where
+ * you actually share. Collapsed by default so it doesn't clutter the common LAN case.
+ */
+@Composable
+private fun TailscaleSetupSection(
+    mode: String,
+    onModeChange: (String) -> Unit,
+    currentUrl: String,
+    clipboard: ClipboardManager,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val active = currentUrl.contains(".ts.net")
+    Column(Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp))
+                .clickable { expanded = !expanded }.padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(if (expanded) "▾" else "▸", color = TextSecondary, fontSize = 13.sp, modifier = Modifier.width(16.dp))
+            Text("Remote access (Tailscale)", color = TextPrimary, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.weight(1f))
+            Text(
+                when {
+                    mode == "off" -> "LAN only"
+                    active -> "$mode · active"
+                    else -> "$mode · not active"
+                },
+                color = if (active) Color(0xFF4CAF50) else TextMuted, fontSize = 11.sp
+            )
+        }
+        if (expanded) {
+            Spacer(Modifier.height(10.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Row(
+                    modifier = Modifier.clip(RoundedCornerShape(6.dp)).background(Track)
+                        .border(1.dp, BorderColor, RoundedCornerShape(6.dp)).padding(2.dp),
+                    horizontalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    Seg("Off", mode == "off") { onModeChange("off") }
+                    Seg("Serve", mode == "serve") { onModeChange("serve") }
+                    Seg("Funnel", mode == "funnel") { onModeChange("funnel") }
+                }
+                Text(
+                    when (mode) {
+                        "serve" -> "Serve = your tailnet only (the viewing device must be signed into your Tailscale)."
+                        "funnel" -> "Funnel = public internet (anyone with the link; no Tailscale needed on their end)."
+                        else -> "Off = LAN/loopback only. Pick Serve (your devices) or Funnel (public) to reach other networks."
+                    },
+                    color = TextMuted, fontSize = 11.sp
+                )
+                if (mode != "off") {
+                    SetupStep(1, "Install Tailscale on this Mac and sign in (menu-bar app, or `tailscale up`).")
+                    SetupStep(2, "Enable HTTPS certificates (required) — admin console → DNS → “Enable HTTPS”. Sign in with the SAME account as this machine, or the page 404s.")
+                    LinkText("Open DNS settings →", "https://login.tailscale.com/admin/dns")
+                    if (mode == "funnel") {
+                        SetupStep(3, "Funnel also needs the Funnel node-attribute in your ACL policy. Add this block and Save:")
+                        LinkText("Open Access controls →", "https://login.tailscale.com/admin/acls/file")
+                        Surface(color = SurfaceColor, shape = RoundedCornerShape(6.dp), modifier = Modifier.fillMaxWidth()) {
+                            Column(Modifier.padding(horizontal = 10.dp, vertical = 8.dp)) {
+                                SelectionContainer {
+                                    Text(FUNNEL_ACL_SNIPPET, fontSize = 11.sp, color = TextSecondary, fontFamily = FontFamily.Monospace)
+                                }
+                                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                                    TextButton(
+                                        onClick = { clipboard.setText(AnnotatedString(FUNNEL_ACL_SNIPPET)) },
+                                        colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
+                                    ) { Text("Copy") }
+                                }
+                            }
+                        }
+                    }
+                    SetupStep(if (mode == "funnel") 4 else 3, "After enabling, wait ~1 min (DNS / policy propagation), then Stop + Share again — the links above upgrade to https://<host>.ts.net.")
+                    if (!active) {
+                        Text(
+                            "Not active yet — the links above still use the LAN address. Finish the steps, then re-share.",
+                            color = TextMuted, fontSize = 11.sp
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SetupStep(n: Int, text: String) {
+    Row(verticalAlignment = Alignment.Top) {
+        Text("$n.", color = TextSecondary, fontSize = 11.sp, modifier = Modifier.width(18.dp))
+        Text(text, color = TextSecondary, fontSize = 11.sp, modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun LinkText(text: String, url: String) {
+    Text(
+        text, color = AccentColor, fontSize = 11.sp,
+        modifier = Modifier.padding(start = 18.dp).clickable {
+            runCatching { java.awt.Desktop.getDesktop().browse(java.net.URI(url)) }
+        }
+    )
 }
 
 /** Render [text] as a QR code into a Compose [ImageBitmap], or null on failure. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -37,7 +37,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -280,6 +284,18 @@ private fun TailscaleSetupSection(
 ) {
     var expanded by remember { mutableStateOf(false) }
     val active = currentUrl.contains(".ts.net")
+    // Tailscale-install detection + one-click Homebrew install. Checked lazily on expand,
+    // off the UI thread (the probes shell out to `tailscale`/`brew`).
+    var installed by remember { mutableStateOf<Boolean?>(null) } // null = not yet checked
+    var brewOk by remember { mutableStateOf(true) }
+    var installing by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    LaunchedEffect(expanded, installing) {
+        if (expanded && installed == null && !installing) {
+            installed = withContext(Dispatchers.IO) { TailscaleExposer.isInstalled() }
+            if (installed == false) brewOk = withContext(Dispatchers.IO) { TailscaleExposer.brewAvailable() }
+        }
+    }
     Column(Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp))
@@ -319,7 +335,19 @@ private fun TailscaleSetupSection(
                     color = TextMuted, fontSize = 11.sp
                 )
                 if (mode != "off") {
-                    SetupStep(1, "Install Tailscale on this Mac and sign in (menu-bar app, or `tailscale up`).")
+                    TailscaleInstallRow(
+                        installed = installed,
+                        installing = installing,
+                        brewOk = brewOk,
+                        onInstall = {
+                            installing = true
+                            scope.launch {
+                                withContext(Dispatchers.IO) { TailscaleExposer.brewInstall() }
+                                installed = withContext(Dispatchers.IO) { TailscaleExposer.isInstalled() }
+                                installing = false
+                            }
+                        }
+                    )
                     SetupStep(2, "Enable HTTPS certificates (required) — admin console → DNS → “Enable HTTPS”. Sign in with the SAME account as this machine, or the page 404s.")
                     LinkText("Open DNS settings →", "https://login.tailscale.com/admin/dns")
                     if (mode == "funnel") {
@@ -347,6 +375,47 @@ private fun TailscaleSetupSection(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+/** Step 1 of the Tailscale setup: live install check + a one-click `brew install tailscale`. */
+@Composable
+private fun TailscaleInstallRow(
+    installed: Boolean?,
+    installing: Boolean,
+    brewOk: Boolean,
+    onInstall: () -> Unit,
+) {
+    Surface(color = SurfaceColor, shape = RoundedCornerShape(6.dp), modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text("1. Tailscale", color = TextMuted, fontSize = 11.sp)
+                Text(
+                    when {
+                        installing -> "Installing via Homebrew… (this can take a minute)"
+                        installed == null -> "Checking…"
+                        installed == true -> "Installed ✓ — now sign in (menu-bar app, or `tailscale up`)."
+                        brewOk -> "Not found — install it, then sign in."
+                        else -> "Not found, and Homebrew isn't available — install manually."
+                    },
+                    color = if (installed == true) Color(0xFF4CAF50) else TextSecondary, fontSize = 11.sp
+                )
+                if (installed == false && !brewOk && !installing) {
+                    LinkText("Download Tailscale →", "https://tailscale.com/download")
+                }
+            }
+            if (installed == false && brewOk) {
+                Button(
+                    onClick = onInstall,
+                    enabled = !installing,
+                    colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                ) { Text(if (installing) "Installing…" else "Install") }
             }
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,6 +48,7 @@ import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -72,6 +74,7 @@ fun ShareWindow(
     onDismiss: () -> Unit,
     onStop: () -> Unit,
     onScopeChange: (ShareScope) -> Unit,
+    focusTick: Int = 0,
 ) {
     val clipboard = LocalClipboardManager.current
     val isWindow = info.scope == ShareScope.WINDOW
@@ -86,6 +89,12 @@ fun ShareWindow(
         resizable = false,
         state = rememberWindowState(size = DpSize(600.dp, 680.dp))
     ) {
+        // Bring this window to the front whenever the share button is clicked again
+        // (focusTick changes) so an already-open share window is raised, not left behind.
+        LaunchedEffect(focusTick) {
+            window.toFront()
+            window.requestFocus()
+        }
         Surface(color = BackgroundColor, modifier = Modifier.fillMaxSize()) {
           Column(modifier = Modifier.fillMaxSize()) {
             // Scrollable content fills the space above the pinned footer.
@@ -100,33 +109,50 @@ fun ShareWindow(
                 )
                 Spacer(Modifier.height(20.dp))
 
-                SettingsSection("Scope") {
-                    SegToggle("Tab", "Window", rightSelected = isWindow) { win ->
-                        onScopeChange(if (win) ShareScope.WINDOW else ShareScope.TAB)
+                SettingsSection("QR code") {
+                    // QR first, then the View/Control toggle below it, then the caption —
+                    // all centered so their left/right margins match.
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        if (qr != null) {
+                            Image(
+                                bitmap = qr,
+                                contentDescription = if (controlQr) "Control link QR" else "View link QR",
+                                modifier = Modifier.size(210.dp).background(Color.White).padding(10.dp)
+                            )
+                        }
+                        SegToggle("View", "Control", rightSelected = controlQr) { controlQr = it }
+                        Text(
+                            if (controlQr) "QR encodes the Control link — scanning grants typing access."
+                            else "QR encodes the View link (read-only).",
+                            color = if (controlQr) Danger else TextMuted, fontSize = 11.sp,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
                     }
-                    Text(
-                        if (isWindow) "Sharing all tabs in this window — switchable in the viewer, with splits."
-                        else "Sharing this tab and its splits.",
-                        color = TextMuted, fontSize = 11.sp
-                    )
                 }
                 Spacer(Modifier.height(20.dp))
 
-                SettingsSection("QR code") {
-                    SegToggle("View", "Control", rightSelected = controlQr) { controlQr = it }
-                    if (qr != null) {
-                        Image(
-                            bitmap = qr,
-                            contentDescription = if (controlQr) "Control link QR" else "View link QR",
-                            modifier = Modifier.size(210.dp).align(Alignment.CenterHorizontally)
-                                .background(Color.White).padding(10.dp)
+                SettingsSection("Scope") {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        SegToggle("Tab", "Window", rightSelected = isWindow) { win ->
+                            onScopeChange(if (win) ShareScope.WINDOW else ShareScope.TAB)
+                        }
+                        Text(
+                            if (isWindow) "Sharing all tabs in this window — switchable in the viewer, with splits."
+                            else "Sharing this tab and its splits.",
+                            color = TextMuted, fontSize = 11.sp,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
                         )
                     }
-                    Text(
-                        if (controlQr) "QR encodes the Control link — scanning grants typing access."
-                        else "QR encodes the View link (read-only).",
-                        color = if (controlQr) Danger else TextMuted, fontSize = 11.sp
-                    )
                 }
                 Spacer(Modifier.height(20.dp))
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -100,6 +101,17 @@ fun ShareWindow(
     var refreshing by remember { mutableStateOf(false) }
     LaunchedEffect(info.url) { refreshing = false }
     LaunchedEffect(refreshing) { if (refreshing) { kotlinx.coroutines.delay(35_000); refreshing = false } }
+    // Inline "↻ Refresh link" action for the QR + Links headers — shown only when a remote
+    // provider is selected (the LAN link never changes). Mints a fresh tunnel link.
+    val refreshAction: (@Composable () -> Unit)? = if (tailscaleMode != "off") {
+        {
+            TextButton(
+                onClick = { refreshing = true; onRefreshLink() },
+                enabled = !refreshing,
+                colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
+            ) { Text(if (refreshing) "Refreshing…" else "↻ Refresh link", fontSize = 12.sp) }
+        }
+    } else null
     val qrUrl = if (controlQr) info.controlUrl else info.url
     val qr = remember(qrUrl) { qrImageBitmap(qrUrl) }
 
@@ -137,7 +149,7 @@ fun ShareWindow(
                     Spacer(Modifier.height(20.dp))
                 }
 
-                SettingsSection("QR code") {
+                ShareSection("QR code", headerAction = refreshAction) {
                     // QR first, then the View/Control toggle below it, then the caption —
                     // all centered so their left/right margins match.
                     Column(
@@ -184,7 +196,7 @@ fun ShareWindow(
                 }
                 Spacer(Modifier.height(20.dp))
 
-                SettingsSection("Links") {
+                ShareSection("Links", headerAction = refreshAction) {
                     LinkRow("View (read-only)", info.url, clipboard)
                     LinkRow("Control (can type)", info.controlUrl, clipboard)
                     Text(
@@ -200,23 +212,11 @@ fun ShareWindow(
                             color = Danger, fontSize = 11.sp
                         )
                     }
-                    // Remote (tunnel) links are ephemeral — let the host mint a fresh one.
-                    if (tailscaleMode != "off") {
-                        Spacer(Modifier.height(2.dp))
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            TextButton(
-                                onClick = { refreshing = true; onRefreshLink() },
-                                enabled = !refreshing,
-                                colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
-                            ) { Text(if (refreshing) "Refreshing…" else "↻ Refresh link") }
-                            Spacer(Modifier.width(4.dp))
-                            Text(
-                                if (tailscaleMode == "cloudflare")
-                                    "Generates a new public link; the current one stops working."
-                                else "Re-establishes the tunnel if the link stopped working.",
-                                color = TextMuted, fontSize = 11.sp, modifier = Modifier.weight(1f)
-                            )
-                        }
+                    if (tailscaleMode == "cloudflare") {
+                        Text(
+                            "The public link is ephemeral — use ↻ Refresh link (above) to mint a new one.",
+                            color = TextMuted, fontSize = 11.sp
+                        )
                     }
                 }
                 Spacer(Modifier.height(20.dp))
@@ -246,6 +246,32 @@ fun ShareWindow(
             }
           }
         }
+    }
+}
+
+/**
+ * Like [SettingsSection] but with an optional [headerAction] rendered inline at the end
+ * of the title row (used for the QR + Links sections' "↻ Refresh link" button).
+ */
+@Composable
+private fun ShareSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    headerAction: (@Composable () -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(title, color = TextPrimary, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+            if (headerAction != null) {
+                Spacer(Modifier.weight(1f))
+                headerAction()
+            }
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp), content = content)
     }
 }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -89,11 +89,17 @@ fun ShareWindow(
     onDenyRequest: (String) -> Unit = {},
     tailscaleMode: String = "off",
     onTailscaleModeChange: (String) -> Unit = {},
+    onRefreshLink: () -> Unit = {},
 ) {
     val clipboard = LocalClipboardManager.current
     val isWindow = info.scope == ShareScope.WINDOW
     val loopbackOnly = info.url.contains("://127.0.0.1") || info.url.contains("://localhost")
     var controlQr by remember { mutableStateOf(false) }
+    // "Refresh link" regenerates the remote tunnel (ephemeral for Cloudflare). Clears when
+    // the URL updates (the dialog refreshes via remoteUrlFlow) or after a timeout fallback.
+    var refreshing by remember { mutableStateOf(false) }
+    LaunchedEffect(info.url) { refreshing = false }
+    LaunchedEffect(refreshing) { if (refreshing) { kotlinx.coroutines.delay(35_000); refreshing = false } }
     val qrUrl = if (controlQr) info.controlUrl else info.url
     val qr = remember(qrUrl) { qrImageBitmap(qrUrl) }
 
@@ -193,6 +199,24 @@ fun ShareWindow(
                             "⚠ Not encrypted — this link is plaintext. Use https (Tailscale Funnel / a TLS tunnel) beyond your trusted LAN.",
                             color = Danger, fontSize = 11.sp
                         )
+                    }
+                    // Remote (tunnel) links are ephemeral — let the host mint a fresh one.
+                    if (tailscaleMode != "off") {
+                        Spacer(Modifier.height(2.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            TextButton(
+                                onClick = { refreshing = true; onRefreshLink() },
+                                enabled = !refreshing,
+                                colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
+                            ) { Text(if (refreshing) "Refreshing…" else "↻ Refresh link") }
+                            Spacer(Modifier.width(4.dp))
+                            Text(
+                                if (tailscaleMode == "cloudflare")
+                                    "Generates a new public link; the current one stops working."
+                                else "Re-establishes the tunnel if the link stopped working.",
+                                color = TextMuted, fontSize = 11.sp, modifier = Modifier.weight(1f)
+                            )
+                        }
                     }
                 }
                 Spacer(Modifier.height(20.dp))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -75,6 +75,9 @@ fun ShareWindow(
     onStop: () -> Unit,
     onScopeChange: (ShareScope) -> Unit,
     focusTick: Int = 0,
+    pendingRequests: List<SessionShareManager.PendingShareRequest> = emptyList(),
+    onApproveRequest: (String) -> Unit = {},
+    onDenyRequest: (String) -> Unit = {},
 ) {
     val clipboard = LocalClipboardManager.current
     val isWindow = info.scope == ShareScope.WINDOW
@@ -108,6 +111,14 @@ fun ShareWindow(
                     color = TextSecondary, fontSize = 12.sp
                 )
                 Spacer(Modifier.height(20.dp))
+
+                // Devices waiting for approval surface first so the host acts on them.
+                if (pendingRequests.isNotEmpty()) {
+                    SettingsSection("Pending requests") {
+                        PendingRequestsList(pendingRequests, onApproveRequest, onDenyRequest)
+                    }
+                    Spacer(Modifier.height(20.dp))
+                }
 
                 SettingsSection("QR code") {
                     // QR first, then the View/Control toggle below it, then the caption —

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -27,8 +27,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ArrowRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -310,7 +314,13 @@ private fun RemoteAccessSetupSection(
                 .clickable { expanded = !expanded }.padding(vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(if (expanded) "▾" else "▸", color = TextSecondary, fontSize = 18.sp, modifier = Modifier.width(22.dp))
+            Icon(
+                imageVector = if (expanded) Icons.Default.ArrowDropDown else Icons.Default.ArrowRight,
+                contentDescription = if (expanded) "Collapse" else "Expand",
+                tint = TextSecondary,
+                modifier = Modifier.size(28.dp)
+            )
+            Spacer(Modifier.width(2.dp))
             Text("Remote access", color = TextPrimary, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
             Spacer(Modifier.weight(1f))
             Text(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -101,17 +101,30 @@ fun ShareWindow(
     var refreshing by remember { mutableStateOf(false) }
     LaunchedEffect(info.url) { refreshing = false }
     LaunchedEffect(refreshing) { if (refreshing) { kotlinx.coroutines.delay(35_000); refreshing = false } }
-    // Inline "↻ Refresh link" action for the QR + Links headers — shown only when a remote
-    // provider is selected (the LAN link never changes). Mints a fresh tunnel link.
-    val refreshAction: (@Composable () -> Unit)? = if (tailscaleMode != "off") {
+    // Inline actions for the QR + Links headers: "↻ Refresh link" (only when a remote
+    // provider is selected — the LAN link never changes) and "⤴ Share" (macOS native
+    // share sheet → AirDrop/Messages/Mail; falls back to copying if the helper can't run).
+    val hasRefresh = tailscaleMode != "off"
+    val canShare = ShareSheet.isSupported()
+    val headerActions: (@Composable () -> Unit)? = if (!hasRefresh && !canShare) null else {
         {
-            TextButton(
-                onClick = { refreshing = true; onRefreshLink() },
-                enabled = !refreshing,
-                colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
-            ) { Text(if (refreshing) "Refreshing…" else "↻ Refresh link", fontSize = 12.sp) }
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                if (hasRefresh) {
+                    TextButton(
+                        onClick = { refreshing = true; onRefreshLink() },
+                        enabled = !refreshing,
+                        colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
+                    ) { Text(if (refreshing) "Refreshing…" else "↻ Refresh link", fontSize = 12.sp) }
+                }
+                if (canShare) {
+                    TextButton(
+                        onClick = { if (!ShareSheet.share(info.url)) clipboard.setText(AnnotatedString(info.url)) },
+                        colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
+                    ) { Text("⤴ Share", fontSize = 12.sp) }
+                }
+            }
         }
-    } else null
+    }
     val qrUrl = if (controlQr) info.controlUrl else info.url
     val qr = remember(qrUrl) { qrImageBitmap(qrUrl) }
 
@@ -149,7 +162,7 @@ fun ShareWindow(
                     Spacer(Modifier.height(20.dp))
                 }
 
-                ShareSection("QR code", headerAction = refreshAction) {
+                ShareSection("QR code", headerAction = headerActions) {
                     // QR first, then the View/Control toggle below it, then the caption —
                     // all centered so their left/right margins match.
                     Column(
@@ -196,7 +209,7 @@ fun ShareWindow(
                 }
                 Spacer(Modifier.height(20.dp))
 
-                ShareSection("Links", headerAction = refreshAction) {
+                ShareSection("Links", headerAction = headerActions) {
                     LinkRow("View (read-only)", info.url, clipboard)
                     LinkRow("Control (can type)", info.controlUrl, clipboard)
                     Text(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -310,7 +310,7 @@ private fun RemoteAccessSetupSection(
                 .clickable { expanded = !expanded }.padding(vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(if (expanded) "▾" else "▸", color = TextSecondary, fontSize = 13.sp, modifier = Modifier.width(16.dp))
+            Text(if (expanded) "▾" else "▸", color = TextSecondary, fontSize = 18.sp, modifier = Modifier.width(22.dp))
             Text("Remote access", color = TextPrimary, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
             Spacer(Modifier.weight(1f))
             Text(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -193,7 +193,7 @@ fun ShareWindow(
                 }
                 Spacer(Modifier.height(20.dp))
 
-                TailscaleSetupSection(
+                RemoteAccessSetupSection(
                     mode = tailscaleMode,
                     onModeChange = onTailscaleModeChange,
                     currentUrl = info.url,
@@ -276,24 +276,32 @@ private const val FUNNEL_ACL_SNIPPET =
  * you actually share. Collapsed by default so it doesn't clutter the common LAN case.
  */
 @Composable
-private fun TailscaleSetupSection(
+private fun RemoteAccessSetupSection(
     mode: String,
     onModeChange: (String) -> Unit,
     currentUrl: String,
     clipboard: ClipboardManager,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val active = currentUrl.contains(".ts.net")
-    // Tailscale-install detection + one-click Homebrew install. Checked lazily on expand,
-    // off the UI thread (the probes shell out to `tailscale`/`brew`).
-    var installed by remember { mutableStateOf<Boolean?>(null) } // null = not yet checked
+    val active = currentUrl.contains(".ts.net") || currentUrl.contains(".trycloudflare.com")
+    val isCloudflare = mode == "cloudflare"
+    val tool = if (isCloudflare) "cloudflared" else "Tailscale"
+    // Install detection + one-click Homebrew install for the selected provider's CLI.
+    // Checked off the UI thread (the probes shell out to the CLI / brew); re-checked when
+    // the mode changes (so switching Tailscale↔Cloudflare re-probes the right binary).
+    var installed by remember { mutableStateOf<Boolean?>(null) }
     var brewOk by remember { mutableStateOf(true) }
     var installing by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
-    LaunchedEffect(expanded, installing) {
-        if (expanded && installed == null && !installing) {
-            installed = withContext(Dispatchers.IO) { TailscaleExposer.isInstalled() }
-            if (installed == false) brewOk = withContext(Dispatchers.IO) { TailscaleExposer.brewAvailable() }
+    fun toolInstalled() = if (isCloudflare) CloudflaredExposer.isInstalled() else TailscaleExposer.isInstalled()
+    fun toolBrewOk() = if (isCloudflare) CloudflaredExposer.brewAvailable() else TailscaleExposer.brewAvailable()
+    fun toolBrewInstall() = if (isCloudflare) CloudflaredExposer.brewInstall() else TailscaleExposer.brewInstall()
+    LaunchedEffect(expanded, mode) {
+        if (expanded && mode != "off" && !installing) {
+            installed = null
+            val ins = withContext(Dispatchers.IO) { toolInstalled() }
+            installed = ins
+            brewOk = if (ins) true else withContext(Dispatchers.IO) { toolBrewOk() }
         }
     }
     Column(Modifier.fillMaxWidth()) {
@@ -303,7 +311,7 @@ private fun TailscaleSetupSection(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(if (expanded) "▾" else "▸", color = TextSecondary, fontSize = 13.sp, modifier = Modifier.width(16.dp))
-            Text("Remote access (Tailscale)", color = TextPrimary, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+            Text("Remote access", color = TextPrimary, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
             Spacer(Modifier.weight(1f))
             Text(
                 when {
@@ -325,52 +333,63 @@ private fun TailscaleSetupSection(
                     Seg("Off", mode == "off") { onModeChange("off") }
                     Seg("Serve", mode == "serve") { onModeChange("serve") }
                     Seg("Funnel", mode == "funnel") { onModeChange("funnel") }
+                    Seg("Cloudflare", isCloudflare) { onModeChange("cloudflare") }
                 }
                 Text(
                     when (mode) {
-                        "serve" -> "Serve = your tailnet only (the viewing device must be signed into your Tailscale)."
-                        "funnel" -> "Funnel = public internet (anyone with the link; no Tailscale needed on their end)."
-                        else -> "Off = LAN/loopback only. Pick Serve (your devices) or Funnel (public) to reach other networks."
+                        "serve" -> "Tailscale Serve = your tailnet only (the viewing device must be signed into your Tailscale)."
+                        "funnel" -> "Tailscale Funnel = public internet (anyone with the link; no Tailscale on their end)."
+                        "cloudflare" -> "Cloudflare = instant public link, no account, no config. Link changes each session (best-effort)."
+                        else -> "Off = LAN/loopback only. Pick a provider to reach other networks."
                     },
                     color = TextMuted, fontSize = 11.sp
                 )
                 if (mode != "off") {
-                    TailscaleInstallRow(
+                    ProviderInstallRow(
+                        label = tool,
+                        downloadUrl = if (isCloudflare)
+                            "https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/"
+                        else "https://tailscale.com/download",
                         installed = installed,
                         installing = installing,
                         brewOk = brewOk,
                         onInstall = {
                             installing = true
                             scope.launch {
-                                withContext(Dispatchers.IO) { TailscaleExposer.brewInstall() }
-                                installed = withContext(Dispatchers.IO) { TailscaleExposer.isInstalled() }
+                                withContext(Dispatchers.IO) { toolBrewInstall() }
+                                installed = withContext(Dispatchers.IO) { toolInstalled() }
                                 installing = false
                             }
                         }
                     )
-                    SetupStep(2, "Enable HTTPS certificates (required) — admin console → DNS → “Enable HTTPS”. Sign in with the SAME account as this machine, or the page 404s.")
-                    LinkText("Open DNS settings →", "https://login.tailscale.com/admin/dns")
-                    if (mode == "funnel") {
-                        SetupStep(3, "Funnel also needs the Funnel node-attribute in your ACL policy. Add this block and Save:")
-                        LinkText("Open Access controls →", "https://login.tailscale.com/admin/acls/file")
-                        Surface(color = SurfaceColor, shape = RoundedCornerShape(6.dp), modifier = Modifier.fillMaxWidth()) {
-                            Column(Modifier.padding(horizontal = 10.dp, vertical = 8.dp)) {
-                                SelectionContainer {
-                                    Text(FUNNEL_ACL_SNIPPET, fontSize = 11.sp, color = TextSecondary, fontFamily = FontFamily.Monospace)
-                                }
-                                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                                    TextButton(
-                                        onClick = { clipboard.setText(AnnotatedString(FUNNEL_ACL_SNIPPET)) },
-                                        colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
-                                    ) { Text("Copy") }
+                    if (isCloudflare) {
+                        SetupStep(2, "That's it — Share, and a public https://…trycloudflare.com link is generated automatically (no account). It appears here in a few seconds and changes each session.")
+                    } else {
+                        SetupStep(2, "Enable HTTPS certificates (required) — admin console → DNS → “Enable HTTPS”. Sign in with the SAME account as this machine, or the page 404s.")
+                        LinkText("Open DNS settings →", "https://login.tailscale.com/admin/dns")
+                        if (mode == "funnel") {
+                            SetupStep(3, "Funnel also needs the Funnel node-attribute in your ACL policy. Add this block and Save:")
+                            LinkText("Open Access controls →", "https://login.tailscale.com/admin/acls/file")
+                            Surface(color = SurfaceColor, shape = RoundedCornerShape(6.dp), modifier = Modifier.fillMaxWidth()) {
+                                Column(Modifier.padding(horizontal = 10.dp, vertical = 8.dp)) {
+                                    SelectionContainer {
+                                        Text(FUNNEL_ACL_SNIPPET, fontSize = 11.sp, color = TextSecondary, fontFamily = FontFamily.Monospace)
+                                    }
+                                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                                        TextButton(
+                                            onClick = { clipboard.setText(AnnotatedString(FUNNEL_ACL_SNIPPET)) },
+                                            colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
+                                        ) { Text("Copy") }
+                                    }
                                 }
                             }
                         }
+                        SetupStep(if (mode == "funnel") 4 else 3, "After enabling, wait ~1 min (DNS / policy propagation), then Stop + Share again — the links above upgrade to https://<host>.ts.net.")
                     }
-                    SetupStep(if (mode == "funnel") 4 else 3, "After enabling, wait ~1 min (DNS / policy propagation), then Stop + Share again — the links above upgrade to https://<host>.ts.net.")
                     if (!active) {
                         Text(
-                            "Not active yet — the links above still use the LAN address. Finish the steps, then re-share.",
+                            "Not active yet — the links above still use the LAN address. " +
+                                if (isCloudflare) "Install cloudflared, then re-share." else "Finish the steps, then re-share.",
                             color = TextMuted, fontSize = 11.sp
                         )
                     }
@@ -380,9 +399,11 @@ private fun TailscaleSetupSection(
     }
 }
 
-/** Step 1 of the Tailscale setup: live install check + a one-click `brew install tailscale`. */
+/** Step 1 of remote-access setup: live install check + a one-click `brew install <tool>`. */
 @Composable
-private fun TailscaleInstallRow(
+private fun ProviderInstallRow(
+    label: String,
+    downloadUrl: String,
     installed: Boolean?,
     installing: Boolean,
     brewOk: Boolean,
@@ -394,20 +415,22 @@ private fun TailscaleInstallRow(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            val isCloudflared = label == "cloudflared"
             Column(Modifier.weight(1f)) {
-                Text("1. Tailscale", color = TextMuted, fontSize = 11.sp)
+                Text("1. $label", color = TextMuted, fontSize = 11.sp)
                 Text(
                     when {
                         installing -> "Installing via Homebrew… (this can take a minute)"
                         installed == null -> "Checking…"
-                        installed == true -> "Installed ✓ — now sign in (menu-bar app, or `tailscale up`)."
-                        brewOk -> "Not found — install it, then sign in."
+                        installed == true -> if (isCloudflared) "Installed ✓ — ready (no sign-in needed)."
+                                             else "Installed ✓ — now sign in (menu-bar app, or `tailscale up`)."
+                        brewOk -> if (isCloudflared) "Not found — install it." else "Not found — install it, then sign in."
                         else -> "Not found, and Homebrew isn't available — install manually."
                     },
                     color = if (installed == true) Color(0xFF4CAF50) else TextSecondary, fontSize = 11.sp
                 )
                 if (installed == false && !brewOk && !installing) {
-                    LinkText("Download Tailscale →", "https://tailscale.com/download")
+                    LinkText("Download $label →", downloadUrl)
                 }
             }
             if (installed == false && brewOk) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TailscaleExposer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TailscaleExposer.kt
@@ -33,6 +33,28 @@ object TailscaleExposer {
     /** Resolve a working `tailscale` binary path, or null if none responds. */
     private fun bin(): String? = candidates.firstOrNull { runCmd(listOf(it, "version"), 3) != null }
 
+    /** True if a working `tailscale` CLI/app is present. Blocking — call off the UI thread. */
+    fun isInstalled(): Boolean = bin() != null
+
+    // Common Homebrew locations (Apple-silicon, Intel, then PATH).
+    private val brewCandidates = listOf("/opt/homebrew/bin/brew", "/usr/local/bin/brew", "brew")
+    private fun brewBin(): String? = brewCandidates.firstOrNull { runCmd(listOf(it, "--version"), 5) != null }
+
+    /** True if Homebrew is available to auto-install Tailscale. Blocking. */
+    fun brewAvailable(): Boolean = brewBin() != null
+
+    /**
+     * Install Tailscale via `brew install tailscale`. Blocking and slow (downloads) —
+     * call off the UI thread. Returns true on success (or if it's already installed).
+     */
+    fun brewInstall(): Boolean {
+        val brew = brewBin() ?: run { log.warn("Homebrew not found; cannot install Tailscale"); return false }
+        log.info("Installing Tailscale: {} install tailscale …", brew)
+        val ok = runCmd(listOf(brew, "install", "tailscale"), 600) != null
+        log.info("`brew install tailscale` {}", if (ok) "succeeded" else "failed")
+        return ok || isInstalled()
+    }
+
     /**
      * Expose [port] via `tailscale serve|funnel --bg`. Returns the published base URL
      * (`https://<magic-dns-name>`) on success, or null if the CLI is missing/fails.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TailscaleExposer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TailscaleExposer.kt
@@ -65,14 +65,29 @@ object TailscaleExposer {
         }.getOrNull()?.takeIf { it.isNotBlank() }
     }
 
-    private fun runCmd(cmd: List<String>, timeoutSec: Long): String? = try {
-        val p = ProcessBuilder(cmd).redirectErrorStream(true).start()
-        val out = p.inputStream.bufferedReader().readText()
-        if (!p.waitFor(timeoutSec, TimeUnit.SECONDS)) {
-            p.destroyForcibly()
+    private fun runCmd(cmd: List<String>, timeoutSec: Long): String? {
+        return try {
+            val p = ProcessBuilder(cmd).redirectErrorStream(true).start()
+            // Close the child's stdin so a CLI that prompts for input (e.g. `tailscale
+            // serve` asking to enable a feature) gets EOF instead of waiting forever.
+            runCatching { p.outputStream.close() }
+            // Drain stdout on a daemon thread. The previous code read to EOF *before*
+            // waitFor(), so a process that never closes its output (a hung `tailscale
+            // serve`) blocked the read indefinitely and the timeout never fired — that
+            // is what froze the UI thread for minutes. Reading off-thread lets waitFor()
+            // own the deadline and destroy the process if it overruns.
+            val sb = StringBuilder()
+            val reader = Thread {
+                runCatching { p.inputStream.bufferedReader().forEachLine { sb.append(it).append('\n') } }
+            }.apply { isDaemon = true; start() }
+            if (!p.waitFor(timeoutSec, TimeUnit.SECONDS)) {
+                p.destroyForcibly()
+                return null
+            }
+            reader.join(500)
+            if (p.exitValue() == 0) sb.toString() else null
+        } catch (e: Exception) {
             null
-        } else if (p.exitValue() == 0) out else null
-    } catch (e: Exception) {
-        null
+        }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -168,8 +168,14 @@ fun TabBar(
             listOf(ContextMenuController.MenuItem(id = "stop_share", label = "Stop Sharing", enabled = true, action = { onStopShare(tabIndex) }))
         } else {
             listOf(
-                ContextMenuController.MenuItem(id = "share_tab", label = "Share Tab…", enabled = true, action = { onShareTab(tabIndex) }),
-                ContextMenuController.MenuItem(id = "share_window", label = "Share Window…", enabled = true, action = { onShareWindow(tabIndex) })
+                ContextMenuController.MenuSubmenu(
+                    id = "share_submenu",
+                    label = "Share",
+                    items = listOf(
+                        ContextMenuController.MenuItem(id = "share_tab", label = "Tab…", enabled = true, action = { onShareTab(tabIndex) }),
+                        ContextMenuController.MenuItem(id = "share_window", label = "Window…", enabled = true, action = { onShareWindow(tabIndex) })
+                    )
+                )
             )
         }
         contextMenuController.showMenu(0f, 0f, items)

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <!-- Allow pinch-zoom + pan so wide/tall terminals are navigable on phones. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>BossTerm — shared session</title>
   <!-- xterm.js vendored locally (works fully offline on a LAN). MIT licensed. -->
   <link rel="stylesheet" href="vendor/xterm.css" />
@@ -23,7 +24,15 @@
     #sidebar { display: none; flex-direction: column; gap: 4px; width: 200px; flex: 0 0 auto; box-sizing: border-box;
                padding: 6px; background: #1e1e1e; border-right: 1px solid #333; overflow-y: auto; }
     #sidebar.show { display: flex; }
-    #stage { flex: 1 1 auto; display: flex; min-width: 0; min-height: 0; }
+    #stage { flex: 1 1 auto; display: flex; min-width: 0; min-height: 0;
+             overflow: auto; -webkit-overflow-scrolling: touch; }
+
+    /* on-screen key bar (mobile): Esc / Tab / Ctrl-combos / arrows, shown with control */
+    #keybar { display: none; flex: 0 0 auto; gap: 6px; padding: 6px 8px; background: #2b2b2b;
+              border-top: 1px solid #404040; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    .keybtn { flex: 0 0 auto; min-width: 42px; padding: 9px 12px; border-radius: 6px; border: 1px solid #505050;
+              background: #1e1e1e; color: #ddd; font-size: 14px; cursor: pointer; -webkit-user-select: none; user-select: none; }
+    .keybtn:active { background: #4a90e2; color: #fff; border-color: #4a90e2; }
 
     /* top tab chips */
     .tab { display: flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 5px; background: #1e1e1e;
@@ -78,6 +87,7 @@
     <div id="sidebar"></div>
     <div id="stage"></div>
   </div>
+  <div id="keybar"></div>
 
   <div id="overlay" style="display:none">
     <div id="overlay-card">

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -16,8 +16,10 @@
            box-sizing: border-box; background: #2b2b2b; border-bottom: 1px solid #404040; font-size: 12px; }
     #status { width: 8px; height: 8px; border-radius: 50%; background: #888; flex: 0 0 auto; }
     #status.live { background: #4caf50; } #status.down { background: #f44336; }
-    #tabbar { display: flex; gap: 4px; overflow-x: auto; flex: 1 1 auto; align-items: center; }
+    #tabbar { display: flex; gap: 12px; overflow-x: auto; flex: 1 1 auto; align-items: center; }
     #tabbar.hidden { display: none; }
+    /* one cluster per tab; panes of a tab sit tight together, tabs spaced apart */
+    .tab-group { display: inline-flex; gap: 3px; align-items: center; flex: 0 0 auto; }
     .badge { padding: 1px 7px; border-radius: 10px; background: #3a3a3a; font-size: 11px; color: #bbb; flex: 0 0 auto; }
 
     #menubtn { display: none; flex: 0 0 auto; padding: 2px 8px; border-radius: 5px; border: 1px solid #404040;
@@ -25,9 +27,11 @@
     #menubtn.show { display: inline-flex; align-items: center; }
 
     #body { flex: 1 1 auto; display: flex; flex-direction: row; min-height: 0; min-width: 0; position: relative; }
-    #sidebar { display: none; flex-direction: column; gap: 4px; width: 200px; flex: 0 0 auto; box-sizing: border-box;
+    #sidebar { display: none; flex-direction: column; gap: 10px; width: 200px; flex: 0 0 auto; box-sizing: border-box;
                padding: 6px; background: #1e1e1e; border-right: 1px solid #333; overflow: auto; -webkit-overflow-scrolling: touch; }
     #sidebar.show { display: flex; }
+    /* one cluster per tab; its per-split sub-tab chips sit tight together */
+    .ltab-group { display: flex; flex-direction: column; gap: 3px; }
     /* On phones the left tab panel becomes a hideable drawer over the terminal (toggled by ☰). */
     @media (max-width: 700px) {
       #sidebar.show { position: absolute; top: 0; bottom: 0; left: 0; z-index: 20; width: 220px;
@@ -66,6 +70,8 @@
     .ltab.active .ltab-title { color: #fff; }
     .ltab-sub { color: #808080; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .ltab-branch { color: #6a9955; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    /* per-split sub-tab chips: indented under their tab to read as nested */
+    .ltab-pane { margin-left: 12px; }
 
     /* close + new-tab affordances (shown only with control) */
     .tabclose { flex: 0 0 auto; color: #707070; font-size: 14px; line-height: 1; padding: 0 3px; border-radius: 3px; }

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -88,6 +88,8 @@
     .ctxitem { padding: 7px 12px; border-radius: 4px; color: #ddd; font-size: 13px; cursor: pointer; white-space: nowrap; }
     .ctxitem:hover { background: #4a90e2; color: #fff; }
     .ctxitem.disabled, .ctxitem.disabled:hover { color: #666; background: transparent; cursor: default; }
+    .ctxitem.ctxsub { padding-left: 24px; font-size: 12px; }
+    .ctxsep { height: 1px; background: #454545; margin: 4px 6px; }
     #overlay { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center;
                background: rgba(20,20,20,0.92); z-index: 10; padding: 24px; }
     #overlay-card { max-width: 360px; text-align: center; background: #2b2b2b; border: 1px solid #404040;

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -45,6 +45,12 @@
               background: #1e1e1e; color: #ddd; font-size: 14px; cursor: pointer; -webkit-user-select: none; user-select: none; }
     .keybtn:active { background: #4a90e2; color: #fff; border-color: #4a90e2; }
 
+    /* zoom controls in the top bar (font size +/- and fit-to-width) */
+    #zoom { display: flex; gap: 4px; flex: 0 0 auto; }
+    #zoom button { padding: 2px 8px; border-radius: 5px; border: 1px solid #404040; background: #1e1e1e;
+                   color: #ddd; font-size: 12px; cursor: pointer; -webkit-user-select: none; user-select: none; }
+    #zoom button:active { background: #4a90e2; color: #fff; border-color: #4a90e2; }
+
     /* top tab chips */
     .tab { display: flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 5px; background: #1e1e1e;
            border: 1px solid #404040; color: #b0b0b0; white-space: nowrap; cursor: pointer; font-size: 12px; }
@@ -94,6 +100,11 @@
     <div id="tabbar"></div>
     <span class="badge" id="viewonly">view only</span>
     <span class="badge" id="presence"></span>
+    <span id="zoom">
+      <button id="zoomout" title="Zoom out">A&minus;</button>
+      <button id="zoomin" title="Zoom in">A+</button>
+      <button id="zoomfit" title="Fit width">Fit</button>
+    </span>
   </div>
   <div id="body">
     <div id="sidebar"></div>

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -10,16 +10,44 @@
     :root { color-scheme: dark; }
     html, body { margin: 0; height: 100%; background: #1e1e1e; color: #ddd;
                  font-family: -apple-system, Menlo, monospace; overflow: hidden; }
-    #bar { display: flex; align-items: center; gap: 8px; padding: 4px 8px; height: 30px;
+    body { display: flex; flex-direction: column; }
+    #bar { display: flex; align-items: center; gap: 8px; padding: 4px 8px; height: 30px; flex: 0 0 auto;
            box-sizing: border-box; background: #2b2b2b; border-bottom: 1px solid #404040; font-size: 12px; }
     #status { width: 8px; height: 8px; border-radius: 50%; background: #888; flex: 0 0 auto; }
     #status.live { background: #4caf50; } #status.down { background: #f44336; }
-    #tabbar { display: flex; gap: 4px; overflow-x: auto; flex: 1 1 auto; }
-    .tab { padding: 2px 10px; border-radius: 5px; background: #1e1e1e; border: 1px solid #404040;
-           color: #b0b0b0; white-space: nowrap; cursor: pointer; font-size: 12px; }
-    .tab.active { background: #2b2b2b; border-color: #4a90e2; color: #fff; }
+    #tabbar { display: flex; gap: 4px; overflow-x: auto; flex: 1 1 auto; align-items: center; }
+    #tabbar.hidden { display: none; }
     .badge { padding: 1px 7px; border-radius: 10px; background: #3a3a3a; font-size: 11px; color: #bbb; flex: 0 0 auto; }
-    #stage { position: absolute; top: 30px; left: 0; right: 0; bottom: 0; display: flex; }
+
+    #body { flex: 1 1 auto; display: flex; flex-direction: row; min-height: 0; min-width: 0; }
+    #sidebar { display: none; flex-direction: column; gap: 4px; width: 200px; flex: 0 0 auto; box-sizing: border-box;
+               padding: 6px; background: #1e1e1e; border-right: 1px solid #333; overflow-y: auto; }
+    #sidebar.show { display: flex; }
+    #stage { flex: 1 1 auto; display: flex; min-width: 0; min-height: 0; }
+
+    /* top tab chips */
+    .tab { display: flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 5px; background: #1e1e1e;
+           border: 1px solid #404040; color: #b0b0b0; white-space: nowrap; cursor: pointer; font-size: 12px; }
+    .tab.active { background: #2b2b2b; border-color: #4a90e2; color: #fff; }
+    .tablabel { max-width: 220px; overflow: hidden; text-overflow: ellipsis; }
+
+    /* left tab chips (Warp-style: title / cwd / branch) */
+    .ltab { display: flex; flex-direction: column; gap: 2px; padding: 6px 8px; border-radius: 6px; background: #1e1e1e;
+            border: 1px solid #404040; cursor: pointer; }
+    .ltab.active { background: #2b2b2b; border-color: #4a90e2; }
+    .ltab-row { display: flex; align-items: center; gap: 6px; }
+    .ltab-title { flex: 1 1 auto; color: #b0b0b0; font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .ltab.active .ltab-title { color: #fff; }
+    .ltab-sub { color: #808080; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .ltab-branch { color: #6a9955; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+    /* close + new-tab affordances (shown only with control) */
+    .tabclose { flex: 0 0 auto; color: #707070; font-size: 14px; line-height: 1; padding: 0 3px; border-radius: 3px; }
+    .tabclose:hover { color: #fff; background: #4a4a4a; }
+    .newtab { flex: 0 0 auto; padding: 2px 9px; border-radius: 5px; border: 1px solid #404040; background: #1e1e1e;
+              color: #b0b0b0; cursor: pointer; font-size: 13px; text-align: center; }
+    .newtab:hover { color: #fff; border-color: #4a90e2; }
+
     .split { display: flex; flex: 1 1 0; min-width: 0; min-height: 0; }
     .split.v { flex-direction: row; }
     .split.h { flex-direction: column; }
@@ -46,7 +74,10 @@
     <span class="badge" id="viewonly">view only</span>
     <span class="badge" id="presence"></span>
   </div>
-  <div id="stage"></div>
+  <div id="body">
+    <div id="sidebar"></div>
+    <div id="stage"></div>
+  </div>
 
   <div id="overlay" style="display:none">
     <div id="overlay-card">

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -20,16 +20,27 @@
     #tabbar.hidden { display: none; }
     .badge { padding: 1px 7px; border-radius: 10px; background: #3a3a3a; font-size: 11px; color: #bbb; flex: 0 0 auto; }
 
-    #body { flex: 1 1 auto; display: flex; flex-direction: row; min-height: 0; min-width: 0; }
+    #menubtn { display: none; flex: 0 0 auto; padding: 2px 8px; border-radius: 5px; border: 1px solid #404040;
+               background: #1e1e1e; color: #ddd; font-size: 15px; line-height: 1; cursor: pointer; }
+    #menubtn.show { display: inline-flex; align-items: center; }
+
+    #body { flex: 1 1 auto; display: flex; flex-direction: row; min-height: 0; min-width: 0; position: relative; }
     #sidebar { display: none; flex-direction: column; gap: 4px; width: 200px; flex: 0 0 auto; box-sizing: border-box;
-               padding: 6px; background: #1e1e1e; border-right: 1px solid #333; overflow-y: auto; }
+               padding: 6px; background: #1e1e1e; border-right: 1px solid #333; overflow: auto; -webkit-overflow-scrolling: touch; }
     #sidebar.show { display: flex; }
+    /* On phones the left tab panel becomes a hideable drawer over the terminal (toggled by ☰). */
+    @media (max-width: 700px) {
+      #sidebar.show { position: absolute; top: 0; bottom: 0; left: 0; z-index: 20; width: 220px;
+                      box-shadow: 2px 0 10px rgba(0,0,0,0.6); transform: translateX(-100%); transition: transform .2s ease; }
+      #sidebar.show.open { transform: translateX(0); }
+    }
     #stage { flex: 1 1 auto; display: flex; min-width: 0; min-height: 0;
              overflow: auto; -webkit-overflow-scrolling: touch; }
 
-    /* on-screen key bar (mobile): Esc / Tab / Ctrl-combos / arrows, shown with control */
-    #keybar { display: none; flex: 0 0 auto; gap: 6px; padding: 6px 8px; background: #2b2b2b;
-              border-top: 1px solid #404040; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    /* on-screen key bar (mobile): Esc / Tab / Ctrl-combos / arrows. Fixed so viewer.js can
+       pin it just above the soft keyboard (via the VisualViewport API). */
+    #keybar { display: none; position: fixed; left: 0; right: 0; bottom: 0; z-index: 30; gap: 6px; padding: 6px 8px;
+              background: #2b2b2b; border-top: 1px solid #404040; overflow-x: auto; -webkit-overflow-scrolling: touch; }
     .keybtn { flex: 0 0 auto; min-width: 42px; padding: 9px 12px; border-radius: 6px; border: 1px solid #505050;
               background: #1e1e1e; color: #ddd; font-size: 14px; cursor: pointer; -webkit-user-select: none; user-select: none; }
     .keybtn:active { background: #4a90e2; color: #fff; border-color: #4a90e2; }
@@ -79,6 +90,7 @@
 <body>
   <div id="bar">
     <span id="status"></span>
+    <button id="menubtn" title="Tabs">☰</button>
     <div id="tabbar"></div>
     <span class="badge" id="viewonly">view only</span>
     <span class="badge" id="presence"></span>

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -28,6 +28,15 @@
             border: 1px solid transparent; }
     .pane.focused { border-color: #4a90e2; }
     .termhost { width: 100%; height: 100%; overflow: hidden; }
+    #overlay { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center;
+               background: rgba(20,20,20,0.92); z-index: 10; padding: 24px; }
+    #overlay-card { max-width: 360px; text-align: center; background: #2b2b2b; border: 1px solid #404040;
+                    border-radius: 10px; padding: 24px 28px; }
+    #overlay-spinner { width: 26px; height: 26px; margin: 0 auto 14px; border: 3px solid #444;
+                       border-top-color: #4a90e2; border-radius: 50%; animation: spin 0.9s linear infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    #overlay-title { font-size: 15px; color: #fff; margin-bottom: 6px; }
+    #overlay-msg { font-size: 12px; color: #b0b0b0; line-height: 1.5; }
   </style>
 </head>
 <body>
@@ -38,6 +47,14 @@
     <span class="badge" id="presence"></span>
   </div>
   <div id="stage"></div>
+
+  <div id="overlay" style="display:none">
+    <div id="overlay-card">
+      <div id="overlay-spinner"></div>
+      <div id="overlay-title">Waiting for host approval…</div>
+      <div id="overlay-msg"></div>
+    </div>
+  </div>
 
   <script src="vendor/xterm.js"></script>
   <script src="viewer.js"></script>

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -74,6 +74,15 @@
               color: #b0b0b0; cursor: pointer; font-size: 13px; text-align: center; }
     .newtab:hover { color: #fff; border-color: #4a90e2; }
 
+    /* tab-bar split buttons (Split L/R, Split T/B) — mirror the host's tab-bar actions */
+    .splitbtn { flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center;
+                padding: 2px 6px; border-radius: 5px; border: 1px solid #404040; background: #1e1e1e;
+                color: #b0b0b0; cursor: pointer; }
+    .splitbtn:hover { color: #fff; border-color: #4a90e2; }
+    .splitbtn svg { display: block; }
+    .ltab-actions { display: flex; gap: 4px; align-items: center; margin-top: 4px; }
+    .ltab-actions .newtab { flex: 1 1 auto; }
+
     .split { display: flex; flex: 1 1 0; min-width: 0; min-height: 0; }
     .split.v { flex-direction: row; }
     .split.h { flex-direction: column; }

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -105,6 +105,8 @@
     .ctxitem.disabled, .ctxitem.disabled:hover { color: #666; background: transparent; cursor: default; }
     .ctxitem.ctxsub { padding-left: 24px; font-size: 12px; }
     .ctxsep { height: 1px; background: #454545; margin: 4px 6px; }
+    .ctxswatch { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 8px;
+                 vertical-align: middle; border: 1px solid rgba(255,255,255,0.25); }
     #overlay { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center;
                background: rgba(20,20,20,0.92); z-index: 10; padding: 24px; }
     #overlay-card { max-width: 360px; text-align: center; background: #2b2b2b; border: 1px solid #404040;

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -82,6 +82,12 @@
             border: 1px solid transparent; }
     .pane.focused { border-color: #4a90e2; }
     .termhost { width: 100%; height: 100%; overflow: hidden; }
+    /* right-click / long-press context menu */
+    #ctxmenu { position: fixed; z-index: 40; display: none; min-width: 168px; background: #2b2b2b;
+               border: 1px solid #505050; border-radius: 6px; padding: 4px; box-shadow: 0 6px 18px rgba(0,0,0,0.55); }
+    .ctxitem { padding: 7px 12px; border-radius: 4px; color: #ddd; font-size: 13px; cursor: pointer; white-space: nowrap; }
+    .ctxitem:hover { background: #4a90e2; color: #fff; }
+    .ctxitem.disabled, .ctxitem.disabled:hover { color: #666; background: transparent; cursor: default; }
     #overlay { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center;
                background: rgba(20,20,20,0.92); z-index: 10; padding: 24px; }
     #overlay-card { max-width: 360px; text-align: center; background: #2b2b2b; border: 1px solid #404040;
@@ -111,6 +117,7 @@
     <div id="stage"></div>
   </div>
   <div id="keybar"></div>
+  <div id="ctxmenu"></div>
 
   <div id="overlay" style="display:none">
     <div id="overlay-card">

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -108,6 +108,31 @@
   window.addEventListener("resize", relayoutSinglePane);
   window.addEventListener("orientationchange", relayoutSinglePane);
 
+  // ---- zoom (viewer-local font size) ----
+  var viewerFont = 0; // 0 = use the host/theme size
+  function activeTabNode() {
+    if (!layout) return null;
+    for (var i = 0; i < layout.tabs.length; i++) if (layout.tabs[i].id === activeTabId) return layout.tabs[i];
+    return layout.tabs[0] || null;
+  }
+  function curFont() { return viewerFont || (theme && theme.fontSize) || 13; }
+  function applyFont(px) {
+    viewerFont = Math.max(6, Math.min(40, Math.round(px)));
+    Object.keys(panes).forEach(function (id) { try { panes[id].term.options.fontSize = viewerFont; } catch (e) {} });
+    relayoutSinglePane();
+  }
+  // Fit the active pane's font so the whole width shows (zoom-out to fit).
+  function fitWidth() {
+    var tab = activeTabNode(); if (!tab || !tab.tree || tab.tree.t !== "pane") return;
+    var p = panes[tab.tree.paneId]; if (!p) return;
+    var screen = p.host.querySelector(".xterm-screen"); if (!screen) return;
+    var avail = stageEl.clientWidth - 2, w = screen.getBoundingClientRect().width;
+    if (avail > 0 && w > 0) applyFont(curFont() * (avail / w));
+  }
+  document.getElementById("zoomin").onclick = function () { applyFont(curFont() + 1); };
+  document.getElementById("zoomout").onclick = function () { applyFont(curFont() - 1); };
+  document.getElementById("zoomfit").onclick = fitWidth;
+
   function setStatus(cls) { statusEl.className = cls; }
 
   if (!token) {
@@ -175,6 +200,7 @@
       ta.setAttribute("autocapitalize", "off");
       ta.setAttribute("spellcheck", "false");
     }
+    if (viewerFont) { try { term.options.fontSize = viewerFont; } catch (e) {} }
     term.onData(function (data) {
       if (controlGranted && ws && ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ t: "input", paneId: paneId, data: data }));
@@ -212,6 +238,8 @@
       document.body.style.background = m.background;
       stageEl.style.background = m.background;
     }
+    // The host theme may carry a fontSize; keep the viewer's chosen zoom if set.
+    if (viewerFont) Object.keys(panes).forEach(function (id) { try { panes[id].term.options.fontSize = viewerFont; } catch (e) {} });
     relayoutSinglePane();
   }
 

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -206,11 +206,11 @@
       var tabId = tab ? tab.id : activeTabId;
       var multiPane = !!(tab && tab.tree && tab.tree.t === "split");
       ctxEl.appendChild(ctxSep());
-      ctxEl.appendChild(ctxItem("Split right", true, function () {
-        sendMsg({ t: "splitRight", tabId: tabId, paneId: paneId });
+      ctxEl.appendChild(ctxItem("Split vertical (left / right)", true, function () {
+        sendMsg({ t: "splitVertical", tabId: tabId, paneId: paneId });
       }));
-      ctxEl.appendChild(ctxItem("Split down", true, function () {
-        sendMsg({ t: "splitDown", tabId: tabId, paneId: paneId });
+      ctxEl.appendChild(ctxItem("Split horizontal (top / bottom)", true, function () {
+        sendMsg({ t: "splitHorizontal", tabId: tabId, paneId: paneId });
       }));
       if (multiPane) ctxEl.appendChild(ctxItem("Close pane", true, function () {
         sendMsg({ t: "closePane", tabId: tabId, paneId: paneId });
@@ -367,15 +367,55 @@
       sidebarEl.classList.add("show"); // .open (drawer) toggled by ☰ on phones
       sidebarEl.innerHTML = "";
       if (layout) layout.tabs.forEach(function (tab) { sidebarEl.appendChild(leftChip(tab)); });
-      if (controlGranted) sidebarEl.appendChild(newTabButton("+ New tab"));
+      // Action row mirroring the host's left bar: Split L/R, Split T/B, then New tab.
+      if (controlGranted) {
+        var actions = document.createElement("div");
+        actions.className = "ltab-actions";
+        actions.appendChild(splitButton("v"));
+        actions.appendChild(splitButton("h"));
+        actions.appendChild(newTabButton("+ New tab"));
+        sidebarEl.appendChild(actions);
+      }
     } else {
       tabbarEl.classList.remove("hidden");
       menubtnEl.classList.remove("show");
       sidebarEl.classList.remove("show", "open");
       tabbarEl.innerHTML = "";
       if (layout) layout.tabs.forEach(function (tab) { tabbarEl.appendChild(topChip(tab)); });
-      if (controlGranted) tabbarEl.appendChild(newTabButton("+"));
+      // Split buttons sit just left of the new-tab (+), like the host's tab-bar actions.
+      if (controlGranted) {
+        tabbarEl.appendChild(splitButton("v"));
+        tabbarEl.appendChild(splitButton("h"));
+        tabbarEl.appendChild(newTabButton("+"));
+      }
     }
+  }
+
+  // Inline SVGs matching the host's Material split icons: a pane outline divided by a
+  // vertical line (left/right) or a horizontal line (top/bottom).
+  var SVG_VSPLIT = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="1"/><line x1="12" y1="4" x2="12" y2="20"/></svg>';
+  var SVG_HSPLIT = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="1"/><line x1="3" y1="12" x2="21" y2="12"/></svg>';
+
+  // The pane a tab-bar split targets: the viewer's current pane if it's in the active
+  // tab, else that tab's focused pane (matches the host splitting the focused pane).
+  function activePaneId() {
+    var tab = activeTabNode(); if (!tab || !tab.tree) return null;
+    if (currentPaneId) { var ids = {}; collectPaneIds(tab.tree, ids); if (ids[currentPaneId]) return currentPaneId; }
+    return firstFocusedPane(tab.tree);
+  }
+  // kind: "v" = Split Left/Right (vertical divider), "h" = Split Top/Bottom (horizontal divider).
+  function splitButton(kind) {
+    var b = document.createElement("div");
+    b.className = "splitbtn";
+    b.title = kind === "v" ? "Split vertical (left / right)" : "Split horizontal (top / bottom)";
+    b.innerHTML = kind === "v" ? SVG_VSPLIT : SVG_HSPLIT;
+    b.onclick = function (ev) {
+      ev.stopPropagation();
+      var tab = activeTabNode(), pid = activePaneId();
+      if (!tab || !pid) return;
+      sendMsg({ t: kind === "v" ? "splitVertical" : "splitHorizontal", tabId: tab.id, paneId: pid });
+    };
+    return b;
   }
 
   function switchTab(id) {

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -20,9 +20,26 @@
   var viewOnlyEl = document.getElementById("viewonly");
 
   var keybarEl = document.getElementById("keybar");
+  var menubtnEl = document.getElementById("menubtn");
+  var bodyEl = document.getElementById("body");
   var tabBarOnLeft = false;       // mirror the host's tab-bar orientation
   var currentPaneId = null;       // pane the on-screen key bar targets
   function sendMsg(o) { if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(o)); }
+
+  // ☰ toggles the left tab drawer (phone); tapping a tab closes it (see switchTab).
+  menubtnEl.onclick = function () { sidebarEl.classList.toggle("open"); };
+
+  // Keep the fixed key bar just above the soft keyboard (and reserve space for it).
+  function layoutForKeyboard() {
+    var vv = window.visualViewport;
+    if (vv) keybarEl.style.bottom = Math.max(0, window.innerHeight - vv.height - vv.offsetTop) + "px";
+    bodyEl.style.paddingBottom = (keybarEl.style.display !== "none" && keybarEl.offsetHeight)
+      ? keybarEl.offsetHeight + "px" : "0px";
+  }
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener("resize", layoutForKeyboard);
+    window.visualViewport.addEventListener("scroll", layoutForKeyboard);
+  }
 
   // ---- on-screen key bar (mobile control keys) ----
   var KEY_ROW = [
@@ -38,7 +55,7 @@
   }
   function buildKeybar() {
     keybarEl.innerHTML = "";
-    if (!controlGranted) { keybarEl.style.display = "none"; return; }
+    if (!controlGranted) { keybarEl.style.display = "none"; layoutForKeyboard(); return; }
     keybarEl.style.display = "flex";
     var kb = document.createElement("button");
     kb.className = "keybtn"; kb.textContent = "⌨"; kb.title = "Show keyboard";
@@ -52,6 +69,7 @@
       b.onclick = function () { sendKey(k[1]); };
       keybarEl.appendChild(b);
     });
+    layoutForKeyboard(); // reserve space + position above the keyboard
   }
   // The focused pane of [node]'s tree (or the first pane), for default key-bar target.
   function firstFocusedPane(node) {
@@ -173,21 +191,28 @@
   // chips) or a top strip. Close + new-tab affordances appear only with control.
   function renderTabBar() {
     if (tabBarOnLeft) {
-      tabbarEl.className = "hidden";
-      sidebarEl.className = "show";
+      tabbarEl.classList.add("hidden");
+      menubtnEl.classList.add("show");
+      sidebarEl.classList.add("show"); // .open (drawer) toggled by ☰ on phones
       sidebarEl.innerHTML = "";
       if (layout) layout.tabs.forEach(function (tab) { sidebarEl.appendChild(leftChip(tab)); });
       if (controlGranted) sidebarEl.appendChild(newTabButton("+ New tab"));
     } else {
-      tabbarEl.className = "";
-      sidebarEl.className = "";
+      tabbarEl.classList.remove("hidden");
+      menubtnEl.classList.remove("show");
+      sidebarEl.classList.remove("show", "open");
       tabbarEl.innerHTML = "";
       if (layout) layout.tabs.forEach(function (tab) { tabbarEl.appendChild(topChip(tab)); });
       if (controlGranted) tabbarEl.appendChild(newTabButton("+"));
     }
   }
 
-  function switchTab(id) { activeTabId = id; renderTabBar(); renderStage(); }
+  function switchTab(id) {
+    activeTabId = id;
+    sidebarEl.classList.remove("open"); // close the phone drawer after picking a tab
+    renderTabBar();
+    renderStage();
+  }
 
   function closeBtn(tabId) {
     var x = document.createElement("span");

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -161,6 +161,13 @@
     { id: "gemini-cli", label: "Gemini CLI" },
     { id: "opencode", label: "OpenCode" }
   ];
+  // Tab accent presets — same names/colors as the host chip menu's Color ▸ submenu.
+  var TAB_COLORS = [
+    { name: "Red", css: "#E06C75" }, { name: "Orange", css: "#D19A66" }, { name: "Yellow", css: "#E5C07B" },
+    { name: "Green", css: "#98C379" }, { name: "Blue", css: "#61AFEF" }, { name: "Purple", css: "#C678DD" },
+    { name: "Gray", css: "#888888" }
+  ];
+  var menuJustOpened = false; // suppress the synthesized mouse event right after open (mobile long-press)
   function hideContextMenu() { ctxEl.style.display = "none"; ctxEl.innerHTML = ""; }
   function ctxItem(label, enabled, onClick, opts) {
     opts = opts || {};
@@ -175,18 +182,20 @@
     return it;
   }
   function ctxSep() { var s = document.createElement("div"); s.className = "ctxsep"; return s; }
+  // Show ctxEl at (x,y), clamped inside the viewport. Re-callable when its height changes.
+  function positionMenu(x, y) {
+    ctxEl.style.left = "0px"; ctxEl.style.top = "0px"; ctxEl.style.display = "block";
+    var w = ctxEl.offsetWidth, h = ctxEl.offsetHeight;
+    ctxEl.style.left = Math.max(0, Math.min(x, window.innerWidth - w - 4)) + "px";
+    ctxEl.style.top = Math.max(0, Math.min(y, window.innerHeight - h - 4)) + "px";
+    menuJustOpened = true; setTimeout(function () { menuJustOpened = false; }, 350);
+  }
   function showContextMenu(x, y, paneId) {
     var p = panes[paneId]; if (!p) return;
     var term = p.term;
     var hasSel = false; try { hasSel = term.hasSelection(); } catch (e) {}
-    // Reposition + clamp inside the viewport (re-run when the menu's height changes,
-    // e.g. the AI submenu expands).
-    function clamp() {
-      ctxEl.style.left = "0px"; ctxEl.style.top = "0px"; ctxEl.style.display = "block";
-      var w = ctxEl.offsetWidth, h = ctxEl.offsetHeight;
-      ctxEl.style.left = Math.max(0, Math.min(x, window.innerWidth - w - 4)) + "px";
-      ctxEl.style.top = Math.max(0, Math.min(y, window.innerHeight - h - 4)) + "px";
-    }
+    // Reposition (re-run when the menu's height changes, e.g. the AI submenu expands).
+    function clamp() { positionMenu(x, y); }
     ctxEl.innerHTML = "";
     ctxEl.appendChild(ctxItem("Copy", hasSel, function () {
       var s = ""; try { s = term.getSelection(); } catch (e) {}
@@ -240,7 +249,73 @@
     ctxEl.appendChild(ctxItem("Scroll to bottom", true, function () { try { term.scrollToBottom(); } catch (e) {} }));
     clamp();
   }
+
+  // Tab-chip context menu — mirrors the host's chip menu (New Tab, Rename…, Color ▸,
+  // Duplicate, Close, Close Other Tabs, Close Tabs Below). All mutate the host, so it's
+  // only attached with control. [pane] null = a whole-tab chip; else a per-split chip.
+  function showTabMenu(x, y, tab, pane) {
+    var pid = pane ? pane.paneId : tab.id;
+    var curTitle = (pane ? pane.title : tab.title) || "";
+    ctxEl.innerHTML = "";
+    ctxEl.appendChild(ctxItem("New Tab", true, function () { sendMsg({ t: "newTab" }); }));
+    ctxEl.appendChild(ctxItem("Rename…", true, function () {
+      var nv = window.prompt("Rename", curTitle);
+      if (nv !== null) sendMsg({ t: "renameTab", tabId: tab.id, paneId: pid, title: nv.trim() });
+    }));
+    // Color ▸ — inline-expanding swatch list + Clear (tap-friendly on mobile).
+    var colorOpen = false, colorBox = document.createElement("div");
+    TAB_COLORS.forEach(function (c) {
+      var it = ctxItem(c.name, true, function () { sendMsg({ t: "setTabColor", tabId: tab.id, paneId: pid, color: c.css }); }, { sub: true });
+      var dot = document.createElement("span"); dot.className = "ctxswatch"; dot.style.background = c.css;
+      it.insertBefore(dot, it.firstChild);
+      colorBox.appendChild(it);
+    });
+    colorBox.appendChild(ctxItem("Clear", true, function () { sendMsg({ t: "setTabColor", tabId: tab.id, paneId: pid, color: null }); }, { sub: true }));
+    colorBox.style.display = "none";
+    var colorParent = ctxItem("Color ▸", true, function (el) {
+      colorOpen = !colorOpen;
+      colorBox.style.display = colorOpen ? "block" : "none";
+      el.textContent = colorOpen ? "Color ▾" : "Color ▸";
+      positionMenu(x, y);
+    }, { keepOpen: true });
+    ctxEl.appendChild(colorParent); ctxEl.appendChild(colorBox);
+    ctxEl.appendChild(ctxSep());
+    ctxEl.appendChild(ctxItem("Duplicate Tab", true, function () { sendMsg({ t: "duplicateTab", tabId: tab.id }); }));
+    ctxEl.appendChild(ctxItem("Close", true, function () {
+      if (pane) sendMsg({ t: "closePane", tabId: tab.id, paneId: pane.paneId });
+      else sendMsg({ t: "closeTab", tabId: tab.id });
+    }));
+    ctxEl.appendChild(ctxItem("Close Other Tabs", true, function () { sendMsg({ t: "closeOtherTabs", tabId: tab.id }); }));
+    ctxEl.appendChild(ctxItem("Close Tabs Below", true, function () { sendMsg({ t: "closeTabsBelow", tabId: tab.id }); }));
+    positionMenu(x, y);
+  }
+
+  // Open the tab menu on right-click (desktop) or long-press (mobile) of a chip.
+  function attachChipMenu(el, tab, pane) {
+    if (!controlGranted) return; // every item mutates the host
+    el.addEventListener("contextmenu", function (e) {
+      e.preventDefault(); e.stopPropagation(); showTabMenu(e.clientX, e.clientY, tab, pane);
+    });
+    var t = null, sx = 0, sy = 0;
+    el.addEventListener("touchstart", function (e) {
+      if (!e.touches || e.touches.length !== 1) return;
+      sx = e.touches[0].clientX; sy = e.touches[0].clientY;
+      t = setTimeout(function () { t = null; showTabMenu(sx, sy, tab, pane); }, 500);
+    }, { passive: true });
+    function cancel(e) {
+      if (t && e && e.touches && e.touches[0]) {
+        var dx = Math.abs(e.touches[0].clientX - sx), dy = Math.abs(e.touches[0].clientY - sy);
+        if (dx < 10 && dy < 10) return;
+      }
+      if (t) { clearTimeout(t); t = null; }
+    }
+    el.addEventListener("touchmove", cancel, { passive: true });
+    el.addEventListener("touchend", cancel);
+    el.addEventListener("touchcancel", cancel);
+  }
+
   document.addEventListener("mousedown", function (e) {
+    if (menuJustOpened) return; // ignore the synthesized click that follows a long-press
     if (ctxEl.style.display === "block" && !ctxEl.contains(e.target)) hideContextMenu();
   });
   document.addEventListener("keydown", function (e) { if (e.key === "Escape") hideContextMenu(); });
@@ -487,6 +562,7 @@
     el.appendChild(label);
     if (controlGranted) el.appendChild(closeBtn(tab.id, isPane ? pane.paneId : null));
     el.onclick = function () { selectPane(tab.id, isPane ? pane.paneId : null); };
+    attachChipMenu(el, tab, isPane ? pane : null);
     return el;
   }
 
@@ -511,6 +587,7 @@
     if (cwd) { var s = document.createElement("div"); s.className = "ltab-sub"; s.textContent = abbreviateCwd(cwd); el.appendChild(s); }
     if (branch) { var b = document.createElement("div"); b.className = "ltab-branch"; b.textContent = "⎇ " + branch; el.appendChild(b); }
     el.onclick = function () { selectPane(tab.id, isPane ? pane.paneId : null); };
+    attachChipMenu(el, tab, isPane ? pane : null);
     return el;
   }
 

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -24,10 +24,11 @@
   var bodyEl = document.getElementById("body");
   var ctxEl = document.getElementById("ctxmenu");
   var tabBarOnLeft = false;       // mirror the host's tab-bar orientation
+  var summaryMode = false;        // host's tabBarSummaryMode: 1 chip/tab vs 1 chip/pane
   var currentPaneId = null;       // pane the on-screen key bar targets
   function sendMsg(o) { if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(o)); }
 
-  // ☰ toggles the left tab drawer (phone); tapping a tab closes it (see switchTab).
+  // ☰ toggles the left tab drawer (phone); tapping a tab closes it (see selectPane).
   menubtnEl.onclick = function () { sidebarEl.classList.toggle("open"); };
 
   // Keep the fixed key bar just above the soft keyboard (and reserve space for it).
@@ -366,7 +367,18 @@
       menubtnEl.classList.add("show");
       sidebarEl.classList.add("show"); // .open (drawer) toggled by ☰ on phones
       sidebarEl.innerHTML = "";
-      if (layout) layout.tabs.forEach(function (tab) { sidebarEl.appendChild(leftChip(tab)); });
+      // One cluster per tab: per-pane sub-tab chips when the tab is split (and the host
+      // isn't in summary mode), otherwise a single tab-level chip — like the host.
+      if (layout) layout.tabs.forEach(function (tab) {
+        var group = document.createElement("div"); group.className = "ltab-group";
+        var ps = []; panesInOrder(tab.tree, ps);
+        if (!summaryMode && tab.tree && tab.tree.t === "split") {
+          ps.forEach(function (pane) { group.appendChild(leftChip(tab, pane)); });
+        } else {
+          group.appendChild(leftChip(tab, null));
+        }
+        sidebarEl.appendChild(group);
+      });
       // Action row mirroring the host's left bar: Split L/R, Split T/B, then New tab.
       if (controlGranted) {
         var actions = document.createElement("div");
@@ -381,7 +393,16 @@
       menubtnEl.classList.remove("show");
       sidebarEl.classList.remove("show", "open");
       tabbarEl.innerHTML = "";
-      if (layout) layout.tabs.forEach(function (tab) { tabbarEl.appendChild(topChip(tab)); });
+      if (layout) layout.tabs.forEach(function (tab) {
+        var grp = document.createElement("div"); grp.className = "tab-group";
+        var ps = []; panesInOrder(tab.tree, ps);
+        if (!summaryMode && tab.tree && tab.tree.t === "split") {
+          ps.forEach(function (pane) { grp.appendChild(topChip(tab, pane)); });
+        } else {
+          grp.appendChild(topChip(tab, null));
+        }
+        tabbarEl.appendChild(grp);
+      });
       // Split buttons sit just left of the new-tab (+), like the host's tab-bar actions.
       if (controlGranted) {
         tabbarEl.appendChild(splitButton("v"));
@@ -389,6 +410,21 @@
         tabbarEl.appendChild(newTabButton("+"));
       }
     }
+  }
+
+  // Panes of a tab in split-tree order (left/top before right/bottom).
+  function panesInOrder(node, out) {
+    if (!node) return;
+    if (node.t === "pane") out.push(node);
+    else { panesInOrder(node.a, out); panesInOrder(node.b, out); }
+  }
+  // Select a tab (and, for a sub-tab chip, the specific pane) as the viewer's target.
+  function selectPane(tabId, paneId) {
+    activeTabId = tabId;
+    if (paneId) currentPaneId = paneId;
+    sidebarEl.classList.remove("open"); // close the phone drawer after picking
+    renderTabBar();
+    renderStage();
   }
 
   // Inline SVGs matching the host's Material split icons: a pane outline divided by a
@@ -418,17 +454,15 @@
     return b;
   }
 
-  function switchTab(id) {
-    activeTabId = id;
-    sidebarEl.classList.remove("open"); // close the phone drawer after picking a tab
-    renderTabBar();
-    renderStage();
-  }
-
-  function closeBtn(tabId) {
+  // Close affordance: closes a single pane (sub-tab chip) or the whole tab (tab chip).
+  function closeBtn(tabId, paneId) {
     var x = document.createElement("span");
-    x.className = "tabclose"; x.textContent = "×"; x.title = "Close tab";
-    x.onclick = function (ev) { ev.stopPropagation(); sendMsg({ t: "closeTab", tabId: tabId }); };
+    x.className = "tabclose"; x.textContent = "×"; x.title = paneId ? "Close pane" : "Close tab";
+    x.onclick = function (ev) {
+      ev.stopPropagation();
+      if (paneId) sendMsg({ t: "closePane", tabId: tabId, paneId: paneId });
+      else sendMsg({ t: "closeTab", tabId: tabId });
+    };
     return x;
   }
 
@@ -439,30 +473,44 @@
     return el;
   }
 
-  function topChip(tab) {
+  // A top-bar chip. [pane] null = whole-tab chip; otherwise a per-split sub-tab chip.
+  function topChip(tab, pane) {
+    var isPane = !!pane;
+    var color = isPane ? pane.color : tab.color;
+    var active = isPane ? (tab.id === activeTabId && pane.paneId === currentPaneId)
+                        : (tab.id === activeTabId);
     var el = document.createElement("div");
-    el.className = "tab" + (tab.id === activeTabId ? " active" : "");
-    if (tab.color) el.style.borderLeft = "3px solid " + tab.color;
+    el.className = "tab" + (active ? " active" : "");
+    if (color) el.style.borderLeft = "3px solid " + color;
     var label = document.createElement("span");
-    label.className = "tablabel"; label.textContent = tab.title || "shell";
+    label.className = "tablabel"; label.textContent = (isPane ? pane.title : tab.title) || "shell";
     el.appendChild(label);
-    if (controlGranted) el.appendChild(closeBtn(tab.id));
-    el.onclick = function () { switchTab(tab.id); };
+    if (controlGranted) el.appendChild(closeBtn(tab.id, isPane ? pane.paneId : null));
+    el.onclick = function () { selectPane(tab.id, isPane ? pane.paneId : null); };
     return el;
   }
 
-  function leftChip(tab) {
+  // A left-bar (Warp-style) chip. [pane] null = whole-tab chip; otherwise a per-split
+  // sub-tab chip (title / cwd / branch / accent come from that pane).
+  function leftChip(tab, pane) {
+    var isPane = !!pane;
+    var color = isPane ? pane.color : tab.color;
+    var cwd = isPane ? pane.cwd : tab.cwd;
+    var branch = isPane ? pane.branch : tab.branch;
+    var active = isPane ? (tab.id === activeTabId && pane.paneId === currentPaneId)
+                        : (tab.id === activeTabId);
     var el = document.createElement("div");
-    el.className = "ltab" + (tab.id === activeTabId ? " active" : "");
-    if (tab.color) el.style.borderLeft = "3px solid " + tab.color;
+    el.className = "ltab" + (active ? " active" : "") + (isPane ? " ltab-pane" : "");
+    if (color) el.style.borderLeft = "3px solid " + color;
     var row = document.createElement("div"); row.className = "ltab-row";
-    var title = document.createElement("span"); title.className = "ltab-title"; title.textContent = tab.title || "shell";
+    var title = document.createElement("span"); title.className = "ltab-title";
+    title.textContent = (isPane ? pane.title : tab.title) || "shell";
     row.appendChild(title);
-    if (controlGranted) row.appendChild(closeBtn(tab.id));
+    if (controlGranted) row.appendChild(closeBtn(tab.id, isPane ? pane.paneId : null));
     el.appendChild(row);
-    if (tab.cwd) { var s = document.createElement("div"); s.className = "ltab-sub"; s.textContent = abbreviateCwd(tab.cwd); el.appendChild(s); }
-    if (tab.branch) { var b = document.createElement("div"); b.className = "ltab-branch"; b.textContent = "⎇ " + tab.branch; el.appendChild(b); }
-    el.onclick = function () { switchTab(tab.id); };
+    if (cwd) { var s = document.createElement("div"); s.className = "ltab-sub"; s.textContent = abbreviateCwd(cwd); el.appendChild(s); }
+    if (branch) { var b = document.createElement("div"); b.className = "ltab-branch"; b.textContent = "⎇ " + branch; el.appendChild(b); }
+    el.onclick = function () { selectPane(tab.id, isPane ? pane.paneId : null); };
     return el;
   }
 
@@ -541,6 +589,7 @@
   function onLayout(m) {
     layout = m;
     tabBarOnLeft = !!m.tabBarOnLeft;
+    summaryMode = !!m.summaryMode;
     var ids = m.tabs.map(function (t) { return t.id; });
     if (activeTabId === null || ids.indexOf(activeTabId) === -1) {
       activeTabId = m.activeTabId && ids.indexOf(m.activeTabId) !== -1 ? m.activeTabId : (ids[0] || null);

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -88,28 +88,25 @@
   var activeTabId = null;         // client-side selected tab
   var panes = {};                 // paneId -> { term, host(el) }
   var ws = null;
-  var baseFontSize = 13;          // host's intended font size; fit never exceeds it
-
-  // Auto-fit a pane's font so the host's full column width is visible (zoom-out to fit),
-  // never larger than the host's size. Linear in fontSize since the grid is monospace;
-  // pinch-zoom still works on top for reading detail. Vertical overflow scrolls.
-  function fitPane(p) {
-    if (!p) return;
-    var pane = p.host.parentElement; if (!pane) return;
-    var screen = p.host.querySelector(".xterm-screen"); if (!screen) return;
-    var avail = pane.clientWidth - 2;
-    var w = screen.getBoundingClientRect().width;
-    if (avail <= 0 || w <= 0) return;
-    var cur = (p.term.options && p.term.options.fontSize) || baseFontSize;
-    var target = Math.max(6, Math.min(baseFontSize, Math.floor(cur * (avail / w))));
-    if (target !== cur) { try { p.term.options.fontSize = target; } catch (e) {} }
+  // Give the active single pane its NATURAL width so a wide host terminal scrolls
+  // horizontally inside #stage. (xterm's own viewport is a y-scroll container that clips
+  // x, so we can't get native horizontal scroll from it — instead we expose the full
+  // width by sizing the pane to content and letting #stage scroll both axes. Vertical
+  // scrollback stays inside xterm; pinch-zoom works on top. Splits keep the fill layout.)
+  function relayoutSinglePane() {
+    if (!layout) return;
+    var tab = null, i;
+    for (i = 0; i < layout.tabs.length; i++) if (layout.tabs[i].id === activeTabId) tab = layout.tabs[i];
+    if (!tab) tab = layout.tabs[0];
+    if (!tab || !tab.tree || tab.tree.t !== "pane") return;
+    var p = panes[tab.tree.paneId]; if (!p) return;
+    requestAnimationFrame(function () {
+      var sc = p.host.querySelector(".xterm-screen");
+      if (sc) { var w = Math.ceil(sc.getBoundingClientRect().width); if (w > 0) p.host.style.width = w + "px"; }
+    });
   }
-  function fitAll() {
-    requestAnimationFrame(function () { Object.keys(panes).forEach(function (id) { fitPane(panes[id]); }); });
-  }
-  window.addEventListener("resize", fitAll);
-  window.addEventListener("orientationchange", fitAll);
-  if (window.visualViewport) window.visualViewport.addEventListener("resize", fitAll);
+  window.addEventListener("resize", relayoutSinglePane);
+  window.addEventListener("orientationchange", relayoutSinglePane);
 
   function setStatus(cls) { statusEl.className = cls; }
 
@@ -203,7 +200,6 @@
 
   function applyTheme(m) {
     theme = m;
-    if (m.fontSize) baseFontSize = m.fontSize;
     Object.keys(panes).forEach(function (id) {
       var o = {}; applyThemeToOpts(o);
       var t = panes[id].term;
@@ -216,7 +212,7 @@
       document.body.style.background = m.background;
       stageEl.style.background = m.background;
     }
-    fitAll();
+    relayoutSinglePane();
   }
 
   // ---- layout rendering ----
@@ -324,9 +320,18 @@
     var ids = {}; collectPaneIds(tab.tree, ids);
     if (!currentPaneId || !ids[currentPaneId]) currentPaneId = firstFocusedPane(tab.tree);
     var root = buildNode(tab.tree);
-    root.style.flex = "1 1 0";
+    if (tab.tree.t === "pane") {
+      // single pane → natural width, scrollable in #stage (don't stretch/clip)
+      root.style.flex = "0 0 auto";
+      root.style.height = "100%";
+      root.style.overflow = "visible";
+      var sp = panes[tab.tree.paneId];
+      if (sp) { sp.host.style.overflow = "visible"; sp.host.style.height = "100%"; }
+    } else {
+      root.style.flex = "1 1 0"; // splits fill the stage
+    }
     stageEl.appendChild(root);
-    fitAll(); // re-fit fonts to the (re)rendered panes' widths
+    relayoutSinglePane(); // size a single pane to its natural width for horizontal scroll
   }
 
   function onLayout(m) {
@@ -384,12 +389,12 @@
         if (m.cols && m.rows) p.term.resize(m.cols, m.rows);
         p.term.reset();
         if (m.data) p.term.write(m.data);
-        fitPane(p);
+        relayoutSinglePane();
         break;
       }
       case "paneOutput": if (m.data) getPane(m.paneId).term.write(m.data); break;
       case "paneResize":
-        if (m.cols && m.rows) { var rp = getPane(m.paneId); rp.term.resize(m.cols, m.rows); fitPane(rp); }
+        if (m.cols && m.rows) { getPane(m.paneId).term.resize(m.cols, m.rows); relayoutSinglePane(); }
         break;
       case "presence":
         presenceEl.textContent = m.viewers === 1 ? "1 viewer" : m.viewers + " viewers"; break;

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -32,6 +32,45 @@
     return;
   }
 
+  // ---- approval handshake (issue #276) ----
+  // Stable per-browser id so the host recognizes this device across reconnects.
+  var clientId = localStorage.getItem("bossterm.clientId");
+  if (!clientId) {
+    clientId = (window.crypto && crypto.randomUUID) ? crypto.randomUUID()
+             : String(Date.now()) + "-" + Math.random().toString(16).slice(2);
+    localStorage.setItem("bossterm.clientId", clientId);
+  }
+  // A previously granted access key (per share token), replayed to skip re-approval.
+  var keyStore = "bossterm.key." + token;
+  function loadKey() {
+    try {
+      var o = JSON.parse(localStorage.getItem(keyStore) || "null");
+      if (o && o.key && o.expiresAt > Date.now()) return o.key;
+      localStorage.removeItem(keyStore);
+    } catch (e) {}
+    return null;
+  }
+  function saveKey(key, expiresAt) {
+    try { localStorage.setItem(keyStore, JSON.stringify({ key: key, expiresAt: expiresAt })); } catch (e) {}
+  }
+  function clearKey() { try { localStorage.removeItem(keyStore); } catch (e) {} }
+
+  var overlayEl = document.getElementById("overlay");
+  var overlayTitleEl = document.getElementById("overlay-title");
+  var overlayMsgEl = document.getElementById("overlay-msg");
+  var overlaySpinnerEl = document.getElementById("overlay-spinner");
+  function showOverlay(title, msg, spinning) {
+    overlayTitleEl.textContent = title;
+    overlayMsgEl.textContent = msg || "";
+    overlaySpinnerEl.style.display = spinning ? "" : "none";
+    overlayEl.style.display = "";
+  }
+  function hideOverlay() { overlayEl.style.display = "none"; }
+
+  function deviceName() {
+    return localStorage.getItem("bossterm.name") || navigator.platform || "browser";
+  }
+
   // ---- xterm pool ----
   function getPane(paneId) {
     var p = panes[paneId];
@@ -152,14 +191,28 @@
 
   ws.onopen = function () {
     setStatus("live");
-    ws.send(JSON.stringify({ t: "hello", name: navigator.platform || "browser" }));
+    ws.send(JSON.stringify({ t: "hello", name: deviceName(), clientId: clientId, key: loadKey() }));
   };
 
   ws.onmessage = function (ev) {
     var m; try { m = JSON.parse(ev.data); } catch (e) { return; }
     switch (m.t) {
+      case "pending":
+        showOverlay("Waiting for host approval…",
+          "Ask the person sharing in BossTerm to approve this device. This window will connect automatically once they do.",
+          true);
+        break;
+      case "grant":
+        // Approved (or refreshed): persist the rolling key and dismiss the overlay.
+        if (m.key) saveKey(m.key, m.expiresAt);
+        hideOverlay();
+        break;
+      case "denied":
+        clearKey();
+        showOverlay("Request denied", m.reason || "The host declined this device.", false);
+        break;
       case "theme": applyTheme(m); break;
-      case "layout": onLayout(m); break;
+      case "layout": hideOverlay(); onLayout(m); break;
       case "paneSnapshot": {
         var p = getPane(m.paneId);
         if (m.cols && m.rows) p.term.resize(m.cols, m.rows);

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -147,6 +147,15 @@
     if (theme) applyThemeToOpts(opts);
     var term = new Terminal(opts);
     term.open(host);
+    // Terminals want raw keystrokes — disable the soft keyboard's autocorrect /
+    // predictive-text / autocapitalize / spellcheck on xterm's hidden input.
+    var ta = term.textarea || host.querySelector(".xterm-helper-textarea");
+    if (ta) {
+      ta.setAttribute("autocomplete", "off");
+      ta.setAttribute("autocorrect", "off");
+      ta.setAttribute("autocapitalize", "off");
+      ta.setAttribute("spellcheck", "false");
+    }
     term.onData(function (data) {
       if (controlGranted && ws && ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ t: "input", paneId: paneId, data: data }));

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -19,8 +19,50 @@
   var presenceEl = document.getElementById("presence");
   var viewOnlyEl = document.getElementById("viewonly");
 
+  var keybarEl = document.getElementById("keybar");
   var tabBarOnLeft = false;       // mirror the host's tab-bar orientation
+  var currentPaneId = null;       // pane the on-screen key bar targets
   function sendMsg(o) { if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(o)); }
+
+  // ---- on-screen key bar (mobile control keys) ----
+  var KEY_ROW = [
+    ["Esc", "\x1b"], ["Tab", "\t"], ["^C", "\x03"], ["^D", "\x04"], ["^Z", "\x1a"], ["^L", "\x0c"],
+    ["←", "\x1b[D"], ["↑", "\x1b[A"], ["↓", "\x1b[B"], ["→", "\x1b[C"]
+  ];
+  function focusCurrent() {
+    if (currentPaneId && panes[currentPaneId]) { try { panes[currentPaneId].term.focus(); } catch (e) {} }
+  }
+  function sendKey(seq) {
+    if (!controlGranted || !currentPaneId) return;
+    sendMsg({ t: "input", paneId: currentPaneId, data: seq });
+  }
+  function buildKeybar() {
+    keybarEl.innerHTML = "";
+    if (!controlGranted) { keybarEl.style.display = "none"; return; }
+    keybarEl.style.display = "flex";
+    var kb = document.createElement("button");
+    kb.className = "keybtn"; kb.textContent = "⌨"; kb.title = "Show keyboard";
+    kb.onclick = focusCurrent;
+    keybarEl.appendChild(kb);
+    KEY_ROW.forEach(function (k) {
+      var b = document.createElement("button");
+      b.className = "keybtn"; b.textContent = k[0];
+      // Don't steal focus from the terminal's input, so the soft keyboard stays up.
+      b.addEventListener("mousedown", function (e) { e.preventDefault(); });
+      b.onclick = function () { sendKey(k[1]); };
+      keybarEl.appendChild(b);
+    });
+  }
+  // The focused pane of [node]'s tree (or the first pane), for default key-bar target.
+  function firstFocusedPane(node) {
+    var found = null, first = null;
+    (function walk(n) {
+      if (!n) return;
+      if (n.t === "pane") { if (first === null) first = n.paneId; if (n.focused) found = n.paneId; }
+      else { walk(n.a); walk(n.b); }
+    })(node);
+    return found || first;
+  }
 
   var controlGranted = false;
   var theme = null;               // last Theme message
@@ -199,6 +241,8 @@
       var wrap = document.createElement("div");
       wrap.className = "pane" + (node.focused ? " focused" : "");
       wrap.appendChild(getPane(node.paneId).host);
+      // Tapping a pane makes it the key-bar / typing target.
+      wrap.addEventListener("pointerdown", function () { currentPaneId = node.paneId; });
       return wrap;
     }
     // split
@@ -218,6 +262,9 @@
     if (!layout) return;
     var tab = layout.tabs.filter(function (t) { return t.id === activeTabId; })[0] || layout.tabs[0];
     if (!tab) return;
+    // Keep the key-bar target on a pane that's actually visible in this tab.
+    var ids = {}; collectPaneIds(tab.tree, ids);
+    if (!currentPaneId || !ids[currentPaneId]) currentPaneId = firstFocusedPane(tab.tree);
     var root = buildNode(tab.tree);
     root.style.flex = "1 1 0";
     stageEl.appendChild(root);
@@ -288,6 +335,7 @@
         controlGranted = !!m.granted;
         viewOnlyEl.style.display = controlGranted ? "none" : "";
         renderTabBar(); // show/hide the close + new-tab affordances
+        buildKeybar();  // show/hide the on-screen control-key bar
         break;
     }
   };

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -14,9 +14,13 @@
 
   var statusEl = document.getElementById("status");
   var tabbarEl = document.getElementById("tabbar");
+  var sidebarEl = document.getElementById("sidebar");
   var stageEl = document.getElementById("stage");
   var presenceEl = document.getElementById("presence");
   var viewOnlyEl = document.getElementById("viewonly");
+
+  var tabBarOnLeft = false;       // mirror the host's tab-bar orientation
+  function sendMsg(o) { if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(o)); }
 
   var controlGranted = false;
   var theme = null;               // last Theme message
@@ -123,16 +127,71 @@
   }
 
   // ---- layout rendering ----
+  // Render the tab bar to mirror the host: a left column (Warp-style title/cwd/branch
+  // chips) or a top strip. Close + new-tab affordances appear only with control.
   function renderTabBar() {
-    tabbarEl.innerHTML = "";
-    if (!layout) return;
-    layout.tabs.forEach(function (tab) {
-      var el = document.createElement("div");
-      el.className = "tab" + (tab.id === activeTabId ? " active" : "");
-      el.textContent = tab.title || "shell";
-      el.onclick = function () { activeTabId = tab.id; renderTabBar(); renderStage(); };
-      tabbarEl.appendChild(el);
-    });
+    if (tabBarOnLeft) {
+      tabbarEl.className = "hidden";
+      sidebarEl.className = "show";
+      sidebarEl.innerHTML = "";
+      if (layout) layout.tabs.forEach(function (tab) { sidebarEl.appendChild(leftChip(tab)); });
+      if (controlGranted) sidebarEl.appendChild(newTabButton("+ New tab"));
+    } else {
+      tabbarEl.className = "";
+      sidebarEl.className = "";
+      tabbarEl.innerHTML = "";
+      if (layout) layout.tabs.forEach(function (tab) { tabbarEl.appendChild(topChip(tab)); });
+      if (controlGranted) tabbarEl.appendChild(newTabButton("+"));
+    }
+  }
+
+  function switchTab(id) { activeTabId = id; renderTabBar(); renderStage(); }
+
+  function closeBtn(tabId) {
+    var x = document.createElement("span");
+    x.className = "tabclose"; x.textContent = "×"; x.title = "Close tab";
+    x.onclick = function (ev) { ev.stopPropagation(); sendMsg({ t: "closeTab", tabId: tabId }); };
+    return x;
+  }
+
+  function newTabButton(label) {
+    var el = document.createElement("div");
+    el.className = "newtab"; el.textContent = label; el.title = "New tab";
+    el.onclick = function () { sendMsg({ t: "newTab" }); };
+    return el;
+  }
+
+  function topChip(tab) {
+    var el = document.createElement("div");
+    el.className = "tab" + (tab.id === activeTabId ? " active" : "");
+    if (tab.color) el.style.borderLeft = "3px solid " + tab.color;
+    var label = document.createElement("span");
+    label.className = "tablabel"; label.textContent = tab.title || "shell";
+    el.appendChild(label);
+    if (controlGranted) el.appendChild(closeBtn(tab.id));
+    el.onclick = function () { switchTab(tab.id); };
+    return el;
+  }
+
+  function leftChip(tab) {
+    var el = document.createElement("div");
+    el.className = "ltab" + (tab.id === activeTabId ? " active" : "");
+    if (tab.color) el.style.borderLeft = "3px solid " + tab.color;
+    var row = document.createElement("div"); row.className = "ltab-row";
+    var title = document.createElement("span"); title.className = "ltab-title"; title.textContent = tab.title || "shell";
+    row.appendChild(title);
+    if (controlGranted) row.appendChild(closeBtn(tab.id));
+    el.appendChild(row);
+    if (tab.cwd) { var s = document.createElement("div"); s.className = "ltab-sub"; s.textContent = abbreviateCwd(tab.cwd); el.appendChild(s); }
+    if (tab.branch) { var b = document.createElement("div"); b.className = "ltab-branch"; b.textContent = "⎇ " + tab.branch; el.appendChild(b); }
+    el.onclick = function () { switchTab(tab.id); };
+    return el;
+  }
+
+  function abbreviateCwd(p) {
+    var parts = p.split("/").filter(Boolean);
+    if (parts.length <= 2) return p;
+    return "…/" + parts.slice(-2).join("/");
   }
 
   function buildNode(node) {
@@ -166,6 +225,7 @@
 
   function onLayout(m) {
     layout = m;
+    tabBarOnLeft = !!m.tabBarOnLeft;
     var ids = m.tabs.map(function (t) { return t.id; });
     if (activeTabId === null || ids.indexOf(activeTabId) === -1) {
       activeTabId = m.activeTabId && ids.indexOf(m.activeTabId) !== -1 ? m.activeTabId : (ids[0] || null);
@@ -227,6 +287,7 @@
       case "control":
         controlGranted = !!m.granted;
         viewOnlyEl.style.display = controlGranted ? "none" : "";
+        renderTabBar(); // show/hide the close + new-tab affordances
         break;
     }
   };

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -88,6 +88,28 @@
   var activeTabId = null;         // client-side selected tab
   var panes = {};                 // paneId -> { term, host(el) }
   var ws = null;
+  var baseFontSize = 13;          // host's intended font size; fit never exceeds it
+
+  // Auto-fit a pane's font so the host's full column width is visible (zoom-out to fit),
+  // never larger than the host's size. Linear in fontSize since the grid is monospace;
+  // pinch-zoom still works on top for reading detail. Vertical overflow scrolls.
+  function fitPane(p) {
+    if (!p) return;
+    var pane = p.host.parentElement; if (!pane) return;
+    var screen = p.host.querySelector(".xterm-screen"); if (!screen) return;
+    var avail = pane.clientWidth - 2;
+    var w = screen.getBoundingClientRect().width;
+    if (avail <= 0 || w <= 0) return;
+    var cur = (p.term.options && p.term.options.fontSize) || baseFontSize;
+    var target = Math.max(6, Math.min(baseFontSize, Math.floor(cur * (avail / w))));
+    if (target !== cur) { try { p.term.options.fontSize = target; } catch (e) {} }
+  }
+  function fitAll() {
+    requestAnimationFrame(function () { Object.keys(panes).forEach(function (id) { fitPane(panes[id]); }); });
+  }
+  window.addEventListener("resize", fitAll);
+  window.addEventListener("orientationchange", fitAll);
+  if (window.visualViewport) window.visualViewport.addEventListener("resize", fitAll);
 
   function setStatus(cls) { statusEl.className = cls; }
 
@@ -181,6 +203,7 @@
 
   function applyTheme(m) {
     theme = m;
+    if (m.fontSize) baseFontSize = m.fontSize;
     Object.keys(panes).forEach(function (id) {
       var o = {}; applyThemeToOpts(o);
       var t = panes[id].term;
@@ -193,6 +216,7 @@
       document.body.style.background = m.background;
       stageEl.style.background = m.background;
     }
+    fitAll();
   }
 
   // ---- layout rendering ----
@@ -302,6 +326,7 @@
     var root = buildNode(tab.tree);
     root.style.flex = "1 1 0";
     stageEl.appendChild(root);
+    fitAll(); // re-fit fonts to the (re)rendered panes' widths
   }
 
   function onLayout(m) {
@@ -359,10 +384,13 @@
         if (m.cols && m.rows) p.term.resize(m.cols, m.rows);
         p.term.reset();
         if (m.data) p.term.write(m.data);
+        fitPane(p);
         break;
       }
       case "paneOutput": if (m.data) getPane(m.paneId).term.write(m.data); break;
-      case "paneResize": if (m.cols && m.rows) getPane(m.paneId).term.resize(m.cols, m.rows); break;
+      case "paneResize":
+        if (m.cols && m.rows) { var rp = getPane(m.paneId); rp.term.resize(m.cols, m.rows); fitPane(rp); }
+        break;
       case "presence":
         presenceEl.textContent = m.viewers === 1 ? "1 viewer" : m.viewers + " viewers"; break;
       case "control":

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -152,20 +152,40 @@
       document.execCommand("copy"); document.body.removeChild(ta);
     } catch (e) {}
   }
+  // AI assistants mirrored from the host menu (Tools ▸ AI). Launching one runs the
+  // host's configured command for that assistant in the clicked pane (control only).
+  var AI_ASSISTANTS = [
+    { id: "claude-code", label: "Claude Code" },
+    { id: "codex", label: "Codex" },
+    { id: "gemini-cli", label: "Gemini CLI" },
+    { id: "opencode", label: "OpenCode" }
+  ];
   function hideContextMenu() { ctxEl.style.display = "none"; ctxEl.innerHTML = ""; }
-  function ctxItem(label, enabled, onClick) {
+  function ctxItem(label, enabled, onClick, opts) {
+    opts = opts || {};
     var it = document.createElement("div");
-    it.className = "ctxitem" + (enabled ? "" : " disabled");
+    it.className = "ctxitem" + (enabled ? "" : " disabled") + (opts.sub ? " ctxsub" : "");
     it.textContent = label;
     if (enabled) it.addEventListener("mousedown", function (e) {
-      e.preventDefault(); e.stopPropagation(); hideContextMenu(); onClick();
+      e.preventDefault(); e.stopPropagation();
+      if (!opts.keepOpen) hideContextMenu();
+      onClick(it);
     });
     return it;
   }
+  function ctxSep() { var s = document.createElement("div"); s.className = "ctxsep"; return s; }
   function showContextMenu(x, y, paneId) {
     var p = panes[paneId]; if (!p) return;
     var term = p.term;
     var hasSel = false; try { hasSel = term.hasSelection(); } catch (e) {}
+    // Reposition + clamp inside the viewport (re-run when the menu's height changes,
+    // e.g. the AI submenu expands).
+    function clamp() {
+      ctxEl.style.left = "0px"; ctxEl.style.top = "0px"; ctxEl.style.display = "block";
+      var w = ctxEl.offsetWidth, h = ctxEl.offsetHeight;
+      ctxEl.style.left = Math.max(0, Math.min(x, window.innerWidth - w - 4)) + "px";
+      ctxEl.style.top = Math.max(0, Math.min(y, window.innerHeight - h - 4)) + "px";
+    }
     ctxEl.innerHTML = "";
     ctxEl.appendChild(ctxItem("Copy", hasSel, function () {
       var s = ""; try { s = term.getSelection(); } catch (e) {}
@@ -179,13 +199,45 @@
       }).catch(function () {});
     }));
     ctxEl.appendChild(ctxItem("Select all", true, function () { try { term.selectAll(); } catch (e) {} }));
-    ctxEl.appendChild(ctxItem("Clear scrollback", controlGranted, function () { try { term.clear(); } catch (e) {} }));
+
+    // Splits + AI assistant — host-mutating, so controller role only.
+    if (controlGranted) {
+      var tab = activeTabNode();
+      var tabId = tab ? tab.id : activeTabId;
+      var multiPane = !!(tab && tab.tree && tab.tree.t === "split");
+      ctxEl.appendChild(ctxSep());
+      ctxEl.appendChild(ctxItem("Split right", true, function () {
+        sendMsg({ t: "splitRight", tabId: tabId, paneId: paneId });
+      }));
+      ctxEl.appendChild(ctxItem("Split down", true, function () {
+        sendMsg({ t: "splitDown", tabId: tabId, paneId: paneId });
+      }));
+      if (multiPane) ctxEl.appendChild(ctxItem("Close pane", true, function () {
+        sendMsg({ t: "closePane", tabId: tabId, paneId: paneId });
+      }));
+      // AI assistant submenu: expand inline (click/tap-friendly on mobile too).
+      var aiOpen = false;
+      var aiBox = document.createElement("div");
+      AI_ASSISTANTS.forEach(function (a) {
+        aiBox.appendChild(ctxItem(a.label, true, function () {
+          sendMsg({ t: "launchAI", tabId: tabId, paneId: paneId, assistantId: a.id });
+        }, { sub: true }));
+      });
+      aiBox.style.display = "none";
+      var aiParent = ctxItem("AI assistant ▸", true, function (el) {
+        aiOpen = !aiOpen;
+        aiBox.style.display = aiOpen ? "block" : "none";
+        el.textContent = aiOpen ? "AI assistant ▾" : "AI assistant ▸";
+        clamp(); // height changed
+      }, { keepOpen: true });
+      ctxEl.appendChild(aiParent);
+      ctxEl.appendChild(aiBox);
+    }
+
+    ctxEl.appendChild(ctxSep());
+    if (controlGranted) ctxEl.appendChild(ctxItem("Clear scrollback", true, function () { try { term.clear(); } catch (e) {} }));
     ctxEl.appendChild(ctxItem("Scroll to bottom", true, function () { try { term.scrollToBottom(); } catch (e) {} }));
-    // Show off-screen first to measure, then clamp inside the viewport.
-    ctxEl.style.left = "0px"; ctxEl.style.top = "0px"; ctxEl.style.display = "block";
-    var w = ctxEl.offsetWidth, h = ctxEl.offsetHeight;
-    ctxEl.style.left = Math.max(0, Math.min(x, window.innerWidth - w - 4)) + "px";
-    ctxEl.style.top = Math.max(0, Math.min(y, window.innerHeight - h - 4)) + "px";
+    clamp();
   }
   document.addEventListener("mousedown", function (e) {
     if (ctxEl.style.display === "block" && !ctxEl.contains(e.target)) hideContextMenu();

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -22,6 +22,7 @@
   var keybarEl = document.getElementById("keybar");
   var menubtnEl = document.getElementById("menubtn");
   var bodyEl = document.getElementById("body");
+  var ctxEl = document.getElementById("ctxmenu");
   var tabBarOnLeft = false;       // mirror the host's tab-bar orientation
   var currentPaneId = null;       // pane the on-screen key bar targets
   function sendMsg(o) { if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(o)); }
@@ -132,6 +133,67 @@
   document.getElementById("zoomin").onclick = function () { applyFont(curFont() + 1); };
   document.getElementById("zoomout").onclick = function () { applyFont(curFont() - 1); };
   document.getElementById("zoomfit").onclick = fitWidth;
+
+  // ---- right-click / long-press context menu ----
+  // Copy via the async Clipboard API where available (needs a secure context: https /
+  // localhost), else fall back to a hidden-textarea execCommand("copy") so plain-LAN
+  // http viewers can still copy.
+  function copyText(t) {
+    if (!t) return;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(t).catch(function () { copyFallback(t); });
+    } else { copyFallback(t); }
+  }
+  function copyFallback(t) {
+    try {
+      var ta = document.createElement("textarea");
+      ta.value = t; ta.style.position = "fixed"; ta.style.opacity = "0";
+      document.body.appendChild(ta); ta.focus(); ta.select();
+      document.execCommand("copy"); document.body.removeChild(ta);
+    } catch (e) {}
+  }
+  function hideContextMenu() { ctxEl.style.display = "none"; ctxEl.innerHTML = ""; }
+  function ctxItem(label, enabled, onClick) {
+    var it = document.createElement("div");
+    it.className = "ctxitem" + (enabled ? "" : " disabled");
+    it.textContent = label;
+    if (enabled) it.addEventListener("mousedown", function (e) {
+      e.preventDefault(); e.stopPropagation(); hideContextMenu(); onClick();
+    });
+    return it;
+  }
+  function showContextMenu(x, y, paneId) {
+    var p = panes[paneId]; if (!p) return;
+    var term = p.term;
+    var hasSel = false; try { hasSel = term.hasSelection(); } catch (e) {}
+    ctxEl.innerHTML = "";
+    ctxEl.appendChild(ctxItem("Copy", hasSel, function () {
+      var s = ""; try { s = term.getSelection(); } catch (e) {}
+      copyText(s); try { term.clearSelection(); } catch (e) {}
+    }));
+    // Paste needs control (we send the text as input) + clipboard read (secure context).
+    var canRead = controlGranted && navigator.clipboard && navigator.clipboard.readText;
+    ctxEl.appendChild(ctxItem("Paste", canRead, function () {
+      navigator.clipboard.readText().then(function (txt) {
+        if (txt) sendMsg({ t: "input", paneId: paneId, data: txt });
+      }).catch(function () {});
+    }));
+    ctxEl.appendChild(ctxItem("Select all", true, function () { try { term.selectAll(); } catch (e) {} }));
+    ctxEl.appendChild(ctxItem("Clear scrollback", controlGranted, function () { try { term.clear(); } catch (e) {} }));
+    ctxEl.appendChild(ctxItem("Scroll to bottom", true, function () { try { term.scrollToBottom(); } catch (e) {} }));
+    // Show off-screen first to measure, then clamp inside the viewport.
+    ctxEl.style.left = "0px"; ctxEl.style.top = "0px"; ctxEl.style.display = "block";
+    var w = ctxEl.offsetWidth, h = ctxEl.offsetHeight;
+    ctxEl.style.left = Math.max(0, Math.min(x, window.innerWidth - w - 4)) + "px";
+    ctxEl.style.top = Math.max(0, Math.min(y, window.innerHeight - h - 4)) + "px";
+  }
+  document.addEventListener("mousedown", function (e) {
+    if (ctxEl.style.display === "block" && !ctxEl.contains(e.target)) hideContextMenu();
+  });
+  document.addEventListener("keydown", function (e) { if (e.key === "Escape") hideContextMenu(); });
+  window.addEventListener("blur", hideContextMenu);
+  window.addEventListener("resize", hideContextMenu);
+  stageEl.addEventListener("scroll", hideContextMenu, true);
 
   function setStatus(cls) { statusEl.className = cls; }
 
@@ -323,8 +385,30 @@
       var wrap = document.createElement("div");
       wrap.className = "pane" + (node.focused ? " focused" : "");
       wrap.appendChild(getPane(node.paneId).host);
+      var pid = node.paneId;
       // Tapping a pane makes it the key-bar / typing target.
-      wrap.addEventListener("pointerdown", function () { currentPaneId = node.paneId; });
+      wrap.addEventListener("pointerdown", function () { currentPaneId = pid; });
+      // Desktop right-click → context menu.
+      wrap.addEventListener("contextmenu", function (e) {
+        e.preventDefault(); currentPaneId = pid; showContextMenu(e.clientX, e.clientY, pid);
+      });
+      // Mobile long-press (~500ms) → same menu, anchored at the touch point.
+      var lpTimer = null, lpX = 0, lpY = 0;
+      wrap.addEventListener("touchstart", function (e) {
+        if (!e.touches || e.touches.length !== 1) return;
+        lpX = e.touches[0].clientX; lpY = e.touches[0].clientY; currentPaneId = pid;
+        lpTimer = setTimeout(function () { lpTimer = null; showContextMenu(lpX, lpY, pid); }, 500);
+      }, { passive: true });
+      function cancelLongPress(e) {
+        if (lpTimer && e && e.touches && e.touches[0]) {
+          var dx = Math.abs(e.touches[0].clientX - lpX), dy = Math.abs(e.touches[0].clientY - lpY);
+          if (dx < 10 && dy < 10) return; // small jitter — keep the timer
+        }
+        if (lpTimer) { clearTimeout(lpTimer); lpTimer = null; }
+      }
+      wrap.addEventListener("touchmove", cancelLongPress, { passive: true });
+      wrap.addEventListener("touchend", cancelLongPress);
+      wrap.addEventListener("touchcancel", cancelLongPress);
       return wrap;
     }
     // split


### PR DESCRIPTION
## Summary

UI/UX follow-ups and a bug fix on top of the merged session-sharing feature (#276 / PR #277).

### Share window
- **QR section first**, with the **View/Control toggle moved below** the QR code, then the caption.
- **Centered** the QR, both segmented toggles (Scope + View/Control), and the section captions so their left/right margins match.
- **Share submenu**: the tab-chip and terminal right-click menus now nest sharing under a single **Share ▸ Tab… / Window…** submenu (Stop Sharing stays flat while active).

### Window focus
- Clicking any share entry point (sharing pill, toolbar QR button, context-menu Share) while a **share window is already open** now raises that window to the front and focuses it instead of leaving it behind.
- Same for the **settings window**: requesting settings again (left-bar button, ⌘/Ctrl+,, menu, MCP deep link) raises the existing window.
- Implemented with a `focusTick` that `ShareWindow` / `SettingsWindow` react to via `window.toFront()` / `requestFocus()`.

### Bug fix
- **No more leaked `BindException` on relaunch.** CIO binds its listening socket asynchronously, so a port already in use (a prior instance still shutting down) escaped the `try/catch` in `ensureEngineLocked` and surfaced as an uncaught exception. The port is now probed with a `ServerSocket` before Ktor starts, and taken ports are skipped — synchronous, deterministic fallback.

## Test plan
- `./gradlew :compose-ui:compileKotlinDesktop :bossterm-app:compileKotlinDesktop :compose-ui:desktopTest` — green.
- Manual: open the share dialog → QR-first layout, everything centered, Share submenu in right-click menus; with the share/settings window open, click the button again → it comes to front; relaunch while sharing → clean "port in use, trying next" log with no stack trace.

Generated with [Claude Code](https://claude.com/claude-code)