### PR TITLE
Session sharing: live remote-mode switch, verified Cloudflare links, and viewer parity (resize/splits/focus/tabs)

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -642,6 +642,10 @@ class BossTerminal(
         }
     }
 
+    /** Last cell pixel size the UI measured (physical px) — used for remote "fit-to-client" resizing. */
+    val cellWidthPx: Float get() = myCellWidthPx
+    val cellHeightPx: Float get() = myCellHeightPx
+
     /**
      * Notify image storage when buffer scrolls.
      * Call this when lines are added to history.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -226,12 +226,14 @@ class TabbedTerminalState {
     fun createTab(
         workingDir: String? = null,
         initialCommand: String? = null,
-        tabId: String? = null
+        tabId: String? = null,
+        activate: Boolean = true
     ): String? {
         return tabController?.createTab(
             workingDir = workingDir,
             initialCommand = initialCommand,
-            tabId = tabId
+            tabId = tabId,
+            activate = activate
         )?.id
     }
 
@@ -276,10 +278,14 @@ class TabbedTerminalState {
         if (i >= 0) tabController?.closeTabsBelow(i)
     }
 
-    /** Duplicate [tabId] into a new tab starting in the same cwd (mirrors "Duplicate Tab"). */
+    /**
+     * Duplicate [tabId] into a new tab starting in the same cwd (mirrors "Duplicate Tab").
+     * Created in the background ([activate] = false) so a viewer duplicating doesn't switch
+     * the host user's active tab.
+     */
     fun duplicateTab(tabId: String) {
         val wd = tabs.firstOrNull { it.id == tabId }?.workingDirectory?.value
-        createTab(workingDir = wd)
+        createTab(workingDir = wd, activate = false)
     }
 
     /** The session a chip refers to: a split pane by id, else the tab itself (summary/unsplit). */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/CloudflaredExposer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/CloudflaredExposer.kt
@@ -4,6 +4,12 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
+/** The public URL cloudflared prints for a quick tunnel. */
+private val URL_RE = Regex("""https://[a-z0-9-]+\.trycloudflare\.com""")
+
+/** cloudflared logs this once an edge connection is live → the tunnel is actually routable. */
+private val READY_RE = Regex("Registered tunnel connection")
+
 /**
  * Remote-reach via **Cloudflare Quick Tunnel** (issue #276) — the zero-config public
  * sharing option, an alternative to Tailscale. Shells out to the `cloudflared` CLI:
@@ -52,23 +58,22 @@ object CloudflaredExposer {
         return ok || isInstalled()
     }
 
-    private val URL_RE = Regex("""https://[a-z0-9-]+\.trycloudflare\.com""")
-
     /**
-     * Start a quick tunnel to `127.0.0.1:`[port]. Returns the **long-lived** [Process]
-     * (caller must keep it and [Process.destroyForcibly] it on teardown), or null if the
-     * CLI is missing / failed to spawn. Pair with [awaitUrl] to get the public URL.
+     * Start a quick tunnel to `127.0.0.1:`[port]. Returns a [QuickTunnel] handle wrapping
+     * the **long-lived** process (caller keeps it and [QuickTunnel.destroy]s it on teardown),
+     * or null if the CLI is missing / failed to spawn.
      */
-    fun start(port: Int): Process? {
+    fun start(port: Int): QuickTunnel? {
         val b = bin() ?: run { log.warn("cloudflared not found; cannot start quick tunnel"); return null }
         return try {
             // `--no-autoupdate` is a GLOBAL flag — it must precede the `tunnel` subcommand,
             // or cloudflared rejects/ignores it (and an auto-update mid-session would restart
             // the process and drop the tunnel).
-            ProcessBuilder(b, "--no-autoupdate", "tunnel", "--url", "http://127.0.0.1:$port")
+            val proc = ProcessBuilder(b, "--no-autoupdate", "tunnel", "--url", "http://127.0.0.1:$port")
                 .redirectErrorStream(true)
                 .start()
                 .also { runCatching { it.outputStream.close() } } // no stdin needed
+            QuickTunnel(proc)
         } catch (e: Exception) {
             log.warn("failed to start cloudflared: {}", e.message)
             null
@@ -76,21 +81,44 @@ object CloudflaredExposer {
     }
 
     /**
-     * Read [process] output until the assigned `*.trycloudflare.com` URL appears (or
-     * [timeoutMs] elapses). The reader keeps draining the pipe afterwards so the process
-     * doesn't stall on a full output buffer. Returns the URL, or null on timeout / early exit.
+     * A running quick tunnel. One daemon thread drains cloudflared's output once, completing
+     * [awaitUrl] when the public URL is printed and [awaitReady] when an edge connection
+     * registers — the point at which the URL actually routes to us instead of serving a
+     * Cloudflare "tunnel error" page. Draining continues so the process never stalls on a
+     * full pipe.
      */
-    fun awaitUrl(process: Process, timeoutMs: Long = 30_000): String? {
-        val result = CompletableFuture<String?>()
-        Thread {
-            runCatching {
-                process.inputStream.bufferedReader().forEachLine { line ->
-                    URL_RE.find(line)?.value?.let { result.complete(it) } // first match wins; keep draining
+    class QuickTunnel internal constructor(val process: Process) {
+        private val urlFuture = CompletableFuture<String?>()
+        private val readyFuture = CompletableFuture<Boolean>()
+
+        init {
+            Thread {
+                runCatching {
+                    process.inputStream.bufferedReader().forEachLine { line ->
+                        if (!urlFuture.isDone) URL_RE.find(line)?.value?.let { urlFuture.complete(it) }
+                        if (!readyFuture.isDone && READY_RE.containsMatchIn(line)) readyFuture.complete(true)
+                    }
                 }
-            }
-            result.complete(null) // EOF without a URL
-        }.apply { isDaemon = true; start() }
-        return runCatching { result.get(timeoutMs, TimeUnit.MILLISECONDS) }.getOrNull()
+                urlFuture.complete(null)    // EOF without a URL
+                readyFuture.complete(false) // EOF without registering a connection
+            }.apply { isDaemon = true; name = "cloudflared-reader"; start() }
+        }
+
+        /** The assigned `*.trycloudflare.com` URL, or null on timeout / early exit. */
+        fun awaitUrl(timeoutMs: Long = 30_000): String? =
+            runCatching { urlFuture.get(timeoutMs, TimeUnit.MILLISECONDS) }.getOrNull()
+
+        /**
+         * True once cloudflared registers an edge connection (the tunnel is routable).
+         * Read from cloudflared's own output, so it works even when this host can't resolve
+         * `*.trycloudflare.com` itself (e.g. Tailscale MagicDNS returns NXDOMAIN) — probing
+         * the public URL from the host would falsely fail in that case.
+         */
+        fun awaitReady(timeoutMs: Long = 20_000): Boolean =
+            runCatching { readyFuture.get(timeoutMs, TimeUnit.MILLISECONDS) }.getOrDefault(false)
+
+        /** Kill the tunnel (ends the public URL). */
+        fun destroy() { runCatching { process.destroyForcibly() } }
     }
 
     /** Run a short-lived command; return stdout on exit 0, else null. Bounded by [timeoutSec]. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -199,7 +199,14 @@ class MirrorShare(
                 val sy = gc?.defaultTransform?.scaleY?.takeIf { it > 0 } ?: 1.0
                 var newW = (win.width + (cols - cur.columns) * cw / sx).toInt()
                 var newH = (win.height + (rows - cur.rows) * ch / sy).toInt()
-                gc?.bounds?.let { b -> newW = newW.coerceIn(480, b.width); newH = newH.coerceIn(320, b.height) }
+                // Clamp to the screen, accounting for the window's position (setSize keeps the
+                // top-left), so growing a window that isn't at the origin can't run off-screen.
+                gc?.bounds?.let { b ->
+                    val maxW = (b.x + b.width - win.x).coerceAtLeast(480)
+                    val maxH = (b.y + b.height - win.y).coerceAtLeast(320)
+                    newW = newW.coerceIn(480, maxW)
+                    newH = newH.coerceIn(320, maxH)
+                }
                 if (newW != win.width || newH != win.height) {
                     win.setSize(newW, newH)
                     win.validate()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -10,6 +10,7 @@ import ai.rever.bossterm.compose.settings.theme.ColorPaletteManager
 import ai.rever.bossterm.compose.settings.theme.ThemeManager
 import ai.rever.bossterm.compose.splits.SplitNode
 import ai.rever.bossterm.compose.tabs.TerminalTab
+import ai.rever.bossterm.compose.window.WindowManager
 import ai.rever.bossterm.terminal.TerminalColor
 import ai.rever.bossterm.terminal.TextStyle
 import ai.rever.bossterm.terminal.model.TerminalLine
@@ -165,7 +166,42 @@ class MirrorShare(
                 McpTerminalRegistry.findState(tabId)?.closeOtherTabs(msg.tabId)
             is ClientMessage.CloseTabsBelow ->
                 McpTerminalRegistry.findState(tabId)?.closeTabsBelow(msg.tabId)
+            is ClientMessage.ResizeHost -> resizeHostWindow(msg.cols, msg.rows)
             else -> {} // Hello / Focus / RequestControl: no-op (focus is viewer-side; control via token)
+        }
+    }
+
+    /**
+     * "Fit host to client": resize the host's OS window so its terminal grid lands near
+     * [cols]×[rows]. The grid is slaved to the canvas, so we nudge the window by the pixel
+     * delta for the column/row change — the per-cell pixel size comes from the host's own
+     * measurement and the window chrome (left tab bar, title) cancels out of the delta.
+     * Best-effort and single-pane-oriented; multi-window picks the focused (else first) window.
+     */
+    private fun resizeHostWindow(cols: Int, rows: Int) {
+        if (cols < 2 || rows < 2) return
+        val tab = McpTerminalRegistry.findTab(tabId) ?: return
+        val cw = tab.terminal.cellWidthPx
+        val ch = tab.terminal.cellHeightPx
+        if (cw <= 0f || ch <= 0f) return
+        val cur = tab.display.termSize.value
+        val win = WindowManager.windows.firstOrNull { it.isWindowFocused.value && it.awtWindow != null }?.awtWindow
+            ?: WindowManager.windows.firstOrNull { it.awtWindow != null }?.awtWindow
+            ?: return
+        // AWT window size is in points; cell px is physical — divide by the display scale.
+        javax.swing.SwingUtilities.invokeLater {
+            runCatching {
+                val gc = win.graphicsConfiguration
+                val sx = gc?.defaultTransform?.scaleX?.takeIf { it > 0 } ?: 1.0
+                val sy = gc?.defaultTransform?.scaleY?.takeIf { it > 0 } ?: 1.0
+                var newW = (win.width + (cols - cur.columns) * cw / sx).toInt()
+                var newH = (win.height + (rows - cur.rows) * ch / sy).toInt()
+                gc?.bounds?.let { b -> newW = newW.coerceIn(480, b.width); newH = newH.coerceIn(320, b.height) }
+                if (newW != win.width || newH != win.height) {
+                    win.setSize(newW, newH)
+                    win.validate()
+                }
+            }
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -133,7 +133,8 @@ class MirrorShare(
             is ClientMessage.CloseTab ->
                 McpTerminalRegistry.findState(tabId)?.closeTab(msg.tabId)
             is ClientMessage.NewTab ->
-                McpTerminalRegistry.findState(tabId)?.createTab()
+                // Background: a viewer creating a tab shouldn't switch the host user's active tab.
+                McpTerminalRegistry.findState(tabId)?.createTab(activate = false)
             is ClientMessage.SplitVertical ->
                 McpTerminalRegistry.findState(tabId)?.splitVerticalFromPane(msg.tabId, msg.paneId)
             is ClientMessage.SplitHorizontal ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -167,6 +167,8 @@ class MirrorShare(
             is ClientMessage.CloseTabsBelow ->
                 McpTerminalRegistry.findState(tabId)?.closeTabsBelow(msg.tabId)
             is ClientMessage.ResizeHost -> resizeHostWindow(msg.cols, msg.rows)
+            is ClientMessage.ResizeSplit ->
+                McpTerminalRegistry.findState(tabId)?.splitStates?.get(msg.tabId)?.updateSplitRatio(msg.splitId, msg.ratio)
             else -> {} // Hello / Focus / RequestControl: no-op (focus is viewer-side; control via token)
         }
     }
@@ -296,9 +298,9 @@ class MirrorShare(
             )
         }
         is SplitNode.VerticalSplit ->
-            PaneTreeNode.Split("v", node.ratio, sigNode(node.left, focusedId, sizes), sigNode(node.right, focusedId, sizes))
+            PaneTreeNode.Split("v", node.ratio, sigNode(node.left, focusedId, sizes), sigNode(node.right, focusedId, sizes), node.id)
         is SplitNode.HorizontalSplit ->
-            PaneTreeNode.Split("h", node.ratio, sigNode(node.top, focusedId, sizes), sigNode(node.bottom, focusedId, sizes))
+            PaneTreeNode.Split("h", node.ratio, sigNode(node.top, focusedId, sizes), sigNode(node.bottom, focusedId, sizes), node.id)
     }
 
     /** Current paneId → owning session, across all in-scope tabs. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -2,11 +2,6 @@ package ai.rever.bossterm.compose.share
 
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.TerminalSettings
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO as ClientCIO
-import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.request.get
-import io.ktor.client.statement.bodyAsText
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.cio.CIOApplicationEngine
@@ -26,7 +21,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -100,29 +94,12 @@ object SessionShareManager {
     /** Observed by the share dialog to show "starting / verifying / retrying / active / fell back". */
     val remoteStateFlow: StateFlow<RemoteState> = _remoteStateFlow.asStateFlow()
 
-    // Cloudflare quick tunnels often 5xx for a few seconds after the URL prints (edge warming
-    // up), so we poll the link before publishing it; if it never comes good we spin a fresh
-    // tunnel a couple of times, else fall back to the LAN link.
-    private const val VERIFY_POLLS = 6
-    private const val VERIFY_INTERVAL_MS = 2_000L
+    // A Cloudflare quick tunnel serves a "tunnel error" page until cloudflared registers an
+    // edge connection, so we wait for that readiness signal before publishing the URL; if it
+    // never comes we spin a fresh tunnel a couple of times, else fall back to the LAN link.
+    // (We can't HTTP-probe the public URL from the host: a Tailscale-MagicDNS resolver returns
+    // NXDOMAIN for *.trycloudflare.com, so a host-side check would falsely fail working links.)
     private const val MAX_REFRESHES = 2
-
-    // Short-lived HTTP client for the link health-check (Ktor client; already a dependency).
-    private val httpClientLazy = lazy {
-        HttpClient(ClientCIO) {
-            install(HttpTimeout) { requestTimeoutMillis = 5_000; connectTimeoutMillis = 4_000 }
-        }
-    }
-    private val httpClient by httpClientLazy
-
-    /**
-     * True if [url] actually serves our viewer end-to-end (GET `<url>/` → 200 + the viewer's
-     * "BossTerm" title), i.e. the tunnel routes to us rather than a Cloudflare error page.
-     */
-    private suspend fun linkHealthy(url: String): Boolean = runCatching {
-        val resp = httpClient.get("${url.trimEnd('/')}/")
-        resp.status.value in 200..299 && resp.bodyAsText().contains("BossTerm")
-    }.getOrDefault(false)
 
     /** A token resolves to a share and whether that token grants control. */
     private data class TokenRef(val share: MirrorShare, val canControl: Boolean)
@@ -360,37 +337,31 @@ object SessionShareManager {
     }
 
     /**
-     * Start a Cloudflare quick tunnel and return its URL only once it actually serves us.
-     * Polls the freshly-printed URL ([VERIFY_POLLS] × [VERIFY_INTERVAL_MS], to ride out the
-     * edge warm-up), and if it never comes good spins a brand-new tunnel up to
-     * [MAX_REFRESHES] times. Returns null (→ caller falls back to LAN) if all attempts fail.
+     * Start a Cloudflare quick tunnel and return its URL only once cloudflared reports the
+     * tunnel is routable (an edge connection registered) — so we never hand out a link that
+     * still serves the Cloudflare error page. If a tunnel prints a URL but never becomes
+     * ready, spin a brand-new one up to [MAX_REFRESHES] times. Returns null (→ caller falls
+     * back to LAN) if all attempts fail.
      */
     private suspend fun establishCloudflareVerified(port: Int): String? {
         runCatching { remoteProcess?.destroyForcibly() } // kill a prior tunnel (refresh/switch)
-        var proc = CloudflaredExposer.start(port) ?: return null
-        remoteProcess = proc
-        var url = CloudflaredExposer.awaitUrl(proc)
         var refreshes = 0
         while (true) {
-            val u = url
-            if (u != null) {
+            val tunnel = CloudflaredExposer.start(port) ?: run { remoteProcess = null; return null }
+            remoteProcess = tunnel.process
+            val url = withContext(Dispatchers.IO) { tunnel.awaitUrl() }
+            if (url != null) {
                 _remoteStateFlow.value = RemoteState(RemoteStatus.Verifying, "cloudflare")
-                repeat(VERIFY_POLLS) { i ->
-                    if (linkHealthy(u)) return u
-                    if (i < VERIFY_POLLS - 1) delay(VERIFY_INTERVAL_MS)
-                }
+                if (withContext(Dispatchers.IO) { tunnel.awaitReady() }) return url
             }
             if (refreshes >= MAX_REFRESHES) {
-                runCatching { proc.destroyForcibly() }
+                tunnel.destroy()
                 remoteProcess = null
                 return null
             }
             refreshes++
             _remoteStateFlow.value = RemoteState(RemoteStatus.Retrying, "cloudflare", refreshes, MAX_REFRESHES)
-            runCatching { proc.destroyForcibly() }
-            proc = CloudflaredExposer.start(port) ?: run { remoteProcess = null; return null }
-            remoteProcess = proc
-            url = CloudflaredExposer.awaitUrl(proc)
+            tunnel.destroy()
         }
     }
 
@@ -462,7 +433,6 @@ object SessionShareManager {
         failAllPending()
         _sharedTabIds.value = emptySet()
         teardownRemoteAccess(boundPort)
-        if (httpClientLazy.isInitialized()) runCatching { httpClient.close() }
         val e = engine ?: return
         runCatching { e.stop(200, 800) }
         engine = null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -2,6 +2,11 @@ package ai.rever.bossterm.compose.share
 
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.TerminalSettings
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO as ClientCIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.cio.CIOApplicationEngine
@@ -21,6 +26,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -78,6 +84,45 @@ object SessionShareManager {
      * the UI observes this to refresh the dialog to the public link when it's ready.
      */
     val remoteUrlFlow: StateFlow<String?> = _remoteUrlFlow.asStateFlow()
+
+    /** Lifecycle of the remote-access link, surfaced in the share dialog. */
+    enum class RemoteStatus { Off, Starting, Verifying, Active, Retrying, FellBack }
+
+    /** Remote-access status snapshot: phase + provider [mode] + retry progress. */
+    data class RemoteState(
+        val status: RemoteStatus,
+        val mode: String,
+        val attempt: Int = 0,
+        val maxAttempts: Int = 0,
+    )
+
+    private val _remoteStateFlow = MutableStateFlow(RemoteState(RemoteStatus.Off, "off"))
+    /** Observed by the share dialog to show "starting / verifying / retrying / active / fell back". */
+    val remoteStateFlow: StateFlow<RemoteState> = _remoteStateFlow.asStateFlow()
+
+    // Cloudflare quick tunnels often 5xx for a few seconds after the URL prints (edge warming
+    // up), so we poll the link before publishing it; if it never comes good we spin a fresh
+    // tunnel a couple of times, else fall back to the LAN link.
+    private const val VERIFY_POLLS = 6
+    private const val VERIFY_INTERVAL_MS = 2_000L
+    private const val MAX_REFRESHES = 2
+
+    // Short-lived HTTP client for the link health-check (Ktor client; already a dependency).
+    private val httpClientLazy = lazy {
+        HttpClient(ClientCIO) {
+            install(HttpTimeout) { requestTimeoutMillis = 5_000; connectTimeoutMillis = 4_000 }
+        }
+    }
+    private val httpClient by httpClientLazy
+
+    /**
+     * True if [url] actually serves our viewer end-to-end (GET `<url>/` → 200 + the viewer's
+     * "BossTerm" title), i.e. the tunnel routes to us rather than a Cloudflare error page.
+     */
+    private suspend fun linkHealthy(url: String): Boolean = runCatching {
+        val resp = httpClient.get("${url.trimEnd('/')}/")
+        resp.status.value in 200..299 && resp.bodyAsText().contains("BossTerm")
+    }.getOrDefault(false)
 
     /** A token resolves to a share and whether that token grants control. */
     private data class TokenRef(val share: MirrorShare, val canControl: Boolean)
@@ -249,47 +294,103 @@ object SessionShareManager {
     }
 
     /**
-     * Regenerate the remote-access link in place — get a fresh tunnel and publish it.
-     * Cloudflare quick-tunnel URLs are ephemeral (new one per process, and a tunnel can
-     * drop), so this is the "give me a new link" action in the share dialog. The share
-     * server + viewers keep running; the open dialog updates via [remoteUrlFlow].
-     *
-     * For Cloudflare the new tunnel is brought up and its URL captured *before* the old
-     * process is killed, so the dialog jumps straight from the old link to the new one
-     * (no momentary fallback to the LAN URL). Tailscale serve/funnel URLs are stable, so
-     * this just re-affirms the mapping. No-op when remote access is off (the LAN link
-     * never changes). Runs off the UI thread.
+     * Regenerate the remote-access link in place — the "give me a new link" action in the
+     * share dialog (Cloudflare quick-tunnel URLs are ephemeral and can drop). Re-runs the
+     * configured provider through the verified establish path (so the new Cloudflare link
+     * is health-checked before it's published) and drives [remoteStateFlow]. No-op when
+     * remote access is off. Runs off the UI thread.
      */
     fun refreshRemoteLink() {
         scope.launch {
             val port = boundPort ?: return@launch
             val mode = SettingsManager.instance.settings.value.shareTailscaleMode
             if (mode == "off") return@launch
+            withContext(Dispatchers.IO) { establishRemote(mode, port) }
+        }
+    }
+
+    /**
+     * Switch the **live** remote-access provider (the share dialog's Off/Serve/Funnel/
+     * Cloudflare picker, after the user confirms). Tears down the current exposure and
+     * establishes the new one in place — same server + viewers, a new link. When sharing
+     * isn't active (no bound port) this is a no-op; the persisted setting applies next share.
+     */
+    fun applyRemoteMode(mode: String) {
+        scope.launch {
+            val port = boundPort ?: return@launch
             withContext(Dispatchers.IO) {
-                val newUrl = when (mode) {
-                    "cloudflare" -> {
-                        val newProc = CloudflaredExposer.start(port)
-                        val u = newProc?.let { CloudflaredExposer.awaitUrl(it) }
-                        if (u != null) {
-                            val old = remoteProcess
-                            remoteProcess = newProc
-                            runCatching { old?.destroyForcibly() } // swap, then kill the old tunnel
-                        } else {
-                            runCatching { newProc?.destroyForcibly() } // failed — don't leak it
-                        }
-                        u
-                    }
-                    else -> TailscaleExposer.enable(mode, port) // serve/funnel: URL is stable
-                }
-                activeRemoteMode = mode
-                if (newUrl != null) {
-                    remoteUrl = newUrl
-                    _remoteUrlFlow.value = newUrl
-                    log.info("Session-sharing remote link refreshed via {}: {}", mode, newUrl)
-                } else {
-                    log.warn("Remote link refresh ({}) did not yield a URL; keeping the current link.", mode)
+                teardownRemoteAccess(port)
+                if (mode != "off") establishRemote(mode, port)
+                else _remoteStateFlow.value = RemoteState(RemoteStatus.Off, "off")
+            }
+        }
+    }
+
+    /**
+     * Bring up remote access for [mode] on [port], publishing the URL only once it's
+     * confirmed working, and driving [remoteStateFlow] through Starting → Verifying/
+     * Retrying → Active, or → FellBack (URL stays unpublished, so [buildUrl] uses the LAN
+     * link). Shared by the initial share, manual refresh, and live mode switch.
+     */
+    private suspend fun establishRemote(mode: String, port: Int) {
+        activeRemoteMode = mode
+        // Drop any stale link while we (re)establish, so the dialog shows the LAN link +
+        // progress rather than a soon-to-be-dead URL.
+        remoteUrl = null
+        _remoteUrlFlow.value = null
+        _remoteStateFlow.value = RemoteState(RemoteStatus.Starting, mode)
+        val url: String? = when (mode) {
+            "cloudflare" -> establishCloudflareVerified(port)
+            "serve", "funnel" -> TailscaleExposer.enable(mode, port) // stable URL; published as-is
+            else -> null
+        }
+        if (url != null) {
+            remoteUrl = url
+            _remoteUrlFlow.value = url
+            _remoteStateFlow.value = RemoteState(RemoteStatus.Active, mode)
+            log.info("Session-sharing reachable via {}: {}", mode, url)
+        } else {
+            _remoteStateFlow.value = RemoteState(RemoteStatus.FellBack, mode)
+            log.warn(
+                "Remote access ({}) did not yield a working link; using the LAN link. " +
+                    "For tailscale check `tailscale status`; for cloudflare ensure `cloudflared` is installed.",
+                mode
+            )
+        }
+    }
+
+    /**
+     * Start a Cloudflare quick tunnel and return its URL only once it actually serves us.
+     * Polls the freshly-printed URL ([VERIFY_POLLS] × [VERIFY_INTERVAL_MS], to ride out the
+     * edge warm-up), and if it never comes good spins a brand-new tunnel up to
+     * [MAX_REFRESHES] times. Returns null (→ caller falls back to LAN) if all attempts fail.
+     */
+    private suspend fun establishCloudflareVerified(port: Int): String? {
+        runCatching { remoteProcess?.destroyForcibly() } // kill a prior tunnel (refresh/switch)
+        var proc = CloudflaredExposer.start(port) ?: return null
+        remoteProcess = proc
+        var url = CloudflaredExposer.awaitUrl(proc)
+        var refreshes = 0
+        while (true) {
+            val u = url
+            if (u != null) {
+                _remoteStateFlow.value = RemoteState(RemoteStatus.Verifying, "cloudflare")
+                repeat(VERIFY_POLLS) { i ->
+                    if (linkHealthy(u)) return u
+                    if (i < VERIFY_POLLS - 1) delay(VERIFY_INTERVAL_MS)
                 }
             }
+            if (refreshes >= MAX_REFRESHES) {
+                runCatching { proc.destroyForcibly() }
+                remoteProcess = null
+                return null
+            }
+            refreshes++
+            _remoteStateFlow.value = RemoteState(RemoteStatus.Retrying, "cloudflare", refreshes, MAX_REFRESHES)
+            runCatching { proc.destroyForcibly() }
+            proc = CloudflaredExposer.start(port) ?: run { remoteProcess = null; return null }
+            remoteProcess = proc
+            url = CloudflaredExposer.awaitUrl(proc)
         }
     }
 
@@ -361,6 +462,7 @@ object SessionShareManager {
         failAllPending()
         _sharedTabIds.value = emptySet()
         teardownRemoteAccess(boundPort)
+        if (httpClientLazy.isInitialized()) runCatching { httpClient.close() }
         val e = engine ?: return
         runCatching { e.stop(200, 800) }
         engine = null
@@ -444,27 +546,8 @@ object SessionShareManager {
                 if (settings.shareTailscaleMode != "off" && activeRemoteMode == "off") {
                     val mode = settings.shareTailscaleMode
                     val rPort = port
-                    activeRemoteMode = mode
-                    scope.launch {
-                        val url = when (mode) {
-                            "cloudflare" -> CloudflaredExposer.start(rPort)?.let { proc ->
-                                remoteProcess = proc
-                                CloudflaredExposer.awaitUrl(proc)
-                            }
-                            else -> TailscaleExposer.enable(mode, rPort) // "serve" / "funnel"
-                        }
-                        if (url != null) {
-                            remoteUrl = url
-                            _remoteUrlFlow.value = url  // refresh any open share dialog to the public URL
-                            log.info("Session-sharing reachable via {}: {}", mode, url)
-                        } else {
-                            log.warn(
-                                "Remote access ({}) did not yield a URL; using the LAN link. " +
-                                    "For tailscale check `tailscale status`; for cloudflare ensure `cloudflared` is installed.",
-                                mode
-                            )
-                        }
-                    }
+                    activeRemoteMode = mode // claim it now so this fires once per lifecycle
+                    scope.launch { establishRemote(mode, rPort) }
                 }
                 return true
             } catch (e: Throwable) {
@@ -510,6 +593,7 @@ object SessionShareManager {
         remoteProcess = null
         remoteUrl = null
         _remoteUrlFlow.value = null
+        _remoteStateFlow.value = RemoteState(RemoteStatus.Off, "off")
         activeRemoteMode = "off"
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -366,18 +366,26 @@ object SessionShareManager {
      */
     private suspend fun establishCloudflareVerified(port: Int, op: Int): String? {
         var refreshes = 0
+        // Already runs on Dispatchers.IO (manager scope / caller's withContext), so the
+        // blocking awaitUrl/awaitReady don't need their own withContext.
         while (isCurrentRemoteOp(op)) {
             val tunnel = CloudflaredExposer.start(port) ?: return null
-            val url = withContext(Dispatchers.IO) { tunnel.awaitUrl() }
+            val url = tunnel.awaitUrl()
             var ready = false
             if (url != null && isCurrentRemoteOp(op)) {
                 _remoteStateFlow.value = RemoteState(RemoteStatus.Verifying, "cloudflare")
-                ready = withContext(Dispatchers.IO) { tunnel.awaitReady() }
+                ready = tunnel.awaitReady()
             }
             if (ready && isCurrentRemoteOp(op)) {
                 runCatching { remoteProcess?.destroyForcibly() } // replace any prior tunnel
                 remoteProcess = tunnel.process
-                return url
+                // Re-check after adopting: a teardown/newer op could have slipped in between
+                // the guard above and this assignment (and walked past our not-yet-set tunnel).
+                // If so, reclaim our tunnel rather than leak it — the winner owns remoteProcess.
+                if (isCurrentRemoteOp(op)) return url
+                tunnel.destroy()
+                if (remoteProcess === tunnel.process) remoteProcess = null
+                return null
             }
             tunnel.destroy() // failed / superseded — never leak this tunnel
             if (!isCurrentRemoteOp(op) || refreshes >= MAX_REFRESHES) return null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -61,15 +61,24 @@ object SessionShareManager {
     private val mutex = Mutex()
 
     private var engine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
-    private var boundPort: Int? = null
+    @Volatile private var boundPort: Int? = null
     private var boundHost: String? = null
     // Remote access (Phase 3): the published public/tunnel URL + which provider is live.
     // [activeRemoteMode] mirrors a TerminalSettings.shareTailscaleMode value:
     // "off" | "serve" | "funnel" (Tailscale) | "cloudflare" (Cloudflare Quick Tunnel).
-    private var remoteUrl: String? = null
-    private var activeRemoteMode: String = "off"
+    // @Volatile: read/written from multiple Dispatchers.IO threads (establish / teardown).
+    @Volatile private var remoteUrl: String? = null
+    @Volatile private var activeRemoteMode: String = "off"
     // For long-lived tunnels (cloudflared): the running process to kill on teardown.
-    private var remoteProcess: Process? = null
+    @Volatile private var remoteProcess: Process? = null
+    // Monotonic token serializing remote-access operations WITHOUT a long-held lock: each
+    // establish/teardown/stop "claims" the next value; a long-running establish (Cloudflare
+    // verify can take tens of seconds) checks it's still current before publishing state or
+    // adopting its tunnel, and otherwise bails and kills its own tunnel — so a concurrent
+    // mode-switch / refresh / unshare can't leak a cloudflared process or stomp shared state.
+    private val remoteOp = java.util.concurrent.atomic.AtomicInteger(0)
+    private fun claimRemoteOp(): Int = remoteOp.incrementAndGet()
+    private fun isCurrentRemoteOp(op: Int): Boolean = remoteOp.get() == op
     private val _remoteUrlFlow = MutableStateFlow<String?>(null)
     /**
      * The published remote-access URL (Tailscale `https://<host>.ts.net` or a Cloudflare
@@ -282,7 +291,8 @@ object SessionShareManager {
             val port = boundPort ?: return@launch
             val mode = SettingsManager.instance.settings.value.shareTailscaleMode
             if (mode == "off") return@launch
-            withContext(Dispatchers.IO) { establishRemote(mode, port) }
+            val op = claimRemoteOp()
+            withContext(Dispatchers.IO) { establishRemote(mode, port, op) }
         }
     }
 
@@ -295,10 +305,11 @@ object SessionShareManager {
     fun applyRemoteMode(mode: String) {
         scope.launch {
             val port = boundPort ?: return@launch
+            val op = claimRemoteOp() // supersede any in-flight establish (it will bail + self-clean)
             withContext(Dispatchers.IO) {
                 teardownRemoteAccess(port)
-                if (mode != "off") establishRemote(mode, port)
-                else _remoteStateFlow.value = RemoteState(RemoteStatus.Off, "off")
+                if (mode != "off") establishRemote(mode, port, op)
+                else if (isCurrentRemoteOp(op)) _remoteStateFlow.value = RemoteState(RemoteStatus.Off, "off")
             }
         }
     }
@@ -308,8 +319,13 @@ object SessionShareManager {
      * confirmed working, and driving [remoteStateFlow] through Starting → Verifying/
      * Retrying → Active, or → FellBack (URL stays unpublished, so [buildUrl] uses the LAN
      * link). Shared by the initial share, manual refresh, and live mode switch.
+     *
+     * [op] is this operation's token: if a newer remote op is claimed while we're working,
+     * we stop publishing state and don't adopt our tunnel (Cloudflare self-cleans), so a
+     * concurrent switch / refresh / stop wins cleanly.
      */
-    private suspend fun establishRemote(mode: String, port: Int) {
+    private suspend fun establishRemote(mode: String, port: Int, op: Int) {
+        if (!isCurrentRemoteOp(op)) return
         activeRemoteMode = mode
         // Drop any stale link while we (re)establish, so the dialog shows the LAN link +
         // progress rather than a soon-to-be-dead URL.
@@ -317,10 +333,11 @@ object SessionShareManager {
         _remoteUrlFlow.value = null
         _remoteStateFlow.value = RemoteState(RemoteStatus.Starting, mode)
         val url: String? = when (mode) {
-            "cloudflare" -> establishCloudflareVerified(port)
+            "cloudflare" -> establishCloudflareVerified(port, op)
             "serve", "funnel" -> TailscaleExposer.enable(mode, port) // stable URL; published as-is
             else -> null
         }
+        if (!isCurrentRemoteOp(op)) return // superseded while establishing — don't publish
         if (url != null) {
             remoteUrl = url
             _remoteUrlFlow.value = url
@@ -342,27 +359,32 @@ object SessionShareManager {
      * still serves the Cloudflare error page. If a tunnel prints a URL but never becomes
      * ready, spin a brand-new one up to [MAX_REFRESHES] times. Returns null (→ caller falls
      * back to LAN) if all attempts fail.
+     *
+     * Each attempt holds its tunnel in a local until it's verified AND still the current
+     * [op]; only then does it kill the prior tunnel and adopt itself as [remoteProcess]. A
+     * failed attempt or a superseded op destroys its own tunnel, so nothing is ever leaked.
      */
-    private suspend fun establishCloudflareVerified(port: Int): String? {
-        runCatching { remoteProcess?.destroyForcibly() } // kill a prior tunnel (refresh/switch)
+    private suspend fun establishCloudflareVerified(port: Int, op: Int): String? {
         var refreshes = 0
-        while (true) {
-            val tunnel = CloudflaredExposer.start(port) ?: run { remoteProcess = null; return null }
-            remoteProcess = tunnel.process
+        while (isCurrentRemoteOp(op)) {
+            val tunnel = CloudflaredExposer.start(port) ?: return null
             val url = withContext(Dispatchers.IO) { tunnel.awaitUrl() }
-            if (url != null) {
+            var ready = false
+            if (url != null && isCurrentRemoteOp(op)) {
                 _remoteStateFlow.value = RemoteState(RemoteStatus.Verifying, "cloudflare")
-                if (withContext(Dispatchers.IO) { tunnel.awaitReady() }) return url
+                ready = withContext(Dispatchers.IO) { tunnel.awaitReady() }
             }
-            if (refreshes >= MAX_REFRESHES) {
-                tunnel.destroy()
-                remoteProcess = null
-                return null
+            if (ready && isCurrentRemoteOp(op)) {
+                runCatching { remoteProcess?.destroyForcibly() } // replace any prior tunnel
+                remoteProcess = tunnel.process
+                return url
             }
+            tunnel.destroy() // failed / superseded — never leak this tunnel
+            if (!isCurrentRemoteOp(op) || refreshes >= MAX_REFRESHES) return null
             refreshes++
             _remoteStateFlow.value = RemoteState(RemoteStatus.Retrying, "cloudflare", refreshes, MAX_REFRESHES)
-            tunnel.destroy()
         }
+        return null
     }
 
     /**
@@ -432,6 +454,7 @@ object SessionShareManager {
         grants.clear()
         failAllPending()
         _sharedTabIds.value = emptySet()
+        claimRemoteOp() // cancel any in-flight establish before tearing down
         teardownRemoteAccess(boundPort)
         val e = engine ?: return
         runCatching { e.stop(200, 800) }
@@ -517,7 +540,8 @@ object SessionShareManager {
                     val mode = settings.shareTailscaleMode
                     val rPort = port
                     activeRemoteMode = mode // claim it now so this fires once per lifecycle
-                    scope.launch { establishRemote(mode, rPort) }
+                    val op = claimRemoteOp()
+                    scope.launch { establishRemote(mode, rPort, op) }
                 }
                 return true
             } catch (e: Throwable) {
@@ -537,6 +561,8 @@ object SessionShareManager {
     private suspend fun stopEngineLocked() {
         val e = engine ?: return
         // Tear down any active remote-access exposure first (best-effort, off the UI thread).
+        // Bump the op so an in-flight establish bails + self-cleans instead of racing teardown.
+        claimRemoteOp()
         withContext(Dispatchers.IO) { teardownRemoteAccess(boundPort) }
         try {
             withContext(Dispatchers.IO) { e.stop(300, 1000) }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -248,4 +248,13 @@ sealed class ClientMessage {
     @Serializable
     @SerialName("closeTabsBelow")
     data class CloseTabsBelow(val tabId: String) : ClientMessage()
+
+    /**
+     * "Fit host to my screen": resize the host so [tabId]'s terminal grid becomes about
+     * [cols]×[rows] (what fits the viewer's viewport). The host terminal size is slaved to
+     * its window, so the host resizes its OS window to best approximate this. Controller only.
+     */
+    @Serializable
+    @SerialName("resizeHost")
+    data class ResizeHost(val tabId: String, val cols: Int, val rows: Int) : ClientMessage()
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -126,10 +126,20 @@ data class TabNode(
 /** Recursive split-layout node: either a binary split or a leaf pane. */
 @Serializable
 sealed class PaneTreeNode {
-    /** A split: [dir] "v" = side-by-side (left/right at [ratio]); "h" = stacked (top/bottom). */
+    /**
+     * A split: [dir] "v" = side-by-side (left/right at [ratio]); "h" = stacked (top/bottom).
+     * [id] is the host split node's stable id, so the viewer can drag the divider and ask the
+     * host to update this split's ratio.
+     */
     @Serializable
     @SerialName("split")
-    data class Split(val dir: String, val ratio: Float, val a: PaneTreeNode, val b: PaneTreeNode) : PaneTreeNode()
+    data class Split(
+        val dir: String,
+        val ratio: Float,
+        val a: PaneTreeNode,
+        val b: PaneTreeNode,
+        val id: String = "",
+    ) : PaneTreeNode()
 
     /**
      * A leaf terminal pane. [color] (CSS accent) and [branch] (git branch) mirror the
@@ -257,4 +267,12 @@ sealed class ClientMessage {
     @Serializable
     @SerialName("resizeHost")
     data class ResizeHost(val tabId: String, val cols: Int, val rows: Int) : ClientMessage()
+
+    /**
+     * Drag a split divider: set the split node [splitId] in [tabId] to [ratio] (0..1,
+     * fraction of the first child) — mirrors dragging the divider on the host. Controller only.
+     */
+    @Serializable
+    @SerialName("resizeSplit")
+    data class ResizeSplit(val tabId: String, val splitId: String, val ratio: Float) : ClientMessage()
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -355,6 +355,10 @@ private fun RemoteAccessSetupSection(
     var pendingMode by remember { mutableStateOf<String?>(null) } // a mode awaiting the user's confirm
     val remote by SessionShareManager.remoteStateFlow.collectAsState()
     val active = remote.status == SessionShareManager.RemoteStatus.Active
+    // A switch/establish is in progress — don't let the picker queue a second one mid-flight.
+    val busy = remote.status == SessionShareManager.RemoteStatus.Starting ||
+        remote.status == SessionShareManager.RemoteStatus.Verifying ||
+        remote.status == SessionShareManager.RemoteStatus.Retrying
     val isCloudflare = mode == "cloudflare"
     val tool = if (isCloudflare) "cloudflared" else "Tailscale"
     // Install detection + one-click Homebrew install for the selected provider's CLI.
@@ -444,11 +448,12 @@ private fun RemoteAccessSetupSection(
                     horizontalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
                     // Clicking a different mode asks for confirmation (pendingMode) — the
-                    // actual switch happens on confirm in the AlertDialog above.
-                    Seg("Off", mode == "off") { if (mode != "off") pendingMode = "off" }
-                    Seg("Serve", mode == "serve") { if (mode != "serve") pendingMode = "serve" }
-                    Seg("Funnel", mode == "funnel") { if (mode != "funnel") pendingMode = "funnel" }
-                    Seg("Cloudflare", isCloudflare) { if (mode != "cloudflare") pendingMode = "cloudflare" }
+                    // actual switch happens on confirm in the AlertDialog above. Ignored while
+                    // an establish is already in progress (busy) so switches can't pile up.
+                    Seg("Off", mode == "off") { if (!busy && mode != "off") pendingMode = "off" }
+                    Seg("Serve", mode == "serve") { if (!busy && mode != "serve") pendingMode = "serve" }
+                    Seg("Funnel", mode == "funnel") { if (!busy && mode != "funnel") pendingMode = "funnel" }
+                    Seg("Cloudflare", isCloudflare) { if (!busy && mode != "cloudflare") pendingMode = "cloudflare" }
                 }
                 Text(
                     when (mode) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -28,10 +28,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.AlertDialog
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowRight
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -402,8 +402,7 @@ private fun RemoteAccessSetupSection(
             dismissButton = {
                 TextButton(onClick = { pendingMode = null }) { Text("Cancel", color = TextSecondary) }
             },
-            backgroundColor = SurfaceColor,
-            contentColor = TextPrimary,
+            containerColor = SurfaceColor,
         )
     }
     Column(Modifier.fillMaxWidth()) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowRight
@@ -39,6 +40,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -96,11 +98,13 @@ fun ShareWindow(
     val isWindow = info.scope == ShareScope.WINDOW
     val loopbackOnly = info.url.contains("://127.0.0.1") || info.url.contains("://localhost")
     var controlQr by remember { mutableStateOf(false) }
-    // "Refresh link" regenerates the remote tunnel (ephemeral for Cloudflare). Clears when
-    // the URL updates (the dialog refreshes via remoteUrlFlow) or after a timeout fallback.
-    var refreshing by remember { mutableStateOf(false) }
-    LaunchedEffect(info.url) { refreshing = false }
-    LaunchedEffect(refreshing) { if (refreshing) { kotlinx.coroutines.delay(35_000); refreshing = false } }
+    // Remote-access lifecycle (starting/verifying/retrying/active/fell-back) drives the
+    // Refresh button's disabled state, so "↻ Refresh link" reads "Refreshing…" for exactly
+    // as long as a new link is actually being established + verified.
+    val remoteState by SessionShareManager.remoteStateFlow.collectAsState()
+    val remoteBusy = remoteState.status == SessionShareManager.RemoteStatus.Starting ||
+        remoteState.status == SessionShareManager.RemoteStatus.Verifying ||
+        remoteState.status == SessionShareManager.RemoteStatus.Retrying
     // Inline actions for the QR + Links headers: "↻ Refresh link" (only when a remote
     // provider is selected — the LAN link never changes) and "⤴ Share" (macOS native
     // share sheet → AirDrop/Messages/Mail; falls back to copying if the helper can't run).
@@ -111,10 +115,10 @@ fun ShareWindow(
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(2.dp)) {
                 if (hasRefresh) {
                     TextButton(
-                        onClick = { refreshing = true; onRefreshLink() },
-                        enabled = !refreshing,
+                        onClick = onRefreshLink,
+                        enabled = !remoteBusy,
                         colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
-                    ) { Text(if (refreshing) "Refreshing…" else "↻ Refresh link", fontSize = 12.sp) }
+                    ) { Text(if (remoteBusy) "Refreshing…" else "↻ Refresh link", fontSize = 12.sp) }
                 }
                 if (canShare) {
                     TextButton(
@@ -237,7 +241,6 @@ fun ShareWindow(
                 RemoteAccessSetupSection(
                     mode = tailscaleMode,
                     onModeChange = onTailscaleModeChange,
-                    currentUrl = info.url,
                     clipboard = clipboard,
                 )
 
@@ -346,11 +349,12 @@ private const val FUNNEL_ACL_SNIPPET =
 private fun RemoteAccessSetupSection(
     mode: String,
     onModeChange: (String) -> Unit,
-    currentUrl: String,
     clipboard: ClipboardManager,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val active = currentUrl.contains(".ts.net") || currentUrl.contains(".trycloudflare.com")
+    var pendingMode by remember { mutableStateOf<String?>(null) } // a mode awaiting the user's confirm
+    val remote by SessionShareManager.remoteStateFlow.collectAsState()
+    val active = remote.status == SessionShareManager.RemoteStatus.Active
     val isCloudflare = mode == "cloudflare"
     val tool = if (isCloudflare) "cloudflared" else "Tailscale"
     // Install detection + one-click Homebrew install for the selected provider's CLI.
@@ -371,6 +375,33 @@ private fun RemoteAccessSetupSection(
             brewOk = if (ins) true else withContext(Dispatchers.IO) { toolBrewOk() }
         }
     }
+    // Confirm before switching provider — it tears down the current tunnel and brings up a
+    // new link. On confirm we persist the choice (onModeChange) AND switch the live tunnel.
+    pendingMode?.let { target ->
+        val msg = when (target) {
+            "off" -> "Turn off remote access? The public link stops working — sharing stays on your LAN only."
+            "cloudflare" -> "Switch to Cloudflare? A new public https://…trycloudflare.com link is generated; the current link stops working."
+            "serve" -> "Switch to Tailscale Serve? A new tailnet-only link replaces the current one."
+            "funnel" -> "Switch to Tailscale Funnel? A new public link replaces the current one."
+            else -> "Switch remote access to $target?"
+        }
+        AlertDialog(
+            onDismissRequest = { pendingMode = null },
+            title = { Text("Switch remote access?", color = TextPrimary, fontWeight = FontWeight.SemiBold) },
+            text = { Text(msg, color = TextSecondary, fontSize = 13.sp) },
+            confirmButton = {
+                Button(
+                    onClick = { onModeChange(target); SessionShareManager.applyRemoteMode(target); pendingMode = null },
+                    colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                ) { Text(if (target == "off") "Turn off" else "Switch") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingMode = null }) { Text("Cancel", color = TextSecondary) }
+            },
+            backgroundColor = SurfaceColor,
+            contentColor = TextPrimary,
+        )
+    }
     Column(Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp))
@@ -387,12 +418,21 @@ private fun RemoteAccessSetupSection(
             Text("Remote access", color = TextPrimary, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
             Spacer(Modifier.weight(1f))
             Text(
-                when {
-                    mode == "off" -> "LAN only"
-                    active -> "$mode · active"
-                    else -> "$mode · not active"
+                when (remote.status) {
+                    SessionShareManager.RemoteStatus.Off -> "LAN only"
+                    SessionShareManager.RemoteStatus.Starting -> "${remote.mode} · starting…"
+                    SessionShareManager.RemoteStatus.Verifying -> "${remote.mode} · verifying link…"
+                    SessionShareManager.RemoteStatus.Retrying ->
+                        "${remote.mode} · retrying (${remote.attempt}/${remote.maxAttempts})…"
+                    SessionShareManager.RemoteStatus.Active -> "${remote.mode} · active"
+                    SessionShareManager.RemoteStatus.FellBack -> "${remote.mode} · unreachable — using LAN link"
                 },
-                color = if (active) Color(0xFF4CAF50) else TextMuted, fontSize = 11.sp
+                color = when (remote.status) {
+                    SessionShareManager.RemoteStatus.Active -> Color(0xFF4CAF50)
+                    SessionShareManager.RemoteStatus.FellBack -> Danger
+                    else -> TextMuted
+                },
+                fontSize = 11.sp
             )
         }
         if (expanded) {
@@ -403,10 +443,12 @@ private fun RemoteAccessSetupSection(
                         .border(1.dp, BorderColor, RoundedCornerShape(6.dp)).padding(2.dp),
                     horizontalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
-                    Seg("Off", mode == "off") { onModeChange("off") }
-                    Seg("Serve", mode == "serve") { onModeChange("serve") }
-                    Seg("Funnel", mode == "funnel") { onModeChange("funnel") }
-                    Seg("Cloudflare", isCloudflare) { onModeChange("cloudflare") }
+                    // Clicking a different mode asks for confirmation (pendingMode) — the
+                    // actual switch happens on confirm in the AlertDialog above.
+                    Seg("Off", mode == "off") { if (mode != "off") pendingMode = "off" }
+                    Seg("Serve", mode == "serve") { if (mode != "serve") pendingMode = "serve" }
+                    Seg("Funnel", mode == "funnel") { if (mode != "funnel") pendingMode = "funnel" }
+                    Seg("Cloudflare", isCloudflare) { if (mode != "cloudflare") pendingMode = "cloudflare" }
                 }
                 Text(
                     when (mode) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -316,7 +316,8 @@ class TabController(
         onProcessExit: (() -> Unit)? = null,
         initialCommand: String? = null,
         onInitialCommandComplete: ((success: Boolean, exitCode: Int) -> Unit)? = null,
-        tabId: String? = null
+        tabId: String? = null,
+        activate: Boolean = true
     ): TerminalTab {
         // Validate tab ID uniqueness if custom ID provided
         if (tabId != null && tabs.any { it.id == tabId }) {
@@ -554,8 +555,9 @@ class TabController(
         // Notify listeners about new session
         notifySessionCreated(tab)
 
-        // Switch to newly created tab
-        switchToTab(tabs.size - 1)
+        // Switch to newly created tab (unless the caller wants it created in the background —
+        // e.g. a remote viewer creating a tab shouldn't yank the host user's active tab).
+        if (activate) switchToTab(tabs.size - 1)
 
         return tab
     }

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -93,8 +93,9 @@
     .split.v { flex-direction: row; }
     .split.h { flex-direction: column; }
     .divider { background: #000; flex: 0 0 1px; }
+    /* a visible frame so the host terminal's bounds are clear against the stage */
     .pane { position: relative; min-width: 0; min-height: 0; overflow: hidden; box-sizing: border-box;
-            border: 1px solid transparent; }
+            border: 1px solid #3a3a3a; }
     .pane.focused { border-color: #4a90e2; }
     .termhost { width: 100%; height: 100%; overflow: hidden; }
     /* right-click / long-press context menu */
@@ -131,7 +132,9 @@
     <div id="tabbar"></div>
     <span class="badge" id="viewonly">view only</span>
     <span class="badge" id="presence"></span>
+    <span class="badge" id="dims" title="Host terminal size (columns × rows)"></span>
     <span id="zoom">
+      <button id="fithost" title="Resize the host to fit this screen" style="display:none">⇲ Fit host</button>
       <button id="zoomout" title="Zoom out">A&minus;</button>
       <button id="zoomin" title="Zoom in">A+</button>
       <button id="zoomfit" title="Fit width">Fit</button>

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -116,6 +116,12 @@
     @keyframes spin { to { transform: rotate(360deg); } }
     #overlay-title { font-size: 15px; color: #fff; margin-bottom: 6px; }
     #overlay-msg { font-size: 12px; color: #b0b0b0; line-height: 1.5; }
+    #overlay-actions { display: flex; gap: 10px; justify-content: center; margin-top: 16px; }
+    #overlay-actions:empty { display: none; }
+    #overlay-actions button { padding: 7px 16px; border-radius: 6px; border: 1px solid #505050;
+                              background: #1e1e1e; color: #ddd; font-size: 13px; cursor: pointer; }
+    #overlay-actions button:hover { border-color: #4a90e2; }
+    #overlay-actions button.primary { background: #4a90e2; border-color: #4a90e2; color: #fff; }
   </style>
 </head>
 <body>
@@ -143,6 +149,7 @@
       <div id="overlay-spinner"></div>
       <div id="overlay-title">Waiting for host approval…</div>
       <div id="overlay-msg"></div>
+      <div id="overlay-actions"></div>
     </div>
   </div>
 

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -134,10 +134,10 @@
     <span class="badge" id="presence"></span>
     <span class="badge" id="dims" title="Host terminal size (columns × rows)"></span>
     <span id="zoom">
-      <button id="fithost" title="Resize the host to fit this screen" style="display:none">⇲ Fit host</button>
       <button id="zoomout" title="Zoom out">A&minus;</button>
       <button id="zoomin" title="Zoom in">A+</button>
-      <button id="zoomfit" title="Fit width">Fit</button>
+      <button id="zoomfit" title="Zoom so the terminal's full width fits your view (local only)">Fit view</button>
+      <button id="fithost" title="Resize the host terminal to fit this screen" style="display:none">Fit host</button>
     </span>
   </div>
   <div id="body">

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -92,7 +92,8 @@
     .split { display: flex; flex: 1 1 0; min-width: 0; min-height: 0; }
     .split.v { flex-direction: row; }
     .split.h { flex-direction: column; }
-    .divider { background: #000; flex: 0 0 1px; }
+    .divider { background: #000; flex: 0 0 4px; -webkit-user-select: none; user-select: none; touch-action: none; }
+    .divider.draggable:hover, .divider.draggable:active { background: #4a90e2; }
     /* a visible frame so the host terminal's bounds are clear against the stage */
     .pane { position: relative; min-width: 0; min-height: 0; overflow: hidden; box-sizing: border-box;
             border: 1px solid #3a3a3a; }

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -76,15 +76,16 @@
     });
     layoutForKeyboard(); // reserve space + position above the keyboard
   }
-  // The focused pane of [node]'s tree (or the first pane), for default key-bar target.
+  // The first pane of [node]'s tree (tree order) — the client's default focus / key-bar
+  // target. Host focus is intentionally NOT reflected on the client; the client picks its own.
   function firstFocusedPane(node) {
-    var found = null, first = null;
+    var first = null;
     (function walk(n) {
-      if (!n) return;
-      if (n.t === "pane") { if (first === null) first = n.paneId; if (n.focused) found = n.paneId; }
+      if (!n || first !== null) return;
+      if (n.t === "pane") first = n.paneId;
       else { walk(n.a); walk(n.b); }
     })(node);
-    return found || first;
+    return first;
   }
 
   var controlGranted = false;
@@ -551,6 +552,21 @@
     renderTabBar();
     renderStage();
   }
+  // Client-side pane focus: move the focus border to [paneId] and reflect it in the sub-tab
+  // chips, without rebuilding the stage (so xterms/selection survive). Independent of the host.
+  function setClientFocus(paneId) {
+    if (currentPaneId === paneId) return;
+    currentPaneId = paneId;
+    refreshPaneFocus();
+    renderTabBar(); // per-split sub-tab chip highlight follows the client's focus
+  }
+  function refreshPaneFocus() {
+    var els = stageEl.querySelectorAll(".pane");
+    for (var i = 0; i < els.length; i++) {
+      if (els[i].dataset.paneId === currentPaneId) els[i].classList.add("focused");
+      else els[i].classList.remove("focused");
+    }
+  }
 
   // Inline SVGs matching the host's Material split icons: a pane outline divided by a
   // vertical line (left/right) or a horizontal line (top/bottom).
@@ -649,21 +665,23 @@
 
   function buildNode(node) {
     if (node.t === "pane") {
-      var wrap = document.createElement("div");
-      wrap.className = "pane" + (node.focused ? " focused" : "");
-      wrap.appendChild(getPane(node.paneId).host);
       var pid = node.paneId;
-      // Tapping a pane makes it the key-bar / typing target.
-      wrap.addEventListener("pointerdown", function () { currentPaneId = pid; });
+      var wrap = document.createElement("div");
+      // Focus is the CLIENT's own (currentPaneId) — not the host's — and follows clicks.
+      wrap.className = "pane" + (pid === currentPaneId ? " focused" : "");
+      wrap.dataset.paneId = pid;
+      wrap.appendChild(getPane(pid).host);
+      // Clicking/tapping a pane focuses it on the client (border + key-bar / typing target).
+      wrap.addEventListener("pointerdown", function () { setClientFocus(pid); });
       // Desktop right-click → context menu.
       wrap.addEventListener("contextmenu", function (e) {
-        e.preventDefault(); currentPaneId = pid; showContextMenu(e.clientX, e.clientY, pid);
+        e.preventDefault(); setClientFocus(pid); showContextMenu(e.clientX, e.clientY, pid);
       });
       // Mobile long-press (~500ms) → same menu, anchored at the touch point.
       var lpTimer = null, lpX = 0, lpY = 0;
       wrap.addEventListener("touchstart", function (e) {
         if (!e.touches || e.touches.length !== 1) return;
-        lpX = e.touches[0].clientX; lpY = e.touches[0].clientY; currentPaneId = pid;
+        lpX = e.touches[0].clientX; lpY = e.touches[0].clientY; setClientFocus(pid);
         lpTimer = setTimeout(function () { lpTimer = null; showContextMenu(lpX, lpY, pid); }, 500);
       }, { passive: true });
       function cancelLongPress(e) {

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -357,13 +357,40 @@
   var overlayTitleEl = document.getElementById("overlay-title");
   var overlayMsgEl = document.getElementById("overlay-msg");
   var overlaySpinnerEl = document.getElementById("overlay-spinner");
-  function showOverlay(title, msg, spinning) {
+  var overlayActionsEl = document.getElementById("overlay-actions");
+  // [actions] = optional [{label, primary, onClick}] rendered as buttons under the message.
+  function showOverlay(title, msg, spinning, actions) {
     overlayTitleEl.textContent = title;
     overlayMsgEl.textContent = msg || "";
     overlaySpinnerEl.style.display = spinning ? "" : "none";
+    overlayActionsEl.innerHTML = "";
+    (actions || []).forEach(function (a) {
+      var b = document.createElement("button");
+      b.textContent = a.label;
+      if (a.primary) b.className = "primary";
+      b.onclick = a.onClick;
+      overlayActionsEl.appendChild(b);
+    });
     overlayEl.style.display = "";
   }
   function hideOverlay() { overlayEl.style.display = "none"; }
+
+  var sessionEnded = false;   // host denied/expired → don't offer a pointless reconnect
+  var disconnectShown = false; // de-dupe onerror + onclose firing together
+  // The link dropped (host stopped sharing, network blip, etc.): tell the user instead of
+  // just flipping the status dot red, and offer to reconnect (reload) or close.
+  function showDisconnected() {
+    setStatus("down");
+    if (sessionEnded || disconnectShown) return;
+    disconnectShown = true;
+    showOverlay("Disconnected", "The connection to the host was lost.", false, [
+      { label: "Reconnect", primary: true, onClick: function () { location.reload(); } },
+      { label: "Close", onClick: function () {
+          window.close(); // ignored for user-opened tabs — fall back to a hint
+          showOverlay("Disconnected", "You can close this tab.", false, []);
+        } }
+    ]);
+  }
 
   function deviceName() {
     return localStorage.getItem("bossterm.name") || navigator.platform || "browser";
@@ -710,6 +737,7 @@
         break;
       case "denied":
         clearKey();
+        sessionEnded = true; // terminal — keep this message, don't replace with "Disconnected"
         showOverlay("Request denied", m.reason || "The host declined this device.", false);
         break;
       case "theme": applyTheme(m); break;
@@ -737,6 +765,6 @@
     }
   };
 
-  ws.onclose = function () { setStatus("down"); };
-  ws.onerror = function () { setStatus("down"); };
+  ws.onclose = showDisconnected;
+  ws.onerror = showDisconnected;
 })();

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -78,7 +78,7 @@
   }
   // The first pane of [node]'s tree (tree order) — the client's default focus / key-bar
   // target. Host focus is intentionally NOT reflected on the client; the client picks its own.
-  function firstFocusedPane(node) {
+  function defaultPaneId(node) {
     var first = null;
     (function walk(n) {
       if (!n || first !== null) return;
@@ -579,7 +579,7 @@
   function activePaneId() {
     var tab = activeTabNode(); if (!tab || !tab.tree) return null;
     if (currentPaneId) { var ids = {}; collectPaneIds(tab.tree, ids); if (ids[currentPaneId]) return currentPaneId; }
-    return firstFocusedPane(tab.tree);
+    return defaultPaneId(tab.tree);
   }
   // kind: "v" = Split Left/Right (vertical divider), "h" = Split Top/Bottom (horizontal divider).
   function splitButton(kind) {
@@ -731,18 +731,26 @@
       if (now - lastSent > 60) { lastSent = now; sendMsg({ t: "resizeSplit", tabId: activeTabId, splitId: node.id, ratio: ratio }); }
       e.preventDefault();
     }
-    function onUp(e) {
+    // End the drag for any reason. pointercancel (gesture interrupted / scroll takeover on
+    // touch) MUST be handled too, or splitDragging would stick true and onLayout would stop
+    // re-rendering for the rest of the session (frozen viewer) and the window listeners leak.
+    function endDrag(commit, e) {
+      if (!splitDragging) return;
       splitDragging = false;
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
-      sendMsg({ t: "resizeSplit", tabId: activeTabId, splitId: node.id, ratio: ratioAt(e) }); // final
-      renderStage(); // apply whatever layout arrived while we suppressed re-renders
+      window.removeEventListener("pointercancel", onCancel);
+      if (commit) sendMsg({ t: "resizeSplit", tabId: activeTabId, splitId: node.id, ratio: ratioAt(e) }); // final
+      renderStage(); // settle to the host layout + resume normal re-renders
     }
+    function onUp(e) { endDrag(true, e); }
+    function onCancel() { endDrag(false, null); } // interrupted — keep the last-sent ratio
     div.addEventListener("pointerdown", function (e) {
       splitDragging = true;
       e.preventDefault(); e.stopPropagation();
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onCancel);
     });
   }
 
@@ -753,7 +761,7 @@
     if (!tab) return;
     // Keep the key-bar target on a pane that's actually visible in this tab.
     var ids = {}; collectPaneIds(tab.tree, ids);
-    if (!currentPaneId || !ids[currentPaneId]) currentPaneId = firstFocusedPane(tab.tree);
+    if (!currentPaneId || !ids[currentPaneId]) currentPaneId = defaultPaneId(tab.tree);
     var root = buildNode(tab.tree);
     if (tab.tree.t === "pane") {
       // single pane → natural width, scrollable in #stage (don't stretch/clip)

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -23,6 +23,8 @@
   var menubtnEl = document.getElementById("menubtn");
   var bodyEl = document.getElementById("body");
   var ctxEl = document.getElementById("ctxmenu");
+  var dimsEl = document.getElementById("dims");
+  var fithostEl = document.getElementById("fithost");
   var tabBarOnLeft = false;       // mirror the host's tab-bar orientation
   var summaryMode = false;        // host's tabBarSummaryMode: 1 chip/tab vs 1 chip/pane
   var currentPaneId = null;       // pane the on-screen key bar targets
@@ -134,6 +136,26 @@
   document.getElementById("zoomin").onclick = function () { applyFont(curFont() + 1); };
   document.getElementById("zoomout").onclick = function () { applyFont(curFont() - 1); };
   document.getElementById("zoomfit").onclick = fitWidth;
+
+  // Show the host terminal's grid size (cols × rows) so its bounds are explicit.
+  function updateDims() {
+    var id = activePaneId(), p = id && panes[id];
+    if (p && p.term && p.term.cols) { dimsEl.textContent = p.term.cols + "×" + p.term.rows; dimsEl.style.display = ""; }
+    else dimsEl.style.display = "none";
+  }
+  // "Fit host to my screen": measure the client's cell size + viewport, work out the grid
+  // that fills it, and ask the host to resize its window to match (control only).
+  fithostEl.onclick = function () {
+    var id = activePaneId(), p = id && panes[id];
+    if (!p || !p.term || !p.term.cols) return;
+    var sc = p.host.querySelector(".xterm-screen"); if (!sc) return;
+    var r = sc.getBoundingClientRect();
+    var cellW = r.width / p.term.cols, cellH = r.height / p.term.rows;
+    if (!(cellW > 0) || !(cellH > 0)) return;
+    var cols = Math.max(20, Math.floor((stageEl.clientWidth - 6) / cellW));
+    var rows = Math.max(6, Math.floor((stageEl.clientHeight - 6) / cellH));
+    sendMsg({ t: "resizeHost", tabId: activeTabId, cols: cols, rows: rows });
+  };
 
   // ---- right-click / long-press context menu ----
   // Copy via the async Clipboard API where available (needs a secure context: https /
@@ -688,6 +710,7 @@
     }
     stageEl.appendChild(root);
     relayoutSinglePane(); // size a single pane to its natural width for horizontal scroll
+    updateDims();
   }
 
   function onLayout(m) {
@@ -748,17 +771,19 @@
         p.term.reset();
         if (m.data) p.term.write(m.data);
         relayoutSinglePane();
+        updateDims();
         break;
       }
       case "paneOutput": if (m.data) getPane(m.paneId).term.write(m.data); break;
       case "paneResize":
-        if (m.cols && m.rows) { getPane(m.paneId).term.resize(m.cols, m.rows); relayoutSinglePane(); }
+        if (m.cols && m.rows) { getPane(m.paneId).term.resize(m.cols, m.rows); relayoutSinglePane(); updateDims(); }
         break;
       case "presence":
         presenceEl.textContent = m.viewers === 1 ? "1 viewer" : m.viewers + " viewers"; break;
       case "control":
         controlGranted = !!m.granted;
         viewOnlyEl.style.display = controlGranted ? "none" : "";
+        fithostEl.style.display = controlGranted ? "" : "none"; // resizing the host needs control
         renderTabBar(); // show/hide the close + new-tab affordances
         buildKeybar();  // show/hide the on-screen control-key bar
         break;

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -154,8 +154,9 @@
     var r = sc.getBoundingClientRect();
     var cellW = r.width / p.term.cols, cellH = r.height / p.term.rows;
     if (!(cellW > 0) || !(cellH > 0)) return;
-    var cols = Math.max(20, Math.floor((stageEl.clientWidth - 6) / cellW));
-    var rows = Math.max(6, Math.floor((stageEl.clientHeight - 6) / cellH));
+    var CHROME = 8; // leave room for the pane border (1px/side) + a little slack so it fits
+    var cols = Math.max(20, Math.floor((stageEl.clientWidth - CHROME) / cellW));
+    var rows = Math.max(6, Math.floor((stageEl.clientHeight - CHROME) / cellH));
     sendMsg({ t: "resizeHost", tabId: activeTabId, cols: cols, rows: rows });
   };
 

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -27,6 +27,7 @@
   var fithostEl = document.getElementById("fithost");
   var tabBarOnLeft = false;       // mirror the host's tab-bar orientation
   var summaryMode = false;        // host's tabBarSummaryMode: 1 chip/tab vs 1 chip/pane
+  var splitDragging = false;      // a divider is being dragged → suppress layout re-renders
   var currentPaneId = null;       // pane the on-screen key bar targets
   function sendMsg(o) { if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(o)); }
 
@@ -684,9 +685,46 @@
     a.style.flex = (node.ratio || 0.5) + " 1 0";
     b.style.flex = (1 - (node.ratio || 0.5)) + " 1 0";
     var div = document.createElement("div");
-    div.className = "divider";
+    div.className = "divider " + (node.dir === "h" ? "h" : "v");
+    if (controlGranted && node.id) attachDividerDrag(div, split, a, b, node);
     split.appendChild(a); split.appendChild(div); split.appendChild(b);
     return split;
+  }
+
+  // Drag a split divider to re-ratio the split — mirrors dragging it on the host. Updates
+  // the local layout live for smoothness and streams the ratio to the host (throttled);
+  // re-renders are suppressed mid-drag so the divider isn't rebuilt under the pointer.
+  function attachDividerDrag(div, split, a, b, node) {
+    var horiz = node.dir === "h"; // h = stacked → drag vertically; v = side-by-side → horizontally
+    div.classList.add("draggable");
+    div.style.cursor = horiz ? "row-resize" : "col-resize";
+    var lastSent = 0;
+    function ratioAt(e) {
+      var r = split.getBoundingClientRect();
+      var v = horiz ? (e.clientY - r.top) / r.height : (e.clientX - r.left) / r.width;
+      return Math.max(0.1, Math.min(0.9, v));
+    }
+    function onMove(e) {
+      var ratio = ratioAt(e);
+      a.style.flex = ratio + " 1 0";
+      b.style.flex = (1 - ratio) + " 1 0";
+      var now = Date.now();
+      if (now - lastSent > 60) { lastSent = now; sendMsg({ t: "resizeSplit", tabId: activeTabId, splitId: node.id, ratio: ratio }); }
+      e.preventDefault();
+    }
+    function onUp(e) {
+      splitDragging = false;
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      sendMsg({ t: "resizeSplit", tabId: activeTabId, splitId: node.id, ratio: ratioAt(e) }); // final
+      renderStage(); // apply whatever layout arrived while we suppressed re-renders
+    }
+    div.addEventListener("pointerdown", function (e) {
+      splitDragging = true;
+      e.preventDefault(); e.stopPropagation();
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    });
   }
 
   function renderStage() {
@@ -728,7 +766,9 @@
       if (!live[id]) { try { panes[id].term.dispose(); } catch (e) {} delete panes[id]; }
     });
     renderTabBar();
-    renderStage();
+    // Mid divider-drag, the host echoes ratio changes back as layouts — don't rebuild the
+    // stage (it would destroy the divider under the pointer); onUp re-renders to settle.
+    if (!splitDragging) renderStage();
   }
 
   function collectPaneIds(node, out) {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -70,4 +70,39 @@ class ShareProtocolTest {
         val msg = ShareProtocol.decodeClient("""{"t":"hello","name":"x","futureField":42}""")
         assertIs<ClientMessage.Hello>(msg)
     }
+
+    @Test
+    fun `viewer resize messages decode by discriminator`() {
+        val rh = ShareProtocol.decodeClient("""{"t":"resizeHost","tabId":"t1","cols":120,"rows":40}""")
+        assertIs<ClientMessage.ResizeHost>(rh)
+        assertEquals("t1", rh.tabId)
+        assertEquals(120, rh.cols)
+        assertEquals(40, rh.rows)
+
+        val rs = ShareProtocol.decodeClient("""{"t":"resizeSplit","tabId":"t1","splitId":"s1","ratio":0.3}""")
+        assertIs<ClientMessage.ResizeSplit>(rs)
+        assertEquals("s1", rs.splitId)
+        assertEquals(0.3f, rs.ratio)
+    }
+
+    @Test
+    fun `split id serializes and is optional for forward-compat`() {
+        val tree = PaneTreeNode.Split(
+            "v", 0.5f,
+            PaneTreeNode.Pane("p1", "zsh", "/home", focused = true),
+            PaneTreeNode.Pane("p2", "vim", "/x", focused = false),
+            id = "split-1",
+        )
+        val json = ShareProtocol.encodeServer(ServerMessage.Layout(listOf(TabNode("t1", "~", true, tree)), "t1"))
+        assertTrue(json.contains("\"id\":\"split-1\""), "split id should serialize: $json")
+
+        // An older host→viewer payload without `id` still decodes (default ""), so a viewer
+        // built against the new protocol tolerates an older peer.
+        val old = """{"t":"layout","tabs":[{"id":"t1","title":"~","active":true,"tree":{"t":"split","dir":"v","ratio":0.5,"a":{"t":"pane","paneId":"p1","title":"z","cwd":null,"focused":true},"b":{"t":"pane","paneId":"p2","title":"v","cwd":null,"focused":false}}}],"activeTabId":"t1"}"""
+        val decoded = ShareProtocol.json.decodeFromString(ServerMessage.serializer(), old)
+        assertIs<ServerMessage.Layout>(decoded)
+        val split = decoded.tabs[0].tree
+        assertIs<PaneTreeNode.Split>(split)
+        assertEquals("", split.id)
+    }
 }


### PR DESCRIPTION
Builds on the merged session-sharing work (#278). All changes are scoped to the share host (`SessionShareManager` / `MirrorShare` / `ShareWindow`) and the browser viewer; default sharing behavior is unchanged until a remote provider is selected.

## Remote access (host dialog)
- **Confirm-then-switch, live.** Clicking a different provider (Off / Serve / Funnel / Cloudflare) now prompts to confirm, and on confirm switches the **live** tunnel in place (`applyRemoteMode`) instead of only persisting the setting for next share.
- **Verified Cloudflare links + status.** A quick tunnel serves a Cloudflare error page until its edge connection registers, so we no longer publish the URL the instant `cloudflared` prints it. `establishCloudflareVerified` waits for cloudflared's own `Registered tunnel connection` readiness signal (DNS-independent — a host-side HTTP probe falsely fails under Tailscale MagicDNS, which returns NXDOMAIN for `*.trycloudflare.com`), retrying with a fresh tunnel up to 2× before falling back to the LAN link. A new `remoteStateFlow` (Off/Starting/Verifying/Active/Retrying/FellBack) surfaces the lifecycle as status in the dialog and disables Refresh while in progress.

## Viewer
- **Disconnect prompt.** On WS drop, an overlay with **Reconnect** (reloads, replaying the stored key) / **Close**, instead of only a red dot. Denied/expired sessions keep their terminal message.
- **Host bounds + fit.** A visible pane frame and a `cols×rows` badge make the host grid explicit; **Fit host** (control only) resizes the host window so its grid fills the viewer (the grid is slaved to the window, so we nudge the window by the pixel delta; chrome cancels out). The two Fit buttons are grouped and renamed **Fit view** (local zoom) / **Fit host**.
- **Drag split dividers** to re-ratio host splits (`ResizeSplit` → `updateSplitRatio`); live + throttled, re-renders suppressed mid-drag.
- **Client-owned pane focus** — the focus border follows the client's clicks, not the host's focused pane.
- **Non-disruptive viewer tabs** — creating/duplicating a tab from the viewer no longer switches the host user's (or the client's) active tab (`createTab(activate = false)`).

## Verify
`./gradlew :compose-ui:compileKotlinDesktop :bossterm-app:compileKotlinDesktop` green; manually exercised end-to-end (share → verified Cloudflare link, mode switch, disconnect/reconnect, fit host, divider drag, pane focus, background tab create). cloudflared readiness verified against live `cloudflared 2026.5.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)