### PR TITLE
Connect to a remote BossTerm session: mirror its tabs as local tabs

### DIFF
--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -115,6 +115,8 @@ kotlin {
                 implementation("io.ktor:ktor-client-cio:$ktorVersion")
                 implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
                 implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+                // WebSocket client — native viewer that connects to a remote BossTerm share.
+                implementation("io.ktor:ktor-client-websockets:$ktorVersion")
 
                 // MCP (Model Context Protocol) server + Ktor CIO server backend.
                 // `api` for the SDK because BossTermMcpConfig's additionalTools

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1839,6 +1839,24 @@ fun TabbedTerminal(
         )
     }
 
+    // Typing into a read-only mirror (no control, or read-only via an upstream host) surfaces
+    // the same request-control prompt; dismissing snoozes it so it doesn't nag per keystroke.
+    state?.remoteSessions?.let { mgr ->
+        mgr.blockedInput.value?.let { blocked ->
+            ai.rever.bossterm.compose.remote.RequestControlPrompt(
+                onConfirm = {
+                    if (blocked.tabId != null) blocked.session.requestControlFor(blocked.tabId)
+                    else blocked.session.requestControl()
+                    mgr.blockedInput.value = null
+                },
+                onDismiss = {
+                    mgr.snoozeBlockedInputPrompt()
+                    mgr.blockedInput.value = null
+                },
+            )
+        }
+    }
+
     // Disconnect → reconnect dialog (like the web viewer's overlay): prompt for the first
     // remote session that lost its connection and hasn't had this failure dismissed.
     state?.remoteSessions?.let { mgr ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1002,6 +1002,7 @@ fun TabbedTerminal(
                     // The same share link this group mirrors, in the web viewer.
                     onOpenInBrowser = { HyperlinkDetector.openUrl(session.link) },
                     onCopyLink = { tabBarClipboard.setText(androidx.compose.ui.text.AnnotatedString(session.link)) },
+                    onRequestControl = { session.requestControl() },
                 )
             }
             // In summary mode the active tab's single chip carries the tab id; match it

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1010,6 +1010,7 @@ fun TabbedTerminal(
                         ai.rever.bossterm.compose.tabs.RemoteNestedGroup(
                             label = up.name ?: "remote",
                             readOnly = up.readOnly,
+                            offline = up.offline,
                             groups = items.map { it.third },
                             onSplitVertical = { splitNest(horizontal = false) },
                             onSplitHorizontal = { splitNest(horizontal = true) },
@@ -1031,6 +1032,19 @@ fun TabbedTerminal(
                     colorHex = session.accent.value,
                     groups = gs,
                     canControl = session.canControlState.value, // Compose state → menus update on grant
+                    statusLabel = when (session.statusState.value) {
+                        is ai.rever.bossterm.compose.remote.RemoteStatus.Connected -> null
+                        ai.rever.bossterm.compose.remote.RemoteStatus.Connecting -> "connecting…"
+                        ai.rever.bossterm.compose.remote.RemoteStatus.Pending -> "awaiting approval…"
+                        is ai.rever.bossterm.compose.remote.RemoteStatus.Failed -> "disconnected"
+                        is ai.rever.bossterm.compose.remote.RemoteStatus.Denied -> "denied"
+                        ai.rever.bossterm.compose.remote.RemoteStatus.Closed -> "closed"
+                    },
+                    statusError = session.statusState.value.let {
+                        it is ai.rever.bossterm.compose.remote.RemoteStatus.Failed ||
+                            it is ai.rever.bossterm.compose.remote.RemoteStatus.Denied ||
+                            it is ai.rever.bossterm.compose.remote.RemoteStatus.Closed
+                    },
                     // View-only: split/new-tab first confirm via the request-control dialog
                     // (confirming sends the request; the host shows its approval toast).
                     onSplitVertical = {
@@ -1823,6 +1837,23 @@ fun TabbedTerminal(
             onConfirm = { send(); requestControlPrompt = null },
             onDismiss = { requestControlPrompt = null },
         )
+    }
+
+    // Disconnect → reconnect dialog (like the web viewer's overlay): prompt for the first
+    // remote session that lost its connection and hasn't had this failure dismissed.
+    state?.remoteSessions?.let { mgr ->
+        mgr.sessions.firstOrNull {
+            it.statusState.value is ai.rever.bossterm.compose.remote.RemoteStatus.Failed && !it.failureDismissed.value
+        }?.let { failed ->
+            ai.rever.bossterm.compose.remote.RemoteDisconnectedDialog(
+                name = failed.customName.value ?: failed.hostName.value
+                    ?: runCatching { java.net.URI(failed.link).host ?: failed.link }.getOrDefault(failed.link),
+                message = (failed.statusState.value as? ai.rever.bossterm.compose.remote.RemoteStatus.Failed)?.message,
+                onReconnect = { failed.reconnect() },
+                onDisconnect = { mgr.disconnect(failed) },
+                onDismiss = { failed.failureDismissed.value = true },
+            )
+        }
     }
 
     // "Add remote": connect to another BossTerm's shared session and mirror its tabs here.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -979,8 +979,22 @@ fun TabbedTerminal(
             // a link header + footer actions (split / new tab / disconnect) targeting the host.
             val tabGroups = tabGroupsWithTab.filter { rm?.sessionForTab(it.first) == null }.map { it.second }
             val remoteGroups = rm?.sessions.orEmpty().mapNotNull { session ->
-                val gs = tabGroupsWithTab.filter { rm?.sessionForTab(it.first) === session }.map { it.second }
-                if (gs.isEmpty()) null else ai.rever.bossterm.compose.tabs.RemoteTabGroup(
+                session.upstreamRev.value // subscribe: re-partition when upstream info changes
+                val mine = tabGroupsWithTab.filter { rm?.sessionForTab(it.first) === session }
+                // The host's own tabs render directly; tabs the host itself mirrors from OTHER
+                // sessions nest under a labeled subsection per upstream (read-only flagged).
+                val gs = mine.filter { session.upstreamFor(it.first.id) == null }.map { it.second }
+                val nested = mine
+                    .mapNotNull { (t, g) -> session.upstreamFor(t.id)?.let { up -> up to g } }
+                    .groupBy({ it.first.key }, { it })
+                    .map { (_, items) ->
+                        ai.rever.bossterm.compose.tabs.RemoteNestedGroup(
+                            label = items.first().first.name ?: "remote",
+                            readOnly = items.first().first.readOnly,
+                            groups = items.map { it.second },
+                        )
+                    }
+                if (gs.isEmpty() && nested.isEmpty()) null else ai.rever.bossterm.compose.tabs.RemoteTabGroup(
                     id = session.link,
                     header = session.customName.value
                         ?: runCatching { java.net.URI(session.link).host ?: session.link }.getOrDefault(session.link),
@@ -1005,6 +1019,7 @@ fun TabbedTerminal(
                     onOpenInBrowser = { HyperlinkDetector.openUrl(session.link) },
                     onCopyLink = { tabBarClipboard.setText(androidx.compose.ui.text.AnnotatedString(session.link)) },
                     onRequestControl = { session.requestControl() },
+                    nested = nested,
                 )
             }
             // In summary mode the active tab's single chip carries the tab id; match it

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -900,12 +900,17 @@ fun TabbedTerminal(
             // Tab bar (show when multiple tabs or alwaysShowTabBar is set).
             if (tabBarVisible) {
             val summaryMode = settings.tabBarSummaryMode
+            val rm = state?.remoteSessions
 
             // Resolve the per-tab accent color: a manual color (Color ▸ menu) always
             // wins; otherwise, when color-by-directory is on, derive a stable accent
             // from the session's cwd. Reads MutableState so the bar recomposes live.
             fun colorHexFor(session: TerminalSession): String? {
-                if (session.isRemote) return "0xFF4FC3F7" // cyan accent marks mirrored remote tabs
+                if (session.isRemote) {
+                    // Group accent (set via the remote box header's right-click) wins; the
+                    // default cyan marks mirrored remote tabs.
+                    return rm?.sessionForMirror(session)?.accent?.value ?: "0xFF4FC3F7"
+                }
                 session.tabColor.value?.let { return it }
                 if (settings.tabColorByDirectory) {
                     val cwd = session.workingDirectory.value
@@ -969,12 +974,14 @@ fun TabbedTerminal(
             // Partition local tabs from mirrored remote-session tabs: local tabs render as
             // normal chip clusters; each remote session renders as its own boxed group with
             // a link header + footer actions (split / new tab / disconnect) targeting the host.
-            val rm = state?.remoteSessions
             val tabGroups = tabGroupsWithTab.filter { rm?.sessionForTab(it.first) == null }.map { it.second }
             val remoteGroups = rm?.sessions.orEmpty().mapNotNull { session ->
                 val gs = tabGroupsWithTab.filter { rm?.sessionForTab(it.first) === session }.map { it.second }
                 if (gs.isEmpty()) null else ai.rever.bossterm.compose.tabs.RemoteTabGroup(
-                    header = runCatching { java.net.URI(session.link).host ?: session.link }.getOrDefault(session.link),
+                    id = session.link,
+                    header = session.customName.value
+                        ?: runCatching { java.net.URI(session.link).host ?: session.link }.getOrDefault(session.link),
+                    colorHex = session.accent.value,
                     groups = gs,
                     canControl = session.canControl,
                     onSplitVertical = { session.splitFocused(horizontal = false) },
@@ -987,6 +994,10 @@ fun TabbedTerminal(
                     onChipLaunchAI = { tabIndex, paneId, assistantId ->
                         tabController.tabs.getOrNull(tabIndex)?.let { session.launchAI(it.id, paneId, assistantId) }
                     },
+                    // Local group customization (box header right-click): blank name reverts
+                    // to the link's host; null color reverts to the default remote cyan.
+                    onRename = { session.customName.value = it.trim().ifBlank { null } },
+                    onSetColor = { hex -> session.accent.value = hex },
                 )
             }
             // In summary mode the active tab's single chip carries the tab id; match it

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1,6 +1,8 @@
 package ai.rever.bossterm.compose
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -1257,6 +1259,7 @@ fun TabbedTerminal(
                 splitState.navigateFocus(direction)
             }
 
+            Box(modifier = Modifier.fillMaxSize()) {
             SplitContainer(
                 splitState = splitState,
                 sharedFont = sharedFont,
@@ -1555,6 +1558,28 @@ fun TabbedTerminal(
                 hyperlinkRegistry = hyperlinkRegistry,
                 modifier = Modifier.fillMaxSize()
             )
+            // Read-only indicator: a subtle pill over the pane while this remote session is
+            // view-only; clicking it asks the host for control (same as the menus' Request
+            // Control). Disappears the moment the grant arrives (canControlState is observable).
+            if (remoteForActive != null && !remoteForActive.canControlState.value) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = 8.dp, end = 16.dp)
+                        .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                        .background(Color(0xE6252526))
+                        .border(1.dp, Color(0xFF404040), androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                        .clickable { remoteForActive.requestControl() }
+                ) {
+                    androidx.compose.material3.Text(
+                        "View only — click to request control",
+                        color = Color(0xFFB0B0B0),
+                        fontSize = 11.sp,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                    )
+                }
+            }
+            }
         }
         }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -973,10 +973,17 @@ fun TabbedTerminal(
                 if (gs.isEmpty()) null else ai.rever.bossterm.compose.tabs.RemoteTabGroup(
                     header = runCatching { java.net.URI(session.link).host ?: session.link }.getOrDefault(session.link),
                     groups = gs,
+                    canControl = session.canControl,
                     onSplitVertical = { session.splitFocused(horizontal = false) },
                     onSplitHorizontal = { session.splitFocused(horizontal = true) },
                     onNewTab = { session.newRemoteTab() },
                     onDisconnect = { rm?.disconnect(session) },
+                    onChipSplit = { tabIndex, paneId, horizontal ->
+                        tabController.tabs.getOrNull(tabIndex)?.let { session.splitPane(it.id, paneId, horizontal) }
+                    },
+                    onChipLaunchAI = { tabIndex, paneId, assistantId ->
+                        tabController.tabs.getOrNull(tabIndex)?.let { session.launchAI(it.id, paneId, assistantId) }
+                    },
                 )
             }
             // In summary mode the active tab's single chip carries the tab id; match it
@@ -1022,7 +1029,13 @@ fun TabbedTerminal(
                     WindowManager.createWindowWithTab(extractedTab, splitState)
                 },
                 onRename = { tabIndex, paneId, newTitle ->
-                    sessionFor(tabIndex, paneId)?.let { session ->
+                    val t = tabController.tabs.getOrNull(tabIndex)
+                    val remote = t?.let { rm?.sessionForTab(it) }
+                    if (remote != null && t != null) {
+                        // Remote chip: route to the host; the resulting Layout reflects the new
+                        // title locally (don't mutate the mirror's title directly).
+                        remote.renameTab(t.id, paneId, newTitle.trim())
+                    } else sessionFor(tabIndex, paneId)?.let { session ->
                         val trimmed = newTitle.trim()
                         if (trimmed.isBlank()) {
                             // Clear the custom title; wireCwdTitle reverts it to the cwd.
@@ -1034,13 +1047,31 @@ fun TabbedTerminal(
                     }
                 },
                 onSetColor = { tabIndex, paneId, hex ->
-                    sessionFor(tabIndex, paneId)?.let { it.tabColor.value = hex }
+                    val t = tabController.tabs.getOrNull(tabIndex)
+                    val remote = t?.let { rm?.sessionForTab(it) }
+                    if (remote != null && t != null) remote.setTabColor(t.id, paneId, hex)
+                    else sessionFor(tabIndex, paneId)?.let { it.tabColor.value = hex }
                 },
-                onCloseOthers = { tabController.closeOtherTabs(it) },
-                onCloseBelow = { tabController.closeTabsBelow(it) },
+                onCloseOthers = { index ->
+                    val t = tabController.tabs.getOrNull(index)
+                    val remote = t?.let { rm?.sessionForTab(it) }
+                    if (remote != null && t != null) remote.closeOtherTabs(t.id)
+                    else tabController.closeOtherTabs(index)
+                },
+                onCloseBelow = { index ->
+                    val t = tabController.tabs.getOrNull(index)
+                    val remote = t?.let { rm?.sessionForTab(it) }
+                    if (remote != null && t != null) remote.closeTabsBelow(t.id)
+                    else tabController.closeTabsBelow(index)
+                },
                 onDuplicate = { index ->
-                    val wd = tabController.tabs.getOrNull(index)?.workingDirectory?.value
-                    tabController.createTab(workingDir = wd)
+                    val t = tabController.tabs.getOrNull(index)
+                    val remote = t?.let { rm?.sessionForTab(it) }
+                    if (remote != null && t != null) remote.duplicateTab(t.id)
+                    else {
+                        val wd = t?.workingDirectory?.value
+                        tabController.createTab(workingDir = wd)
+                    }
                 },
                 onShareTab = { index ->
                     tabController.tabs.getOrNull(index)?.let { startShare(it.id, ai.rever.bossterm.compose.share.ShareScope.TAB) }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -985,13 +985,34 @@ fun TabbedTerminal(
                 // sessions nest under a labeled subsection per upstream (read-only flagged).
                 val gs = mine.filter { session.upstreamFor(it.first.id) == null }.map { it.second }
                 val nested = mine
-                    .mapNotNull { (t, g) -> session.upstreamFor(t.id)?.let { up -> up to g } }
-                    .groupBy({ it.first.key }, { it })
+                    .mapNotNull { (t, g) -> session.upstreamFor(t.id)?.let { up -> Triple(up, t, g) } }
+                    .groupBy { it.first.key }
                     .map { (_, items) ->
+                        val up = items.first().first
+                        val nestTabs = items.map { it.second }
+                        // Footer actions target the active tab when it's in this nest, else its
+                        // first tab; the host relays them to the origin. When the host itself is
+                        // view-only on the origin, route to the relayed control request instead
+                        // of a silent no-op.
+                        fun anchor() = nestTabs.firstOrNull { it.id == tabController.activeTab?.id } ?: nestTabs.first()
+                        fun splitNest(horizontal: Boolean) {
+                            if (up.readOnly) { session.requestControlFor(anchor().id); return }
+                            val t = anchor()
+                            val paneId = splitStates[t.id]?.focusedPaneId ?: return
+                            session.splitPane(t.id, paneId, horizontal)
+                        }
                         ai.rever.bossterm.compose.tabs.RemoteNestedGroup(
-                            label = items.first().first.name ?: "remote",
-                            readOnly = items.first().first.readOnly,
-                            groups = items.map { it.second },
+                            label = up.name ?: "remote",
+                            readOnly = up.readOnly,
+                            groups = items.map { it.third },
+                            onSplitVertical = { splitNest(horizontal = false) },
+                            onSplitHorizontal = { splitNest(horizontal = true) },
+                            onNewTab = {
+                                if (up.readOnly) session.requestControlFor(anchor().id)
+                                else session.newTabIn(anchor().id)
+                            },
+                            onClose = { session.disconnectUpstream(nestTabs.first().id) },
+                            onRequestControl = { session.requestControlFor(anchor().id) },
                         )
                     }
                 if (gs.isEmpty() && nested.isEmpty()) null else ai.rever.bossterm.compose.tabs.RemoteTabGroup(
@@ -1001,9 +1022,20 @@ fun TabbedTerminal(
                     colorHex = session.accent.value,
                     groups = gs,
                     canControl = session.canControlState.value, // Compose state → menus update on grant
-                    onSplitVertical = { session.splitFocused(horizontal = false) },
-                    onSplitHorizontal = { session.splitFocused(horizontal = true) },
-                    onNewTab = { session.newRemoteTab() },
+                    // View-only: split/new-tab route to the control request (the host shows
+                    // its approval prompt) instead of silently doing nothing.
+                    onSplitVertical = {
+                        if (session.canControlState.value) session.splitFocused(horizontal = false)
+                        else session.requestControl()
+                    },
+                    onSplitHorizontal = {
+                        if (session.canControlState.value) session.splitFocused(horizontal = true)
+                        else session.requestControl()
+                    },
+                    onNewTab = {
+                        if (session.canControlState.value) session.newRemoteTab()
+                        else session.requestControl()
+                    },
                     onDisconnect = { rm?.disconnect(session) },
                     onChipSplit = { tabIndex, paneId, horizontal ->
                         tabController.tabs.getOrNull(tabIndex)?.let { session.splitPane(it.id, paneId, horizontal) }
@@ -1726,16 +1758,20 @@ fun TabbedTerminal(
                     }
                 }
                 // Upstream read-only (A→B→C): we may control the host, but the host itself is
-                // view-only on this tab's origin, so typing still can't land. Info only.
+                // view-only on this tab's origin, so typing still can't land. Clicking relays a
+                // control request through the host to the origin (its user sees the approval).
                 upstreamReadOnly?.let { up ->
                     Box(
                         modifier = Modifier
                             .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
                             .background(Color(0xE6252526))
                             .border(1.dp, Color(0xFF404040), androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                            .clickable {
+                                tabController.activeTab?.id?.let { id -> activeRemoteSession?.requestControlFor(id) }
+                            }
                     ) {
                         androidx.compose.material3.Text(
-                            "View only — host is view-only on ${up.name ?: "this session"}",
+                            "View only — click to request control of ${up.name ?: "the origin"}",
                             color = Color(0xFFB0B0B0),
                             fontSize = 11.sp,
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -995,11 +995,19 @@ fun TabbedTerminal(
                 onPaneClosed = { tabIndex, paneId ->
                     val t = tabController.tabs.getOrNull(tabIndex)
                     if (t != null) {
-                        val st = splitStates[t.id]
-                        // paneId == t.id is a synthetic tab-level chip (summary / single
-                        // pane) — close the whole tab. Real split panes close just the pane.
-                        if (st == null || st.isSinglePane || paneId == t.id) tabController.closeTab(tabIndex)
-                        else st.closePane(paneId)
+                        val session = rm?.sessionForTab(t)
+                        if (session != null) {
+                            // Remote: structure is host-driven. Route the close to the host
+                            // (control only) — the resulting Layout removes it locally. Never
+                            // dispose a mirror locally (the next Layout would resurrect it).
+                            session.closeFromChip(t.id, paneId)
+                        } else {
+                            val st = splitStates[t.id]
+                            // paneId == t.id is a synthetic tab-level chip (summary / single
+                            // pane) — close the whole tab. Real split panes close just the pane.
+                            if (st == null || st.isSinglePane || paneId == t.id) tabController.closeTab(tabIndex)
+                            else st.closePane(paneId)
+                        }
                     }
                 },
                 onNewTab = {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1259,7 +1259,6 @@ fun TabbedTerminal(
                 splitState.navigateFocus(direction)
             }
 
-            Box(modifier = Modifier.fillMaxSize()) {
             SplitContainer(
                 splitState = splitState,
                 sharedFont = sharedFont,
@@ -1558,28 +1557,6 @@ fun TabbedTerminal(
                 hyperlinkRegistry = hyperlinkRegistry,
                 modifier = Modifier.fillMaxSize()
             )
-            // Read-only indicator: a subtle pill over the pane while this remote session is
-            // view-only; clicking it asks the host for control (same as the menus' Request
-            // Control). Disappears the moment the grant arrives (canControlState is observable).
-            if (remoteForActive != null && !remoteForActive.canControlState.value) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(top = 8.dp, end = 16.dp)
-                        .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
-                        .background(Color(0xE6252526))
-                        .border(1.dp, Color(0xFF404040), androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
-                        .clickable { remoteForActive.requestControl() }
-                ) {
-                    androidx.compose.material3.Text(
-                        "View only — click to request control",
-                        color = Color(0xFFB0B0B0),
-                        fontSize = 11.sp,
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
-                    )
-                }
-            }
-            }
         }
         }
 
@@ -1635,7 +1612,12 @@ fun TabbedTerminal(
         // QR/links dialog if already shared). Shown per its own toggle.
         val showMcpStatus = settings.mcpShowStatusIndicator
         val showSharingStatus = settings.sessionSharingShowIndicator
-        if (showMcpStatus || showSharingStatus || attachStatus != null || pendingShareRequests.isNotEmpty()) {
+        // The active tab's remote session while it's still view-only — drives the read-only
+        // pill, stacked in this same column so it sits BELOW the MCP/Sharing pills.
+        val viewOnlyRemote = tabController.activeTab
+            ?.let { t -> state?.remoteSessions?.sessionForTab(t) }
+            ?.takeIf { !it.canControlState.value }
+        if (showMcpStatus || showSharingStatus || attachStatus != null || pendingShareRequests.isNotEmpty() || viewOnlyRemote != null) {
             Column(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
@@ -1700,6 +1682,24 @@ fun TabbedTerminal(
                         onApprove = { ai.rever.bossterm.compose.share.SessionShareManager.approveRequest(req.id) },
                         onDeny = { ai.rever.bossterm.compose.share.SessionShareManager.denyRequest(req.id) },
                     )
+                }
+                // Read-only indicator: the active tab mirrors a remote we can't type into.
+                // Clicking requests control; vanishes the moment the grant arrives.
+                viewOnlyRemote?.let { session ->
+                    Box(
+                        modifier = Modifier
+                            .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                            .background(Color(0xE6252526))
+                            .border(1.dp, Color(0xFF404040), androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                            .clickable { session.requestControl() }
+                    ) {
+                        androidx.compose.material3.Text(
+                            "View only — click to request control",
+                            color = Color(0xFFB0B0B0),
+                            fontSize = 11.sp,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                        )
+                    }
                 }
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -998,6 +998,8 @@ fun TabbedTerminal(
                     // to the link's host; null color reverts to the default remote cyan.
                     onRename = { session.customName.value = it.trim().ifBlank { null } },
                     onSetColor = { hex -> session.accent.value = hex },
+                    // The same share link this group mirrors, in the web viewer.
+                    onOpenInBrowser = { HyperlinkDetector.openUrl(session.link) },
                 )
             }
             // In summary mode the active tab's single chip carries the tab id; match it

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1203,6 +1203,37 @@ fun TabbedTerminal(
                 if (remoteForActive != null) { { remoteForActive.closeFromChip(activeTab.id, splitState.focusedPaneId) } }
                 else onClosePane
 
+            // "Fit to client": resize THIS window so [focused]'s pane renders the remote's current
+            // grid 1:1 — the reverse of "Fit host to my screen". Mirrors the host's own
+            // resizeHostWindow nudge (per-cell px × the grid delta, window chrome cancels out);
+            // purely local, needs no control. No-op until the canvas has been measured once.
+            fun fitClientWindowToHost(focused: ai.rever.bossterm.compose.tabs.TerminalTab) {
+                val cw = focused.terminal.cellWidthPx
+                val ch = focused.terminal.cellHeightPx
+                if (cw <= 0f || ch <= 0f) return
+                val grid = focused.display.termSize.value
+                val hostCols = grid.columns; val hostRows = grid.rows
+                val curCols = focused.remoteFitCols; val curRows = focused.remoteFitRows
+                if (hostCols < 2 || hostRows < 2 || curCols < 2 || curRows < 2) return
+                val win = WindowManager.windows.firstOrNull { it.isWindowFocused.value && it.awtWindow != null }?.awtWindow
+                    ?: WindowManager.windows.firstOrNull { it.awtWindow != null }?.awtWindow ?: return
+                javax.swing.SwingUtilities.invokeLater {
+                    runCatching {
+                        val gc = win.graphicsConfiguration
+                        val sx = gc?.defaultTransform?.scaleX?.takeIf { it > 0 } ?: 1.0
+                        val sy = gc?.defaultTransform?.scaleY?.takeIf { it > 0 } ?: 1.0
+                        var newW = (win.width + (hostCols - curCols) * cw / sx).toInt()
+                        var newH = (win.height + (hostRows - curRows) * ch / sy).toInt()
+                        gc?.bounds?.let { b ->
+                            val maxW = (b.x + b.width - win.x).coerceAtLeast(480)
+                            val maxH = (b.y + b.height - win.y).coerceAtLeast(320)
+                            newW = newW.coerceIn(480, maxW); newH = newH.coerceIn(320, maxH)
+                        }
+                        if (newW != win.width || newH != win.height) { win.setSize(newW, newH); win.validate() }
+                    }
+                }
+            }
+
             val onNavigatePane: (NavigationDirection) -> Unit = { direction ->
                 splitState.navigateFocus(direction)
             }
@@ -1307,11 +1338,31 @@ fun TabbedTerminal(
                     var items = userItems
 
                     if (remoteForActive != null) {
-                        // Remote (mirrored) pane: show the viewer's pane menu — a host-routed AI
-                        // Assistant submenu (runs the host's configured command, honoring its
-                        // YOLO/auto-mode), launched in the focused pane. Copy/Paste/Find/Split/Close
-                        // come from the base menu; local-host items (MCP attach, Share, VCS, shell
-                        // customization) don't apply to a mirror, so they're omitted.
+                        // Remote (mirrored) pane: show the viewer's pane menu — two fit actions plus
+                        // a host-routed AI Assistant submenu (runs the host's configured command,
+                        // honoring its YOLO/auto-mode), launched in the focused pane. Copy/Paste/
+                        // Find/Split/Close come from the base menu; local-host items (MCP attach,
+                        // Share, VCS, shell customization) don't apply to a mirror, so they're omitted.
+                        val focusedRemote = splitState.getFocusedSession() as? ai.rever.bossterm.compose.tabs.TerminalTab
+                        // Fit host to my screen: resize the REMOTE so its grid matches this pane
+                        // (like the viewer's top-bar button). Mutates the host → control only.
+                        if (focusedRemote != null && remoteForActive.canControl) {
+                            items = items + ContextMenuItem(
+                                id = "remote_fit_host", label = "Fit host to my screen",
+                                action = {
+                                    if (focusedRemote.remoteFitCols >= 2 && focusedRemote.remoteFitRows >= 2)
+                                        remoteForActive.resizeHost(activeTab.id, focusedRemote.remoteFitCols, focusedRemote.remoteFitRows)
+                                }
+                            )
+                        }
+                        // Fit my window to host: resize THIS window so the remote's grid renders
+                        // 1:1 here — the reverse direction, and purely local (no control needed).
+                        if (focusedRemote != null) {
+                            items = items + ContextMenuItem(
+                                id = "remote_fit_client", label = "Fit my window to host",
+                                action = { fitClientWindowToHost(focusedRemote) }
+                            )
+                        }
                         items = items + ContextMenuSubmenu(
                             id = "remote_ai_assistants",
                             label = "AI Assistant",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -984,7 +984,7 @@ fun TabbedTerminal(
                         ?: runCatching { java.net.URI(session.link).host ?: session.link }.getOrDefault(session.link),
                     colorHex = session.accent.value,
                     groups = gs,
-                    canControl = session.canControl,
+                    canControl = session.canControlState.value, // Compose state → menus update on grant
                     onSplitVertical = { session.splitFocused(horizontal = false) },
                     onSplitHorizontal = { session.splitFocused(horizontal = true) },
                     onNewTab = { session.newRemoteTab() },
@@ -1363,6 +1363,15 @@ fun TabbedTerminal(
                         // Find/Split/Close come from the base menu; local-host items (MCP attach,
                         // Share, VCS, shell customization) don't apply to a mirror, so they're omitted.
                         val focusedRemote = splitState.getFocusedSession() as? ai.rever.bossterm.compose.tabs.TerminalTab
+                        // View-only: the host ignores mutating actions, so keep the menu lean —
+                        // the upgrade path instead of host-routed items (the base menu's Copy/
+                        // Paste/Find stay useful; its Split/Close no-op until control is granted).
+                        if (!remoteForActive.canControl) {
+                            items = items + ContextMenuItem(
+                                id = "remote_request_control", label = "Request Control",
+                                action = { remoteForActive.requestControl() }
+                            )
+                        }
                         // Fit host to my screen: resize the REMOTE so its grid matches this pane
                         // (like the viewer's top-bar button). Mutates the host → control only.
                         if (focusedRemote != null && remoteForActive.canControl) {
@@ -1382,21 +1391,23 @@ fun TabbedTerminal(
                                 action = { fitClientWindowToHost(focusedRemote) }
                             )
                         }
-                        items = items + ContextMenuSubmenu(
-                            id = "remote_ai_assistants",
-                            label = "AI Assistant",
-                            items = listOf(
-                                "claude-code" to "Claude Code",
-                                "codex" to "Codex",
-                                "gemini-cli" to "Gemini CLI",
-                                "opencode" to "OpenCode",
-                            ).map { (aid, label) ->
-                                ContextMenuItem(
-                                    id = "remote_ai_$aid", label = label,
-                                    action = { remoteForActive.launchAI(activeTab.id, splitState.focusedPaneId, aid) }
-                                )
-                            }
-                        )
+                        if (remoteForActive.canControl) {
+                            items = items + ContextMenuSubmenu(
+                                id = "remote_ai_assistants",
+                                label = "AI Assistant",
+                                items = listOf(
+                                    "claude-code" to "Claude Code",
+                                    "codex" to "Codex",
+                                    "gemini-cli" to "Gemini CLI",
+                                    "opencode" to "OpenCode",
+                                ).map { (aid, label) ->
+                                    ContextMenuItem(
+                                        id = "remote_ai_$aid", label = label,
+                                        action = { remoteForActive.launchAI(activeTab.id, splitState.focusedPaneId, aid) }
+                                    )
+                                }
+                            )
+                        }
                     } else {
 
                     // Add AI assistant menu items

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -944,7 +944,7 @@ fun TabbedTerminal(
             // Each tab contributes a group of pane-chips (one chip per split pane).
             // In summary mode (or before a tab is split) a single chip represents the
             // whole tab, labeled with the tab's title.
-            val tabGroups = tabController.tabs.mapIndexed { index, tab ->
+            val tabGroupsWithTab = tabController.tabs.mapIndexed { index, tab ->
                 val st = splitStates[tab.id]
                 val panes = if (st != null && !summaryMode) {
                     st.getAllPanes().map { p ->
@@ -961,7 +961,23 @@ fun TabbedTerminal(
                         branch = tab.gitBranch.value
                     ))
                 }
-                ai.rever.bossterm.compose.tabs.TabBarGroup(index, panes)
+                tab to ai.rever.bossterm.compose.tabs.TabBarGroup(index, panes)
+            }
+            // Partition local tabs from mirrored remote-session tabs: local tabs render as
+            // normal chip clusters; each remote session renders as its own boxed group with
+            // a link header + footer actions (split / new tab / disconnect) targeting the host.
+            val rm = state?.remoteSessions
+            val tabGroups = tabGroupsWithTab.filter { rm?.sessionForTab(it.first) == null }.map { it.second }
+            val remoteGroups = rm?.sessions.orEmpty().mapNotNull { session ->
+                val gs = tabGroupsWithTab.filter { rm?.sessionForTab(it.first) === session }.map { it.second }
+                if (gs.isEmpty()) null else ai.rever.bossterm.compose.tabs.RemoteTabGroup(
+                    header = runCatching { java.net.URI(session.link).host ?: session.link }.getOrDefault(session.link),
+                    groups = gs,
+                    onSplitVertical = { session.splitFocused(horizontal = false) },
+                    onSplitHorizontal = { session.splitFocused(horizontal = true) },
+                    onNewTab = { session.newRemoteTab() },
+                    onDisconnect = { rm?.disconnect(session) },
+                )
             }
             // In summary mode the active tab's single chip carries the tab id; match it
             // so it highlights. Otherwise highlight the focused split pane.
@@ -969,6 +985,7 @@ fun TabbedTerminal(
                                 else tabController.activeTab?.let { splitStates[it.id]?.focusedPaneId }
             TabBar(
                 groups = tabGroups,
+                remoteGroups = remoteGroups,
                 activeTabIndex = tabController.activeTabIndex,
                 focusedPaneId = focusedPaneId,
                 onPaneSelected = { tabIndex, paneId ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -901,6 +901,7 @@ fun TabbedTerminal(
             if (tabBarVisible) {
             val summaryMode = settings.tabBarSummaryMode
             val rm = state?.remoteSessions
+            val tabBarClipboard = androidx.compose.ui.platform.LocalClipboardManager.current
 
             // Resolve the per-tab accent color: a manual color (Color ▸ menu) always
             // wins; otherwise, when color-by-directory is on, derive a stable accent
@@ -1000,6 +1001,7 @@ fun TabbedTerminal(
                     onSetColor = { hex -> session.accent.value = hex },
                     // The same share link this group mirrors, in the web viewer.
                     onOpenInBrowser = { HyperlinkDetector.openUrl(session.link) },
+                    onCopyLink = { tabBarClipboard.setText(androidx.compose.ui.text.AnnotatedString(session.link)) },
                 )
             }
             // In summary mode the active tab's single chip carries the tab id; match it

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1017,7 +1017,10 @@ fun TabbedTerminal(
                     }
                 if (gs.isEmpty() && nested.isEmpty()) null else ai.rever.bossterm.compose.tabs.RemoteTabGroup(
                     id = session.link,
+                    // Group label precedence: local rename → the host's session name (its
+                    // username by default) → the link's host.
                     header = session.customName.value
+                        ?: session.hostName.value
                         ?: runCatching { java.net.URI(session.link).host ?: session.link }.getOrDefault(session.link),
                     colorHex = session.accent.value,
                     groups = gs,
@@ -1803,6 +1806,8 @@ fun TabbedTerminal(
             tailscaleMode = settings.shareTailscaleMode,
             onTailscaleModeChange = { SettingsManager.instance.updateSetting { copy(shareTailscaleMode = it) } },
             onRefreshLink = { ai.rever.bossterm.compose.share.SessionShareManager.refreshRemoteLink() },
+            sessionName = ai.rever.bossterm.compose.share.SessionShareManager.sessionNameFor(info.tabId) ?: "",
+            onSessionNameChange = { ai.rever.bossterm.compose.share.SessionShareManager.setSessionName(info.tabId, it) },
         )
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -786,6 +786,8 @@ fun TabbedTerminal(
     var mcpAttaching by remember { mutableStateOf(false) }
     // Session sharing (issue #276): dialog state + live set of shared tab ids.
     var shareDialog by remember { mutableStateOf<ai.rever.bossterm.compose.share.SessionShareManager.ShareInfo?>(null) }
+    // "Add remote": connect to another BossTerm's shared session (native client).
+    var showAddRemote by remember { mutableStateOf(false) }
     // Bumped every time the share window is opened/reopened; ShareWindow brings its OS
     // window to the front when this changes, so clicking the share button while a share
     // window is already open raises that window instead of leaving it behind.
@@ -903,6 +905,7 @@ fun TabbedTerminal(
             // wins; otherwise, when color-by-directory is on, derive a stable accent
             // from the session's cwd. Reads MutableState so the bar recomposes live.
             fun colorHexFor(session: TerminalSession): String? {
+                if (session.isRemote) return "0xFF4FC3F7" // cyan accent marks mirrored remote tabs
                 session.tabColor.value?.let { return it }
                 if (settings.tabColorByDirectory) {
                     val cwd = session.workingDirectory.value
@@ -1029,6 +1032,7 @@ fun TabbedTerminal(
                 onSplitVertical = { splitActiveTab(SplitOrientation.VERTICAL) },
                 onSplitHorizontal = { splitActiveTab(SplitOrientation.HORIZONTAL) },
                 onSettings = onShowSettings,
+                onAddRemote = { showAddRemote = true },
                 orientation = if (tabBarOnLeft) ai.rever.bossterm.compose.tabs.TabBarOrientation.LEFT
                               else ai.rever.bossterm.compose.tabs.TabBarOrientation.TOP,
                 verticalWidth = settings.tabBarVerticalWidth.dp
@@ -1521,6 +1525,19 @@ fun TabbedTerminal(
             onTailscaleModeChange = { SettingsManager.instance.updateSetting { copy(shareTailscaleMode = it) } },
             onRefreshLink = { ai.rever.bossterm.compose.share.SessionShareManager.refreshRemoteLink() },
         )
+    }
+
+    // "Add remote": connect to another BossTerm's shared session and mirror its tabs here.
+    // Requires an external TabbedTerminalState (it owns the RemoteSessionManager + tab list).
+    if (showAddRemote) {
+        if (state != null) {
+            ai.rever.bossterm.compose.remote.AddRemoteDialog(
+                manager = state.remoteSessions,
+                onDismiss = { showAddRemote = false },
+            )
+        } else {
+            showAddRemote = false
+        }
     }
 
     // AI Assistant Installation Wizard (command interception, context menu, and programmatic API)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -918,7 +918,9 @@ fun TabbedTerminal(
             }
 
             // Abbreviate a working directory for the chip's second line (Warp-style):
-            // home → "~", otherwise collapse long paths to "~/…/parent/dir".
+            // collapse long paths to "~/…/parent/dir". At home the title is already "~", so the
+            // second line would collapse to "~" too and get hidden (== title) — instead show the
+            // full home path there, matching the web viewer (its second line is never blank/"~").
             fun abbreviateCwd(path: String?): String? {
                 if (path.isNullOrBlank()) return null
                 val home = System.getProperty("user.home")?.trimEnd('/')
@@ -927,7 +929,8 @@ fun TabbedTerminal(
                     "~" + clean.removePrefix(home) else clean
                 val parts = withTilde.split('/').filter { it.isNotEmpty() }
                 return when {
-                    withTilde == "~" || withTilde == "/" -> withTilde
+                    withTilde == "~" -> clean // home: show the real path (the "~" title carries the tilde)
+                    withTilde == "/" -> "/"
                     parts.size <= 2 -> withTilde
                     withTilde.startsWith("~") -> "~/…/" + parts.takeLast(2).joinToString("/")
                     else -> "/…/" + parts.takeLast(2).joinToString("/")

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1188,6 +1188,21 @@ fun TabbedTerminal(
                 }
             }
 
+            // For a mirrored remote tab, the pane-body (shell) right-click menu's structural
+            // actions must target the HOST — the local split tree is rebuilt from the host's
+            // Layout, so a local split/close would be wiped on the next reconcile. This mirrors
+            // the browser viewer's pane menu. Normal tabs keep the local handlers.
+            val remoteForActive = state?.remoteSessions?.sessionForTab(activeTab)
+            val paneSplitVertical: () -> Unit =
+                if (remoteForActive != null) { { remoteForActive.splitPane(activeTab.id, splitState.focusedPaneId, horizontal = false) } }
+                else onSplitVertical
+            val paneSplitHorizontal: () -> Unit =
+                if (remoteForActive != null) { { remoteForActive.splitPane(activeTab.id, splitState.focusedPaneId, horizontal = true) } }
+                else onSplitHorizontal
+            val paneClose: () -> Unit =
+                if (remoteForActive != null) { { remoteForActive.closeFromChip(activeTab.id, splitState.focusedPaneId) } }
+                else onClosePane
+
             val onNavigatePane: (NavigationDirection) -> Unit = { direction ->
                 splitState.navigateFocus(direction)
             }
@@ -1227,13 +1242,14 @@ fun TabbedTerminal(
                 onNewWindow = onNewWindow,
                 onShowSettings = onShowSettings,
                 onShowWelcomeWizard = onShowWelcomeWizard,
-                onSplitHorizontal = onSplitHorizontal,
-                onSplitVertical = onSplitVertical,
-                onClosePane = onClosePane,
+                onSplitHorizontal = paneSplitHorizontal,
+                onSplitVertical = paneSplitVertical,
+                onClosePane = paneClose,
                 onNavigatePane = onNavigatePane,
                 onNavigateNextPane = { splitState.navigateToNextPane() },
                 onNavigatePreviousPane = { splitState.navigateToPreviousPane() },
-                onMoveToNewTab = if (!splitState.isSinglePane) {
+                // A remote mirror pane can't be moved into a local tab (it has no local PTY).
+                onMoveToNewTab = if (!splitState.isSinglePane && remoteForActive == null) {
                     {
                         // Extract the session from the split and move it to a new tab
                         val extractedSession = splitState.extractFocusedPaneSession()
@@ -1289,6 +1305,29 @@ fun TabbedTerminal(
                 customContextMenuItemsProvider = {
                     val userItems = contextMenuItemsProvider?.invoke() ?: contextMenuItems
                     var items = userItems
+
+                    if (remoteForActive != null) {
+                        // Remote (mirrored) pane: show the viewer's pane menu — a host-routed AI
+                        // Assistant submenu (runs the host's configured command, honoring its
+                        // YOLO/auto-mode), launched in the focused pane. Copy/Paste/Find/Split/Close
+                        // come from the base menu; local-host items (MCP attach, Share, VCS, shell
+                        // customization) don't apply to a mirror, so they're omitted.
+                        items = items + ContextMenuSubmenu(
+                            id = "remote_ai_assistants",
+                            label = "AI Assistant",
+                            items = listOf(
+                                "claude-code" to "Claude Code",
+                                "codex" to "Codex",
+                                "gemini-cli" to "Gemini CLI",
+                                "opencode" to "OpenCode",
+                            ).map { (aid, label) ->
+                                ContextMenuItem(
+                                    id = "remote_ai_$aid", label = label,
+                                    action = { remoteForActive.launchAI(activeTab.id, splitState.focusedPaneId, aid) }
+                                )
+                            }
+                        )
+                    } else {
 
                     // Add AI assistant menu items
                     if (settings.aiAssistantsEnabled) {
@@ -1399,6 +1438,7 @@ fun TabbedTerminal(
                         }
                     )
                     items = items + shellItems
+                    } // end non-remote (local host) menu items
 
                     items
                 },

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -790,6 +790,9 @@ fun TabbedTerminal(
     var shareDialog by remember { mutableStateOf<ai.rever.bossterm.compose.share.SessionShareManager.ShareInfo?>(null) }
     // "Add remote": connect to another BossTerm's shared session (native client).
     var showAddRemote by remember { mutableStateOf(false) }
+    // Pending "request control?" confirmation: a view-only group's split/new-tab click stores
+    // the actual request here; confirming the dialog runs it, dismissing drops it.
+    var requestControlPrompt by remember { mutableStateOf<(() -> Unit)?>(null) }
     // Bumped every time the share window is opened/reopened; ShareWindow brings its OS
     // window to the front when this changes, so clicking the share button while a share
     // window is already open raises that window instead of leaving it behind.
@@ -996,7 +999,10 @@ fun TabbedTerminal(
                         // of a silent no-op.
                         fun anchor() = nestTabs.firstOrNull { it.id == tabController.activeTab?.id } ?: nestTabs.first()
                         fun splitNest(horizontal: Boolean) {
-                            if (up.readOnly) { session.requestControlFor(anchor().id); return }
+                            if (up.readOnly) {
+                                requestControlPrompt = { session.requestControlFor(anchor().id) }
+                                return
+                            }
                             val t = anchor()
                             val paneId = splitStates[t.id]?.focusedPaneId ?: return
                             session.splitPane(t.id, paneId, horizontal)
@@ -1008,7 +1014,7 @@ fun TabbedTerminal(
                             onSplitVertical = { splitNest(horizontal = false) },
                             onSplitHorizontal = { splitNest(horizontal = true) },
                             onNewTab = {
-                                if (up.readOnly) session.requestControlFor(anchor().id)
+                                if (up.readOnly) requestControlPrompt = { session.requestControlFor(anchor().id) }
                                 else session.newTabIn(anchor().id)
                             },
                             onClose = { session.disconnectUpstream(nestTabs.first().id) },
@@ -1025,19 +1031,19 @@ fun TabbedTerminal(
                     colorHex = session.accent.value,
                     groups = gs,
                     canControl = session.canControlState.value, // Compose state → menus update on grant
-                    // View-only: split/new-tab route to the control request (the host shows
-                    // its approval prompt) instead of silently doing nothing.
+                    // View-only: split/new-tab first confirm via the request-control dialog
+                    // (confirming sends the request; the host shows its approval toast).
                     onSplitVertical = {
                         if (session.canControlState.value) session.splitFocused(horizontal = false)
-                        else session.requestControl()
+                        else requestControlPrompt = { session.requestControl() }
                     },
                     onSplitHorizontal = {
                         if (session.canControlState.value) session.splitFocused(horizontal = true)
-                        else session.requestControl()
+                        else requestControlPrompt = { session.requestControl() }
                     },
                     onNewTab = {
                         if (session.canControlState.value) session.newRemoteTab()
-                        else session.requestControl()
+                        else requestControlPrompt = { session.requestControl() }
                     },
                     onDisconnect = { rm?.disconnect(session) },
                     onChipSplit = { tabIndex, paneId, horizontal ->
@@ -1808,6 +1814,14 @@ fun TabbedTerminal(
             onRefreshLink = { ai.rever.bossterm.compose.share.SessionShareManager.refreshRemoteLink() },
             sessionName = ai.rever.bossterm.compose.share.SessionShareManager.sessionNameFor(info.tabId) ?: "",
             onSessionNameChange = { ai.rever.bossterm.compose.share.SessionShareManager.setSessionName(info.tabId, it) },
+        )
+    }
+
+    // Confirm-before-requesting-control (a view-only group's split/new-tab click).
+    requestControlPrompt?.let { send ->
+        ai.rever.bossterm.compose.remote.RequestControlPrompt(
+            onConfirm = { send(); requestControlPrompt = null },
+            onDismiss = { requestControlPrompt = null },
         )
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1629,10 +1629,19 @@ fun TabbedTerminal(
         val showSharingStatus = settings.sessionSharingShowIndicator
         // The active tab's remote session while it's still view-only — drives the read-only
         // pill, stacked in this same column so it sits BELOW the MCP/Sharing pills.
-        val viewOnlyRemote = tabController.activeTab
-            ?.let { t -> state?.remoteSessions?.sessionForTab(t) }
-            ?.takeIf { !it.canControlState.value }
-        if (showMcpStatus || showSharingStatus || attachStatus != null || pendingShareRequests.isNotEmpty() || viewOnlyRemote != null) {
+        val activeRemoteSession = tabController.activeTab?.let { t -> state?.remoteSessions?.sessionForTab(t) }
+        val viewOnlyRemote = activeRemoteSession?.takeIf { !it.canControlState.value }
+        // Even with control of the host, the active tab may mirror an upstream the HOST itself
+        // can't type into (A shared view-only to B, B shared to us) — input dies at the host.
+        // Informational pill only: control must be requested by the host from the origin.
+        val upstreamReadOnly = if (viewOnlyRemote == null) {
+            activeRemoteSession?.let { s ->
+                s.upstreamRev.value // subscribe: re-evaluate when upstream info changes
+                tabController.activeTab?.id?.let { id -> s.upstreamFor(id)?.takeIf { it.readOnly } }
+            }
+        } else null
+        if (showMcpStatus || showSharingStatus || attachStatus != null || pendingShareRequests.isNotEmpty() ||
+            viewOnlyRemote != null || upstreamReadOnly != null) {
             Column(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
@@ -1710,6 +1719,23 @@ fun TabbedTerminal(
                     ) {
                         androidx.compose.material3.Text(
                             "View only — click to request control",
+                            color = Color(0xFFB0B0B0),
+                            fontSize = 11.sp,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                        )
+                    }
+                }
+                // Upstream read-only (A→B→C): we may control the host, but the host itself is
+                // view-only on this tab's origin, so typing still can't land. Info only.
+                upstreamReadOnly?.let { up ->
+                    Box(
+                        modifier = Modifier
+                            .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                            .background(Color(0xE6252526))
+                            .border(1.dp, Color(0xFF404040), androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                    ) {
+                        androidx.compose.material3.Text(
+                            "View only — host is view-only on ${up.name ?: "this session"}",
                             color = Color(0xFFB0B0B0),
                             fontSize = 11.sp,
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -95,6 +95,15 @@ class TabbedTerminalState {
      */
     internal val splitStates: SnapshotStateMap<String, SplitViewState> = mutableStateMapOf()
 
+    /**
+     * Connections to remote BossTerm shared sessions whose tabs are mirrored into this
+     * window's tab list (the native client of the share protocol). Created lazily on first
+     * "Add remote"; torn down in [dispose].
+     */
+    val remoteSessions: ai.rever.bossterm.compose.remote.RemoteSessionManager by lazy {
+        ai.rever.bossterm.compose.remote.RemoteSessionManager(this)
+    }
+
     // Flow infrastructure for reactive state bridges (T7)
     private var flowScope: CoroutineScope? = null
     private val _tabsFlow = MutableStateFlow<List<TerminalTabInfo>>(emptyList())
@@ -198,6 +207,8 @@ class TabbedTerminalState {
         flowScope = null
         _tabsFlow.value = emptyList()
         _activeTabIndexFlow.value = 0
+        // Tear down any remote-session connections (closes sockets + mirror tabs).
+        runCatching { remoteSessions.disconnectAll() }
         // Dispose all split states
         splitStates.values.forEach { it.dispose() }
         splitStates.clear()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSession.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSession.kt
@@ -246,6 +246,15 @@ interface TerminalSession {
     val tabColor: MutableState<String?>
         get() = androidx.compose.runtime.mutableStateOf(null)  // Default: no color
 
+    /**
+     * True for a **remote mirror** session (no local PTY): bytes are fed from a remote
+     * BossTerm share over a WebSocket and its grid size is dictated by the host. The renderer
+     * uses this to render without a local connection state and to skip local auto-fit resizing.
+     * Default false for normal local sessions.
+     */
+    val isRemote: Boolean
+        get() = false
+
     // === Lifecycle Methods ===
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
@@ -180,7 +180,8 @@ fun RequestControlPrompt(onConfirm: () -> Unit, onDismiss: () -> Unit) {
         text = {
             Text(
                 "You're viewing this session read-only — splits, new tabs, and typing need " +
-                    "control. Ask the host to grant it?",
+                    "control. Ask for it? When the session is reached through another host, " +
+                    "each host is asked in turn and its owner approves.",
                 color = TextSecondary, fontSize = 12.sp
             )
         },

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
@@ -176,7 +176,10 @@ private fun RemoteSessionRow(session: RemoteSession, onDisconnect: () -> Unit) {
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             Column(Modifier.weight(1f)) {
-                Text(hostOf(session.link), color = TextPrimary, fontSize = 13.sp, maxLines = 1)
+                Text(
+                    session.customName.value ?: session.hostName.value ?: hostOf(session.link),
+                    color = TextPrimary, fontSize = 13.sp, maxLines = 1
+                )
                 Text(statusLabel(status), color = statusColor(status), fontSize = 11.sp, maxLines = 1)
             }
             val s = status

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
@@ -2,20 +2,23 @@ package ai.rever.bossterm.compose.remote
 
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
+import ai.rever.bossterm.compose.settings.components.SettingsTextField
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -62,12 +65,11 @@ fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
                         "marked in cyan; with control granted you can type into them.",
                     color = TextSecondary, fontSize = 12.sp
                 )
-                OutlinedTextField(
+                SettingsTextField(
+                    label = "Share link",
                     value = link,
                     onValueChange = { link = it },
-                    label = { Text("Share link (https://….trycloudflare.com/?t=…)") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
+                    placeholder = "https://….trycloudflare.com/?t=…",
                 )
                 if (manager.sessions.isNotEmpty()) {
                     Text("Connected", color = TextMuted, fontSize = 11.sp)
@@ -92,20 +94,22 @@ fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
 @Composable
 private fun RemoteSessionRow(session: RemoteSession, onDisconnect: () -> Unit) {
     val status by session.status.collectAsState()
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp)
-    ) {
-        Column(Modifier.weight(1f)) {
-            Text(hostOf(session.link), color = TextPrimary, fontSize = 13.sp, maxLines = 1)
-            Text(statusLabel(status), color = statusColor(status), fontSize = 11.sp, maxLines = 1)
+    Surface(color = SurfaceColor, shape = RoundedCornerShape(6.dp), modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(hostOf(session.link), color = TextPrimary, fontSize = 13.sp, maxLines = 1)
+                Text(statusLabel(status), color = statusColor(status), fontSize = 11.sp, maxLines = 1)
+            }
+            val s = status
+            if (s is RemoteStatus.Connected && !s.canControl) {
+                TextButton(onClick = { session.requestControl() }) { Text("Request control", color = AccentColor) }
+            }
+            TextButton(onClick = onDisconnect) { Text("Disconnect", color = Danger) }
         }
-        val s = status
-        if (s is RemoteStatus.Connected && !s.canControl) {
-            TextButton(onClick = { session.requestControl() }) { Text("Request control", color = AccentColor) }
-        }
-        TextButton(onClick = onDisconnect) { Text("Disconnect", color = Danger) }
     }
 }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
@@ -56,12 +56,20 @@ private val Danger = Color(0xFFE57373)
 @Composable
 fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
     var link by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
     val deviceName = remember {
         (System.getProperty("user.name")?.takeIf { it.isNotBlank() }?.let { "$it (BossTerm)" }) ?: "BossTerm"
     }
     fun connect() {
         val l = link.trim()
-        if (l.isNotBlank()) { manager.connect(l, deviceName); link = "" }
+        if (l.isBlank()) return
+        if (manager.connect(l, deviceName) == null) {
+            // connect() refuses our own share links — mirroring a session into itself loops.
+            error = "That's this BossTerm's own share link — a session can't mirror itself."
+        } else {
+            link = ""
+            error = null
+        }
     }
     Window(
         onCloseRequest = onDismiss,
@@ -93,9 +101,10 @@ fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
                     SettingsTextField(
                         label = "Share link",
                         value = link,
-                        onValueChange = { link = it },
+                        onValueChange = { link = it; error = null },
                         placeholder = "https://….trycloudflare.com/?t=…",
                     )
+                    error?.let { Text(it, color = Danger, fontSize = 11.sp) }
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.End

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
@@ -2,26 +2,32 @@ package ai.rever.bossterm.compose.remote
 
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
-import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
+import ai.rever.bossterm.compose.settings.components.SettingsSection
 import ai.rever.bossterm.compose.settings.components.SettingsTextField
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,16 +37,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.rememberWindowState
 
 private val Green = Color(0xFF4CAF50)
 private val Amber = Color(0xFFE0A030)
 private val Danger = Color(0xFFE57373)
 
 /**
- * "Add remote" dialog: paste another BossTerm's share link to mirror its tabs into this
- * window, and manage the live connections (status + view-only/control + disconnect).
+ * "Remote sessions" window — a top-level OS window styled like
+ * [ai.rever.bossterm.compose.share.ShareWindow] (SettingsTheme colors + SettingsSection
+ * headers, pinned footer). Paste another BossTerm's share link to mirror its tabs into
+ * this window, and manage the live connections (status + view-only/control + disconnect).
  */
 @Composable
 fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
@@ -52,43 +63,75 @@ fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
         val l = link.trim()
         if (l.isNotBlank()) { manager.connect(l, deviceName); link = "" }
     }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Remote sessions", color = TextPrimary, fontWeight = FontWeight.SemiBold) },
-        text = {
+    Window(
+        onCloseRequest = onDismiss,
+        title = "BossTerm — Remote Sessions",
+        resizable = false,
+        state = rememberWindowState(size = DpSize(560.dp, 520.dp))
+    ) {
+        // Raise the window if "Add remote" is clicked while it's already open.
+        LaunchedEffect(Unit) {
+            window.toFront()
+            window.requestFocus()
+        }
+        Surface(color = BackgroundColor, modifier = Modifier.fillMaxSize()) {
+          Column(modifier = Modifier.fillMaxSize()) {
+            // Scrollable content fills the space above the pinned footer.
             Column(
-                modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
+                modifier = Modifier.weight(1f).fillMaxWidth().verticalScroll(rememberScrollState()).padding(20.dp)
             ) {
+                Text("Remote sessions", color = TextPrimary, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.height(4.dp))
                 Text(
-                    "Paste a BossTerm share link to mirror its tabs here. You'll see them as tabs " +
+                    "Paste a BossTerm share link to mirror its tabs here. They appear as tabs " +
                         "marked in cyan; with control granted you can type into them.",
                     color = TextSecondary, fontSize = 12.sp
                 )
-                SettingsTextField(
-                    label = "Share link",
-                    value = link,
-                    onValueChange = { link = it },
-                    placeholder = "https://….trycloudflare.com/?t=…",
-                )
-                if (manager.sessions.isNotEmpty()) {
-                    Text("Connected", color = TextMuted, fontSize = 11.sp)
-                    manager.sessions.forEach { session ->
-                        RemoteSessionRow(session, onDisconnect = { manager.disconnect(session) })
+                Spacer(Modifier.height(20.dp))
+
+                SettingsSection("Add remote") {
+                    SettingsTextField(
+                        label = "Share link",
+                        value = link,
+                        onValueChange = { link = it },
+                        placeholder = "https://….trycloudflare.com/?t=…",
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        Button(
+                            onClick = { connect() },
+                            enabled = link.isNotBlank(),
+                            colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                        ) { Text("Connect") }
                     }
                 }
+
+                if (manager.sessions.isNotEmpty()) {
+                    Spacer(Modifier.height(20.dp))
+                    SettingsSection("Connected") {
+                        manager.sessions.forEach { session ->
+                            RemoteSessionRow(session, onDisconnect = { manager.disconnect(session) })
+                        }
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
             }
-        },
-        confirmButton = {
-            Button(
-                onClick = { connect() },
-                enabled = link.isNotBlank(),
-                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
-            ) { Text("Connect") }
-        },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Close", color = TextSecondary) } },
-        containerColor = BackgroundColor,
-    )
+            // Pinned footer — always visible without scrolling.
+            Box(Modifier.fillMaxWidth().height(1.dp).background(BorderColor))
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Button(onClick = onDismiss, colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)) {
+                    Text("Close")
+                }
+            }
+          }
+        }
+    }
 }
 
 @Composable

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
@@ -4,6 +4,7 @@ import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 import ai.rever.bossterm.compose.settings.components.SettingsSection
@@ -23,6 +24,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -57,13 +60,14 @@ private val Danger = Color(0xFFE57373)
 fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
     var link by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
+    var shareBack by remember { mutableStateOf(false) }
     val deviceName = remember {
         (System.getProperty("user.name")?.takeIf { it.isNotBlank() }?.let { "$it (BossTerm)" }) ?: "BossTerm"
     }
     fun connect() {
         val l = link.trim()
         if (l.isBlank()) return
-        if (manager.connect(l, deviceName) == null) {
+        if (manager.connect(l, deviceName, shareBack) == null) {
             // connect() refuses our own share links — mirroring a session into itself loops.
             error = "That's this BossTerm's own share link — a session can't mirror itself."
         } else {
@@ -105,6 +109,25 @@ fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
                         placeholder = "https://….trycloudflare.com/?t=…",
                     )
                     error?.let { Text(it, color = Danger, fontSize = 11.sp) }
+                    // Two-way: once the host grants control, offer it this window's own share
+                    // link so it mirrors our tabs back (starts a window share here if needed).
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = shareBack,
+                            onCheckedChange = { shareBack = it },
+                            colors = CheckboxDefaults.colors(checkedColor = AccentColor, uncheckedColor = TextMuted)
+                        )
+                        Column {
+                            Text("Two-way: also share my tabs with the host", color = TextPrimary, fontSize = 12.sp)
+                            Text(
+                                "Shares this window and offers the host the link once it grants control.",
+                                color = TextMuted, fontSize = 11.sp
+                            )
+                        }
+                    }
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.End

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
@@ -166,6 +166,34 @@ fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
     }
 }
 
+/**
+ * Confirmation shown when a view-only action needs control (e.g. the sidebar's split/new-tab
+ * icons on a view-only group): explains the state and asks before sending the host a control
+ * request — the host then sees its usual approval toast.
+ */
+@Composable
+fun RequestControlPrompt(onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = BackgroundColor,
+        title = { Text("View-only session", color = TextPrimary, fontWeight = FontWeight.SemiBold) },
+        text = {
+            Text(
+                "You're viewing this session read-only — splits, new tabs, and typing need " +
+                    "control. Ask the host to grant it?",
+                color = TextSecondary, fontSize = 12.sp
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+            ) { Text("Request Control") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel", color = TextSecondary) } },
+    )
+}
+
 @Composable
 private fun RemoteSessionRow(session: RemoteSession, onDisconnect: () -> Unit) {
     val status by session.status.collectAsState()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
@@ -195,6 +195,44 @@ fun RequestControlPrompt(onConfirm: () -> Unit, onDismiss: () -> Unit) {
     )
 }
 
+/**
+ * Shown when a remote session drops after exhausting its reconnect budget (the native
+ * counterpart of the web viewer's disconnect overlay): Reconnect retries with a fresh
+ * budget; Disconnect removes the session + its mirror tabs; dismissing keeps the frozen
+ * mirror without re-prompting for this failure.
+ */
+@Composable
+fun RemoteDisconnectedDialog(
+    name: String,
+    message: String?,
+    onReconnect: () -> Unit,
+    onDisconnect: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = BackgroundColor,
+        title = { Text("Remote disconnected", color = TextPrimary, fontWeight = FontWeight.SemiBold) },
+        text = {
+            Text(
+                "Lost the connection to $name." +
+                    (message?.let { "\n$it" } ?: "") +
+                    "\nIts tabs stay frozen until it reconnects.",
+                color = TextSecondary, fontSize = 12.sp
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = onReconnect,
+                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+            ) { Text("Reconnect") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDisconnect) { Text("Disconnect", color = Danger) }
+        },
+    )
+}
+
 @Composable
 private fun RemoteSessionRow(session: RemoteSession, onDisconnect: () -> Unit) {
     val status by session.status.collectAsState()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
@@ -1,0 +1,130 @@
+package ai.rever.bossterm.compose.remote
+
+import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+private val Green = Color(0xFF4CAF50)
+private val Amber = Color(0xFFE0A030)
+private val Danger = Color(0xFFE57373)
+
+/**
+ * "Add remote" dialog: paste another BossTerm's share link to mirror its tabs into this
+ * window, and manage the live connections (status + view-only/control + disconnect).
+ */
+@Composable
+fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
+    var link by remember { mutableStateOf("") }
+    val deviceName = remember {
+        (System.getProperty("user.name")?.takeIf { it.isNotBlank() }?.let { "$it (BossTerm)" }) ?: "BossTerm"
+    }
+    fun connect() {
+        val l = link.trim()
+        if (l.isNotBlank()) { manager.connect(l, deviceName); link = "" }
+    }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Remote sessions", color = TextPrimary, fontWeight = FontWeight.SemiBold) },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Text(
+                    "Paste a BossTerm share link to mirror its tabs here. You'll see them as tabs " +
+                        "marked in cyan; with control granted you can type into them.",
+                    color = TextSecondary, fontSize = 12.sp
+                )
+                OutlinedTextField(
+                    value = link,
+                    onValueChange = { link = it },
+                    label = { Text("Share link (https://….trycloudflare.com/?t=…)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                if (manager.sessions.isNotEmpty()) {
+                    Text("Connected", color = TextMuted, fontSize = 11.sp)
+                    manager.sessions.forEach { session ->
+                        RemoteSessionRow(session, onDisconnect = { manager.disconnect(session) })
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { connect() },
+                enabled = link.isNotBlank(),
+                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+            ) { Text("Connect") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Close", color = TextSecondary) } },
+        containerColor = BackgroundColor,
+    )
+}
+
+@Composable
+private fun RemoteSessionRow(session: RemoteSession, onDisconnect: () -> Unit) {
+    val status by session.status.collectAsState()
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(hostOf(session.link), color = TextPrimary, fontSize = 13.sp, maxLines = 1)
+            Text(statusLabel(status), color = statusColor(status), fontSize = 11.sp, maxLines = 1)
+        }
+        val s = status
+        if (s is RemoteStatus.Connected && !s.canControl) {
+            TextButton(onClick = { session.requestControl() }) { Text("Request control", color = AccentColor) }
+        }
+        TextButton(onClick = onDisconnect) { Text("Disconnect", color = Danger) }
+    }
+}
+
+private fun statusLabel(s: RemoteStatus): String = when (s) {
+    RemoteStatus.Connecting -> "connecting…"
+    RemoteStatus.Pending -> "waiting for host approval…"
+    is RemoteStatus.Connected -> if (s.canControl) "connected · control" else "connected · view only"
+    is RemoteStatus.Denied -> "denied" + (s.reason?.let { ": $it" } ?: "")
+    is RemoteStatus.Failed -> "disconnected: ${s.message}"
+    RemoteStatus.Closed -> "closed"
+}
+
+private fun statusColor(s: RemoteStatus): Color = when (s) {
+    is RemoteStatus.Connected -> Green
+    RemoteStatus.Pending, RemoteStatus.Connecting -> Amber
+    is RemoteStatus.Denied, is RemoteStatus.Failed -> Danger
+    RemoteStatus.Closed -> Color(0xFF888888)
+}
+
+private fun hostOf(link: String): String = runCatching {
+    java.net.URI(link).host ?: link
+}.getOrDefault(link)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
@@ -1,0 +1,159 @@
+package ai.rever.bossterm.compose.remote
+
+import ai.rever.bossterm.compose.share.ClientMessage
+import ai.rever.bossterm.compose.share.ServerMessage
+import ai.rever.bossterm.compose.share.ShareProtocol
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import io.ktor.websocket.readText
+import io.ktor.websocket.send
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.net.URLDecoder
+
+/** Lifecycle of a connection to a remote BossTerm share, surfaced in the UI. */
+sealed class RemoteStatus {
+    data object Connecting : RemoteStatus()
+    /** Connected; awaiting the host's approval of this device. */
+    data object Pending : RemoteStatus()
+    /** Live; [canControl] = the host granted write access (else view-only). */
+    data class Connected(val canControl: Boolean) : RemoteStatus()
+    /** Host denied / the key expired. Terminal — no reconnect. */
+    data class Denied(val reason: String?) : RemoteStatus()
+    /** Could not connect / dropped after exhausting retries. */
+    data class Failed(val message: String) : RemoteStatus()
+    /** Closed by the user (remote removed). */
+    data object Closed : RemoteStatus()
+}
+
+/**
+ * The native counterpart of the browser `viewer.js`: a WebSocket client that connects to a
+ * remote BossTerm shared session via its share **link** and streams [ServerMessage]s to a
+ * handler (which mirrors the remote tabs locally). Reuses [ShareProtocol] for the wire format.
+ *
+ * Link `http(s)://host[:port]/?t=TOKEN` → WS `ws(s)://host[:port]/ws/TOKEN`. The handshake
+ * sends [ClientMessage.Hello] (device name + stable clientId + any saved access key); the host
+ * replies [ServerMessage.Pending] → [ServerMessage.Grant]/[ServerMessage.Denied], then streams
+ * Theme/Layout/PaneSnapshot/Control and live PaneOutput/PaneResize. Reconnects (replaying the
+ * saved key to skip re-approval) on a transient drop, up to [MAX_RECONNECTS].
+ */
+class RemoteSessionConnection(
+    val link: String,
+    private val clientId: String,
+    private val deviceName: String,
+    private val keyProvider: () -> String?,
+    /** Persist a freshly granted key for this link (per the host's rolling 24h window). */
+    private val onGrant: (key: String, expiresAt: Long) -> Unit,
+    /** Every decoded server message (handshake handled here too, for status). */
+    private val onServerMessage: (ServerMessage) -> Unit,
+) {
+    private val log = LoggerFactory.getLogger(RemoteSessionConnection::class.java)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val client = HttpClient(CIO) { install(WebSockets) }
+
+    @Volatile private var session: DefaultClientWebSocketSession? = null
+    @Volatile private var closedByUser = false
+
+    private val wsUrl: String = toWsUrl(link)
+
+    private val _status = MutableStateFlow<RemoteStatus>(RemoteStatus.Connecting)
+    val status: StateFlow<RemoteStatus> = _status.asStateFlow()
+
+    fun start() {
+        scope.launch { runWithReconnect() }
+    }
+
+    private suspend fun runWithReconnect() {
+        var attempt = 0
+        while (scope.isActive && !closedByUser) {
+            try {
+                connectOnce()
+            } catch (t: Throwable) {
+                log.warn("remote session ({}) error: {}", wsUrl, t.message)
+            }
+            if (closedByUser || _status.value is RemoteStatus.Denied) return
+            attempt++
+            if (attempt > MAX_RECONNECTS) {
+                _status.value = RemoteStatus.Failed("Lost connection to the remote session.")
+                return
+            }
+            _status.value = RemoteStatus.Connecting
+            delay((attempt * 1500L).coerceAtMost(8_000L))
+        }
+    }
+
+    private suspend fun connectOnce() {
+        client.webSocket(wsUrl) {
+            session = this
+            send(Frame.Text(ShareProtocol.encodeClient(
+                ClientMessage.Hello(name = deviceName, clientId = clientId, key = keyProvider()))))
+            try {
+                for (frame in incoming) {
+                    if (frame is Frame.Text) {
+                        val msg = runCatching { ShareProtocol.decodeServer(frame.readText()) }.getOrNull() ?: continue
+                        handle(msg)
+                    }
+                }
+            } finally {
+                session = null
+            }
+        }
+    }
+
+    private fun handle(msg: ServerMessage) {
+        when (msg) {
+            is ServerMessage.Pending -> _status.value = RemoteStatus.Pending
+            is ServerMessage.Grant -> onGrant(msg.key, msg.expiresAt)
+            is ServerMessage.Denied -> _status.value = RemoteStatus.Denied(msg.reason)
+            is ServerMessage.Control -> _status.value = RemoteStatus.Connected(msg.granted)
+            else -> {}
+        }
+        onServerMessage(msg)
+    }
+
+    /** Send a client message (Input / RequestControl / etc.). No-op if not connected. */
+    fun send(msg: ClientMessage) {
+        val s = session ?: return
+        scope.launch { runCatching { s.send(Frame.Text(ShareProtocol.encodeClient(msg))) } }
+    }
+
+    /** Whether write/control was granted by the host. */
+    val canControl: Boolean get() = (_status.value as? RemoteStatus.Connected)?.canControl == true
+
+    fun close() {
+        closedByUser = true
+        _status.value = RemoteStatus.Closed
+        scope.launch { runCatching { session?.close() } }
+        scope.cancel()
+        runCatching { client.close() }
+    }
+
+    private fun toWsUrl(link: String): String {
+        val uri = URI(link.trim())
+        val rawToken = (uri.rawQuery ?: "").split("&")
+            .firstOrNull { it.startsWith("t=") }?.substringAfter("t=").orEmpty()
+        val token = runCatching { URLDecoder.decode(rawToken, "UTF-8") }.getOrDefault(rawToken)
+        val wsScheme = if (uri.scheme.equals("https", ignoreCase = true)) "wss" else "ws"
+        val port = if (uri.port != -1) ":${uri.port}" else ""
+        return "$wsScheme://${uri.host}$port/ws/$token"
+    }
+
+    private companion object {
+        const val MAX_RECONNECTS = 5
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
@@ -70,8 +70,15 @@ class RemoteSessionConnection(
     @Volatile private var closedByUser = false
     @Volatile private var sawData = false // a Layout arrived this connection → it was healthy
 
+    // Outbound messages go through a per-connection channel drained by ONE writer coroutine, so
+    // frames reach the socket in submission order — independent `launch`-per-send would let two
+    // rapid keystrokes race and arrive reordered (a terminal-input correctness bug).
+    @Volatile private var outbox: kotlinx.coroutines.channels.SendChannel<ClientMessage>? = null
+
     // Best-effort: a malformed link must not crash construction — it just fails to connect.
     private val wsUrl: String = runCatching { toWsUrl(link) }.getOrDefault(link)
+    // Host portion only — safe to log (the token, a bearer credential, must never hit logs).
+    private val safeUrl: String = wsUrl.substringBefore("/ws/").substringBefore("?").ifBlank { "remote" } + "/…"
 
     private val _status = MutableStateFlow<RemoteStatus>(RemoteStatus.Connecting)
     val status: StateFlow<RemoteStatus> = _status.asStateFlow()
@@ -93,7 +100,7 @@ class RemoteSessionConnection(
             try {
                 connectOnce()
             } catch (t: Throwable) {
-                log.warn("remote session ({}) error: {}", wsUrl, t.message)
+                log.warn("remote session ({}) error: {}", safeUrl, t.message ?: t::class.simpleName)
             }
             if (closedByUser || _status.value is RemoteStatus.Denied) return
             // A connection that had actually loaded (received a Layout) gets a fresh retry
@@ -112,8 +119,17 @@ class RemoteSessionConnection(
     private suspend fun connectOnce() {
         client.webSocket(wsUrl) {
             session = this
+            // Per-connection outbox + single writer → strict send ordering. Fresh each connection
+            // so messages queued while disconnected aren't replayed stale on reconnect.
+            val box = kotlinx.coroutines.channels.Channel<ClientMessage>(kotlinx.coroutines.channels.Channel.BUFFERED)
+            outbox = box
+            // Handshake first, ahead of any queued input.
             send(Frame.Text(ShareProtocol.encodeClient(
                 ClientMessage.Hello(name = deviceName, clientId = clientId, key = keyProvider()))))
+            val writer = launch {
+                for (m in box) runCatching { send(Frame.Text(ShareProtocol.encodeClient(m))) }
+                    .onFailure { log.debug("ws send failed: {}", it.message) }
+            }
             try {
                 for (frame in incoming) {
                     if (frame is Frame.Text) {
@@ -122,6 +138,9 @@ class RemoteSessionConnection(
                     }
                 }
             } finally {
+                outbox = null
+                box.close()
+                writer.cancel()
                 session = null
             }
         }
@@ -130,7 +149,9 @@ class RemoteSessionConnection(
     private fun handle(msg: ServerMessage) {
         when (msg) {
             is ServerMessage.Pending -> _status.value = RemoteStatus.Pending
-            is ServerMessage.Grant -> onGrant(msg.key, msg.expiresAt)
+            // Defensive: mark Connected on Grant too, not just the Control that the host sends
+            // right after — so a future reorder can't leave status stuck at Pending.
+            is ServerMessage.Grant -> { onGrant(msg.key, msg.expiresAt); _status.value = RemoteStatus.Connected(msg.control) }
             is ServerMessage.Denied -> _status.value = RemoteStatus.Denied(msg.reason)
             is ServerMessage.Control -> _status.value = RemoteStatus.Connected(msg.granted)
             is ServerMessage.Layout -> sawData = true // session is up and rendering
@@ -139,10 +160,9 @@ class RemoteSessionConnection(
         onServerMessage(msg)
     }
 
-    /** Send a client message (Input / RequestControl / etc.). No-op if not connected. */
+    /** Send a client message (Input / RequestControl / etc.). Queued in submission order; dropped if not connected. */
     fun send(msg: ClientMessage) {
-        val s = session ?: return
-        scope.launch { runCatching { s.send(Frame.Text(ShareProtocol.encodeClient(msg))) } }
+        outbox?.trySend(msg)
     }
 
     /** Whether write/control was granted by the host. */
@@ -155,14 +175,16 @@ class RemoteSessionConnection(
         runCatching { client.close() } // tear down the engine + any open socket
     }
 
-    private fun toWsUrl(link: String): String {
+    // Visible for tests. https→wss, anything else→ws; token taken from ?t= (URL-decoded).
+    internal fun toWsUrl(link: String): String {
         val uri = URI(link.trim())
+        val host = uri.host ?: throw IllegalArgumentException("share link has no host: $link")
         val rawToken = (uri.rawQuery ?: "").split("&")
             .firstOrNull { it.startsWith("t=") }?.substringAfter("t=").orEmpty()
         val token = runCatching { URLDecoder.decode(rawToken, "UTF-8") }.getOrDefault(rawToken)
         val wsScheme = if (uri.scheme.equals("https", ignoreCase = true)) "wss" else "ws"
         val port = if (uri.port != -1) ":${uri.port}" else ""
-        return "$wsScheme://${uri.host}$port/ws/$token"
+        return "$wsScheme://$host$port/ws/$token"
     }
 
     private companion object {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
@@ -80,6 +80,13 @@ class RemoteSessionConnection(
         scope.launch { runWithReconnect() }
     }
 
+    /** Restart the loop after a terminal [RemoteStatus.Failed] (the disconnect dialog's Reconnect). */
+    fun reconnect() {
+        if (closedByUser || _status.value !is RemoteStatus.Failed) return
+        _status.value = RemoteStatus.Connecting
+        scope.launch { runWithReconnect() } // fresh retry budget (locals reset on entry)
+    }
+
     private suspend fun runWithReconnect() {
         var attempt = 0
         while (scope.isActive && !closedByUser) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
@@ -68,8 +68,10 @@ class RemoteSessionConnection(
 
     @Volatile private var session: DefaultClientWebSocketSession? = null
     @Volatile private var closedByUser = false
+    @Volatile private var sawData = false // a Layout arrived this connection → it was healthy
 
-    private val wsUrl: String = toWsUrl(link)
+    // Best-effort: a malformed link must not crash construction — it just fails to connect.
+    private val wsUrl: String = runCatching { toWsUrl(link) }.getOrDefault(link)
 
     private val _status = MutableStateFlow<RemoteStatus>(RemoteStatus.Connecting)
     val status: StateFlow<RemoteStatus> = _status.asStateFlow()
@@ -87,6 +89,9 @@ class RemoteSessionConnection(
                 log.warn("remote session ({}) error: {}", wsUrl, t.message)
             }
             if (closedByUser || _status.value is RemoteStatus.Denied) return
+            // A connection that had actually loaded (received a Layout) gets a fresh retry
+            // budget, so an occasional blip over a long session doesn't exhaust it.
+            if (sawData) { attempt = 0; sawData = false }
             attempt++
             if (attempt > MAX_RECONNECTS) {
                 _status.value = RemoteStatus.Failed("Lost connection to the remote session.")
@@ -121,6 +126,7 @@ class RemoteSessionConnection(
             is ServerMessage.Grant -> onGrant(msg.key, msg.expiresAt)
             is ServerMessage.Denied -> _status.value = RemoteStatus.Denied(msg.reason)
             is ServerMessage.Control -> _status.value = RemoteStatus.Connected(msg.granted)
+            is ServerMessage.Layout -> sawData = true // session is up and rendering
             else -> {}
         }
         onServerMessage(msg)
@@ -138,9 +144,8 @@ class RemoteSessionConnection(
     fun close() {
         closedByUser = true
         _status.value = RemoteStatus.Closed
-        scope.launch { runCatching { session?.close() } }
-        scope.cancel()
-        runCatching { client.close() }
+        scope.cancel()              // cancels the read loop → ktor closes the session
+        runCatching { client.close() } // tear down the engine + any open socket
     }
 
     private fun toWsUrl(link: String): String {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -4,6 +4,7 @@ import ai.rever.bossterm.compose.TabbedTerminalState
 import ai.rever.bossterm.compose.share.ClientMessage
 import ai.rever.bossterm.compose.share.PaneTreeNode
 import ai.rever.bossterm.compose.share.ServerMessage
+import ai.rever.bossterm.compose.share.ShareProtocol
 import ai.rever.bossterm.compose.splits.SplitNode
 import ai.rever.bossterm.compose.splits.SplitViewState
 import ai.rever.bossterm.compose.tabs.TerminalTab
@@ -47,13 +48,6 @@ class RemoteSessionManager(private val state: TabbedTerminalState) {
     fun isOwnShareLink(link: String): Boolean =
         tokenOf(link)?.let { ai.rever.bossterm.compose.share.SessionShareManager.ownsToken(it) } == true
 
-    /** The `t=` token in a share [link], or null if absent/malformed. */
-    private fun tokenOf(link: String): String? = runCatching {
-        val raw = java.net.URI(link.trim()).rawQuery ?: return@runCatching null
-        raw.split("&").firstOrNull { it.startsWith("t=") }?.substringAfter("t=")
-            ?.let { java.net.URLDecoder.decode(it, "UTF-8") }?.takeIf { it.isNotBlank() }
-    }.getOrNull()
-
     fun disconnect(session: RemoteSession) {
         session.close()
         sessions.remove(session)
@@ -68,6 +62,13 @@ class RemoteSessionManager(private val state: TabbedTerminalState) {
         sessions.clear()
     }
 }
+
+/** The `t=` token in a share [link], or null if absent/malformed. */
+private fun tokenOf(link: String): String? = runCatching {
+    val raw = java.net.URI(link.trim()).rawQuery ?: return@runCatching null
+    raw.split("&").firstOrNull { it.startsWith("t=") }?.substringAfter("t=")
+        ?.let { java.net.URLDecoder.decode(it, "UTF-8") }?.takeIf { it.isNotBlank() }
+}.getOrNull()
 
 /**
  * One live connection to a remote share + its mirrored local tabs. Decodes [ServerMessage]s
@@ -104,6 +105,14 @@ class RemoteSession internal constructor(
 
     val status: StateFlow<RemoteStatus> get() = conn.status
     val canControl: Boolean get() = conn.canControl
+
+    /**
+     * Identifies which share this session mirrors: SHA-256 of [link]'s token. Stamped on this
+     * session's container tabs in OUR outgoing Layout ([TabNode.origin][ai.rever.bossterm.compose.share.TabNode]),
+     * so a client connecting to US can skip tabs that mirror its own session. Null if the link
+     * carries no token.
+     */
+    val originHash: String? = tokenOf(link)?.let { ShareProtocol.sha256Hex(it) }
 
     // remote tabId → the local **container** tab in tabController.tabs. A container is a
     // PTY-less, stream-less shell that owns the chip + the split tree; it is never a pane itself.
@@ -296,7 +305,14 @@ class RemoteSession internal constructor(
         // ratio we just sent) so the drag isn't interrupted — the post-release Layout reconciles.
         if (draggingSplit) return
         val controller = state.tabController ?: return
-        val remoteIds = layout.tabs.map { it.id }.toSet()
+        // Skip the host's tabs that mirror OUR OWN session (their origin is the hash of one of
+        // this instance's share tokens) — mirroring them back here would loop our tabs through
+        // the peer. The host's own tabs, and its mirrors of third sessions, come through as-is.
+        val tabs = layout.tabs.filter { node ->
+            val o = node.origin
+            o == null || !ai.rever.bossterm.compose.share.SessionShareManager.ownsTokenHash(o)
+        }
+        val remoteIds = tabs.map { it.id }.toSet()
 
         // Self-heal: a container the user closed via its chip (×) is gone from the controller but
         // still in our maps — forget it + dispose its pane mirrors so it can be rebuilt fresh.
@@ -307,7 +323,7 @@ class RemoteSession internal constructor(
                 // layout — getAllPanes()/SplitNode.Pane.id are the remote paneIds.
                 val owned = buildSet {
                     state.splitStates[container.id]?.getAllPanes()?.forEach { add(it.id) }
-                    layout.tabs.firstOrNull { it.id == remoteId }?.let { addAll(paneIds(it.tree)) }
+                    tabs.firstOrNull { it.id == remoteId }?.let { addAll(paneIds(it.tree)) }
                 }
                 owned.forEach { pid -> sessionByPane.remove(pid)?.let { disposeSession(it) } }
                 state.splitStates.remove(container.id)
@@ -319,12 +335,12 @@ class RemoteSession internal constructor(
             localTabByRemote.remove(gone)?.let { removeMirrorTab(it) }
         }
         // Drop pane mirrors whose remote paneId vanished (host closed a split pane).
-        val livePaneIds = layout.tabs.flatMap { paneIds(it.tree) }.toSet()
+        val livePaneIds = tabs.flatMap { paneIds(it.tree) }.toSet()
         (sessionByPane.keys - livePaneIds).toList().forEach { gone ->
             sessionByPane.remove(gone)?.let { disposeSession(it) }
         }
 
-        for (tabNode in layout.tabs) {
+        for (tabNode in tabs) {
             // The container — a PTY-less, stream-less tab that owns the chip and hosts the split
             // tree of pane mirrors. It is never itself a pane.
             val isNew = !localTabByRemote.containsKey(tabNode.id)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -108,7 +108,7 @@ class RemoteSession internal constructor(
      */
     fun closeFromChip(localTabId: String, paneId: String) {
         if (!conn.canControl) return
-        val remoteTabId = localTabByRemote.entries.firstOrNull { it.value.id == localTabId }?.key ?: return
+        val remoteTabId = remoteTabIdFor(localTabId) ?: return
         val ss = state.splitStates[localTabId]
         val wholeTab = paneId == localTabId || ss == null || ss.isSinglePane
         conn.send(
@@ -116,6 +116,69 @@ class RemoteSession internal constructor(
             else ClientMessage.ClosePane(remoteTabId, paneId)
         )
     }
+
+    // ---- chip context-menu actions (mirror the browser viewer's menu, routed to the host) ----
+    // Each maps the local container id back to the remote tab id and forwards the host the same
+    // ClientMessage the viewer would send. All are control-only (the host also re-checks control).
+
+    /** Split [paneId] of [localTabId]'s tab on the host (mirrors back via Layout). */
+    fun splitPane(localTabId: String, paneId: String, horizontal: Boolean) {
+        if (!conn.canControl) return
+        val rid = remoteTabIdFor(localTabId) ?: return
+        conn.send(
+            if (horizontal) ClientMessage.SplitHorizontal(rid, paneId)
+            else ClientMessage.SplitVertical(rid, paneId)
+        )
+    }
+
+    /** Launch an AI assistant in [paneId] on the host (runs the host's configured command). */
+    fun launchAI(localTabId: String, paneId: String, assistantId: String) {
+        if (!conn.canControl) return
+        val rid = remoteTabIdFor(localTabId) ?: return
+        conn.send(ClientMessage.LaunchAI(rid, paneId, assistantId))
+    }
+
+    /** Rename a tab/pane chip on the host (blank [title] clears the custom title). */
+    fun renameTab(localTabId: String, paneId: String, title: String) {
+        if (!conn.canControl) return
+        val rid = remoteTabIdFor(localTabId) ?: return
+        conn.send(ClientMessage.RenameTab(rid, paneId, title))
+    }
+
+    /** Set/clear a chip's accent on the host. Native hex "0xFFRRGGBB" → host-expected CSS "#RRGGBB". */
+    fun setTabColor(localTabId: String, paneId: String, nativeHex: String?) {
+        if (!conn.canControl) return
+        val rid = remoteTabIdFor(localTabId) ?: return
+        val css = nativeHex?.removePrefix("0x")?.removePrefix("0X")
+            ?.let { if (it.length == 8) it.substring(2) else it }   // drop the FF alpha
+            ?.let { "#$it" }
+        conn.send(ClientMessage.SetTabColor(rid, paneId, css))
+    }
+
+    /** Duplicate the tab on the host. */
+    fun duplicateTab(localTabId: String) {
+        if (!conn.canControl) return
+        val rid = remoteTabIdFor(localTabId) ?: return
+        conn.send(ClientMessage.DuplicateTab(rid))
+    }
+
+    /** Close every other tab of this remote session on the host. */
+    fun closeOtherTabs(localTabId: String) {
+        if (!conn.canControl) return
+        val rid = remoteTabIdFor(localTabId) ?: return
+        conn.send(ClientMessage.CloseOtherTabs(rid))
+    }
+
+    /** Close all tabs after this one on the host. */
+    fun closeTabsBelow(localTabId: String) {
+        if (!conn.canControl) return
+        val rid = remoteTabIdFor(localTabId) ?: return
+        conn.send(ClientMessage.CloseTabsBelow(rid))
+    }
+
+    /** Map a local container tab id back to its remote tab id. */
+    private fun remoteTabIdFor(localTabId: String): String? =
+        localTabByRemote.entries.firstOrNull { it.value.id == localTabId }?.key
 
     /**
      * Split the remote session's current pane (the active mirror tab if it belongs to this

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -180,13 +180,32 @@ class RemoteSession internal constructor(
     fun start() = conn.start()
 
     /** Ask the host to grant write/control (when connected view-only). */
-    fun requestControl() = conn.send(ClientMessage.RequestControl)
+    fun requestControl() = conn.send(ClientMessage.RequestControl())
+
+    /**
+     * Control request targeted at [localTabId]'s tab: when that tab mirrors an upstream session
+     * on the host (A→B→C), the host relays the request to the origin instead.
+     */
+    fun requestControlFor(localTabId: String) =
+        conn.send(ClientMessage.RequestControl(remoteTabIdFor(localTabId)))
+
+    /** New tab in [localTabId]'s session — the host relays upstream for mirrored tabs. */
+    fun newTabIn(localTabId: String) {
+        if (!conn.canControl) return
+        conn.send(ClientMessage.NewTab(remoteTabIdFor(localTabId) ?: return))
+    }
+
+    /** Ask the host to disconnect from the upstream session that [localTabId] mirrors. */
+    fun disconnectUpstream(localTabId: String) {
+        if (!conn.canControl) return
+        conn.send(ClientMessage.DisconnectUpstream(remoteTabIdFor(localTabId) ?: return))
+    }
 
     /** True if [tab] is one of this session's mirror tabs. */
     fun containsTab(tab: TerminalTab): Boolean = localTabByRemote.values.any { it === tab }
 
     /** Open a new tab in the remote session (mirrors back as another tab). Control only. */
-    fun newRemoteTab() = conn.send(ClientMessage.NewTab)
+    fun newRemoteTab() = conn.send(ClientMessage.NewTab())
 
     /**
      * Mirror a local close of a remote chip back to the host (control only): close the whole

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -148,6 +148,13 @@ class RemoteSession internal constructor(
      */
     val canControlState = androidx.compose.runtime.mutableStateOf(false)
 
+    /**
+     * Connection status as Compose state — drives the group box's header indicator
+     * (connecting…/disconnected) and, read inside the share signature's snapshotFlow, the
+     * originOffline flag forwarded to nested viewers when WE are someone's upstream host.
+     */
+    val statusState = androidx.compose.runtime.mutableStateOf<RemoteStatus>(RemoteStatus.Connecting)
+
     /** True if [s] is any of this session's mirrors — the containers or their pane mirrors. */
     fun ownsMirror(s: ai.rever.bossterm.compose.TerminalSession): Boolean =
         localTabByRemote.values.any { it === s } || sessionByPane.values.any { it === s }
@@ -157,7 +164,7 @@ class RemoteSession internal constructor(
      * remote): [key] groups tabs of the same upstream, [name] labels the subsection, and
      * [readOnly] means the host can't type into it either — so neither can we through it.
      */
-    data class UpstreamOrigin(val key: String, val name: String?, val readOnly: Boolean)
+    data class UpstreamOrigin(val key: String, val name: String?, val readOnly: Boolean, val offline: Boolean = false)
 
     // localTabId (container) → upstream-origin info; bumping [upstreamRev] re-renders the bar
     // when only this map changed (e.g. the host's upstream control was granted mid-session).
@@ -183,7 +190,23 @@ class RemoteSession internal constructor(
     // (including a tab's first) can never orphan a survivor's output.
     private val sessionByPane = HashMap<String, TerminalTab>()
 
-    fun start() = conn.start()
+    fun start() {
+        // Mirror the connection's StateFlow status into Compose state (see [statusState]).
+        scope.launch { conn.status.collect { statusState.value = it } }
+        conn.start()
+    }
+
+    /**
+     * Don't re-show the disconnect dialog for this failure (its dismiss); reset by [reconnect],
+     * so a later failure prompts again.
+     */
+    val failureDismissed = androidx.compose.runtime.mutableStateOf(false)
+
+    /** Restart a failed connection (the disconnect dialog's Reconnect). */
+    fun reconnect() {
+        failureDismissed.value = false
+        conn.reconnect()
+    }
 
     /** Ask the host to grant write/control (when connected view-only). */
     fun requestControl() = conn.send(ClientMessage.RequestControl())
@@ -492,7 +515,7 @@ class RemoteSession internal constructor(
             // Track whether this host tab itself mirrors ANOTHER session (and our effective
             // writability through it) — the tab bar nests those under a labeled subsection.
             val upstream = tabNode.origin?.let {
-                UpstreamOrigin(it, tabNode.originName, tabNode.originReadOnly == true)
+                UpstreamOrigin(it, tabNode.originName, tabNode.originReadOnly == true, tabNode.originOffline == true)
             }
             if (upstreamByTab[container.id] != upstream) {
                 if (upstream != null) upstreamByTab[container.id] = upstream else upstreamByTab.remove(container.id)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -1,0 +1,231 @@
+package ai.rever.bossterm.compose.remote
+
+import ai.rever.bossterm.compose.TabbedTerminalState
+import ai.rever.bossterm.compose.share.ClientMessage
+import ai.rever.bossterm.compose.share.PaneTreeNode
+import ai.rever.bossterm.compose.share.ServerMessage
+import ai.rever.bossterm.compose.splits.SplitNode
+import ai.rever.bossterm.compose.splits.SplitViewState
+import ai.rever.bossterm.compose.tabs.TerminalTab
+import ai.rever.bossterm.core.util.TermSize
+import ai.rever.bossterm.terminal.RequestOrigin
+import androidx.compose.runtime.mutableStateListOf
+import kotlinx.coroutines.flow.StateFlow
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+/**
+ * Per-window registry of connections to **remote** BossTerm shared sessions (the native
+ * counterpart of the browser viewer). Each [connect] dials a share link and mirrors the
+ * remote session's tabs (and their split layouts) into this window's tab list as read-or-write
+ * mirror tabs ([TerminalTab.isRemote]).
+ *
+ * Owned by a [TabbedTerminalState] (the window whose left-bar "Add remote" was used).
+ */
+class RemoteSessionManager(private val state: TabbedTerminalState) {
+
+    /** Stable per-install client id so the host recognizes this device across reconnects. */
+    private val clientId: String = UUID.randomUUID().toString()
+
+    /** Active remote sessions — observed by the UI to list them + show status. */
+    val sessions = mutableStateListOf<RemoteSession>()
+
+    fun connect(link: String, deviceName: String): RemoteSession {
+        val session = RemoteSession(link, deviceName, state, clientId)
+        sessions.add(session)
+        session.start()
+        return session
+    }
+
+    fun disconnect(session: RemoteSession) {
+        session.close()
+        sessions.remove(session)
+    }
+
+    /** Tear down every remote session (e.g. when the window closes). */
+    fun disconnectAll() {
+        sessions.toList().forEach { it.close() }
+        sessions.clear()
+    }
+}
+
+/**
+ * One live connection to a remote share + its mirrored local tabs. Decodes [ServerMessage]s
+ * from the [RemoteSessionConnection] and reconciles them into [state]'s tab list: a `Layout`
+ * (re)builds the mirror tabs and their split trees; `PaneSnapshot`/`PaneOutput` feed each
+ * mirror pane's terminal; `PaneResize` resizes it; `Input` is sent back when control is granted.
+ */
+class RemoteSession internal constructor(
+    val link: String,
+    val deviceName: String,
+    private val state: TabbedTerminalState,
+    clientId: String,
+) {
+    private val log = LoggerFactory.getLogger(RemoteSession::class.java)
+
+    // In-memory access key for this link (persistence across restarts is a follow-up).
+    @Volatile private var key: String? = null
+
+    private val conn = RemoteSessionConnection(
+        link = link,
+        clientId = clientId,
+        deviceName = deviceName,
+        keyProvider = { key },
+        onGrant = { k, _ -> key = k },
+        onServerMessage = ::onMessage,
+    )
+
+    val status: StateFlow<RemoteStatus> get() = conn.status
+    val canControl: Boolean get() = conn.canControl
+
+    // remote tabId → the local mirror tab placed in tabController.tabs.
+    private val localTabByRemote = LinkedHashMap<String, TerminalTab>()
+    // remote paneId → the mirror session feeding that pane's terminal.
+    private val sessionByPane = HashMap<String, TerminalTab>()
+
+    fun start() = conn.start()
+
+    /** Ask the host to grant write/control (when connected view-only). */
+    fun requestControl() = conn.send(ClientMessage.RequestControl)
+
+    fun close() {
+        conn.close()
+        localTabByRemote.values.toList().forEach { removeMirrorTab(it) }
+        localTabByRemote.clear()
+        sessionByPane.clear()
+    }
+
+    // ---- message handling ----
+    private fun onMessage(msg: ServerMessage) {
+        when (msg) {
+            is ServerMessage.Layout -> runCatching { reconcile(msg) }
+                .onFailure { log.warn("remote layout reconcile failed: {}", it.message) }
+            is ServerMessage.PaneSnapshot -> {
+                val s = sessionByPane[msg.paneId] ?: return
+                if (msg.cols >= 2 && msg.rows >= 2) s.terminal.resize(TermSize(msg.cols, msg.rows), RequestOrigin.User)
+                s.dataStream.append(msg.data)
+            }
+            is ServerMessage.PaneOutput -> sessionByPane[msg.paneId]?.dataStream?.append(msg.data)
+            is ServerMessage.PaneResize -> {
+                val s = sessionByPane[msg.paneId] ?: return
+                if (msg.cols >= 2 && msg.rows >= 2) s.terminal.resize(TermSize(msg.cols, msg.rows), RequestOrigin.User)
+            }
+            else -> {} // Theme/Presence/Control/Pending/Grant/Denied handled in the connection
+        }
+    }
+
+    /**
+     * Rebuild the local mirror tabs from the remote [layout]: create tabs for new remote tabs,
+     * remove vanished ones, and (re)build each tab's split tree (reusing mirror sessions by
+     * remote paneId). Runs whenever the host's structure changes — Layout is only resent then.
+     */
+    private fun reconcile(layout: ServerMessage.Layout) {
+        val controller = state.tabController ?: return
+        val remoteIds = layout.tabs.map { it.id }.toSet()
+
+        // Self-heal: a mirror tab the user closed via its chip (×) is gone from the controller
+        // but still in our maps — forget it (+ its pane sessions) so it can be rebuilt fresh.
+        localTabByRemote.entries.toList().forEach { (remoteId, t) ->
+            if (controller.tabs.none { it === t }) {
+                localTabByRemote.remove(remoteId)
+                val panes = state.splitStates[t.id]?.getAllSessions()?.toList() ?: listOf(t)
+                sessionByPane.entries.removeIf { e -> e.value === t || panes.any { it === e.value } }
+                state.splitStates.remove(t.id)
+            }
+        }
+
+        // Drop mirror tabs for remote tabs that no longer exist.
+        (localTabByRemote.keys - remoteIds).toList().forEach { gone ->
+            localTabByRemote.remove(gone)?.let { removeMirrorTab(it) }
+        }
+        // Drop pane sessions whose remote paneId vanished.
+        val livePaneIds = layout.tabs.flatMap { paneIds(it.tree) }.toSet()
+        (sessionByPane.keys - livePaneIds).toList().forEach { gone ->
+            sessionByPane.remove(gone)?.let { s ->
+                if (localTabByRemote.values.none { it === s }) disposeSession(s) // not a tab-level session
+            }
+        }
+
+        for (tabNode in layout.tabs) {
+            val firstPane = firstPaneId(tabNode.tree) ?: continue
+            // Ensure the tab-level mirror session exists (it IS the first pane).
+            val tab = localTabByRemote.getOrPut(tabNode.id) {
+                val t = controller.createRemoteSession(
+                    title = tabNode.title.ifBlank { "remote" },
+                    remotePaneId = firstPane,
+                    onUserInput = { data -> if (conn.canControl) conn.send(ClientMessage.Input(firstPane, data)) },
+                )
+                sessionByPane[firstPane] = t
+                controller.tabs.add(t)
+                t
+            }
+            tab.title.value = tabNode.title.ifBlank { "remote" }
+            tab.workingDirectory.value = tabNode.cwd
+
+            // Single pane → no split state; multi-pane → (re)build the split tree.
+            if (tabNode.tree is PaneTreeNode.Split) {
+                val ss = state.splitStates.getOrPut(tab.id) { SplitViewState(initialSession = tab) }
+                ss.setTree(buildTree(tabNode.tree, tab, firstPane), firstPane)
+            } else {
+                state.splitStates.remove(tab.id)
+            }
+        }
+    }
+
+    /** Map a remote pane tree to a local [SplitNode] tree, reusing mirror sessions by paneId. */
+    private fun buildTree(node: PaneTreeNode, tabSession: TerminalTab, firstPaneId: String): SplitNode = when (node) {
+        is PaneTreeNode.Pane -> {
+            val session = if (node.paneId == firstPaneId) tabSession else sessionByPane.getOrPut(node.paneId) {
+                state.tabController!!.createRemoteSession(
+                    title = node.title,
+                    remotePaneId = node.paneId,
+                    onUserInput = { data -> if (conn.canControl) conn.send(ClientMessage.Input(node.paneId, data)) },
+                )
+            }
+            SplitNode.Pane(id = node.paneId, session = session)
+        }
+        is PaneTreeNode.Split -> if (node.dir == "h") {
+            SplitNode.HorizontalSplit(
+                id = node.id.ifBlank { node.paneIdKey() },
+                top = buildTree(node.a, tabSession, firstPaneId),
+                bottom = buildTree(node.b, tabSession, firstPaneId),
+                ratio = node.ratio,
+            )
+        } else {
+            SplitNode.VerticalSplit(
+                id = node.id.ifBlank { node.paneIdKey() },
+                left = buildTree(node.a, tabSession, firstPaneId),
+                right = buildTree(node.b, tabSession, firstPaneId),
+                ratio = node.ratio,
+            )
+        }
+    }
+
+    private fun removeMirrorTab(tab: TerminalTab) {
+        val controller = state.tabController
+        // Dispose every mirror session in the tab (the tab itself + any extra split panes).
+        val sessions = state.splitStates[tab.id]?.getAllSessions()?.filterIsInstance<TerminalTab>() ?: listOf(tab)
+        sessions.forEach { sessionByPane.entries.removeIf { e -> e.value === it } ; disposeSession(it) }
+        state.splitStates.remove(tab.id)
+        val idx = controller?.tabs?.indexOf(tab) ?: -1
+        if (idx >= 0) controller?.closeTab(idx) // index-safe removal (no PTY to kill)
+    }
+
+    private fun disposeSession(s: TerminalTab) {
+        runCatching { s.dataStream.close() } // unblocks the emulator loop
+        runCatching { s.dispose() }
+    }
+
+    private fun paneIds(node: PaneTreeNode): List<String> = when (node) {
+        is PaneTreeNode.Pane -> listOf(node.paneId)
+        is PaneTreeNode.Split -> paneIds(node.a) + paneIds(node.b)
+    }
+
+    private fun firstPaneId(node: PaneTreeNode): String? = when (node) {
+        is PaneTreeNode.Pane -> node.paneId
+        is PaneTreeNode.Split -> firstPaneId(node.a) ?: firstPaneId(node.b)
+    }
+
+    // Fallback stable id for a split node when the host didn't send one (old peer).
+    private fun PaneTreeNode.Split.paneIdKey(): String = "split:" + paneIds(this).joinToString(",")
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -325,14 +325,6 @@ class RemoteSession internal constructor(
             ss.onRemoteDividerDrag = { splitId, ratio, committed -> resizeSplit(container.id, splitId, ratio, committed) }
             ss.setTree(buildTree(tabNode.tree), ss.focusedPaneId)
 
-            // Auto "Fit host to my screen": only a single-pane tab can drive the host window size
-            // from its canvas — wire the lone pane mirror, clear the hook on every other pane.
-            val lone = (tabNode.tree as? PaneTreeNode.Pane)?.let { sessionByPane[it.paneId] }
-            ss.getAllSessions().filterIsInstance<TerminalTab>().forEach { m ->
-                m.onRemoteResizeRequest =
-                    if (m === lone) { { cols, rows -> resizeHost(container.id, cols, rows) } } else null
-            }
-
             // Add to the tab list only AFTER the split tree is populated — so the UI never renders
             // a not-yet-built container, and without switching focus (must not steal the local
             // active tab). New tabs append at the end.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -136,6 +136,12 @@ class RemoteSession internal constructor(
     val accent = androidx.compose.runtime.mutableStateOf<String?>(null)
 
     /**
+     * The host's own name for its session (Layout.sessionName — defaults to its username).
+     * Used as the group label when no local [customName] is set; falls back to the link host.
+     */
+    val hostName = androidx.compose.runtime.mutableStateOf<String?>(null)
+
+    /**
      * [canControl] as Compose state — updated on the host's Control messages, so the tab bar's
      * remote menus rebuild the moment control is granted/revoked (a StateFlow read wouldn't
      * trigger recomposition).
@@ -350,8 +356,11 @@ class RemoteSession internal constructor(
     // ---- message handling ----
     private fun onMessage(msg: ServerMessage) {
         when (msg) {
-            is ServerMessage.Layout -> runCatching { reconcile(msg) }
-                .onFailure { log.warn("remote layout reconcile failed: {}", it.message) }
+            is ServerMessage.Layout -> {
+                msg.sessionName?.takeIf { it.isNotBlank() }?.let { hostName.value = it }
+                runCatching { reconcile(msg) }
+                    .onFailure { log.warn("remote layout reconcile failed: {}", it.message) }
+            }
             is ServerMessage.PaneSnapshot -> {
                 val s = sessionByPane[msg.paneId] ?: return
                 if (msg.cols >= 2 && msg.rows >= 2) s.terminal.resize(TermSize(msg.cols, msg.rows), RequestOrigin.User)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -30,12 +30,29 @@ class RemoteSessionManager(private val state: TabbedTerminalState) {
     /** Active remote sessions — observed by the UI to list them + show status. */
     val sessions = mutableStateListOf<RemoteSession>()
 
-    fun connect(link: String, deviceName: String): RemoteSession {
+    /**
+     * Dial [link] and mirror its tabs here. Returns null (refusing to connect) when [link] is one
+     * of THIS instance's own share links — mirroring a session into itself would feed the mirror
+     * tabs back into the share in a loop.
+     */
+    fun connect(link: String, deviceName: String): RemoteSession? {
+        if (isOwnShareLink(link)) return null
         val session = RemoteSession(link, deviceName, state, clientId)
         sessions.add(session)
         session.start()
         return session
     }
+
+    /** True if [link]'s token belongs to a session this instance is hosting. */
+    fun isOwnShareLink(link: String): Boolean =
+        tokenOf(link)?.let { ai.rever.bossterm.compose.share.SessionShareManager.ownsToken(it) } == true
+
+    /** The `t=` token in a share [link], or null if absent/malformed. */
+    private fun tokenOf(link: String): String? = runCatching {
+        val raw = java.net.URI(link.trim()).rawQuery ?: return@runCatching null
+        raw.split("&").firstOrNull { it.startsWith("t=") }?.substringAfter("t=")
+            ?.let { java.net.URLDecoder.decode(it, "UTF-8") }?.takeIf { it.isNotBlank() }
+    }.getOrNull()
 
     fun disconnect(session: RemoteSession) {
         session.close()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -79,6 +79,26 @@ class RemoteSessionManager(private val state: TabbedTerminalState) {
         sessions.toList().forEach { it.close() }
         sessions.clear()
     }
+
+    /** A blocked-typing event awaiting the user's decision ([tabId] != null → relay upstream). */
+    data class BlockedInput(val session: RemoteSession, val tabId: String?)
+
+    /** Non-null while the "typing needs control" prompt should show; cleared by the dialog. */
+    val blockedInput = androidx.compose.runtime.mutableStateOf<BlockedInput?>(null)
+    @Volatile private var inputPromptQuietUntil = 0L
+
+    /** Typing hit a read-only path — surface the request-control prompt (throttled). */
+    internal fun notifyBlockedInput(session: RemoteSession, upstreamTabId: String?) {
+        val now = System.currentTimeMillis()
+        if (now < inputPromptQuietUntil) return
+        inputPromptQuietUntil = now + 2_000 // buffered keystrokes → one prompt
+        blockedInput.value = BlockedInput(session, upstreamTabId)
+    }
+
+    /** The user dismissed the typing prompt — stay quiet a while instead of nagging per key. */
+    internal fun snoozeBlockedInputPrompt() {
+        inputPromptQuietUntil = System.currentTimeMillis() + 30_000
+    }
 }
 
 /** The `t=` token in a share [link], or null if absent/malformed. */
@@ -528,7 +548,7 @@ class RemoteSession internal constructor(
             val ss = state.splitStates.getOrPut(container.id) { SplitViewState(initialSession = container) }
             // Route divider drags in this mirror's split tree to the host (idempotent each pass).
             ss.onRemoteDividerDrag = { splitId, ratio, committed -> resizeSplit(container.id, splitId, ratio, committed) }
-            ss.setTree(buildTree(tabNode.tree), ss.focusedPaneId)
+            ss.setTree(buildTree(tabNode.tree, container.id), ss.focusedPaneId)
 
             // Add to the tab list only AFTER the split tree is populated — so the UI never renders
             // a not-yet-built container, and without switching focus (must not steal the local
@@ -538,13 +558,25 @@ class RemoteSession internal constructor(
     }
 
     /** Map a remote pane tree to a local [SplitNode] tree, reusing pane mirrors by remote paneId. */
-    private fun buildTree(node: PaneTreeNode): SplitNode = when (node) {
+    private fun buildTree(node: PaneTreeNode, containerId: String): SplitNode = when (node) {
         is PaneTreeNode.Pane -> {
             val session = sessionByPane.getOrPut(node.paneId) {
                 state.tabController!!.createRemoteSession(
                     title = node.title,
                     remotePaneId = node.paneId,
-                    onUserInput = { data -> if (conn.canControl) conn.send(ClientMessage.Input(node.paneId, data)) },
+                    onUserInput = { data ->
+                        // Typing into a read-only path (no control of the host, or the host
+                        // itself is view-only on this tab's upstream) prompts to request
+                        // control instead of vanishing — same as the web viewer.
+                        val upstreamReadOnly = upstreamFor(containerId)?.readOnly == true
+                        if (conn.canControl && !upstreamReadOnly) {
+                            conn.send(ClientMessage.Input(node.paneId, data))
+                        } else {
+                            state.remoteSessions.notifyBlockedInput(
+                                this, containerId.takeIf { upstreamReadOnly }
+                            )
+                        }
+                    },
                 )
             }
             session.title.value = node.title
@@ -554,15 +586,15 @@ class RemoteSession internal constructor(
         is PaneTreeNode.Split -> if (node.dir == "h") {
             SplitNode.HorizontalSplit(
                 id = node.id.ifBlank { node.paneIdKey() },
-                top = buildTree(node.a),
-                bottom = buildTree(node.b),
+                top = buildTree(node.a, containerId),
+                bottom = buildTree(node.b, containerId),
                 ratio = node.ratio,
             )
         } else {
             SplitNode.VerticalSplit(
                 id = node.id.ifBlank { node.paneIdKey() },
-                left = buildTree(node.a),
-                right = buildTree(node.b),
+                left = buildTree(node.a, containerId),
+                right = buildTree(node.b, containerId),
                 ratio = node.ratio,
             )
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -42,6 +42,9 @@ class RemoteSessionManager(private val state: TabbedTerminalState) {
         sessions.remove(session)
     }
 
+    /** The remote session that owns [tab] (a mirror tab), or null if it's a local tab. */
+    fun sessionForTab(tab: TerminalTab): RemoteSession? = sessions.firstOrNull { it.containsTab(tab) }
+
     /** Tear down every remote session (e.g. when the window closes). */
     fun disconnectAll() {
         sessions.toList().forEach { it.close() }
@@ -87,6 +90,30 @@ class RemoteSession internal constructor(
 
     /** Ask the host to grant write/control (when connected view-only). */
     fun requestControl() = conn.send(ClientMessage.RequestControl)
+
+    /** True if [tab] is one of this session's mirror tabs. */
+    fun containsTab(tab: TerminalTab): Boolean = localTabByRemote.values.any { it === tab }
+
+    /** Open a new tab in the remote session (mirrors back as another tab). Control only. */
+    fun newRemoteTab() = conn.send(ClientMessage.NewTab)
+
+    /**
+     * Split the remote session's current pane (the active mirror tab if it belongs to this
+     * session, else this session's first tab) left/right or top/bottom — the host applies it
+     * and it mirrors back. Control only.
+     */
+    fun splitFocused(horizontal: Boolean) {
+        val controller = state.tabController ?: return
+        val tab = controller.tabs.getOrNull(controller.activeTabIndex)?.takeIf { containsTab(it) }
+            ?: localTabByRemote.values.firstOrNull() ?: return
+        val remoteTabId = localTabByRemote.entries.firstOrNull { it.value === tab }?.key ?: return
+        val paneId = state.splitStates[tab.id]?.focusedPaneId?.takeIf { sessionByPane.containsKey(it) }
+            ?: tab.remotePaneId ?: return
+        conn.send(
+            if (horizontal) ClientMessage.SplitHorizontal(remoteTabId, paneId)
+            else ClientMessage.SplitVertical(remoteTabId, paneId)
+        )
+    }
 
     fun close() {
         conn.close()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -147,6 +147,21 @@ class RemoteSession internal constructor(
         localTabByRemote.values.any { it === s } || sessionByPane.values.any { it === s }
 
     /**
+     * Upstream-origin info for a host tab that itself mirrors ANOTHER session (the host's
+     * remote): [key] groups tabs of the same upstream, [name] labels the subsection, and
+     * [readOnly] means the host can't type into it either — so neither can we through it.
+     */
+    data class UpstreamOrigin(val key: String, val name: String?, val readOnly: Boolean)
+
+    // localTabId (container) → upstream-origin info; bumping [upstreamRev] re-renders the bar
+    // when only this map changed (e.g. the host's upstream control was granted mid-session).
+    private val upstreamByTab = HashMap<String, UpstreamOrigin>()
+    val upstreamRev = androidx.compose.runtime.mutableStateOf(0)
+
+    /** The upstream origin of [localTabId]'s host tab, or null if it's the host's own tab. */
+    fun upstreamFor(localTabId: String): UpstreamOrigin? = upstreamByTab[localTabId]
+
+    /**
      * Identifies which share this session mirrors: SHA-256 of [link]'s token. Stamped on this
      * session's container tabs in OUR outgoing Layout ([TabNode.origin][ai.rever.bossterm.compose.share.TabNode]),
      * so a client connecting to US can skip tabs that mirror its own session. Null if the link
@@ -310,6 +325,7 @@ class RemoteSession internal constructor(
         localTabByRemote.values.toList().forEach { removeMirrorTab(it) }
         localTabByRemote.clear()
         sessionByPane.clear()
+        upstreamByTab.clear()
     }
 
     // ---- message handling ----
@@ -400,6 +416,7 @@ class RemoteSession internal constructor(
                 }
                 owned.forEach { pid -> sessionByPane.remove(pid)?.let { disposeSession(it) } }
                 state.splitStates.remove(container.id)
+                upstreamByTab.remove(container.id)
             }
         }
 
@@ -422,6 +439,16 @@ class RemoteSession internal constructor(
             }
             container.title.value = tabNode.title.ifBlank { "remote" }
             container.workingDirectory.value = tabNode.cwd
+
+            // Track whether this host tab itself mirrors ANOTHER session (and our effective
+            // writability through it) — the tab bar nests those under a labeled subsection.
+            val upstream = tabNode.origin?.let {
+                UpstreamOrigin(it, tabNode.originName, tabNode.originReadOnly == true)
+            }
+            if (upstreamByTab[container.id] != upstream) {
+                if (upstream != null) upstreamByTab[container.id] = upstream else upstreamByTab.remove(container.id)
+                upstreamRev.value++
+            }
 
             // (Re)build the split tree of pane mirrors — always present, even for a single pane.
             // Preserve the client's own focused pane across structural updates (setTree falls back
@@ -478,6 +505,7 @@ class RemoteSession internal constructor(
             disposeSession(mirror)
         }
         state.splitStates.remove(container.id)
+        upstreamByTab.remove(container.id)
         val idx = controller?.tabs?.indexOf(container) ?: -1
         if (idx >= 0) controller?.closeTab(idx) // index-safe removal; closeTab disposes the container
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -10,6 +10,7 @@ import ai.rever.bossterm.compose.share.ShareProtocol
 import ai.rever.bossterm.compose.share.ShareScope
 import ai.rever.bossterm.compose.splits.SplitNode
 import ai.rever.bossterm.compose.splits.SplitViewState
+import ai.rever.bossterm.compose.tabs.TabController
 import ai.rever.bossterm.compose.tabs.TerminalTab
 import ai.rever.bossterm.core.util.TermSize
 import ai.rever.bossterm.terminal.RequestOrigin
@@ -33,7 +34,11 @@ import java.util.UUID
  */
 class RemoteSessionManager(private val state: TabbedTerminalState) {
 
-    /** Stable per-install client id so the host recognizes this device across reconnects. */
+    /**
+     * Client id the host uses to recognize this device across reconnects WITHIN a session. It's a
+     * fresh UUID per window/launch (not persisted), so a host re-approval is needed after restart
+     * — consistent with the in-memory access keys. Persisting it is a follow-up.
+     */
     private val clientId: String = UUID.randomUUID().toString()
 
     /** Active remote sessions — observed by the UI to list them + show status. */
@@ -47,10 +52,16 @@ class RemoteSessionManager(private val state: TabbedTerminalState) {
      * [shareBack] = two-way: once the host grants control, offer it this window's own share link
      * so it mirrors our tabs too.
      */
+    @Synchronized
     fun connect(link: String, deviceName: String, shareBack: Boolean = false): RemoteSession? {
         if (isOwnShareLink(link)) return null
+        // @Synchronized makes the lookup-then-add atomic — connect() is called from the UI thread
+        // (AddRemoteDialog) and from the host's OfferShare handler (a server coroutine).
         tokenOf(link)?.let { token ->
-            sessions.firstOrNull { tokenOf(it.link) == token }?.let { return it }
+            sessions.firstOrNull { tokenOf(it.link) == token }?.let { existing ->
+                if (shareBack) existing.enableShareBack() // honor a newly-ticked two-way box
+                return existing
+            }
         }
         val session = RemoteSession(link, deviceName, state, clientId, shareBack)
         sessions.add(session)
@@ -101,8 +112,8 @@ class RemoteSessionManager(private val state: TabbedTerminalState) {
     }
 }
 
-/** The `t=` token in a share [link], or null if absent/malformed. */
-private fun tokenOf(link: String): String? = runCatching {
+/** The `t=` token in a share [link], or null if absent/malformed. Visible for tests. */
+internal fun tokenOf(link: String): String? = runCatching {
     val raw = java.net.URI(link.trim()).rawQuery ?: return@runCatching null
     raw.split("&").firstOrNull { it.startsWith("t=") }?.substringAfter("t=")
         ?.let { java.net.URLDecoder.decode(it, "UTF-8") }?.takeIf { it.isNotBlank() }
@@ -120,11 +131,18 @@ class RemoteSession internal constructor(
     private val state: TabbedTerminalState,
     clientId: String,
     /** Two-way: once the host grants control, offer it this window's own share link. */
-    private val shareBack: Boolean = false,
+    shareBack: Boolean = false,
 ) {
     private val log = LoggerFactory.getLogger(RemoteSession::class.java)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val offeredShareBack = java.util.concurrent.atomic.AtomicBoolean(false)
+    @Volatile private var shareBackEnabled = shareBack
+
+    /** Turn on two-way share-back after construction (a re-paste with the box newly ticked). */
+    fun enableShareBack() {
+        shareBackEnabled = true
+        if (conn.canControl) maybeOfferShareBack()
+    }
 
     // In-memory access key for this link (persistence across restarts is a follow-up).
     @Volatile private var key: String? = null
@@ -188,7 +206,8 @@ class RemoteSession internal constructor(
 
     // localTabId (container) → upstream-origin info; bumping [upstreamRev] re-renders the bar
     // when only this map changed (e.g. the host's upstream control was granted mid-session).
-    private val upstreamByTab = HashMap<String, UpstreamOrigin>()
+    // Concurrent: written on Main (the inbox drain), read on host threads (MirrorShare).
+    private val upstreamByTab = java.util.concurrent.ConcurrentHashMap<String, UpstreamOrigin>()
     val upstreamRev = androidx.compose.runtime.mutableStateOf(0)
 
     /** The upstream origin of [localTabId]'s host tab, or null if it's the host's own tab. */
@@ -204,15 +223,31 @@ class RemoteSession internal constructor(
 
     // remote tabId → the local **container** tab in tabController.tabs. A container is a
     // PTY-less, stream-less shell that owns the chip + the split tree; it is never a pane itself.
-    private val localTabByRemote = LinkedHashMap<String, TerminalTab>()
+    // Concurrent maps: mutated only on Main (the inbox drain / disconnect), but read on the
+    // Compose thread (sessionForTab during composition) and host threads (MirrorShare). Insertion
+    // order isn't relied on — tab display order comes from controller.tabs.
+    private val localTabByRemote = java.util.concurrent.ConcurrentHashMap<String, TerminalTab>()
     // remote paneId → the mirror session feeding that pane's terminal. Holds ONLY pane mirrors
     // (every remote pane, even a single one), never a container — so the host closing any pane
-    // (including a tab's first) can never orphan a survivor's output.
-    private val sessionByPane = HashMap<String, TerminalTab>()
+    // (including a tab's first) can never orphan a survivor's output. Read on the WS IO thread
+    // (PaneOutput hot path) and host threads, hence concurrent.
+    private val sessionByPane = java.util.concurrent.ConcurrentHashMap<String, TerminalTab>()
+
+    // Inbound server messages are drained by ONE coroutine on Main, in wire order — so reconcile's
+    // tab-list/splitState mutation and the snapshot-after-layout ordering both run on the UI thread,
+    // matching TabController's convention and removing the cross-thread tab-mutation races.
+    private val uiScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val inbox = kotlinx.coroutines.channels.Channel<ServerMessage>(kotlinx.coroutines.channels.Channel.UNLIMITED)
 
     fun start() {
-        // Mirror the connection's StateFlow status into Compose state (see [statusState]).
-        scope.launch { conn.status.collect { statusState.value = it } }
+        uiScope.launch {
+            // Mirror the connection's status into Compose state (read in composition).
+            conn.status.collect { statusState.value = it }
+        }
+        uiScope.launch {
+            for (msg in inbox) runCatching { handleMessage(msg) }
+                .onFailure { log.warn("remote message handling failed: {}", it.message) }
+        }
         conn.start()
     }
 
@@ -401,7 +436,8 @@ class RemoteSession internal constructor(
     }
 
     fun close() {
-        runCatching { scope.cancel() } // abandon a pending share-back offer
+        runCatching { scope.cancel() }   // status collector + share-back offer
+        runCatching { uiScope.cancel() } // the inbox drain
         conn.close()
         localTabByRemote.values.toList().forEach { removeMirrorTab(it) }
         localTabByRemote.clear()
@@ -410,7 +446,11 @@ class RemoteSession internal constructor(
     }
 
     // ---- message handling ----
-    private fun onMessage(msg: ServerMessage) {
+    // Called on the WS IO thread — just hand off to the ordered Main drain (see [inbox]).
+    private fun onMessage(msg: ServerMessage) { inbox.trySend(msg) }
+
+    // Runs on Main, in wire order.
+    private fun handleMessage(msg: ServerMessage) {
         when (msg) {
             is ServerMessage.Layout -> {
                 msg.sessionName?.takeIf { it.isNotBlank() }?.let { hostName.value = it }
@@ -454,7 +494,7 @@ class RemoteSession internal constructor(
      * (booting the share server/tunnel as needed — hence async).
      */
     private fun maybeOfferShareBack() {
-        if (!shareBack || !offeredShareBack.compareAndSet(false, true)) return
+        if (!shareBackEnabled || !offeredShareBack.compareAndSet(false, true)) return
         scope.launch {
             runCatching {
                 val ownLink = ensureOwnShareLink() ?: return@launch
@@ -548,7 +588,7 @@ class RemoteSession internal constructor(
             val ss = state.splitStates.getOrPut(container.id) { SplitViewState(initialSession = container) }
             // Route divider drags in this mirror's split tree to the host (idempotent each pass).
             ss.onRemoteDividerDrag = { splitId, ratio, committed -> resizeSplit(container.id, splitId, ratio, committed) }
-            ss.setTree(buildTree(tabNode.tree, container.id), ss.focusedPaneId)
+            ss.setTree(buildTree(tabNode.tree, container.id, controller), ss.focusedPaneId)
 
             // Add to the tab list only AFTER the split tree is populated — so the UI never renders
             // a not-yet-built container, and without switching focus (must not steal the local
@@ -558,10 +598,10 @@ class RemoteSession internal constructor(
     }
 
     /** Map a remote pane tree to a local [SplitNode] tree, reusing pane mirrors by remote paneId. */
-    private fun buildTree(node: PaneTreeNode, containerId: String): SplitNode = when (node) {
+    private fun buildTree(node: PaneTreeNode, containerId: String, controller: TabController): SplitNode = when (node) {
         is PaneTreeNode.Pane -> {
             val session = sessionByPane.getOrPut(node.paneId) {
-                state.tabController!!.createRemoteSession(
+                controller.createRemoteSession(
                     title = node.title,
                     remotePaneId = node.paneId,
                     onUserInput = { data ->
@@ -586,15 +626,15 @@ class RemoteSession internal constructor(
         is PaneTreeNode.Split -> if (node.dir == "h") {
             SplitNode.HorizontalSplit(
                 id = node.id.ifBlank { node.paneIdKey() },
-                top = buildTree(node.a, containerId),
-                bottom = buildTree(node.b, containerId),
+                top = buildTree(node.a, containerId, controller),
+                bottom = buildTree(node.b, containerId, controller),
                 ratio = node.ratio,
             )
         } else {
             SplitNode.VerticalSplit(
                 id = node.id.ifBlank { node.paneIdKey() },
-                left = buildTree(node.a, containerId),
-                right = buildTree(node.b, containerId),
+                left = buildTree(node.a, containerId, controller),
+                right = buildTree(node.b, containerId, controller),
                 ratio = node.ratio,
             )
         }
@@ -611,7 +651,17 @@ class RemoteSession internal constructor(
         state.splitStates.remove(container.id)
         upstreamByTab.remove(container.id)
         val idx = controller?.tabs?.indexOf(container) ?: -1
-        if (idx >= 0) controller?.closeTab(idx) // index-safe removal; closeTab disposes the container
+        if (idx >= 0) {
+            if (controller!!.tabs.size <= 1) {
+                // Don't let a remote-driven teardown close the window via onLastTabClosed (e.g. the
+                // host closes its tab while this mirror is the only tab left). Dispose + remove the
+                // mirror directly, leaving an empty window rather than exiting.
+                runCatching { container.dispose() }
+                controller.tabs.removeAt(idx)
+            } else {
+                controller.closeTab(idx) // index-safe removal; closeTab disposes the container
+            }
+        }
     }
 
     private fun disposeSession(s: TerminalTab) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -205,6 +205,16 @@ class RemoteSession internal constructor(
         }
     }
 
+    /**
+     * "Fit host to my screen": ask the host to resize its window so [localTabId]'s grid becomes
+     * about [cols]×[rows] (what fits this client's canvas). The host echoes PaneResize back.
+     */
+    fun resizeHost(localTabId: String, cols: Int, rows: Int) {
+        if (!conn.canControl) return
+        val rid = remoteTabIdFor(localTabId) ?: return
+        conn.send(ClientMessage.ResizeHost(rid, cols, rows))
+    }
+
     /** Map a local container tab id back to its remote tab id. */
     private fun remoteTabIdFor(localTabId: String): String? =
         localTabByRemote.entries.firstOrNull { it.value.id == localTabId }?.key
@@ -314,6 +324,14 @@ class RemoteSession internal constructor(
             // Route divider drags in this mirror's split tree to the host (idempotent each pass).
             ss.onRemoteDividerDrag = { splitId, ratio, committed -> resizeSplit(container.id, splitId, ratio, committed) }
             ss.setTree(buildTree(tabNode.tree), ss.focusedPaneId)
+
+            // Auto "Fit host to my screen": only a single-pane tab can drive the host window size
+            // from its canvas — wire the lone pane mirror, clear the hook on every other pane.
+            val lone = (tabNode.tree as? PaneTreeNode.Pane)?.let { sessionByPane[it.paneId] }
+            ss.getAllSessions().filterIsInstance<TerminalTab>().forEach { m ->
+                m.onRemoteResizeRequest =
+                    if (m === lone) { { cols, rows -> resizeHost(container.id, cols, rows) } } else null
+            }
 
             // Add to the tab list only AFTER the split tree is populated — so the UI never renders
             // a not-yet-built container, and without switching focus (must not steal the local

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -69,6 +69,13 @@ class RemoteSession internal constructor(
     // In-memory access key for this link (persistence across restarts is a follow-up).
     @Volatile private var key: String? = null
 
+    // While the user drags a split divider locally we stream the ratio to the host (throttled) and
+    // ignore the host's Layout echoes (which carry the same ratio) so the divider doesn't fight the
+    // drag — mirrors the browser viewer's `splitDragging` guard. Set on the UI thread, read by the
+    // WS IO thread in reconcile().
+    @Volatile private var draggingSplit = false
+    @Volatile private var lastResizeSentAt = 0L
+
     private val conn = RemoteSessionConnection(
         link = link,
         clientId = clientId,
@@ -176,6 +183,28 @@ class RemoteSession internal constructor(
         conn.send(ClientMessage.CloseTabsBelow(rid))
     }
 
+    /**
+     * Drag a split divider: set split node [splitId] in [localTabId]'s tab to [ratio] on the host
+     * (mirrors dragging the divider on the host). During the drag ([committed] = false) sends are
+     * throttled and Layout echoes are ignored (see [draggingSplit]); on release ([committed] =
+     * true) sends the final ratio and resumes reconciling.
+     */
+    fun resizeSplit(localTabId: String, splitId: String, ratio: Float, committed: Boolean) {
+        if (!conn.canControl) return
+        val rid = remoteTabIdFor(localTabId) ?: return
+        if (committed) {
+            draggingSplit = false
+            conn.send(ClientMessage.ResizeSplit(rid, splitId, ratio))
+        } else {
+            draggingSplit = true
+            val now = System.currentTimeMillis()
+            if (now - lastResizeSentAt >= 60L) { // ~16fps, matches the viewer's throttle
+                lastResizeSentAt = now
+                conn.send(ClientMessage.ResizeSplit(rid, splitId, ratio))
+            }
+        }
+    }
+
     /** Map a local container tab id back to its remote tab id. */
     private fun remoteTabIdFor(localTabId: String): String? =
         localTabByRemote.entries.firstOrNull { it.value.id == localTabId }?.key
@@ -236,6 +265,9 @@ class RemoteSession internal constructor(
      * changes — Layout is only resent then. Reuses containers/panes by remote id across rebuilds.
      */
     private fun reconcile(layout: ServerMessage.Layout) {
+        // While a divider is being dragged locally, ignore the host's Layout echoes (they carry the
+        // ratio we just sent) so the drag isn't interrupted — the post-release Layout reconciles.
+        if (draggingSplit) return
         val controller = state.tabController ?: return
         val remoteIds = layout.tabs.map { it.id }.toSet()
 
@@ -279,6 +311,8 @@ class RemoteSession internal constructor(
             // Preserve the client's own focused pane across structural updates (setTree falls back
             // to the first pane if the focused one is gone) — client focus is independent of host.
             val ss = state.splitStates.getOrPut(container.id) { SplitViewState(initialSession = container) }
+            // Route divider drags in this mirror's split tree to the host (idempotent each pass).
+            ss.onRemoteDividerDrag = { splitId, ratio, committed -> resizeSplit(container.id, splitId, ratio, committed) }
             ss.setTree(buildTree(tabNode.tree), ss.focusedPaneId)
 
             // Add to the tab list only AFTER the split tree is populated — so the UI never renders

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -1,17 +1,25 @@
 package ai.rever.bossterm.compose.remote
 
 import ai.rever.bossterm.compose.TabbedTerminalState
+import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.share.ClientMessage
 import ai.rever.bossterm.compose.share.PaneTreeNode
 import ai.rever.bossterm.compose.share.ServerMessage
+import ai.rever.bossterm.compose.share.SessionShareManager
 import ai.rever.bossterm.compose.share.ShareProtocol
+import ai.rever.bossterm.compose.share.ShareScope
 import ai.rever.bossterm.compose.splits.SplitNode
 import ai.rever.bossterm.compose.splits.SplitViewState
 import ai.rever.bossterm.compose.tabs.TerminalTab
 import ai.rever.bossterm.core.util.TermSize
 import ai.rever.bossterm.terminal.RequestOrigin
 import androidx.compose.runtime.mutableStateListOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
@@ -34,11 +42,17 @@ class RemoteSessionManager(private val state: TabbedTerminalState) {
     /**
      * Dial [link] and mirror its tabs here. Returns null (refusing to connect) when [link] is one
      * of THIS instance's own share links — mirroring a session into itself would feed the mirror
-     * tabs back into the share in a loop.
+     * tabs back into the share in a loop. Reconnecting to a share we're already mirroring (same
+     * token — e.g. a repeated two-way offer or a double-pasted link) returns the existing session.
+     * [shareBack] = two-way: once the host grants control, offer it this window's own share link
+     * so it mirrors our tabs too.
      */
-    fun connect(link: String, deviceName: String): RemoteSession? {
+    fun connect(link: String, deviceName: String, shareBack: Boolean = false): RemoteSession? {
         if (isOwnShareLink(link)) return null
-        val session = RemoteSession(link, deviceName, state, clientId)
+        tokenOf(link)?.let { token ->
+            sessions.firstOrNull { tokenOf(it.link) == token }?.let { return it }
+        }
+        val session = RemoteSession(link, deviceName, state, clientId, shareBack)
         sessions.add(session)
         session.start()
         return session
@@ -81,8 +95,12 @@ class RemoteSession internal constructor(
     val deviceName: String,
     private val state: TabbedTerminalState,
     clientId: String,
+    /** Two-way: once the host grants control, offer it this window's own share link. */
+    private val shareBack: Boolean = false,
 ) {
     private val log = LoggerFactory.getLogger(RemoteSession::class.java)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val offeredShareBack = java.util.concurrent.atomic.AtomicBoolean(false)
 
     // In-memory access key for this link (persistence across restarts is a follow-up).
     @Volatile private var key: String? = null
@@ -265,6 +283,7 @@ class RemoteSession internal constructor(
     }
 
     fun close() {
+        runCatching { scope.cancel() } // abandon a pending share-back offer
         conn.close()
         localTabByRemote.values.toList().forEach { removeMirrorTab(it) }
         localTabByRemote.clear()
@@ -289,8 +308,38 @@ class RemoteSession internal constructor(
                 val s = sessionByPane[msg.paneId] ?: return
                 if (msg.cols >= 2 && msg.rows >= 2) s.terminal.resize(TermSize(msg.cols, msg.rows), RequestOrigin.User)
             }
-            else -> {} // Theme/Presence/Control/Pending/Grant/Denied handled in the connection
+            is ServerMessage.Control ->
+                // Two-way sharing offers only matter once the host trusts us with control —
+                // it ignores OfferShare from view-only clients anyway.
+                if (msg.granted) maybeOfferShareBack()
+            else -> {} // Theme/Presence/Pending/Grant/Denied handled in the connection
         }
+    }
+
+    /**
+     * Two-way sharing: offer this window's own share link to the host (once per session) so it
+     * mirrors our tabs back. Reuses an active share of this window, else starts a WINDOW share
+     * (booting the share server/tunnel as needed — hence async).
+     */
+    private fun maybeOfferShareBack() {
+        if (!shareBack || !offeredShareBack.compareAndSet(false, true)) return
+        scope.launch {
+            runCatching {
+                val ownLink = ensureOwnShareLink() ?: return@launch
+                conn.send(ClientMessage.OfferShare(ownLink))
+            }.onFailure { log.warn("two-way share-back failed: {}", it.message) }
+        }
+    }
+
+    /** This window's own view link — an active share if present, else a fresh WINDOW share. */
+    private suspend fun ensureOwnShareLink(): String? {
+        state.tabs.firstOrNull { SessionShareManager.isSharing(it.id) }
+            ?.let { SessionShareManager.urlFor(it.id) }?.let { return it }
+        val tabId = state.activeTabId ?: state.tabs.firstOrNull()?.id ?: return null
+        if (!SettingsManager.instance.settings.value.sessionSharingEnabled) {
+            SettingsManager.instance.updateSetting { copy(sessionSharingEnabled = true) }
+        }
+        return SessionShareManager.share(tabId, ShareScope.WINDOW)?.url
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -135,6 +135,13 @@ class RemoteSession internal constructor(
     /** Custom group accent ("0xFFRRGGBB"); null → the default remote cyan. */
     val accent = androidx.compose.runtime.mutableStateOf<String?>(null)
 
+    /**
+     * [canControl] as Compose state — updated on the host's Control messages, so the tab bar's
+     * remote menus rebuild the moment control is granted/revoked (a StateFlow read wouldn't
+     * trigger recomposition).
+     */
+    val canControlState = androidx.compose.runtime.mutableStateOf(false)
+
     /** True if [s] is any of this session's mirrors — the containers or their pane mirrors. */
     fun ownsMirror(s: ai.rever.bossterm.compose.TerminalSession): Boolean =
         localTabByRemote.values.any { it === s } || sessionByPane.values.any { it === s }
@@ -323,10 +330,12 @@ class RemoteSession internal constructor(
                 val s = sessionByPane[msg.paneId] ?: return
                 if (msg.cols >= 2 && msg.rows >= 2) s.terminal.resize(TermSize(msg.cols, msg.rows), RequestOrigin.User)
             }
-            is ServerMessage.Control ->
+            is ServerMessage.Control -> {
+                canControlState.value = msg.granted // recompose the tab bar's remote menus
                 // Two-way sharing offers only matter once the host trusts us with control —
                 // it ignores OfferShare from view-only clients anyway.
                 if (msg.granted) maybeOfferShareBack()
+            }
             else -> {} // Theme/Presence/Pending/Grant/Denied handled in the connection
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -70,6 +70,10 @@ class RemoteSessionManager(private val state: TabbedTerminalState) {
     /** The remote session that owns [tab] (a mirror tab), or null if it's a local tab. */
     fun sessionForTab(tab: TerminalTab): RemoteSession? = sessions.firstOrNull { it.containsTab(tab) }
 
+    /** Like [sessionForTab] but also matches pane mirrors inside a container's split tree. */
+    fun sessionForMirror(s: ai.rever.bossterm.compose.TerminalSession): RemoteSession? =
+        sessions.firstOrNull { it.ownsMirror(s) }
+
     /** Tear down every remote session (e.g. when the window closes). */
     fun disconnectAll() {
         sessions.toList().forEach { it.close() }
@@ -123,6 +127,17 @@ class RemoteSession internal constructor(
 
     val status: StateFlow<RemoteStatus> get() = conn.status
     val canControl: Boolean get() = conn.canControl
+
+    // Local-only customization of this remote's group box in the left bar (right-click the
+    // box header). Not sent to the host; lives as long as the connection.
+    /** Custom group name; null → the link's host. */
+    val customName = androidx.compose.runtime.mutableStateOf<String?>(null)
+    /** Custom group accent ("0xFFRRGGBB"); null → the default remote cyan. */
+    val accent = androidx.compose.runtime.mutableStateOf<String?>(null)
+
+    /** True if [s] is any of this session's mirrors — the containers or their pane mirrors. */
+    fun ownsMirror(s: ai.rever.bossterm.compose.TerminalSession): Boolean =
+        localTabByRemote.values.any { it === s } || sessionByPane.values.any { it === s }
 
     /**
      * Identifies which share this session mirrors: SHA-256 of [link]'s token. Stamped on this

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -188,12 +188,25 @@ class RemoteSession internal constructor(
     /** Ask the host to grant write/control (when connected view-only). */
     fun requestControl() = conn.send(ClientMessage.RequestControl())
 
+    // An upstream control request queued until OUR control of the host is granted — the host
+    // only relays upstream requests from controlling clients, so (A view-only on B, B view-only
+    // on C) chains as: ask B for control first, then automatically ask C through it.
+    @Volatile private var pendingUpstreamControlTab: String? = null
+
     /**
      * Control request targeted at [localTabId]'s tab: when that tab mirrors an upstream session
-     * on the host (A→B→C), the host relays the request to the origin instead.
+     * on the host (A→B→C), the host relays the request to the origin. If we don't control the
+     * host yet, first request that (its user approves), then the upstream request fires
+     * automatically when the grant arrives.
      */
-    fun requestControlFor(localTabId: String) =
+    fun requestControlFor(localTabId: String) {
+        if (!conn.canControl) {
+            pendingUpstreamControlTab = localTabId
+            conn.send(ClientMessage.RequestControl())
+            return
+        }
         conn.send(ClientMessage.RequestControl(remoteTabIdFor(localTabId)))
+    }
 
     /** New tab in [localTabId]'s session — the host relays upstream for mirrored tabs. */
     fun newTabIn(localTabId: String) {
@@ -376,9 +389,17 @@ class RemoteSession internal constructor(
             }
             is ServerMessage.Control -> {
                 canControlState.value = msg.granted // recompose the tab bar's remote menus
-                // Two-way sharing offers only matter once the host trusts us with control —
-                // it ignores OfferShare from view-only clients anyway.
-                if (msg.granted) maybeOfferShareBack()
+                if (msg.granted) {
+                    // Two-way sharing offers only matter once the host trusts us with control —
+                    // it ignores OfferShare from view-only clients anyway.
+                    maybeOfferShareBack()
+                    // Fire a queued upstream control request (the second hop of the chain):
+                    // now that the host trusts us, it will relay it to the origin.
+                    pendingUpstreamControlTab?.let { tabId ->
+                        pendingUpstreamControlTab = null
+                        conn.send(ClientMessage.RequestControl(remoteTabIdFor(tabId)))
+                    }
+                }
             }
             else -> {} // Theme/Presence/Pending/Grant/Denied handled in the connection
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -81,9 +81,12 @@ class RemoteSession internal constructor(
     val status: StateFlow<RemoteStatus> get() = conn.status
     val canControl: Boolean get() = conn.canControl
 
-    // remote tabId → the local mirror tab placed in tabController.tabs.
+    // remote tabId → the local **container** tab in tabController.tabs. A container is a
+    // PTY-less, stream-less shell that owns the chip + the split tree; it is never a pane itself.
     private val localTabByRemote = LinkedHashMap<String, TerminalTab>()
-    // remote paneId → the mirror session feeding that pane's terminal.
+    // remote paneId → the mirror session feeding that pane's terminal. Holds ONLY pane mirrors
+    // (every remote pane, even a single one), never a container — so the host closing any pane
+    // (including a tab's first) can never orphan a survivor's output.
     private val sessionByPane = HashMap<String, TerminalTab>()
 
     fun start() = conn.start()
@@ -98,17 +101,35 @@ class RemoteSession internal constructor(
     fun newRemoteTab() = conn.send(ClientMessage.NewTab)
 
     /**
+     * Mirror a local close of a remote chip back to the host (control only): close the whole
+     * remote tab for a tab-level / single-pane chip, else just that pane. Structure is
+     * host-driven — we never dispose a mirror locally (that would be resurrected by the next
+     * Layout); the host's resulting Layout removes it here. No-op when view-only.
+     */
+    fun closeFromChip(localTabId: String, paneId: String) {
+        if (!conn.canControl) return
+        val remoteTabId = localTabByRemote.entries.firstOrNull { it.value.id == localTabId }?.key ?: return
+        val ss = state.splitStates[localTabId]
+        val wholeTab = paneId == localTabId || ss == null || ss.isSinglePane
+        conn.send(
+            if (wholeTab) ClientMessage.CloseTab(remoteTabId)
+            else ClientMessage.ClosePane(remoteTabId, paneId)
+        )
+    }
+
+    /**
      * Split the remote session's current pane (the active mirror tab if it belongs to this
      * session, else this session's first tab) left/right or top/bottom — the host applies it
      * and it mirrors back. Control only.
      */
     fun splitFocused(horizontal: Boolean) {
         val controller = state.tabController ?: return
-        val tab = controller.tabs.getOrNull(controller.activeTabIndex)?.takeIf { containsTab(it) }
+        // The container to split: the active tab if it's one of ours, else this session's first.
+        val container = controller.tabs.getOrNull(controller.activeTabIndex)?.takeIf { containsTab(it) }
             ?: localTabByRemote.values.firstOrNull() ?: return
-        val remoteTabId = localTabByRemote.entries.firstOrNull { it.value === tab }?.key ?: return
-        val paneId = state.splitStates[tab.id]?.focusedPaneId?.takeIf { sessionByPane.containsKey(it) }
-            ?: tab.remotePaneId ?: return
+        val remoteTabId = localTabByRemote.entries.firstOrNull { it.value === container }?.key ?: return
+        // The focused pane id IS a remote paneId (split-tree pane ids are the host's paneIds).
+        val paneId = state.splitStates[container.id]?.focusedPaneId?.takeIf { sessionByPane.containsKey(it) } ?: return
         conn.send(
             if (horizontal) ClientMessage.SplitHorizontal(remoteTabId, paneId)
             else ClientMessage.SplitVertical(remoteTabId, paneId)
@@ -130,7 +151,10 @@ class RemoteSession internal constructor(
             is ServerMessage.PaneSnapshot -> {
                 val s = sessionByPane[msg.paneId] ?: return
                 if (msg.cols >= 2 && msg.rows >= 2) s.terminal.resize(TermSize(msg.cols, msg.rows), RequestOrigin.User)
-                s.dataStream.append(msg.data)
+                // Clear scrollback+screen IN-BAND (processed by the emulator loop, no cross-thread
+                // buffer race) before painting the snapshot — so a reconnect's re-sent snapshot
+                // replaces the old content instead of duplicating it.
+                s.dataStream.append("[3J[2J[H" + msg.data)
             }
             is ServerMessage.PaneOutput -> sessionByPane[msg.paneId]?.dataStream?.append(msg.data)
             is ServerMessage.PaneResize -> {
@@ -142,115 +166,117 @@ class RemoteSession internal constructor(
     }
 
     /**
-     * Rebuild the local mirror tabs from the remote [layout]: create tabs for new remote tabs,
-     * remove vanished ones, and (re)build each tab's split tree (reusing mirror sessions by
-     * remote paneId). Runs whenever the host's structure changes — Layout is only resent then.
+     * Rebuild the local mirror from the remote [layout]. Each remote tab maps to a local
+     * **container** tab (chip + index only); every remote pane — even a lone one — is its own
+     * mirror session living in the container's split tree. So when the host closes a tab's first
+     * pane, the survivors keep streaming (no pane is special). Runs whenever the host's structure
+     * changes — Layout is only resent then. Reuses containers/panes by remote id across rebuilds.
      */
     private fun reconcile(layout: ServerMessage.Layout) {
         val controller = state.tabController ?: return
         val remoteIds = layout.tabs.map { it.id }.toSet()
 
-        // Self-heal: a mirror tab the user closed via its chip (×) is gone from the controller
-        // but still in our maps — forget it (+ its pane sessions) so it can be rebuilt fresh.
-        localTabByRemote.entries.toList().forEach { (remoteId, t) ->
-            if (controller.tabs.none { it === t }) {
+        // Self-heal: a container the user closed via its chip (×) is gone from the controller but
+        // still in our maps — forget it + dispose its pane mirrors so it can be rebuilt fresh.
+        localTabByRemote.entries.toList().forEach { (remoteId, container) ->
+            if (controller.tabs.none { it === container }) {
                 localTabByRemote.remove(remoteId)
-                val panes = state.splitStates[t.id]?.getAllSessions()?.toList() ?: listOf(t)
-                sessionByPane.entries.removeIf { e -> e.value === t || panes.any { it === e.value } }
-                state.splitStates.remove(t.id)
+                // Owned paneIds: from the (maybe still-present) split tree, plus the incoming
+                // layout — getAllPanes()/SplitNode.Pane.id are the remote paneIds.
+                val owned = buildSet {
+                    state.splitStates[container.id]?.getAllPanes()?.forEach { add(it.id) }
+                    layout.tabs.firstOrNull { it.id == remoteId }?.let { addAll(paneIds(it.tree)) }
+                }
+                owned.forEach { pid -> sessionByPane.remove(pid)?.let { disposeSession(it) } }
+                state.splitStates.remove(container.id)
             }
         }
 
-        // Drop mirror tabs for remote tabs that no longer exist.
+        // Drop containers for remote tabs that no longer exist (host closed the whole tab).
         (localTabByRemote.keys - remoteIds).toList().forEach { gone ->
             localTabByRemote.remove(gone)?.let { removeMirrorTab(it) }
         }
-        // Drop pane sessions whose remote paneId vanished.
+        // Drop pane mirrors whose remote paneId vanished (host closed a split pane).
         val livePaneIds = layout.tabs.flatMap { paneIds(it.tree) }.toSet()
         (sessionByPane.keys - livePaneIds).toList().forEach { gone ->
-            sessionByPane.remove(gone)?.let { s ->
-                if (localTabByRemote.values.none { it === s }) disposeSession(s) // not a tab-level session
-            }
+            sessionByPane.remove(gone)?.let { disposeSession(it) }
         }
 
         for (tabNode in layout.tabs) {
-            val firstPane = firstPaneId(tabNode.tree) ?: continue
-            // Ensure the tab-level mirror session exists (it IS the first pane).
-            val tab = localTabByRemote.getOrPut(tabNode.id) {
-                val t = controller.createRemoteSession(
-                    title = tabNode.title.ifBlank { "remote" },
-                    remotePaneId = firstPane,
-                    onUserInput = { data -> if (conn.canControl) conn.send(ClientMessage.Input(firstPane, data)) },
-                )
-                sessionByPane[firstPane] = t
-                controller.tabs.add(t)
-                t
+            // The container — a PTY-less, stream-less tab that owns the chip and hosts the split
+            // tree of pane mirrors. It is never itself a pane.
+            val isNew = !localTabByRemote.containsKey(tabNode.id)
+            val container = localTabByRemote.getOrPut(tabNode.id) {
+                controller.createRemoteSession(title = tabNode.title.ifBlank { "remote" }, feedsStream = false)
             }
-            tab.title.value = tabNode.title.ifBlank { "remote" }
-            tab.workingDirectory.value = tabNode.cwd
+            container.title.value = tabNode.title.ifBlank { "remote" }
+            container.workingDirectory.value = tabNode.cwd
 
-            // Single pane → no split state; multi-pane → (re)build the split tree.
-            if (tabNode.tree is PaneTreeNode.Split) {
-                val ss = state.splitStates.getOrPut(tab.id) { SplitViewState(initialSession = tab) }
-                ss.setTree(buildTree(tabNode.tree, tab, firstPane), firstPane)
-            } else {
-                state.splitStates.remove(tab.id)
-            }
+            // (Re)build the split tree of pane mirrors — always present, even for a single pane.
+            // Preserve the client's own focused pane across structural updates (setTree falls back
+            // to the first pane if the focused one is gone) — client focus is independent of host.
+            val ss = state.splitStates.getOrPut(container.id) { SplitViewState(initialSession = container) }
+            ss.setTree(buildTree(tabNode.tree), ss.focusedPaneId)
+
+            // Add to the tab list only AFTER the split tree is populated — so the UI never renders
+            // a not-yet-built container, and without switching focus (must not steal the local
+            // active tab). New tabs append at the end.
+            if (isNew) controller.tabs.add(container)
         }
     }
 
-    /** Map a remote pane tree to a local [SplitNode] tree, reusing mirror sessions by paneId. */
-    private fun buildTree(node: PaneTreeNode, tabSession: TerminalTab, firstPaneId: String): SplitNode = when (node) {
+    /** Map a remote pane tree to a local [SplitNode] tree, reusing pane mirrors by remote paneId. */
+    private fun buildTree(node: PaneTreeNode): SplitNode = when (node) {
         is PaneTreeNode.Pane -> {
-            val session = if (node.paneId == firstPaneId) tabSession else sessionByPane.getOrPut(node.paneId) {
+            val session = sessionByPane.getOrPut(node.paneId) {
                 state.tabController!!.createRemoteSession(
                     title = node.title,
                     remotePaneId = node.paneId,
                     onUserInput = { data -> if (conn.canControl) conn.send(ClientMessage.Input(node.paneId, data)) },
                 )
             }
+            session.title.value = node.title
+            session.workingDirectory.value = node.cwd
             SplitNode.Pane(id = node.paneId, session = session)
         }
         is PaneTreeNode.Split -> if (node.dir == "h") {
             SplitNode.HorizontalSplit(
                 id = node.id.ifBlank { node.paneIdKey() },
-                top = buildTree(node.a, tabSession, firstPaneId),
-                bottom = buildTree(node.b, tabSession, firstPaneId),
+                top = buildTree(node.a),
+                bottom = buildTree(node.b),
                 ratio = node.ratio,
             )
         } else {
             SplitNode.VerticalSplit(
                 id = node.id.ifBlank { node.paneIdKey() },
-                left = buildTree(node.a, tabSession, firstPaneId),
-                right = buildTree(node.b, tabSession, firstPaneId),
+                left = buildTree(node.a),
+                right = buildTree(node.b),
                 ratio = node.ratio,
             )
         }
     }
 
-    private fun removeMirrorTab(tab: TerminalTab) {
+    private fun removeMirrorTab(container: TerminalTab) {
         val controller = state.tabController
-        // Dispose every mirror session in the tab (the tab itself + any extra split panes).
-        val sessions = state.splitStates[tab.id]?.getAllSessions()?.filterIsInstance<TerminalTab>() ?: listOf(tab)
-        sessions.forEach { sessionByPane.entries.removeIf { e -> e.value === it } ; disposeSession(it) }
-        state.splitStates.remove(tab.id)
-        val idx = controller?.tabs?.indexOf(tab) ?: -1
-        if (idx >= 0) controller?.closeTab(idx) // index-safe removal (no PTY to kill)
+        // Dispose every pane mirror in this container's split tree, then the container itself
+        // (closeTab disposes it). No PTY to kill — these are pure mirrors.
+        state.splitStates[container.id]?.getAllSessions()?.filterIsInstance<TerminalTab>()?.forEach { mirror ->
+            sessionByPane.entries.removeIf { it.value === mirror }
+            disposeSession(mirror)
+        }
+        state.splitStates.remove(container.id)
+        val idx = controller?.tabs?.indexOf(container) ?: -1
+        if (idx >= 0) controller?.closeTab(idx) // index-safe removal; closeTab disposes the container
     }
 
     private fun disposeSession(s: TerminalTab) {
-        runCatching { s.dataStream.close() } // unblocks the emulator loop
+        runCatching { s.dataStream.close() } // unblocks the emulator loop (pane mirrors only)
         runCatching { s.dispose() }
     }
 
     private fun paneIds(node: PaneTreeNode): List<String> = when (node) {
         is PaneTreeNode.Pane -> listOf(node.paneId)
         is PaneTreeNode.Split -> paneIds(node.a) + paneIds(node.b)
-    }
-
-    private fun firstPaneId(node: PaneTreeNode): String? = when (node) {
-        is PaneTreeNode.Pane -> node.paneId
-        is PaneTreeNode.Split -> firstPaneId(node.a) ?: firstPaneId(node.b)
     }
 
     // Fallback stable id for a split node when the host didn't send one (old peer).

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -274,7 +274,11 @@ class MirrorShare(
             tabNodes.add(
                 TabNode(
                     id = tab.id, title = tab.title.value, active = tab.id == activeId, tree = tree,
-                    color = tabColorCss(tab), cwd = tab.workingDirectory.value, branch = tab.gitBranch.value
+                    color = tabColorCss(tab), cwd = tab.workingDirectory.value, branch = tab.gitBranch.value,
+                    // Mark tabs that themselves mirror another session with that share's token
+                    // hash, so a client connecting to us can skip the ones mirroring its own
+                    // session (mirroring them back would loop its tabs through us).
+                    origin = state.remoteSessions.sessionForTab(tab)?.originHash,
                 )
             )
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -65,6 +65,15 @@ class MirrorShare(
     private val viewers = CopyOnWriteArrayList<ViewerConnection>()
     private val viewerSeq = AtomicInteger(0)
     private val coro = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /**
+     * The host's name for this shared session, shown to viewers as the default group label
+     * (defaults to the username; editable in the Share window). Compose state — read inside
+     * computeSignature's snapshotFlow, so renames re-broadcast the Layout.
+     */
+    val sessionName = androidx.compose.runtime.mutableStateOf(
+        System.getProperty("user.name")?.takeIf { it.isNotBlank() } ?: "session"
+    )
     private var observerJob: Job? = null
 
     private class TapEntry(val tab: TerminalTab, val prev: ((String) -> Unit)?)
@@ -116,7 +125,7 @@ class MirrorShare(
         val sig = computeSignature()
         val out = ArrayList<ServerMessage>()
         out.add(themeMessage())
-        out.add(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft, sig.summaryMode))
+        out.add(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft, sig.summaryMode, sig.sessionName))
         for ((id, tab) in paneTabMap()) {
             val sz = sig.sizes[id] ?: listOf(80, 24)
             out.add(ServerMessage.PaneSnapshot(id, snapshotText(tab), sz[0], sz[1]))
@@ -299,7 +308,7 @@ class MirrorShare(
                 }
             }
         }
-        broadcast(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft, sig.summaryMode))
+        broadcast(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft, sig.summaryMode, sig.sessionName))
         sig.sizes.forEach { (id, sz) -> broadcast(ServerMessage.PaneResize(id, sz[0], sz[1])) }
     }
 
@@ -310,6 +319,7 @@ class MirrorShare(
         val sizes: Map<String, List<Int>>,
         val tabBarOnLeft: Boolean,
         val summaryMode: Boolean,
+        val sessionName: String? = null,
     )
 
     private fun inScopeTabs(state: TabbedTerminalState): List<TerminalTab> = when (scope) {
@@ -348,13 +358,14 @@ class MirrorShare(
                     color = tabColorCss(tab), cwd = tab.workingDirectory.value, branch = tab.gitBranch.value,
                     origin = upstream?.originHash,
                     originName = upstream?.let {
-                        it.customName.value ?: runCatching { java.net.URI(it.link).host }.getOrNull() ?: it.link
+                        it.customName.value ?: it.hostName.value
+                            ?: runCatching { java.net.URI(it.link).host }.getOrNull() ?: it.link
                     },
                     originReadOnly = upstream?.let { !it.canControlState.value },
                 )
             )
         }
-        return WindowSig(tabNodes, activeId, sizes, onLeft, summary)
+        return WindowSig(tabNodes, activeId, sizes, onLeft, summary, sessionName.value)
     }
 
     /** Resolve a tab's accent as CSS (#RRGGBB), mirroring the host's chip color (manual or auto). */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -166,6 +166,9 @@ class MirrorShare(
                     vc.controlRequestPending = false
                     if (approved) {
                         vc.canControl = true
+                        // Persist the upgrade into the grant so reconnects (same link + key)
+                        // come back WITH control instead of silently demoting to view-only.
+                        vc.grantKey?.let { SessionShareManager.upgradeGrantToControl(it) }
                         vc.outbox.trySend(ShareProtocol.encodeServer(ServerMessage.Control(granted = true)))
                     }
                 }
@@ -528,4 +531,11 @@ class ViewerConnection(
 
     /** A mid-session control request is awaiting the host's decision (dedupes re-requests). */
     @Volatile var controlRequestPending = false
+
+    /**
+     * This connection's access key — an approved mid-session control upgrade is written back
+     * into its grant, so the device keeps control across silent reconnects (the client redials
+     * the same view link + key; without this each blip demoted it to view-only).
+     */
+    @Volatile var grantKey: String? = null
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -363,6 +363,9 @@ class MirrorShare(
                             ?: runCatching { java.net.URI(it.link).host }.getOrNull() ?: it.link
                     },
                     originReadOnly = upstream?.let { !it.canControlState.value },
+                    originOffline = upstream?.let {
+                        it.statusState.value !is ai.rever.bossterm.compose.remote.RemoteStatus.Connected
+                    },
                 )
             )
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -68,12 +68,10 @@ class MirrorShare(
 
     /**
      * The host's name for this shared session, shown to viewers as the default group label
-     * (defaults to the username; editable in the Share window). Compose state — read inside
-     * computeSignature's snapshotFlow, so renames re-broadcast the Layout.
+     * (defaults to `username_machine`; editable in the Share window). Compose state — read
+     * inside computeSignature's snapshotFlow, so renames re-broadcast the Layout.
      */
-    val sessionName = androidx.compose.runtime.mutableStateOf(
-        System.getProperty("user.name")?.takeIf { it.isNotBlank() } ?: "session"
-    )
+    val sessionName = androidx.compose.runtime.mutableStateOf(SessionShareManager.defaultSessionName())
     private var observerJob: Job? = null
 
     private class TapEntry(val tab: TerminalTab, val prev: ((String) -> Unit)?)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -297,14 +297,20 @@ class MirrorShare(
                     color = tabColorCss(tab), branch = tab.gitBranch.value
                 )
             }
+            // Mark tabs that themselves mirror another session with that share's token hash
+            // (so a client connecting to us can skip the ones mirroring its own session), a
+            // friendly label, and whether WE are view-only on it (then input can't flow
+            // through us — nested viewers should mark those tabs read-only too).
+            val upstream = state.remoteSessions.sessionForTab(tab)
             tabNodes.add(
                 TabNode(
                     id = tab.id, title = tab.title.value, active = tab.id == activeId, tree = tree,
                     color = tabColorCss(tab), cwd = tab.workingDirectory.value, branch = tab.gitBranch.value,
-                    // Mark tabs that themselves mirror another session with that share's token
-                    // hash, so a client connecting to us can skip the ones mirroring its own
-                    // session (mirroring them back would loop its tabs through us).
-                    origin = state.remoteSessions.sessionForTab(tab)?.originHash,
+                    origin = upstream?.originHash,
+                    originName = upstream?.let {
+                        it.customName.value ?: runCatching { java.net.URI(it.link).host }.getOrNull() ?: it.link
+                    },
+                    originReadOnly = upstream?.let { !it.canControlState.value },
                 )
             )
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -125,8 +125,27 @@ class MirrorShare(
     }
 
     /** Route viewer messages — input + tab close/new — to the host (controller role only). */
+    /**
+     * The remote session a host tab itself mirrors (so a viewer's action on it can be relayed
+     * to the origin instead of mutating the local mirror — which the next upstream Layout
+     * would wipe). Null for the host's own tabs.
+     */
+    private fun upstreamSession(targetTabId: String?): ai.rever.bossterm.compose.remote.RemoteSession? {
+        if (targetTabId == null) return null
+        val st = McpTerminalRegistry.findState(tabId) ?: return null
+        val tab = st.tabs.firstOrNull { it.id == targetTabId } ?: return null
+        return st.remoteSessions.sessionForTab(tab)
+    }
+
     fun handleClient(vc: ViewerConnection, msg: ClientMessage) {
         if (msg is ClientMessage.RequestControl) {
+            val upstream = upstreamSession(msg.tabId)
+            if (upstream != null) {
+                // Relay an upstream control request (A→B→C: C asked us, we ask A — A's user
+                // sees its approval toast with OUR device name). Needs control of this share.
+                if (vc.canControl) upstream.requestControl()
+                return
+            }
             // A view-only viewer asking for an upgrade — must run BEFORE the control gate.
             // Surfaces the same approval toast as a join request; on approve, flip this live
             // connection's role and tell the viewer. (The viewer's saved key keeps its original
@@ -145,26 +164,46 @@ class MirrorShare(
             return
         }
         if (!vc.canControl) return // all mutating actions require the control role
+        // Structural actions on a tab WE mirror from another session relay to that origin
+        // (our RemoteSession methods no-op silently if we're view-only on it).
         when (msg) {
             is ClientMessage.Input ->
                 (taps[msg.paneId]?.tab ?: paneTabMap()[msg.paneId])?.writeUserInput(msg.data)
             is ClientMessage.CloseTab ->
-                McpTerminalRegistry.findState(tabId)?.closeTab(msg.tabId)
+                upstreamSession(msg.tabId)?.closeFromChip(msg.tabId, msg.tabId)
+                    ?: McpTerminalRegistry.findState(tabId)?.closeTab(msg.tabId)
             is ClientMessage.NewTab ->
                 // Background: a viewer creating a tab shouldn't switch the host user's active tab.
-                McpTerminalRegistry.findState(tabId)?.createTab(activate = false)
+                upstreamSession(msg.tabId)?.newRemoteTab()
+                    ?: McpTerminalRegistry.findState(tabId)?.createTab(activate = false)
             is ClientMessage.SplitVertical ->
-                McpTerminalRegistry.findState(tabId)?.splitVerticalFromPane(msg.tabId, msg.paneId)
+                upstreamSession(msg.tabId)?.splitPane(msg.tabId, msg.paneId, horizontal = false)
+                    ?: McpTerminalRegistry.findState(tabId)?.splitVerticalFromPane(msg.tabId, msg.paneId)
             is ClientMessage.SplitHorizontal ->
-                McpTerminalRegistry.findState(tabId)?.splitHorizontalFromPane(msg.tabId, msg.paneId)
+                upstreamSession(msg.tabId)?.splitPane(msg.tabId, msg.paneId, horizontal = true)
+                    ?: McpTerminalRegistry.findState(tabId)?.splitHorizontalFromPane(msg.tabId, msg.paneId)
             is ClientMessage.ClosePane -> {
-                // Target the clicked pane (focus it), then close; closeFocusedPane closes
-                // the whole tab when it's the only pane (matches the host's behavior).
-                val st = McpTerminalRegistry.findState(tabId)
-                st?.splitStates?.get(msg.tabId)?.setFocusedPane(msg.paneId)
-                st?.closeFocusedPane(msg.tabId)
+                val upstream = upstreamSession(msg.tabId)
+                if (upstream != null) {
+                    upstream.closeFromChip(msg.tabId, msg.paneId)
+                } else {
+                    // Target the clicked pane (focus it), then close; closeFocusedPane closes
+                    // the whole tab when it's the only pane (matches the host's behavior).
+                    val st = McpTerminalRegistry.findState(tabId)
+                    st?.splitStates?.get(msg.tabId)?.setFocusedPane(msg.paneId)
+                    st?.closeFocusedPane(msg.tabId)
+                }
             }
+            is ClientMessage.DisconnectUpstream ->
+                upstreamSession(msg.tabId)?.let { up ->
+                    McpTerminalRegistry.findState(tabId)?.remoteSessions?.disconnect(up)
+                }
             is ClientMessage.LaunchAI -> {
+                val upstream = upstreamSession(msg.tabId)
+                if (upstream != null) {
+                    upstream.launchAI(msg.tabId, msg.paneId, msg.assistantId)
+                    return
+                }
                 // Run the same launch command the host's AI menu would (honoring the
                 // user's per-assistant YOLO/auto-mode config), in the clicked pane.
                 val target = taps[msg.paneId]?.tab ?: paneTabMap()[msg.paneId]
@@ -187,7 +226,8 @@ class MirrorShare(
                 McpTerminalRegistry.findState(tabId)?.closeTabsBelow(msg.tabId)
             is ClientMessage.ResizeHost -> resizeHostWindow(msg.cols, msg.rows)
             is ClientMessage.ResizeSplit ->
-                McpTerminalRegistry.findState(tabId)?.splitStates?.get(msg.tabId)?.updateSplitRatio(msg.splitId, msg.ratio)
+                upstreamSession(msg.tabId)?.resizeSplit(msg.tabId, msg.splitId, msg.ratio, committed = true)
+                    ?: McpTerminalRegistry.findState(tabId)?.splitStates?.get(msg.tabId)?.updateSplitRatio(msg.splitId, msg.ratio)
             is ClientMessage.OfferShare -> {
                 // Two-way sharing: mirror the offering client's session back into this window.
                 // connect() dedupes a repeated offer (same token) and refuses our own links;

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -90,8 +90,8 @@ class MirrorShare(
     }
 
     // ---- viewers ----
-    fun addViewer(canControl: Boolean): ViewerConnection {
-        val vc = ViewerConnection(viewerSeq.incrementAndGet(), canControl)
+    fun addViewer(canControl: Boolean, name: String = "Viewer"): ViewerConnection {
+        val vc = ViewerConnection(viewerSeq.incrementAndGet(), canControl, name)
         viewers.add(vc)
         broadcast(ServerMessage.Presence(viewers.size))
         return vc
@@ -126,6 +126,24 @@ class MirrorShare(
 
     /** Route viewer messages — input + tab close/new — to the host (controller role only). */
     fun handleClient(vc: ViewerConnection, msg: ClientMessage) {
+        if (msg is ClientMessage.RequestControl) {
+            // A view-only viewer asking for an upgrade — must run BEFORE the control gate.
+            // Surfaces the same approval toast as a join request; on approve, flip this live
+            // connection's role and tell the viewer. (The viewer's saved key keeps its original
+            // role — a reconnect is view-only again until re-approved.)
+            if (!vc.canControl && !vc.controlRequestPending) {
+                vc.controlRequestPending = true
+                coro.launch {
+                    val approved = SessionShareManager.awaitApproval(tabId, vc.name, wantsControl = true)
+                    vc.controlRequestPending = false
+                    if (approved) {
+                        vc.canControl = true
+                        vc.outbox.trySend(ShareProtocol.encodeServer(ServerMessage.Control(granted = true)))
+                    }
+                }
+            }
+            return
+        }
         if (!vc.canControl) return // all mutating actions require the control role
         when (msg) {
             is ClientMessage.Input ->
@@ -178,7 +196,7 @@ class MirrorShare(
                     ?.let { "$it (BossTerm)" }) ?: "BossTerm"
                 McpTerminalRegistry.findState(tabId)?.remoteSessions?.connect(msg.link, name)
             }
-            else -> {} // Hello / Focus / RequestControl: no-op (focus is viewer-side; control via token)
+            else -> {} // Hello / Focus: no-op (focus is viewer-side; RequestControl handled above)
         }
     }
 
@@ -442,6 +460,15 @@ class MirrorShare(
  * the Ktor route drains it. Bounded + DROP_OLDEST so a slow viewer never stalls the
  * terminal — it just misses intermediate frames (the next snapshot heals it).
  */
-class ViewerConnection(val id: Int, val canControl: Boolean) {
+class ViewerConnection(
+    val id: Int,
+    /** Mutable: a view-only viewer can be upgraded mid-session via an approved RequestControl. */
+    @Volatile var canControl: Boolean,
+    /** Device name from the viewer's Hello — shown in the control-request approval prompt. */
+    val name: String = "Viewer",
+) {
     val outbox: Channel<String> = Channel(capacity = 2048, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+    /** A mid-session control request is awaiting the host's decision (dedupes re-requests). */
+    @Volatile var controlRequestPending = false
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -155,8 +155,8 @@ class MirrorShare(
             }
             // A view-only viewer asking for an upgrade — must run BEFORE the control gate.
             // Surfaces the same approval toast as a join request; on approve, flip this live
-            // connection's role and tell the viewer. (The viewer's saved key keeps its original
-            // role — a reconnect is view-only again until re-approved.)
+            // connection's role, tell the viewer, AND persist the upgrade into its grant (below)
+            // so a reconnect with the same key comes back WITH control rather than demoting.
             if (!vc.canControl && !vc.controlRequestPending) {
                 vc.controlRequestPending = true
                 coro.launch {
@@ -240,8 +240,12 @@ class MirrorShare(
                     ?: McpTerminalRegistry.findState(tabId)?.splitStates?.get(msg.tabId)?.updateSplitRatio(msg.splitId, msg.ratio)
             is ClientMessage.OfferShare -> {
                 // Two-way sharing: mirror the offering client's session back into this window.
-                // connect() dedupes a repeated offer (same token) and refuses our own links;
-                // origin tagging keeps either side's tabs from bouncing back.
+                // NOTE (trust boundary): this makes the host open an OUTBOUND WebSocket to a URL
+                // the peer supplies — a mild SSRF-flavored surface. It's gated on the control role
+                // (the host explicitly approved this device), so granting control also implies
+                // "this device may have my BossTerm dial a link it provides." connect() dedupes a
+                // repeated offer (same token) and refuses our own links; origin tagging keeps
+                // either side's tabs from bouncing back.
                 val name = (System.getProperty("user.name")?.takeIf { it.isNotBlank() }
                     ?.let { "$it (BossTerm)" }) ?: "BossTerm"
                 McpTerminalRegistry.findState(tabId)?.remoteSessions?.connect(msg.link, name)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -352,19 +352,31 @@ class MirrorShare(
             // (so a client connecting to us can skip the ones mirroring its own session), a
             // friendly label, and whether WE are view-only on it (then input can't flow
             // through us — nested viewers should mark those tabs read-only too).
+            //
+            // A mirrored tab may itself mirror a DEEPER session (A→B→C: our B-mirror of B's
+            // C-mirror). Forward the DEEPEST origin — its hash keeps grouping/loop-guarding
+            // correct at the true source — chain the label ("C · via B"), and degrade
+            // read-only/offline if ANY hop along the path is degraded.
             val upstream = state.remoteSessions.sessionForTab(tab)
+            upstream?.upstreamRev?.value // subscribe: deeper-origin changes re-broadcast too
+            val deeper = upstream?.upstreamFor(tab.id)
+            val upstreamName = upstream?.let {
+                it.customName.value ?: it.hostName.value
+                    ?: runCatching { java.net.URI(it.link).host }.getOrNull() ?: it.link
+            }
             tabNodes.add(
                 TabNode(
                     id = tab.id, title = tab.title.value, active = tab.id == activeId, tree = tree,
                     color = tabColorCss(tab), cwd = tab.workingDirectory.value, branch = tab.gitBranch.value,
-                    origin = upstream?.originHash,
-                    originName = upstream?.let {
-                        it.customName.value ?: it.hostName.value
-                            ?: runCatching { java.net.URI(it.link).host }.getOrNull() ?: it.link
+                    origin = deeper?.key ?: upstream?.originHash,
+                    originName = when {
+                        deeper != null -> "${deeper.name ?: "remote"} · via $upstreamName"
+                        else -> upstreamName
                     },
-                    originReadOnly = upstream?.let { !it.canControlState.value },
+                    originReadOnly = upstream?.let { (deeper?.readOnly ?: false) || !it.canControlState.value },
                     originOffline = upstream?.let {
-                        it.statusState.value !is ai.rever.bossterm.compose.remote.RemoteStatus.Connected
+                        (deeper?.offline ?: false) ||
+                            it.statusState.value !is ai.rever.bossterm.compose.remote.RemoteStatus.Connected
                     },
                 )
             )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -170,6 +170,14 @@ class MirrorShare(
             is ClientMessage.ResizeHost -> resizeHostWindow(msg.cols, msg.rows)
             is ClientMessage.ResizeSplit ->
                 McpTerminalRegistry.findState(tabId)?.splitStates?.get(msg.tabId)?.updateSplitRatio(msg.splitId, msg.ratio)
+            is ClientMessage.OfferShare -> {
+                // Two-way sharing: mirror the offering client's session back into this window.
+                // connect() dedupes a repeated offer (same token) and refuses our own links;
+                // origin tagging keeps either side's tabs from bouncing back.
+                val name = (System.getProperty("user.name")?.takeIf { it.isNotBlank() }
+                    ?.let { "$it (BossTerm)" }) ?: "BossTerm"
+                McpTerminalRegistry.findState(tabId)?.remoteSessions?.connect(msg.link, name)
+            }
             else -> {} // Hello / Focus / RequestControl: no-op (focus is viewer-side; control via token)
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -255,6 +255,16 @@ object SessionShareManager {
     fun ownsTokenHash(hash: String): Boolean =
         sharesByToken.keys.any { ShareProtocol.sha256Hex(it) == hash }
 
+    /** The host's name for [tabId]'s share (viewers' default group label), or null if unshared. */
+    fun sessionNameFor(tabId: String): String? = sharesByTab[tabId]?.sessionName?.value
+
+    /** Rename [tabId]'s share; blank reverts to the username default. */
+    fun setSessionName(tabId: String, name: String) {
+        sharesByTab[tabId]?.sessionName?.value = name.trim().ifBlank {
+            System.getProperty("user.name")?.takeIf { it.isNotBlank() } ?: "session"
+        }
+    }
+
     /** The read-only share URL for an active share, or null if not shared / server down. */
     fun urlFor(tabId: String): String? {
         val token = sharesByTab[tabId]?.viewToken ?: return null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -154,6 +154,24 @@ object SessionShareManager {
     val pendingRequests: StateFlow<List<PendingShareRequest>> = _pendingRequests.asStateFlow()
 
     /** Host approved a pending request (admits the viewer + mints a 24h key). */
+    /**
+     * Enqueue an approval request (e.g. a viewer's mid-session control upgrade) and await the
+     * host's decision — surfaces in the same toast/Share-window UI as join requests. Times out
+     * to denied after 2 minutes.
+     */
+    internal suspend fun awaitApproval(tabId: String, deviceName: String, wantsControl: Boolean): Boolean {
+        val req = PendingShareRequest(
+            id = UUID.randomUUID().toString(),
+            tabId = tabId,
+            deviceName = deviceName,
+            wantsControl = wantsControl,
+        )
+        _pendingRequests.value = _pendingRequests.value + req
+        val approved = withTimeoutOrNull(2 * 60_000L) { req.decision.await() } ?: false
+        _pendingRequests.value = _pendingRequests.value.filterNot { it.id == req.id }
+        return approved
+    }
+
     fun approveRequest(id: String) = decideRequest(id, true)
     /** Host denied a pending request (closes the viewer socket). */
     fun denyRequest(id: String) = decideRequest(id, false)
@@ -669,7 +687,7 @@ object SessionShareManager {
         // only carries output produced after the snapshot (avoids double-rendering).
         share.initialMessages().forEach { ws.send(Frame.Text(ShareProtocol.encodeServer(it))) }
         ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Control(granted = canControl))))
-        val vc = share.addViewer(canControl)
+        val vc = share.addViewer(canControl, hello?.name?.takeIf { it.isNotBlank() } ?: "Viewer (${clientId.take(6)})")
         val writer = ws.launch {
             for (text in vc.outbox) ws.send(Frame.Text(text))
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -174,9 +174,23 @@ object SessionShareManager {
             wantsControl = wantsControl,
         )
         _pendingRequests.value = _pendingRequests.value + req
+        notifyApprovalRequest(req)
         val approved = withTimeoutOrNull(2 * 60_000L) { req.decision.await() } ?: false
         _pendingRequests.value = _pendingRequests.value.filterNot { it.id == req.id }
         return approved
+    }
+
+    /**
+     * System notification for an approval request — the in-app toast is easy to miss when the
+     * window is unfocused (same rationale as command-completion notifications).
+     */
+    private fun notifyApprovalRequest(req: PendingShareRequest) {
+        runCatching {
+            ai.rever.bossterm.compose.notification.NotificationService.showNotification(
+                title = "BossTerm session sharing",
+                message = "${req.deviceName} wants ${if (req.wantsControl) "control of" else "to view"} your shared session",
+            )
+        }
     }
 
     fun approveRequest(id: String) = decideRequest(id, true)
@@ -695,6 +709,7 @@ object SessionShareManager {
                     wantsControl = ref.canControl,
                 )
                 _pendingRequests.value = _pendingRequests.value + req
+                notifyApprovalRequest(req)
                 runCatching { ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Pending))) }
                 val approved = withTimeoutOrNull(2 * 60_000L) { req.decision.await() } ?: false
                 _pendingRequests.value = _pendingRequests.value.filterNot { it.id == req.id }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -229,6 +229,14 @@ object SessionShareManager {
      */
     fun ownsToken(token: String): Boolean = sharesByToken.containsKey(token)
 
+    /**
+     * Is [hash] the SHA-256 of one of THIS instance's active share tokens? Matches
+     * [TabNode.origin] stamped by a host on tabs that mirror a remote session, so a client
+     * connecting to that host can skip the tabs that mirror its own session.
+     */
+    fun ownsTokenHash(hash: String): Boolean =
+        sharesByToken.keys.any { ShareProtocol.sha256Hex(it) == hash }
+
     /** The read-only share URL for an active share, or null if not shared / server down. */
     fun urlFor(tabId: String): String? {
         val token = sharesByTab[tabId]?.viewToken ?: return null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -181,14 +181,15 @@ object SessionShareManager {
     }
 
     /**
-     * System notification for an approval request — the in-app toast is easy to miss when the
-     * window is unfocused (same rationale as command-completion notifications).
+     * System notification for an approval request — fires regardless of focus (an approval is
+     * urgent: someone is waiting), with sound so it's audible even while working in the app.
      */
     private fun notifyApprovalRequest(req: PendingShareRequest) {
         runCatching {
             ai.rever.bossterm.compose.notification.NotificationService.showNotification(
                 title = "BossTerm session sharing",
                 message = "${req.deviceName} wants ${if (req.wantsControl) "control of" else "to view"} your shared session",
+                withSound = true,
             )
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -223,6 +223,12 @@ object SessionShareManager {
     /** Is [tabId] currently shared? */
     fun isSharing(tabId: String): Boolean = sharesByTab.containsKey(tabId)
 
+    /**
+     * Is [token] one of THIS instance's active share tokens (view or control)? Used to refuse
+     * adding our own share link as a "remote" session — mirroring a session into itself loops.
+     */
+    fun ownsToken(token: String): Boolean = sharesByToken.containsKey(token)
+
     /** The read-only share URL for an active share, or null if not shared / server down. */
     fun urlFor(tabId: String): String? {
         val token = sharesByTab[tabId]?.viewToken ?: return null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -265,12 +265,21 @@ object SessionShareManager {
     /** The host's name for [tabId]'s share (viewers' default group label), or null if unshared. */
     fun sessionNameFor(tabId: String): String? = sharesByTab[tabId]?.sessionName?.value
 
-    /** Rename [tabId]'s share; blank reverts to the username default. */
+    /** Rename [tabId]'s share; blank reverts to [defaultSessionName]. */
     fun setSessionName(tabId: String, name: String) {
-        sharesByTab[tabId]?.sessionName?.value = name.trim().ifBlank {
-            System.getProperty("user.name")?.takeIf { it.isNotBlank() } ?: "session"
-        }
+        sharesByTab[tabId]?.sessionName?.value = name.trim().ifBlank { defaultSessionName() }
     }
+
+    // Cached — InetAddress.getLocalHost() can stall on bad DNS; compute once, off the hot paths.
+    private val cachedDefaultSessionName by lazy {
+        val user = System.getProperty("user.name")?.takeIf { it.isNotBlank() } ?: "session"
+        val host = runCatching { java.net.InetAddress.getLocalHost().hostName }
+            .getOrNull()?.takeIf { it.isNotBlank() }?.removeSuffix(".local")
+        if (host != null) "${user}_$host" else user
+    }
+
+    /** Default share session name: `username_machine` (e.g. `alice_Alices-MacBook-Pro`). */
+    fun defaultSessionName(): String = cachedDefaultSessionName
 
     /** The read-only share URL for an active share, or null if not shared / server down. */
     fun urlFor(tabId: String): String? {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -131,9 +131,16 @@ object SessionShareManager {
         val key: String,
         val shareId: String,
         val clientId: String,
-        val canControl: Boolean,
+        /** Mutable: an approved mid-session control request upgrades the stored role, so the
+         *  device keeps control across silent reconnects (else each drop demoted it back). */
+        @Volatile var canControl: Boolean,
         @Volatile var expiresAtMs: Long,
     )
+
+    /** Persist an approved mid-session control upgrade into [key]'s grant (see [Grant.canControl]). */
+    internal fun upgradeGrantToControl(key: String) {
+        grants[key]?.canControl = true
+    }
 
     /** Access key → grant. Lazily expired on use; cleared when the share ends. */
     private val grants = ConcurrentHashMap<String, Grant>()
@@ -659,6 +666,7 @@ object SessionShareManager {
         val clientId = hello?.clientId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
         var canControl = ref.canControl
 
+        var accessKey: String? = null // this connection's grant key (for mid-session role upgrades)
         if (requiresApproval()) {
             val now = System.currentTimeMillis()
             val existing = hello?.key?.let { grants[it] }
@@ -666,6 +674,7 @@ object SessionShareManager {
                 // Known device with a live key → slide the 24h window, skip re-approval.
                 existing.expiresAtMs = now + GRANT_TTL_MS
                 canControl = existing.canControl
+                accessKey = existing.key
                 ws.send(Frame.Text(ShareProtocol.encodeServer(
                     ServerMessage.Grant(existing.key, existing.expiresAtMs, canControl))))
             } else {
@@ -689,6 +698,7 @@ object SessionShareManager {
                 val exp = System.currentTimeMillis() + GRANT_TTL_MS
                 grants[key] = Grant(key, shareId, clientId, ref.canControl, exp)
                 canControl = ref.canControl
+                accessKey = key
                 ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Grant(key, exp, canControl))))
             }
         }
@@ -698,6 +708,7 @@ object SessionShareManager {
         share.initialMessages().forEach { ws.send(Frame.Text(ShareProtocol.encodeServer(it))) }
         ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Control(granted = canControl))))
         val vc = share.addViewer(canControl, hello?.name?.takeIf { it.isNotBlank() } ?: "Viewer (${clientId.take(6)})")
+        vc.grantKey = accessKey // lets an approved mid-session upgrade persist into the grant
         val writer = ws.launch {
             for (text in vc.outbox) ws.send(Frame.Text(text))
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -140,6 +140,17 @@ data class TabNode(
      * loop), without leaking the token to viewers. Null for the host's own tabs.
      */
     val origin: String? = null,
+    /**
+     * When [origin] != null: a friendly label for that upstream session (the host's custom
+     * group name, else its link's host) — lets a nested viewer group these tabs under a
+     * labeled subsection instead of mixing them with the host's own tabs.
+     */
+    val originName: String? = null,
+    /**
+     * When [origin] != null: true if the HOST itself is view-only on that upstream session —
+     * input can't flow through it, so these tabs are effectively read-only for viewers too.
+     */
+    val originReadOnly: Boolean? = null,
 )
 
 /** Recursive split-layout node: either a binary split or a leaf pane. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -58,6 +58,11 @@ sealed class ServerMessage {
          * false (default) = one chip per split pane (the viewer shows per-pane sub-tabs).
          */
         val summaryMode: Boolean = false,
+        /**
+         * The host's name for this shared session (defaults to its username; editable in the
+         * Share window). Clients use it as the default group label instead of the link's host.
+         */
+        val sessionName: String? = null,
     ) : ServerMessage()
 
     /** One-time initial paint for a pane: scrollback+screen as a raw escape/text blob. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -294,4 +294,13 @@ sealed class ClientMessage {
     @Serializable
     @SerialName("resizeSplit")
     data class ResizeSplit(val tabId: String, val splitId: String, val ratio: Float) : ClientMessage()
+
+    /**
+     * Two-way sharing: the connecting client offers its OWN session's share [link] so the host
+     * mirrors the client's tabs back (the host dials [link] as a normal remote session — the
+     * client's own approval/key flow applies). Controller role only; old hosts ignore it.
+     */
+    @Serializable
+    @SerialName("offerShare")
+    data class OfferShare(val link: String) : ClientMessage()
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -32,6 +32,14 @@ object ShareProtocol {
     // Client (native viewer) side — symmetric to the host helpers above.
     fun encodeClient(msg: ClientMessage): String = json.encodeToString(ClientMessage.serializer(), msg)
     fun decodeServer(text: String): ServerMessage = json.decodeFromString(ServerMessage.serializer(), text)
+
+    /**
+     * SHA-256 hex of [s]. Used as [TabNode.origin]: identifies which share a mirror tab came
+     * from without leaking the share token itself to viewers.
+     */
+    fun sha256Hex(s: String): String =
+        java.security.MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
 }
 
 /** Host → viewer messages. */
@@ -125,6 +133,13 @@ data class TabNode(
     val color: String? = null,
     val cwd: String? = null,
     val branch: String? = null,
+    /**
+     * For a tab that itself mirrors another BossTerm session (a remote container): the SHA-256
+     * hex of the share token this host dialed ([ShareProtocol.sha256Hex]). Lets a connecting
+     * client recognize — and skip — tabs that mirror its OWN session (mirroring them back would
+     * loop), without leaking the token to viewers. Null for the host's own tabs.
+     */
+    val origin: String? = null,
 )
 
 /** Recursive split-layout node: either a binary split or a leaf pane. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -156,6 +156,11 @@ data class TabNode(
      * input can't flow through it, so these tabs are effectively read-only for viewers too.
      */
     val originReadOnly: Boolean? = null,
+    /**
+     * When [origin] != null: true if the host's connection to that upstream is currently down
+     * (reconnecting or failed) — these tabs show FROZEN content until it comes back.
+     */
+    val originOffline: Boolean? = null,
 )
 
 /** Recursive split-layout node: either a binary split or a leaf pane. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -213,20 +213,37 @@ sealed class ClientMessage {
     @SerialName("focus")
     data class Focus(val tabId: String, val paneId: String) : ClientMessage()
 
-    /** Request write/control access from the host. */
+    /**
+     * Request write/control access from the host. With a [tabId] naming a tab the host itself
+     * mirrors from ANOTHER session, the host relays the request to that upstream instead
+     * (A→B→C: C asks B, B asks A). Null/absent = plain upgrade of this connection (and what
+     * older peers send/understand).
+     */
     @Serializable
     @SerialName("requestControl")
-    data object RequestControl : ClientMessage()
+    data class RequestControl(val tabId: String? = null) : ClientMessage()
 
     /** Close a tab on the host (controller role only). Mirrors the host tab's close button. */
     @Serializable
     @SerialName("closeTab")
     data class CloseTab(val tabId: String) : ClientMessage()
 
-    /** Open a new tab on the host (controller role only). Mirrors the host's new-tab (+) button. */
+    /**
+     * Open a new tab on the host (controller role only). With a [tabId] naming a tab the host
+     * mirrors from another session, the host relays — the new tab opens in that upstream
+     * session instead. Null/absent = a local tab on the host (what older peers send).
+     */
     @Serializable
     @SerialName("newTab")
-    data object NewTab : ClientMessage()
+    data class NewTab(val tabId: String? = null) : ClientMessage()
+
+    /**
+     * Ask the host to disconnect from the upstream session that [tabId] mirrors (the ✕ on a
+     * "via host" group in a nested viewer). Controller role only; old hosts ignore it.
+     */
+    @Serializable
+    @SerialName("disconnectUpstream")
+    data class DisconnectUpstream(val tabId: String) : ClientMessage()
 
     /**
      * Split [paneId] in [tabId] into left/right panes (vertical divider) — the host's

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -28,6 +28,10 @@ object ShareProtocol {
 
     fun encodeServer(msg: ServerMessage): String = json.encodeToString(ServerMessage.serializer(), msg)
     fun decodeClient(text: String): ClientMessage = json.decodeFromString(ClientMessage.serializer(), text)
+
+    // Client (native viewer) side — symmetric to the host helpers above.
+    fun encodeClient(msg: ClientMessage): String = json.encodeToString(ClientMessage.serializer(), msg)
+    fun decodeServer(text: String): ServerMessage = json.decodeFromString(ServerMessage.serializer(), text)
 }
 
 /** Host → viewer messages. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -8,6 +8,7 @@ import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 import ai.rever.bossterm.compose.settings.components.SettingsSection
+import ai.rever.bossterm.compose.settings.components.SettingsTextField
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -93,6 +94,9 @@ fun ShareWindow(
     tailscaleMode: String = "off",
     onTailscaleModeChange: (String) -> Unit = {},
     onRefreshLink: () -> Unit = {},
+    /** The share's name as viewers see it (default: the username). */
+    sessionName: String = "",
+    onSessionNameChange: (String) -> Unit = {},
 ) {
     val clipboard = LocalClipboardManager.current
     val isWindow = info.scope == ShareScope.WINDOW
@@ -155,6 +159,16 @@ fun ShareWindow(
                 Text(
                     "Open a link on another device to watch live; the control link also lets it type.",
                     color = TextSecondary, fontSize = 12.sp
+                )
+                Spacer(Modifier.height(16.dp))
+                // What viewers see as this session's label (their remote group header).
+                // Defaults to the username; blank reverts to it.
+                var nameField by remember(info.tabId) { mutableStateOf(sessionName) }
+                SettingsTextField(
+                    label = "Session name",
+                    value = nameField,
+                    onValueChange = { nameField = it; onSessionNameChange(it) },
+                    placeholder = System.getProperty("user.name") ?: "session",
                 )
                 Spacer(Modifier.height(20.dp))
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -162,13 +162,13 @@ fun ShareWindow(
                 )
                 Spacer(Modifier.height(16.dp))
                 // What viewers see as this session's label (their remote group header).
-                // Defaults to the username; blank reverts to it.
+                // Defaults to username_machine; blank reverts to it.
                 var nameField by remember(info.tabId) { mutableStateOf(sessionName) }
                 SettingsTextField(
                     label = "Session name",
                     value = nameField,
                     onValueChange = { nameField = it; onSessionNameChange(it) },
-                    placeholder = System.getProperty("user.name") ?: "session",
+                    placeholder = SessionShareManager.defaultSessionName(),
                 )
                 Spacer(Modifier.height(20.dp))
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
@@ -499,6 +499,12 @@ private fun RenderVerticalSplit(
             minRatio = splitMinimumSize,
             onRatioChange = { newRatio ->
                 splitState.updateSplitRatio(split.id, newRatio, splitMinimumSize)
+                splitState.onRemoteDividerDrag?.invoke(split.id, newRatio, false)
+            },
+            onDragEnd = {
+                splitState.onRemoteDividerDrag?.let { route ->
+                    (splitState.rootNode.findNode(split.id) as? SplitNode.VerticalSplit)?.let { route(split.id, it.ratio, true) }
+                }
             },
             modifier = Modifier
                 .align(Alignment.CenterStart)
@@ -643,6 +649,12 @@ private fun RenderHorizontalSplit(
             minRatio = splitMinimumSize,
             onRatioChange = { newRatio ->
                 splitState.updateSplitRatio(split.id, newRatio, splitMinimumSize)
+                splitState.onRemoteDividerDrag?.invoke(split.id, newRatio, false)
+            },
+            onDragEnd = {
+                splitState.onRemoteDividerDrag?.let { route ->
+                    (splitState.rootNode.findNode(split.id) as? SplitNode.HorizontalSplit)?.let { route(split.id, it.ratio, true) }
+                }
             },
             modifier = Modifier
                 .align(Alignment.TopCenter)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitDivider.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitDivider.kt
@@ -90,7 +90,9 @@ fun SplitDragHandle(
     onRatioChange: (Float) -> Unit,
     modifier: Modifier = Modifier,
     minRatio: Float = 0.1f,
-    size: Dp = DRAG_AREA_SIZE
+    size: Dp = DRAG_AREA_SIZE,
+    /** Called when the drag ends (or is cancelled) — used to commit the final ratio to a host. */
+    onDragEnd: () -> Unit = {}
 ) {
     // Track the starting ratio when drag begins
     var startRatio by remember { mutableFloatStateOf(currentRatio) }
@@ -124,9 +126,11 @@ fun SplitDragHandle(
                     },
                     onDragEnd = {
                         cumulativeDelta = 0f
+                        onDragEnd()
                     },
                     onDragCancel = {
                         cumulativeDelta = 0f
+                        onDragEnd()
                     },
                     onDrag = { change, dragAmount ->
                         change.consume()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitViewState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitViewState.kt
@@ -44,6 +44,14 @@ class SplitViewState(
     val paneBounds = mutableStateMapOf<String, Rect>()
 
     /**
+     * Remote mirror hook: when this split tree mirrors a remote session, dragging a divider also
+     * streams the ratio to the host — `(splitId, ratio, committed)`. `committed` is true on drag
+     * end (final value). The local ratio is still updated live for smoothness; the host echoes the
+     * final ratio back via its Layout. Null for ordinary local tabs (no remote routing).
+     */
+    var onRemoteDividerDrag: ((splitId: String, ratio: Float, committed: Boolean) -> Unit)? = null
+
+    /**
      * Check if there's only one pane (no splits).
      */
     val isSinglePane: Boolean

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitViewState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitViewState.kt
@@ -94,6 +94,16 @@ class SplitViewState(
     }
 
     /**
+     * Replace the entire split tree. Used by the remote-session mirror to reconstruct (and
+     * re-sync) a host tab's split layout from the wire `Layout`. [focused] should be a pane id
+     * within [root]; if not present, focus falls back to the first pane.
+     */
+    fun setTree(root: SplitNode, focused: String) {
+        rootNode = root
+        focusedPaneId = if (root.findPane(focused) != null) focused else (root.getAllPanes().firstOrNull()?.id ?: focused)
+    }
+
+    /**
      * Split the focused pane in the given orientation.
      * Returns the ID of the new pane, or null if split failed.
      *

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -145,11 +145,23 @@ data class RemoteTabGroup(
     val nested: List<RemoteNestedGroup> = emptyList(),
 )
 
-/** One upstream session's tabs inside a remote group box (see [RemoteTabGroup.nested]). */
+/**
+ * One upstream session's tabs inside a remote group box (see [RemoteTabGroup.nested]).
+ * Actions are relayed by the host to the origin session; when [readOnly] (the host is
+ * view-only on the origin), split/new-tab instead fire [onRequestControl] so the user is
+ * routed to the upgrade path rather than a silent no-op.
+ */
 data class RemoteNestedGroup(
     val label: String,
     val readOnly: Boolean,
     val groups: List<TabBarGroup>,
+    val onSplitVertical: () -> Unit = {},
+    val onSplitHorizontal: () -> Unit = {},
+    val onNewTab: () -> Unit = {},
+    /** Ask the host to disconnect from this upstream (the box's ✕). */
+    val onClose: () -> Unit = {},
+    /** Relay a control request to the origin (host asks it on our behalf). */
+    val onRequestControl: () -> Unit = {},
 )
 
 /** AI assistants offered in the remote chip menu — same set the browser viewer mirrors. */
@@ -248,10 +260,14 @@ fun TabBar(
         contextMenuController.showMenu(0f, 0f, items)
     }
 
-    // Map each mirrored chip's tabIndex → its remote session, so a right-click on a remote chip
-    // opens the host-routed menu instead of the local one.
-    val remoteByTabIndex: Map<Int, RemoteTabGroup> =
-        remoteGroups.flatMap { rg -> rg.groups.map { it.tabIndex to rg } }.toMap()
+    // Map each mirrored chip's tabIndex → its remote session (and its upstream nest, when the
+    // chip lives in a "via host" box), so a right-click opens the right host-routed menu
+    // instead of the local one.
+    val remoteByTabIndex: Map<Int, Pair<RemoteTabGroup, RemoteNestedGroup?>> =
+        remoteGroups.flatMap { rg ->
+            rg.groups.map { it.tabIndex to (rg to (null as RemoteNestedGroup?)) } +
+                rg.nested.flatMap { nest -> nest.groups.map { it.tabIndex to (rg to nest) } }
+        }.toMap()
 
     // Remote group box currently renaming its header inline (by RemoteTabGroup.id).
     var editingRemoteId by remember { mutableStateOf<String?>(null) }
@@ -286,7 +302,7 @@ fun TabBar(
     // Right-click menu for a mirrored remote chip — mirrors the browser viewer's menu, all
     // routed to the host. Host-mutating items are gated on control; "Disconnect remote" is the
     // one native-only affordance and is always enabled.
-    val showRemoteChipMenu: (RemoteTabGroup, Int, String) -> Unit = { rg, tabIndex, paneId ->
+    val showRemoteChipMenu: (RemoteTabGroup, RemoteNestedGroup?, Int, String) -> Unit = { rg, nest, tabIndex, paneId ->
         if (!rg.canControl) {
             // View-only: every chip action mutates the host, so offer just the upgrade path
             // and the local disconnect instead of a wall of disabled items.
@@ -294,6 +310,12 @@ fun TabBar(
                 ContextMenuController.MenuItem(id = "remote_request_control", label = "Request Control", enabled = true, action = { rg.onRequestControl() }),
                 ContextMenuController.MenuSeparator(id = "remote_sep_view"),
                 ContextMenuController.MenuItem(id = "remote_disconnect", label = "Disconnect remote", enabled = true, action = { rg.onDisconnect() }),
+            ))
+        } else if (nest?.readOnly == true) {
+            // Upstream read-only (A→B→C): actions would die at the host — lean menu with the
+            // relayed control request (the host asks the origin on our behalf).
+            contextMenuController.showMenu(0f, 0f, listOf(
+                ContextMenuController.MenuItem(id = "remote_request_upstream", label = "Request Control", enabled = true, action = { nest.onRequestControl() }),
             ))
         } else {
         val ctl = rg.canControl
@@ -382,8 +404,8 @@ fun TabBar(
             onCancelRename = { editingPaneId = null },
             onClose = { onPaneClosed(group.tabIndex, pane.paneId) },
             onContextMenu = {
-                val rg = remoteByTabIndex[group.tabIndex]
-                if (rg != null) showRemoteChipMenu(rg, group.tabIndex, pane.paneId)
+                val ctx = remoteByTabIndex[group.tabIndex]
+                if (ctx != null) showRemoteChipMenu(ctx.first, ctx.second, group.tabIndex, pane.paneId)
                 else showChipMenu(group.tabIndex, pane.paneId)
             },
             modifier = chipModifier
@@ -509,6 +531,9 @@ fun TabBar(
                                             modifier = Modifier.size(12.dp)
                                         )
                                     }
+                                    Box(
+                                        modifier = Modifier.clip(RoundedCornerShape(4.dp)).clickable(onClick = nest.onClose).padding(2.dp)
+                                    ) { Icon(Icons.Default.Close, contentDescription = "Ask host to disconnect this upstream", tint = Color(0xFF808080), modifier = Modifier.size(13.dp)) }
                                 }
                                 Column(verticalArrangement = Arrangement.spacedBy(TabGroupGap)) {
                                     nest.groups.forEach { group ->
@@ -516,6 +541,17 @@ fun TabBar(
                                             group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
                                         }
                                     }
+                                }
+                                // Same footer as the host box; when read-only these route to
+                                // the request-control prompt instead of silently doing nothing.
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(0.dp, Alignment.CenterHorizontally),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    barButton(Icons.Default.VerticalSplit, "Split Left/Right", nest.onSplitVertical)
+                                    barButton(Icons.Default.HorizontalSplit, "Split Top/Bottom", nest.onSplitHorizontal)
+                                    barButton(Icons.Default.Add, "New tab", nest.onNewTab)
                                 }
                             }
                         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -132,6 +132,8 @@ data class RemoteTabGroup(
     val onSetColor: (String?) -> Unit,
     /** Open this remote's share link in the default browser (the web viewer). */
     val onOpenInBrowser: () -> Unit,
+    /** Copy this remote's share link to the clipboard. */
+    val onCopyLink: () -> Unit,
 )
 
 /** AI assistants offered in the remote chip menu — same set the browser viewer mirrors. */
@@ -253,6 +255,7 @@ fun TabBar(
             ContextMenuController.MenuItem(id = "rg_rename", label = "Rename…", enabled = true, action = { editingRemoteId = rg.id }),
             colorSubmenu,
             ContextMenuController.MenuItem(id = "rg_open_browser", label = "Open in Browser", enabled = true, action = { rg.onOpenInBrowser() }),
+            ContextMenuController.MenuItem(id = "rg_copy_link", label = "Copy Link", enabled = true, action = { rg.onCopyLink() }),
             ContextMenuController.MenuSeparator(id = "rg_sep"),
             ContextMenuController.MenuItem(id = "rg_disconnect", label = "Disconnect remote", enabled = true, action = { rg.onDisconnect() }),
         ))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -3,6 +3,7 @@ package ai.rever.bossterm.compose.tabs
 import ai.rever.bossterm.compose.features.ContextMenuController
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
@@ -13,6 +14,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.HorizontalSplit
 import androidx.compose.material.icons.filled.QrCode2
 import androidx.compose.material.icons.filled.Settings
@@ -25,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -132,6 +135,7 @@ fun TabBar(
     onSplitVertical: () -> Unit = {},
     onSplitHorizontal: () -> Unit = {},
     onSettings: () -> Unit = {},
+    onAddRemote: () -> Unit = {},
     orientation: TabBarOrientation = TabBarOrientation.TOP,
     verticalWidth: Dp = TabBarVerticalWidth,
     modifier: Modifier = Modifier
@@ -259,6 +263,24 @@ fun TabBar(
                             group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
                         }
                     }
+                }
+                // Bottom bar — connect to another BossTerm's shared session.
+                Spacer(Modifier.height(8.dp))
+                Box(Modifier.fillMaxWidth().height(1.dp).background(Color(0xFF333333)))
+                Spacer(Modifier.height(6.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp))
+                        .clickable(onClick = onAddRemote).padding(vertical = 6.dp, horizontal = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Cloud,
+                        contentDescription = "Add remote session",
+                        tint = Color(0xFFB0B0B0),
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Text("Add remote", color = Color(0xFFB0B0B0), fontSize = 12.sp)
                 }
             }
         } else {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -104,16 +104,22 @@ data class TabBarGroup(val tabIndex: Int, val panes: List<TabBarPane>)
 
 /**
  * A connected remote BossTerm session, rendered (in the left bar) as a bordered box: a
- * [header] (the remote link/host), the session's mirrored [groups] (its tabs), and a footer
- * of actions that target the remote (split + new tab + disconnect).
+ * [header] (a custom name, else the remote link's host), the session's mirrored [groups]
+ * (its tabs), and a footer of actions that target the remote (split + new tab + disconnect).
  *
  * A right-click on any mirrored chip opens the same host-routed menu the browser viewer shows
  * (new tab / split / AI assistant / rename / color / duplicate / close…). [canControl] gates the
  * host-mutating items; [onChipSplit]/[onChipLaunchAI] act on the clicked pane (the rest reuse the
  * shared TabBar callbacks, which route to the host for remote chips).
+ *
+ * A right-click on the box HEADER customizes the group locally: [onRename] sets the header
+ * (inline edit; blank reverts to the host name), [onSetColor] sets [colorHex], the box's
+ * border/icon/chip accent (null reverts to the default remote cyan).
  */
 data class RemoteTabGroup(
+    val id: String,
     val header: String,
+    val colorHex: String?,
     val groups: List<TabBarGroup>,
     val canControl: Boolean,
     val onSplitVertical: () -> Unit,
@@ -122,6 +128,8 @@ data class RemoteTabGroup(
     val onDisconnect: () -> Unit,
     val onChipSplit: (tabIndex: Int, paneId: String, horizontal: Boolean) -> Unit,
     val onChipLaunchAI: (tabIndex: Int, paneId: String, assistantId: String) -> Unit,
+    val onRename: (String) -> Unit,
+    val onSetColor: (String?) -> Unit,
 )
 
 /** AI assistants offered in the remote chip menu — same set the browser viewer mirrors. */
@@ -224,6 +232,28 @@ fun TabBar(
     // opens the host-routed menu instead of the local one.
     val remoteByTabIndex: Map<Int, RemoteTabGroup> =
         remoteGroups.flatMap { rg -> rg.groups.map { it.tabIndex to rg } }.toMap()
+
+    // Remote group box currently renaming its header inline (by RemoteTabGroup.id).
+    var editingRemoteId by remember { mutableStateOf<String?>(null) }
+
+    // Right-click menu on a remote group's HEADER — local customization of the box
+    // (name + accent color) plus Disconnect. Nothing here touches the host.
+    val showRemoteGroupMenu: (RemoteTabGroup) -> Unit = { rg ->
+        val colorSubmenu = ContextMenuController.MenuSubmenu(
+            id = "remote_group_color",
+            label = "Color",
+            items = TAB_COLOR_PRESETS.map { (name, hex) ->
+                ContextMenuController.MenuItem(id = "rg_color_$name", label = name, enabled = true, action = { rg.onSetColor(hex) })
+            } + ContextMenuController.MenuSeparator(id = "rg_color_sep") +
+                ContextMenuController.MenuItem(id = "rg_color_clear", label = "Clear", enabled = true, action = { rg.onSetColor(null) })
+        )
+        contextMenuController.showMenu(0f, 0f, listOf(
+            ContextMenuController.MenuItem(id = "rg_rename", label = "Rename…", enabled = true, action = { editingRemoteId = rg.id }),
+            colorSubmenu,
+            ContextMenuController.MenuSeparator(id = "rg_sep"),
+            ContextMenuController.MenuItem(id = "rg_disconnect", label = "Disconnect remote", enabled = true, action = { rg.onDisconnect() }),
+        ))
+    }
 
     // Right-click menu for a mirrored remote chip — mirrors the browser viewer's menu, all
     // routed to the host. Host-mutating items are gated on control; "Disconnect remote" is the
@@ -350,21 +380,37 @@ fun TabBar(
                     // Each connected remote session: a bordered box with the link header, its
                     // mirrored tab chips, and footer actions that target the remote.
                     remoteGroups.forEach { rg ->
+                        // Group accent: a custom color set via the header's right-click, else the
+                        // default remote cyan. Drives the box border, the cloud icon, and (via
+                        // colorHexFor upstream) the chips' accent stripes.
+                        val groupAccent = parseTabColor(rg.colorHex) ?: RemoteAccent
                         Column(
                             modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp))
-                                .border(1.dp, RemoteAccent, RoundedCornerShape(8.dp)).padding(4.dp),
+                                .border(1.dp, groupAccent, RoundedCornerShape(8.dp)).padding(4.dp),
                             verticalArrangement = Arrangement.spacedBy(TabChipGap)
                         ) {
                             Row(
-                                modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp, vertical = 2.dp),
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp, vertical = 2.dp)
+                                    .onPointerEvent(PointerEventType.Press) { event ->
+                                        if (event.button == PointerButton.Secondary) showRemoteGroupMenu(rg)
+                                    },
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(4.dp)
                             ) {
-                                Icon(Icons.Default.Cloud, contentDescription = null, tint = RemoteAccent, modifier = Modifier.size(13.dp))
-                                Text(
-                                    rg.header, color = Color(0xFFB0B0B0), fontSize = 11.sp,
-                                    maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
-                                )
+                                Icon(Icons.Default.Cloud, contentDescription = null, tint = groupAccent, modifier = Modifier.size(13.dp))
+                                if (rg.id == editingRemoteId) {
+                                    TabRenameField(
+                                        initial = rg.header,
+                                        onCommit = { editingRemoteId = null; rg.onRename(it) },
+                                        onCancel = { editingRemoteId = null },
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                } else {
+                                    Text(
+                                        rg.header, color = Color(0xFFB0B0B0), fontSize = 11.sp,
+                                        maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
+                                    )
+                                }
                                 Box(
                                     modifier = Modifier.clip(RoundedCornerShape(4.dp)).clickable(onClick = rg.onDisconnect).padding(2.dp)
                                 ) { Icon(Icons.Default.Close, contentDescription = "Disconnect remote", tint = Color(0xFF808080), modifier = Modifier.size(13.dp)) }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.HorizontalSplit
 import androidx.compose.material.icons.filled.QrCode2
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.VerticalSplit
+import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -433,6 +434,15 @@ fun TabBar(
                                     Text(
                                         rg.header, color = Color(0xFFB0B0B0), fontSize = 11.sp,
                                         maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
+                                    )
+                                }
+                                if (!rg.canControl) {
+                                    // Read-only session: eye badge (right-click → Request Control).
+                                    Icon(
+                                        Icons.Default.Visibility,
+                                        contentDescription = "View only — right-click to request control",
+                                        tint = Color(0xFF808080),
+                                        modifier = Modifier.size(12.dp)
                                     )
                                 }
                                 Box(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -3,6 +3,7 @@ package ai.rever.bossterm.compose.tabs
 import ai.rever.bossterm.compose.features.ContextMenuController
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
@@ -58,6 +59,9 @@ enum class TabBarOrientation { TOP, LEFT }
 /** Gap between tab-groups (each group = one tab's panes). Larger than within a group. */
 private val TabGroupGap: Dp = 18.dp
 
+/** Accent for remote (mirrored) sessions — the box border + tab-chip color. */
+private val RemoteAccent: Color = Color(0xFF4FC3F7)
+
 /** Gap between pane chips within the same tab-group. Tight, so they read as one cluster. */
 private val TabChipGap: Dp = 3.dp
 
@@ -99,6 +103,20 @@ data class TabBarPane(
 data class TabBarGroup(val tabIndex: Int, val panes: List<TabBarPane>)
 
 /**
+ * A connected remote BossTerm session, rendered (in the left bar) as a bordered box: a
+ * [header] (the remote link/host), the session's mirrored [groups] (its tabs), and a footer
+ * of actions that target the remote (split + new tab + disconnect).
+ */
+data class RemoteTabGroup(
+    val header: String,
+    val groups: List<TabBarGroup>,
+    val onSplitVertical: () -> Unit,
+    val onSplitHorizontal: () -> Unit,
+    val onNewTab: () -> Unit,
+    val onDisconnect: () -> Unit,
+)
+
+/**
  * Tab bar component for multiple terminal sessions.
  *
  * Displays a strip (top) or column (left) of pane-chips grouped by tab:
@@ -136,6 +154,7 @@ fun TabBar(
     onSplitHorizontal: () -> Unit = {},
     onSettings: () -> Unit = {},
     onAddRemote: () -> Unit = {},
+    remoteGroups: List<RemoteTabGroup> = emptyList(),
     orientation: TabBarOrientation = TabBarOrientation.TOP,
     verticalWidth: Dp = TabBarVerticalWidth,
     modifier: Modifier = Modifier
@@ -263,6 +282,44 @@ fun TabBar(
                             group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
                         }
                     }
+                    // Each connected remote session: a bordered box with the link header, its
+                    // mirrored tab chips, and footer actions that target the remote.
+                    remoteGroups.forEach { rg ->
+                        Column(
+                            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp))
+                                .border(1.dp, RemoteAccent, RoundedCornerShape(8.dp)).padding(4.dp),
+                            verticalArrangement = Arrangement.spacedBy(TabChipGap)
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp, vertical = 2.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(4.dp)
+                            ) {
+                                Icon(Icons.Default.Cloud, contentDescription = null, tint = RemoteAccent, modifier = Modifier.size(13.dp))
+                                Text(
+                                    rg.header, color = Color(0xFFB0B0B0), fontSize = 11.sp,
+                                    maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
+                                )
+                                Box(
+                                    modifier = Modifier.clip(RoundedCornerShape(4.dp)).clickable(onClick = rg.onDisconnect).padding(2.dp)
+                                ) { Icon(Icons.Default.Close, contentDescription = "Disconnect remote", tint = Color(0xFF808080), modifier = Modifier.size(13.dp)) }
+                            }
+                            rg.groups.forEach { group ->
+                                Column(verticalArrangement = Arrangement.spacedBy(TabChipGap)) {
+                                    group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
+                                }
+                            }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(0.dp, Alignment.CenterHorizontally),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                barButton(Icons.Default.VerticalSplit, "Split Left/Right", rg.onSplitVertical)
+                                barButton(Icons.Default.HorizontalSplit, "Split Top/Bottom", rg.onSplitHorizontal)
+                                barButton(Icons.Default.Add, "New tab", rg.onNewTab)
+                            }
+                        }
+                    }
                 }
                 // Bottom bar — connect to another BossTerm's shared session.
                 Spacer(Modifier.height(8.dp))
@@ -294,7 +351,9 @@ fun TabBar(
                     horizontalArrangement = Arrangement.spacedBy(TabGroupGap),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    groups.forEach { group ->
+                    // Local tab clusters, then remote-session clusters (flattened in the top
+                    // bar — the boxed grouping with header/footer is a left-bar affordance).
+                    (groups + remoteGroups.flatMap { it.groups }).forEach { group ->
                         Row(
                             horizontalArrangement = Arrangement.spacedBy(TabChipGap),
                             verticalAlignment = Alignment.CenterVertically

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -106,14 +106,30 @@ data class TabBarGroup(val tabIndex: Int, val panes: List<TabBarPane>)
  * A connected remote BossTerm session, rendered (in the left bar) as a bordered box: a
  * [header] (the remote link/host), the session's mirrored [groups] (its tabs), and a footer
  * of actions that target the remote (split + new tab + disconnect).
+ *
+ * A right-click on any mirrored chip opens the same host-routed menu the browser viewer shows
+ * (new tab / split / AI assistant / rename / color / duplicate / close…). [canControl] gates the
+ * host-mutating items; [onChipSplit]/[onChipLaunchAI] act on the clicked pane (the rest reuse the
+ * shared TabBar callbacks, which route to the host for remote chips).
  */
 data class RemoteTabGroup(
     val header: String,
     val groups: List<TabBarGroup>,
+    val canControl: Boolean,
     val onSplitVertical: () -> Unit,
     val onSplitHorizontal: () -> Unit,
     val onNewTab: () -> Unit,
     val onDisconnect: () -> Unit,
+    val onChipSplit: (tabIndex: Int, paneId: String, horizontal: Boolean) -> Unit,
+    val onChipLaunchAI: (tabIndex: Int, paneId: String, assistantId: String) -> Unit,
+)
+
+/** AI assistants offered in the remote chip menu — same set the browser viewer mirrors. */
+private val REMOTE_AI_ASSISTANTS = listOf(
+    "claude-code" to "Claude Code",
+    "codex" to "Codex",
+    "gemini-cli" to "Gemini CLI",
+    "opencode" to "OpenCode",
 )
 
 /**
@@ -204,6 +220,51 @@ fun TabBar(
         contextMenuController.showMenu(0f, 0f, items)
     }
 
+    // Map each mirrored chip's tabIndex → its remote session, so a right-click on a remote chip
+    // opens the host-routed menu instead of the local one.
+    val remoteByTabIndex: Map<Int, RemoteTabGroup> =
+        remoteGroups.flatMap { rg -> rg.groups.map { it.tabIndex to rg } }.toMap()
+
+    // Right-click menu for a mirrored remote chip — mirrors the browser viewer's menu, all
+    // routed to the host. Host-mutating items are gated on control; "Disconnect remote" is the
+    // one native-only affordance and is always enabled.
+    val showRemoteChipMenu: (RemoteTabGroup, Int, String) -> Unit = { rg, tabIndex, paneId ->
+        val ctl = rg.canControl
+        val aiSubmenu = ContextMenuController.MenuSubmenu(
+            id = "remote_ai",
+            label = "AI assistant",
+            items = REMOTE_AI_ASSISTANTS.map { (id, label) ->
+                ContextMenuController.MenuItem(id = "remote_ai_$id", label = label, enabled = ctl,
+                    action = { rg.onChipLaunchAI(tabIndex, paneId, id) })
+            }
+        )
+        val colorSubmenu = ContextMenuController.MenuSubmenu(
+            id = "remote_color",
+            label = "Color",
+            items = TAB_COLOR_PRESETS.map { (name, hex) ->
+                ContextMenuController.MenuItem(id = "remote_color_$name", label = name, enabled = ctl, action = { onSetColor(tabIndex, paneId, hex) })
+            } + ContextMenuController.MenuSeparator(id = "remote_color_sep") +
+                ContextMenuController.MenuItem(id = "remote_color_clear", label = "Clear", enabled = ctl, action = { onSetColor(tabIndex, paneId, null) })
+        )
+        val items = listOf(
+            ContextMenuController.MenuItem(id = "remote_new_tab", label = "New Tab", enabled = ctl, action = { rg.onNewTab() }),
+            ContextMenuController.MenuItem(id = "remote_split_v", label = "Split Left/Right", enabled = ctl, action = { rg.onChipSplit(tabIndex, paneId, false) }),
+            ContextMenuController.MenuItem(id = "remote_split_h", label = "Split Top/Bottom", enabled = ctl, action = { rg.onChipSplit(tabIndex, paneId, true) }),
+            aiSubmenu,
+            ContextMenuController.MenuSeparator(id = "remote_sep_rename"),
+            ContextMenuController.MenuItem(id = "remote_rename", label = "Rename…", enabled = ctl, action = { editingPaneId = paneId }),
+            colorSubmenu,
+            ContextMenuController.MenuSeparator(id = "remote_sep_close"),
+            ContextMenuController.MenuItem(id = "remote_duplicate", label = "Duplicate Tab", enabled = ctl, action = { onDuplicate(tabIndex) }),
+            ContextMenuController.MenuItem(id = "remote_close", label = "Close", enabled = ctl, action = { onPaneClosed(tabIndex, paneId) }),
+            ContextMenuController.MenuItem(id = "remote_close_others", label = "Close Other Tabs", enabled = ctl, action = { onCloseOthers(tabIndex) }),
+            ContextMenuController.MenuItem(id = "remote_close_below", label = "Close Tabs Below", enabled = ctl, action = { onCloseBelow(tabIndex) }),
+            ContextMenuController.MenuSeparator(id = "remote_sep_disconnect"),
+            ContextMenuController.MenuItem(id = "remote_disconnect", label = "Disconnect remote", enabled = true, action = { rg.onDisconnect() }),
+        )
+        contextMenuController.showMenu(0f, 0f, items)
+    }
+
     val newTabButton: @Composable () -> Unit = {
         IconButton(onClick = onNewTab, modifier = Modifier.size(36.dp)) {
             Icon(imageVector = Icons.Default.Add, contentDescription = "New Tab", tint = Color.White)
@@ -252,7 +313,11 @@ fun TabBar(
             },
             onCancelRename = { editingPaneId = null },
             onClose = { onPaneClosed(group.tabIndex, pane.paneId) },
-            onContextMenu = { showChipMenu(group.tabIndex, pane.paneId) },
+            onContextMenu = {
+                val rg = remoteByTabIndex[group.tabIndex]
+                if (rg != null) showRemoteChipMenu(rg, group.tabIndex, pane.paneId)
+                else showChipMenu(group.tabIndex, pane.paneId)
+            },
             modifier = chipModifier
         )
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -524,7 +524,12 @@ private fun TabItem(
         }
 
         Row(
-            modifier = Modifier.fillMaxSize(),
+            // Multi-line (left bar) chips are wrap-height inside a scroll column, where the
+            // accent stripe's fillMaxHeight() would resolve against an unbounded constraint and
+            // collapse to zero (invisible on unselected tabs). Bound the row to its intrinsic
+            // height so the stripe spans the chip — like the viewer's always-on left border.
+            modifier = if (multiLine) Modifier.fillMaxWidth().heightIn(min = 36.dp).height(IntrinsicSize.Min)
+                       else Modifier.fillMaxSize(),
             verticalAlignment = if (multiLine) Alignment.Top else Alignment.CenterVertically
         ) {
             // Leading accent stripe (manual color or auto-by-directory)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -137,6 +137,19 @@ data class RemoteTabGroup(
     val onCopyLink: () -> Unit,
     /** Ask the host to upgrade this view-only connection to control (host approves via toast). */
     val onRequestControl: () -> Unit,
+    /**
+     * Tabs the host itself mirrors from OTHER sessions, nested as labeled subsections inside
+     * this box (instead of mixing with the host's own tabs). [RemoteNestedGroup.readOnly]
+     * means the host is view-only on that upstream — input can't flow through it.
+     */
+    val nested: List<RemoteNestedGroup> = emptyList(),
+)
+
+/** One upstream session's tabs inside a remote group box (see [RemoteTabGroup.nested]). */
+data class RemoteNestedGroup(
+    val label: String,
+    val readOnly: Boolean,
+    val groups: List<TabBarGroup>,
 )
 
 /** AI assistants offered in the remote chip menu — same set the browser viewer mirrors. */
@@ -457,6 +470,40 @@ fun TabBar(
                                         group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
                                     }
                                 }
+                                // Tabs the host itself mirrors from OTHER sessions: a labeled,
+                                // slightly indented subsection per upstream (eye = the host is
+                                // view-only on it, so input can't flow through).
+                                rg.nested.forEach { nest ->
+                                    Column(
+                                        modifier = Modifier.fillMaxWidth().padding(start = 6.dp),
+                                        verticalArrangement = Arrangement.spacedBy(TabChipGap)
+                                    ) {
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                                        ) {
+                                            Icon(Icons.Default.Cloud, contentDescription = null, tint = Color(0xFF808080), modifier = Modifier.size(11.dp))
+                                            Text(
+                                                nest.label, color = Color(0xFF909090), fontSize = 10.sp,
+                                                maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
+                                            )
+                                            if (nest.readOnly) {
+                                                Icon(
+                                                    Icons.Default.Visibility,
+                                                    contentDescription = "Read-only via this host",
+                                                    tint = Color(0xFF808080),
+                                                    modifier = Modifier.size(11.dp)
+                                                )
+                                            }
+                                        }
+                                        nest.groups.forEach { group ->
+                                            Column(verticalArrangement = Arrangement.spacedBy(TabChipGap)) {
+                                                group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
+                                            }
+                                        }
+                                    }
+                                }
                             }
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
@@ -502,7 +549,7 @@ fun TabBar(
                 ) {
                     // Local tab clusters, then remote-session clusters (flattened in the top
                     // bar — the boxed grouping with header/footer is a left-bar affordance).
-                    (groups + remoteGroups.flatMap { it.groups }).forEach { group ->
+                    (groups + remoteGroups.flatMap { it.groups + it.nested.flatMap { n -> n.groups } }).forEach { group ->
                         Row(
                             horizontalArrangement = Arrangement.spacedBy(TabChipGap),
                             verticalAlignment = Alignment.CenterVertically

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -470,40 +470,6 @@ fun TabBar(
                                         group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
                                     }
                                 }
-                                // Tabs the host itself mirrors from OTHER sessions: a labeled,
-                                // slightly indented subsection per upstream (eye = the host is
-                                // view-only on it, so input can't flow through).
-                                rg.nested.forEach { nest ->
-                                    Column(
-                                        modifier = Modifier.fillMaxWidth().padding(start = 6.dp),
-                                        verticalArrangement = Arrangement.spacedBy(TabChipGap)
-                                    ) {
-                                        Row(
-                                            modifier = Modifier.fillMaxWidth(),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                            horizontalArrangement = Arrangement.spacedBy(4.dp)
-                                        ) {
-                                            Icon(Icons.Default.Cloud, contentDescription = null, tint = Color(0xFF808080), modifier = Modifier.size(11.dp))
-                                            Text(
-                                                nest.label, color = Color(0xFF909090), fontSize = 10.sp,
-                                                maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
-                                            )
-                                            if (nest.readOnly) {
-                                                Icon(
-                                                    Icons.Default.Visibility,
-                                                    contentDescription = "Read-only via this host",
-                                                    tint = Color(0xFF808080),
-                                                    modifier = Modifier.size(11.dp)
-                                                )
-                                            }
-                                        }
-                                        nest.groups.forEach { group ->
-                                            Column(verticalArrangement = Arrangement.spacedBy(TabChipGap)) {
-                                                group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
-                                            }
-                                        }
-                                    }
-                                }
                             }
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
@@ -513,6 +479,44 @@ fun TabBar(
                                 barButton(Icons.Default.VerticalSplit, "Split Left/Right", rg.onSplitVertical)
                                 barButton(Icons.Default.HorizontalSplit, "Split Top/Bottom", rg.onSplitHorizontal)
                                 barButton(Icons.Default.Add, "New tab", rg.onNewTab)
+                            }
+                        }
+                        // Tabs the host itself mirrors from OTHER sessions: flattened — each
+                        // upstream gets its own sibling box (same accent ties it to the host's
+                        // box above; the eye = the host is view-only on it, so input can't
+                        // flow through). No footer — structural actions belong to the origin.
+                        rg.nested.forEach { nest ->
+                            Column(
+                                modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp))
+                                    .border(1.dp, groupAccent, RoundedCornerShape(8.dp)).padding(4.dp),
+                                verticalArrangement = Arrangement.spacedBy(TabChipGap)
+                            ) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp, vertical = 2.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    Icon(Icons.Default.Cloud, contentDescription = null, tint = groupAccent, modifier = Modifier.size(13.dp))
+                                    Text(
+                                        "${nest.label} · via ${rg.header}", color = Color(0xFFB0B0B0), fontSize = 11.sp,
+                                        maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
+                                    )
+                                    if (nest.readOnly) {
+                                        Icon(
+                                            Icons.Default.Visibility,
+                                            contentDescription = "Read-only via this host",
+                                            tint = Color(0xFF808080),
+                                            modifier = Modifier.size(12.dp)
+                                        )
+                                    }
+                                }
+                                Column(verticalArrangement = Arrangement.spacedBy(TabGroupGap)) {
+                                    nest.groups.forEach { group ->
+                                        Column(verticalArrangement = Arrangement.spacedBy(TabChipGap)) {
+                                            group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -369,9 +369,13 @@ fun TabBar(
                                     modifier = Modifier.clip(RoundedCornerShape(4.dp)).clickable(onClick = rg.onDisconnect).padding(2.dp)
                                 ) { Icon(Icons.Default.Close, contentDescription = "Disconnect remote", tint = Color(0xFF808080), modifier = Modifier.size(13.dp)) }
                             }
-                            rg.groups.forEach { group ->
-                                Column(verticalArrangement = Arrangement.spacedBy(TabChipGap)) {
-                                    group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
+                            // Match the local bar: split panes of one tab hug together
+                            // (TabChipGap), separate tabs are spaced further apart (TabGroupGap).
+                            Column(verticalArrangement = Arrangement.spacedBy(TabGroupGap)) {
+                                rg.groups.forEach { group ->
+                                    Column(verticalArrangement = Arrangement.spacedBy(TabChipGap)) {
+                                        group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
+                                    }
                                 }
                             }
                             Row(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -123,6 +123,10 @@ data class RemoteTabGroup(
     val colorHex: String?,
     val groups: List<TabBarGroup>,
     val canControl: Boolean,
+    /** Connection state shown next to the header when not healthy (e.g. "connecting…",
+     *  "disconnected"); null = connected. [statusError] picks red over amber. */
+    val statusLabel: String? = null,
+    val statusError: Boolean = false,
     val onSplitVertical: () -> Unit,
     val onSplitHorizontal: () -> Unit,
     val onNewTab: () -> Unit,
@@ -154,6 +158,8 @@ data class RemoteTabGroup(
 data class RemoteNestedGroup(
     val label: String,
     val readOnly: Boolean,
+    /** The host's connection to this upstream is down — the tabs show frozen content. */
+    val offline: Boolean = false,
     val groups: List<TabBarGroup>,
     val onSplitVertical: () -> Unit = {},
     val onSplitHorizontal: () -> Unit = {},
@@ -475,6 +481,15 @@ fun TabBar(
                                         maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
                                     )
                                 }
+                                rg.statusLabel?.let { label ->
+                                    // Connection state (connecting…/disconnected) — amber while
+                                    // it may heal, red when it gave up.
+                                    Text(
+                                        "· $label",
+                                        color = if (rg.statusError) Color(0xFFE57373) else Color(0xFFE0A030),
+                                        fontSize = 10.sp, maxLines = 1
+                                    )
+                                }
                                 if (!rg.canControl) {
                                     // Read-only session: eye badge (right-click → Request Control).
                                     Icon(
@@ -533,6 +548,10 @@ fun TabBar(
                                         "${nest.label} · via ${rg.header}", color = Color(0xFFB0B0B0), fontSize = 11.sp,
                                         maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
                                     )
+                                    if (nest.offline) {
+                                        // The host lost its upstream — these tabs are frozen.
+                                        Text("· offline", color = Color(0xFFE57373), fontSize = 10.sp, maxLines = 1)
+                                    }
                                     if (nest.readOnly) {
                                         Icon(
                                             Icons.Default.Visibility,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -444,6 +444,10 @@ fun TabBar(
                         // default remote cyan. Drives the box border, the cloud icon, and (via
                         // colorHexFor upstream) the chips' accent stripes.
                         val groupAccent = parseTabColor(rg.colorHex) ?: RemoteAccent
+                        // The host box + its upstream ("via host") boxes render as ONE unit,
+                        // tethered by short accent connector lines — making the "these tabs
+                        // arrive through the box above" relationship visible.
+                        Column(modifier = Modifier.fillMaxWidth()) {
                         Column(
                             modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp))
                                 .border(1.dp, groupAccent, RoundedCornerShape(8.dp)).padding(4.dp),
@@ -508,6 +512,12 @@ fun TabBar(
                         // box above; the eye = the host is view-only on it, so input can't
                         // flow through). No footer — structural actions belong to the origin.
                         rg.nested.forEach { nest ->
+                            // Connector line: ties this upstream box to the box above it
+                            // (aligned under the cloud icon), in the group's accent.
+                            Box(
+                                Modifier.padding(start = 13.dp).width(2.dp).height(10.dp)
+                                    .background(groupAccent)
+                            )
                             Column(
                                 modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp))
                                     .border(1.dp, groupAccent, RoundedCornerShape(8.dp)).padding(4.dp),
@@ -555,6 +565,7 @@ fun TabBar(
                                 }
                             }
                         }
+                        } // end tether unit (host box + its upstream boxes)
                     }
                 }
                 // Bottom bar — connect to another BossTerm's shared session.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -130,6 +130,8 @@ data class RemoteTabGroup(
     val onChipLaunchAI: (tabIndex: Int, paneId: String, assistantId: String) -> Unit,
     val onRename: (String) -> Unit,
     val onSetColor: (String?) -> Unit,
+    /** Open this remote's share link in the default browser (the web viewer). */
+    val onOpenInBrowser: () -> Unit,
 )
 
 /** AI assistants offered in the remote chip menu — same set the browser viewer mirrors. */
@@ -250,6 +252,7 @@ fun TabBar(
         contextMenuController.showMenu(0f, 0f, listOf(
             ContextMenuController.MenuItem(id = "rg_rename", label = "Rename…", enabled = true, action = { editingRemoteId = rg.id }),
             colorSubmenu,
+            ContextMenuController.MenuItem(id = "rg_open_browser", label = "Open in Browser", enabled = true, action = { rg.onOpenInBrowser() }),
             ContextMenuController.MenuSeparator(id = "rg_sep"),
             ContextMenuController.MenuItem(id = "rg_disconnect", label = "Disconnect remote", enabled = true, action = { rg.onDisconnect() }),
         ))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -273,6 +273,15 @@ fun TabBar(
     // routed to the host. Host-mutating items are gated on control; "Disconnect remote" is the
     // one native-only affordance and is always enabled.
     val showRemoteChipMenu: (RemoteTabGroup, Int, String) -> Unit = { rg, tabIndex, paneId ->
+        if (!rg.canControl) {
+            // View-only: every chip action mutates the host, so offer just the upgrade path
+            // and the local disconnect instead of a wall of disabled items.
+            contextMenuController.showMenu(0f, 0f, listOf(
+                ContextMenuController.MenuItem(id = "remote_request_control", label = "Request Control", enabled = true, action = { rg.onRequestControl() }),
+                ContextMenuController.MenuSeparator(id = "remote_sep_view"),
+                ContextMenuController.MenuItem(id = "remote_disconnect", label = "Disconnect remote", enabled = true, action = { rg.onDisconnect() }),
+            ))
+        } else {
         val ctl = rg.canControl
         val aiSubmenu = ContextMenuController.MenuSubmenu(
             id = "remote_ai",
@@ -307,6 +316,7 @@ fun TabBar(
             ContextMenuController.MenuItem(id = "remote_disconnect", label = "Disconnect remote", enabled = true, action = { rg.onDisconnect() }),
         )
         contextMenuController.showMenu(0f, 0f, items)
+        }
     }
 
     val newTabButton: @Composable () -> Unit = {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -134,6 +134,8 @@ data class RemoteTabGroup(
     val onOpenInBrowser: () -> Unit,
     /** Copy this remote's share link to the clipboard. */
     val onCopyLink: () -> Unit,
+    /** Ask the host to upgrade this view-only connection to control (host approves via toast). */
+    val onRequestControl: () -> Unit,
 )
 
 /** AI assistants offered in the remote chip menu — same set the browser viewer mirrors. */
@@ -251,7 +253,13 @@ fun TabBar(
             } + ContextMenuController.MenuSeparator(id = "rg_color_sep") +
                 ContextMenuController.MenuItem(id = "rg_color_clear", label = "Clear", enabled = true, action = { rg.onSetColor(null) })
         )
-        contextMenuController.showMenu(0f, 0f, listOf(
+        // View-only connections get a control-upgrade request at the top (host approves it
+        // via the same toast as join requests).
+        val requestControlItem = if (!rg.canControl) listOf(
+            ContextMenuController.MenuItem(id = "rg_request_control", label = "Request Control", enabled = true, action = { rg.onRequestControl() }),
+            ContextMenuController.MenuSeparator(id = "rg_sep_control"),
+        ) else emptyList()
+        contextMenuController.showMenu(0f, 0f, requestControlItem + listOf(
             ContextMenuController.MenuItem(id = "rg_rename", label = "Rename…", enabled = true, action = { editingRemoteId = rg.id }),
             colorSubmenu,
             ContextMenuController.MenuItem(id = "rg_open_browser", label = "Open in Browser", enabled = true, action = { rg.onOpenInBrowser() }),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -574,8 +574,9 @@ class TabController(
      */
     fun createRemoteSession(
         title: String,
-        remotePaneId: String,
-        onUserInput: (String) -> Unit,
+        remotePaneId: String? = null,
+        onUserInput: ((String) -> Unit)? = null,
+        feedsStream: Boolean = true,
     ): TerminalTab {
         val styleState = StyleState()
         val textBuffer = TerminalTextBuffer(80, 24, styleState, settings.bufferMaxLines)
@@ -627,17 +628,21 @@ class TabController(
 
         // Emulator-processing loop: drain bytes appended from the remote stream. Exits when the
         // stream is closed (dispose) — closing dataStream unblocks the blocking `char` read.
-        scope.launch(Dispatchers.Default) {
-            try {
-                while (isActive) {
-                    try {
-                        tab.emulator.processChar(tab.dataStream.char, tab.terminal)
-                    } catch (_: Exception) {
-                        break // EOF on close, or stream error — stop the loop
+        // Skipped for a container tab ([feedsStream] = false): it owns no remote pane of its own
+        // (its panes are separate mirror sessions in the split tree), so it needs no parked thread.
+        if (feedsStream) {
+            scope.launch(Dispatchers.Default) {
+                try {
+                    while (isActive) {
+                        try {
+                            tab.emulator.processChar(tab.dataStream.char, tab.terminal)
+                        } catch (_: Exception) {
+                            break // EOF on close, or stream error — stop the loop
+                        }
                     }
+                } finally {
+                    runCatching { tab.dataStream.close() }
                 }
-            } finally {
-                runCatching { tab.dataStream.close() }
             }
         }
         return tab

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -563,6 +563,87 @@ class TabController(
     }
 
     /**
+     * Build a **remote mirror** session (no local PTY): a full terminal stack
+     * (BossTerminal/textBuffer/display/dataStream/emulator) whose bytes are fed from a remote
+     * BossTerm share via [TerminalTab.dataStream] `.append(...)` and whose size is set by the
+     * host (`PaneResize` → `terminal.resize`). Used by the native remote-session client to
+     * mirror each remote pane. Does NOT spawn a process or add itself to [tabs] — the caller
+     * places it (as a tab or a split pane) and feeds it. [onUserInput] routes local keystrokes
+     * back to the host (sent as `ClientMessage.Input`); dispose by closing [TerminalTab.dataStream]
+     * then [TerminalTab.dispose].
+     */
+    fun createRemoteSession(
+        title: String,
+        remotePaneId: String,
+        onUserInput: (String) -> Unit,
+    ): TerminalTab {
+        val styleState = StyleState()
+        val textBuffer = TerminalTextBuffer(80, 24, styleState, settings.bufferMaxLines)
+        val display = ComposeTerminalDisplay()
+        val terminal = BossTerminal(display, textBuffer, styleState)
+        terminal.setCharacterEncoding(settings.characterEncoding)
+        val modelListener = object : ai.rever.bossterm.terminal.model.TerminalModelListener {
+            override fun modelChanged() { display.requestRedraw() }
+        }
+        textBuffer.addModelListener(modelListener)
+        val dataStream = BlockingTerminalDataStream(
+            performanceMode = PerformanceMode.fromString(settings.performanceMode)
+        )
+        // Batch each appended chunk so a clear+write renders atomically (no flicker).
+        dataStream.onChunkStart = { textBuffer.beginBatch() }
+        dataStream.onChunkEnd = { textBuffer.endBatch() }
+        val emulator = BossEmulator(dataStream, terminal)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+        val tab = TerminalTab(
+            id = java.util.UUID.randomUUID().toString(),
+            title = mutableStateOf(title),
+            terminal = terminal,
+            textBuffer = textBuffer,
+            display = display,
+            dataStream = dataStream,
+            emulator = emulator,
+            processHandle = mutableStateOf(null),
+            workingDirectory = mutableStateOf(null),
+            connectionState = mutableStateOf(ConnectionState.Initializing),
+            coroutineScope = scope,
+            isFocused = mutableStateOf(false),
+            scrollOffset = mutableStateOf(0),
+            searchVisible = mutableStateOf(false),
+            searchQuery = mutableStateOf(""),
+            searchMatches = mutableStateOf(emptyList()),
+            currentSearchMatchIndex = mutableStateOf(-1),
+            selectionClipboard = mutableStateOf(null),
+            imeState = IMEState(),
+            contextMenuController = ContextMenuController(),
+            hyperlinks = mutableStateOf(emptyList()),
+            hoveredHyperlink = mutableStateOf(null),
+            modelListener = modelListener,
+        ).apply {
+            isRemote = true
+            this.remotePaneId = remotePaneId
+            this.onUserInput = onUserInput
+        }
+
+        // Emulator-processing loop: drain bytes appended from the remote stream. Exits when the
+        // stream is closed (dispose) — closing dataStream unblocks the blocking `char` read.
+        scope.launch(Dispatchers.Default) {
+            try {
+                while (isActive) {
+                    try {
+                        tab.emulator.processChar(tab.dataStream.char, tab.terminal)
+                    } catch (_: Exception) {
+                        break // EOF on close, or stream error — stop the loop
+                    }
+                }
+            } finally {
+                runCatching { tab.dataStream.close() }
+            }
+        }
+        return tab
+    }
+
+    /**
      * Create a terminal session for use in split panes.
      *
      * Unlike createTab(), this method:

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -301,6 +301,13 @@ data class TerminalTab(
      */
     var onUserInput: ((String) -> Unit)? = null
 
+    /**
+     * When set (a single-pane remote mirror), the canvas resize handler routes here to ask the
+     * host to resize its window so its grid ≈ `(cols, rows)` — auto "Fit host to my screen". Null
+     * for local tabs and for split panes (which can't each size the host window).
+     */
+    var onRemoteResizeRequest: ((cols: Int, rows: Int) -> Unit)? = null
+
     // === Warp-style tab customization (left tab bar) ===
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -282,6 +282,25 @@ data class TerminalTab(
      */
     override var commandBlockTracker: ai.rever.bossterm.compose.blocks.CommandBlockTracker? = null
 
+    // === Remote mirror (native client of another BossTerm's share) ===
+
+    /**
+     * True when this tab mirrors a remote BossTerm pane (no local PTY): its bytes come from a
+     * WebSocket and its grid size is the host's. The renderer reads this (via [TerminalSession])
+     * to render without a local PTY connection and to skip local auto-fit resizing.
+     */
+    override var isRemote: Boolean = false
+
+    /** The remote pane id this mirror represents (for routing input back to the host). */
+    var remotePaneId: String? = null
+
+    /**
+     * When set (remote mirror tabs), [writeUserInput] routes here — typically to send the
+     * keystrokes back to the host as `ClientMessage.Input` over the WebSocket — instead of a
+     * local PTY. Null for normal local tabs.
+     */
+    var onUserInput: ((String) -> Unit)? = null
+
     // === Warp-style tab customization (left tab bar) ===
 
     /**
@@ -490,6 +509,9 @@ data class TerminalTab(
     override fun writeUserInput(text: String) {
         // Record in debug collector
         debugCollector?.recordChunk(text, ai.rever.bossterm.compose.debug.ChunkSource.USER_INPUT)
+
+        // Remote mirror: route keystrokes to the host over the WebSocket (no local PTY).
+        onUserInput?.let { it(text); return }
 
         // Queue for sequential processing by writeConsumerJob
         // Uses coroutine with send() to suspend if buffer full (never drops input)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -302,11 +302,12 @@ data class TerminalTab(
     var onUserInput: ((String) -> Unit)? = null
 
     /**
-     * When set (a single-pane remote mirror), the canvas resize handler routes here to ask the
-     * host to resize its window so its grid ≈ `(cols, rows)` — auto "Fit host to my screen". Null
-     * for local tabs and for split panes (which can't each size the host window).
+     * Latest grid (cols×rows) that fits this remote mirror's local canvas, recorded on layout.
+     * The "Fit to host" / "Fit to client" menu actions use it: ask the host to resize to this
+     * grid, or resize our own window so the host's current grid renders 1:1. 0 until first layout.
      */
-    var onRemoteResizeRequest: ((cols: Int, rows: Int) -> Unit)? = null
+    var remoteFitCols: Int = 0
+    var remoteFitRows: Int = 0
 
     // === Warp-style tab customization (left tab bar) ===
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -870,9 +870,9 @@ fun ProperTerminal(
                   remoteFitJob[0] = scope.launch {
                     // Wait for a clear stop before resizing the host's OS window. Each request
                     // physically resizes the host window (and reflows a snapshot), so a long
-                    // trailing debounce keeps a hesitant drag from firing several mid-resize —
-                    // it lands once, like the web viewer's "Fit host to my screen" button.
-                    delay(450)
+                    // trailing debounce keeps a drag from firing several mid-resize — it lands
+                    // once, well after the user has settled on a window size.
+                    delay(3000)
                     hook(cols, rows)
                   }
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -845,6 +845,9 @@ fun ProperTerminal(
       modifier = Modifier
         .fillMaxSize()
         .onGloballyPositioned { coordinates ->
+          // Remote mirror tabs are sized by the host (PaneResize); don't auto-fit them to the
+          // local canvas — that would fight the host's grid.
+          if (tab.isRemote) return@onGloballyPositioned
           // Detect window size changes and resize terminal accordingly
           // Note: This fires frequently, but we validate dimensions carefully to prevent crashes
           // Account for Canvas padding (4dp start, 4dp top) - on desktop 1dp ≈ 1px
@@ -1678,8 +1681,9 @@ fun ProperTerminal(
           isFocused = focusState.isFocused
         }
     ) {
-      // Show loading/error screen before connection is established
-      if (connectionState !is ConnectionState.Connected) {
+      // Show loading/error screen before connection is established. Remote mirror tabs have
+      // no local PTY connection — they render directly from the streamed buffer.
+      if (connectionState !is ConnectionState.Connected && !tab.isRemote) {
         PreConnectScreen(
           state = connectionState,
           onRetry = {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -160,6 +160,10 @@ fun ProperTerminal(
   var userScrollTrigger by remember { mutableStateOf(0) }  // Tracks user-initiated scrolls for scrollbar visibility
   val scope = rememberCoroutineScope()
   var hasPerformedInitialResize by remember { mutableStateOf(false) }  // Track initial resize
+  // Remote mirror: debounced "fit host to my screen" on canvas resize (single-pane tabs only).
+  // lastRemoteFit dedupes identical requests; remoteFitJob[0] holds the pending debounce send.
+  val lastRemoteFit = remember { intArrayOf(-1, -1) }
+  val remoteFitJob = remember { arrayOfNulls<Job>(1) }
   var isModifierPressed by remember { mutableStateOf(false) }  // Track Ctrl/Cmd for hyperlink clicks
   // Remember whether the last press was forwarded to the TUI so Release can
   // mirror that exact decision (instead of re-reading the modifier on release,
@@ -845,9 +849,33 @@ fun ProperTerminal(
       modifier = Modifier
         .fillMaxSize()
         .onGloballyPositioned { coordinates ->
-          // Remote mirror tabs are sized by the host (PaneResize); don't auto-fit them to the
-          // local canvas — that would fight the host's grid.
-          if (tab.isRemote) return@onGloballyPositioned
+          // Remote mirror tabs are sized by the host (PaneResize), so we don't resize the local
+          // terminal here. Instead, for a single-pane remote tab, ask the host to resize its
+          // window so its grid matches what fits our canvas — auto "Fit host to my screen" on
+          // window resize. The host echoes PaneResize and the mirror follows. Debounced so only
+          // the final size (after the user stops dragging) is sent; multi-pane tabs don't drive
+          // this (onRemoteResizeRequest is null — a split's panes can't each size the window).
+          if (tab.isRemote) {
+            val hook = (tab as? ai.rever.bossterm.compose.tabs.TerminalTab)?.onRemoteResizeRequest
+            if (hook != null && cellWidth > 0f && cellHeight > 0f) {
+              val padding = 4
+              val w = coordinates.size.width - padding
+              val h = coordinates.size.height - padding
+              if (w >= 10 && h >= 10) {
+                val cols = (w / cellWidth).toInt().coerceAtLeast(2)
+                val rows = (h / cellHeight).toInt().coerceAtLeast(2)
+                if (cols != lastRemoteFit[0] || rows != lastRemoteFit[1]) {
+                  lastRemoteFit[0] = cols; lastRemoteFit[1] = rows
+                  remoteFitJob[0]?.cancel()
+                  remoteFitJob[0] = scope.launch {
+                    delay(160) // settle until the user stops dragging the window edge
+                    hook(cols, rows)
+                  }
+                }
+              }
+            }
+            return@onGloballyPositioned
+          }
           // Detect window size changes and resize terminal accordingly
           // Note: This fires frequently, but we validate dimensions carefully to prevent crashes
           // Account for Canvas padding (4dp start, 4dp top) - on desktop 1dp ≈ 1px

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -160,10 +160,6 @@ fun ProperTerminal(
   var userScrollTrigger by remember { mutableStateOf(0) }  // Tracks user-initiated scrolls for scrollbar visibility
   val scope = rememberCoroutineScope()
   var hasPerformedInitialResize by remember { mutableStateOf(false) }  // Track initial resize
-  // Remote mirror: debounced "fit host to my screen" on canvas resize (single-pane tabs only).
-  // lastRemoteFit dedupes identical requests; remoteFitJob[0] holds the pending debounce send.
-  val lastRemoteFit = remember { intArrayOf(-1, -1) }
-  val remoteFitJob = remember { arrayOfNulls<Job>(1) }
   var isModifierPressed by remember { mutableStateOf(false) }  // Track Ctrl/Cmd for hyperlink clicks
   // Remember whether the last press was forwarded to the TUI so Release can
   // mirror that exact decision (instead of re-reading the modifier on release,
@@ -849,32 +845,18 @@ fun ProperTerminal(
       modifier = Modifier
         .fillMaxSize()
         .onGloballyPositioned { coordinates ->
-          // Remote mirror tabs are sized by the host (PaneResize), so we don't resize the local
-          // terminal here. Instead, for a single-pane remote tab, ask the host to resize its
-          // window so its grid matches what fits our canvas — auto "Fit host to my screen" on
-          // window resize. The host echoes PaneResize and the mirror follows. Debounced so only
-          // the final size (after the user stops dragging) is sent; multi-pane tabs don't drive
-          // this (onRemoteResizeRequest is null — a split's panes can't each size the window).
+          // Remote mirror tabs are sized by the host (PaneResize), so we don't auto-fit them to
+          // the local canvas — that would fight the host's grid. We only RECORD the grid that
+          // would fit our canvas, so the explicit "Fit to host" / "Fit to client" menu actions
+          // can use it (resize the host to us, or resize our window to the host's grid).
           if (tab.isRemote) {
-            val hook = (tab as? ai.rever.bossterm.compose.tabs.TerminalTab)?.onRemoteResizeRequest
-            if (hook != null && cellWidth > 0f && cellHeight > 0f) {
-              val padding = 4
-              val w = coordinates.size.width - padding
-              val h = coordinates.size.height - padding
-              if (w >= 10 && h >= 10) {
-                val cols = (w / cellWidth).toInt().coerceAtLeast(2)
-                val rows = (h / cellHeight).toInt().coerceAtLeast(2)
-                if (cols != lastRemoteFit[0] || rows != lastRemoteFit[1]) {
-                  lastRemoteFit[0] = cols; lastRemoteFit[1] = rows
-                  remoteFitJob[0]?.cancel()
-                  remoteFitJob[0] = scope.launch {
-                    // Wait for a clear stop before resizing the host's OS window. Each request
-                    // physically resizes the host window (and reflows a snapshot), so a long
-                    // trailing debounce keeps a drag from firing several mid-resize — it lands
-                    // once, well after the user has settled on a window size.
-                    delay(3000)
-                    hook(cols, rows)
-                  }
+            (tab as? ai.rever.bossterm.compose.tabs.TerminalTab)?.let { t ->
+              if (cellWidth > 0f && cellHeight > 0f) {
+                val w = coordinates.size.width - 4
+                val h = coordinates.size.height - 4
+                if (w >= 10 && h >= 10) {
+                  t.remoteFitCols = (w / cellWidth).toInt().coerceAtLeast(2)
+                  t.remoteFitRows = (h / cellHeight).toInt().coerceAtLeast(2)
                 }
               }
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -868,7 +868,11 @@ fun ProperTerminal(
                   lastRemoteFit[0] = cols; lastRemoteFit[1] = rows
                   remoteFitJob[0]?.cancel()
                   remoteFitJob[0] = scope.launch {
-                    delay(160) // settle until the user stops dragging the window edge
+                    // Wait for a clear stop before resizing the host's OS window. Each request
+                    // physically resizes the host window (and reflows a snapshot), so a long
+                    // trailing debounce keeps a hesitant drag from firing several mid-resize —
+                    // it lands once, like the web viewer's "Fit host to my screen" button.
+                    delay(450)
                     hook(cols, rows)
                   }
                 }

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -124,6 +124,12 @@
                               background: #1e1e1e; color: #ddd; font-size: 13px; cursor: pointer; }
     #overlay-actions button:hover { border-color: #4a90e2; }
     #overlay-actions button.primary { background: #4a90e2; border-color: #4a90e2; color: #fff; }
+    /* Floating read-only pill over the stage (native-client parity): shows for our own
+       view-only connection or an upstream-read-only active tab; click = control request. */
+    #viewpill { position: fixed; top: 44px; right: 16px; z-index: 30; padding: 4px 10px;
+      border-radius: 12px; background: rgba(37,37,38,.92); border: 1px solid #404040;
+      color: #b0b0b0; font-size: 11px; cursor: pointer; display: none; }
+    #viewpill:hover { border-color: #4a90e2; }
   </style>
 </head>
 <body>
@@ -145,6 +151,7 @@
     <div id="sidebar"></div>
     <div id="stage"></div>
   </div>
+  <div id="viewpill"></div>
   <div id="keybar"></div>
   <div id="ctxmenu"></div>
 

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -141,6 +141,7 @@
     <span class="badge" id="presence"></span>
     <span class="badge" id="dims" title="Host terminal size (columns × rows)"></span>
     <span id="zoom">
+      <button id="splittabs" title="Show a split tab one pane at a time — switch panes via the sub-tab chips (on by default on phones)">⊞ Panes</button>
       <button id="zoomout" title="Zoom out">A&minus;</button>
       <button id="zoomin" title="Zoom in">A+</button>
       <button id="zoomfit" title="Zoom so the terminal's full width fits your view (local only)">Fit view</button>

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -128,6 +128,13 @@
                               background: #1e1e1e; color: #ddd; font-size: 13px; cursor: pointer; }
     #overlay-actions button:hover { border-color: #4a90e2; }
     #overlay-actions button.primary { background: #4a90e2; border-color: #4a90e2; color: #fff; }
+    /* Install banner: promote the native app at the very top; dismissible (persists). */
+    #installbanner { display: flex; align-items: center; gap: 10px; padding: 5px 10px; flex: 0 0 auto;
+      background: #1b2c3d; border-bottom: 1px solid #2c4a66; font-size: 12px; color: #cfe3f5; }
+    #installbanner a { flex: 0 0 auto; padding: 2px 10px; border-radius: 5px; background: #4a90e2;
+      color: #fff; text-decoration: none; font-size: 12px; }
+    #installbanner .txt { flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    #installbanner .dismiss { flex: 0 0 auto; cursor: pointer; color: #9bb8d4; padding: 0 4px; font-size: 14px; }
     /* Floating read-only pill over the stage (native-client parity): shows for our own
        view-only connection or an upstream-read-only active tab; click = control request. */
     #viewpill { position: fixed; top: 44px; right: 16px; z-index: 30; padding: 4px 10px;
@@ -137,6 +144,11 @@
   </style>
 </head>
 <body>
+  <div id="installbanner" style="display:none">
+    <span class="txt">This session is shared from <b>BossTerm</b> — get the terminal to host and join sessions natively.</span>
+    <a href="https://bossterm.com" target="_blank" rel="noopener">Get BossTerm</a>
+    <span class="dismiss" id="installbanner-close" title="Dismiss">×</span>
+  </div>
   <div id="bar">
     <span id="status"></span>
     <button id="menubtn" title="Tabs">☰</button>

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -13,7 +13,11 @@
                  font-family: -apple-system, Menlo, monospace; overflow: hidden; }
     body { display: flex; flex-direction: column; }
     #bar { display: flex; align-items: center; gap: 8px; padding: 4px 8px; height: 30px; flex: 0 0 auto;
-           box-sizing: border-box; background: #2b2b2b; border-bottom: 1px solid #404040; font-size: 12px; }
+           box-sizing: border-box; background: #2b2b2b; border-bottom: 1px solid #404040; font-size: 12px;
+           /* never clip on narrow screens — the whole bar scrolls horizontally */
+           overflow-x: auto; overflow-y: hidden; white-space: nowrap; scrollbar-width: none;
+           -webkit-overflow-scrolling: touch; }
+    #bar::-webkit-scrollbar { display: none; }
     #status { width: 8px; height: 8px; border-radius: 50%; background: #888; flex: 0 0 auto; }
     #status.live { background: #4caf50; } #status.down { background: #f44336; }
     #tabbar { display: flex; gap: 12px; overflow-x: auto; flex: 1 1 auto; align-items: center; }

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -68,6 +68,18 @@
   // ☰ toggles the left tab drawer (phone); tapping a tab closes it (see selectPane).
   menubtnEl.onclick = function () { sidebarEl.classList.toggle("open"); };
 
+  // Install banner: shown until dismissed (persists across visits).
+  (function () {
+    var banner = document.getElementById("installbanner");
+    var dismissed = null;
+    try { dismissed = localStorage.getItem("bossterm-install-banner"); } catch (e) {}
+    if (dismissed !== "dismissed") banner.style.display = "flex";
+    document.getElementById("installbanner-close").onclick = function () {
+      banner.style.display = "none";
+      try { localStorage.setItem("bossterm-install-banner", "dismissed"); } catch (e) {}
+    };
+  })();
+
   // Keep the fixed key bar just above the soft keyboard (and reserve space for it).
   function layoutForKeyboard() {
     var vv = window.visualViewport;

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -141,8 +141,9 @@
     var tab = null, i;
     for (i = 0; i < layout.tabs.length; i++) if (layout.tabs[i].id === activeTabId) tab = layout.tabs[i];
     if (!tab) tab = layout.tabs[0];
-    if (!tab || !tab.tree || tab.tree.t !== "pane") return;
-    var p = panes[tab.tree.paneId]; if (!p) return;
+    var pid = displayedSinglePaneId(tab); // single-pane tab, or the shown pane in splits-as-tabs
+    if (!pid) return;
+    var p = panes[pid]; if (!p) return;
     requestAnimationFrame(function () {
       var sc = p.host.querySelector(".xterm-screen");
       if (sc) { var w = Math.ceil(sc.getBoundingClientRect().width); if (w > 0) p.host.style.width = w + "px"; }
@@ -166,8 +167,9 @@
   }
   // Fit the active pane's font so the whole width shows (zoom-out to fit).
   function fitWidth() {
-    var tab = activeTabNode(); if (!tab || !tab.tree || tab.tree.t !== "pane") return;
-    var p = panes[tab.tree.paneId]; if (!p) return;
+    var tab = activeTabNode(); if (!tab) return;
+    var pid = displayedSinglePaneId(tab); if (!pid) return;
+    var p = panes[pid]; if (!p) return;
     var screen = p.host.querySelector(".xterm-screen"); if (!screen) return;
     var avail = stageEl.clientWidth - 2, w = screen.getBoundingClientRect().width;
     if (avail > 0 && w > 0) applyFont(curFont() * (avail / w));
@@ -175,6 +177,44 @@
   document.getElementById("zoomin").onclick = function () { applyFont(curFont() + 1); };
   document.getElementById("zoomout").onclick = function () { applyFont(curFont() - 1); };
   document.getElementById("zoomfit").onclick = fitWidth;
+
+  // ---- "splits as tabs" (viewer-local) ----
+  // Render only the selected pane of a split tab, full-screen — switch panes via the
+  // sub-tab chips — instead of the side-by-side split. Defaults ON for phone screens;
+  // the user's explicit choice persists.
+  var splitsAsTabs = (function () {
+    var saved = null;
+    try { saved = localStorage.getItem("bossterm-splits-as-tabs"); } catch (e) {}
+    if (saved === "1") return true;
+    if (saved === "0") return false;
+    return !!(window.matchMedia && window.matchMedia("(max-width: 700px)").matches);
+  })();
+  var splitTabsBtn = document.getElementById("splittabs");
+  function refreshSplitTabsBtn() {
+    splitTabsBtn.style.background = splitsAsTabs ? "#4a90e2" : "";
+    splitTabsBtn.style.color = splitsAsTabs ? "#fff" : "";
+    splitTabsBtn.style.borderColor = splitsAsTabs ? "#4a90e2" : "";
+  }
+  splitTabsBtn.onclick = function () {
+    splitsAsTabs = !splitsAsTabs;
+    try { localStorage.setItem("bossterm-splits-as-tabs", splitsAsTabs ? "1" : "0"); } catch (e) {}
+    refreshSplitTabsBtn();
+    renderTabBar();
+    renderStage();
+  };
+  refreshSplitTabsBtn();
+  // The single pane the stage currently shows for [tab], or null when a split renders as a grid.
+  function displayedSinglePaneId(tab) {
+    if (!tab || !tab.tree) return null;
+    if (tab.tree.t === "pane") return tab.tree.paneId;
+    if (splitsAsTabs && tab.tree.t === "split") return currentPaneId || defaultPaneId(tab.tree);
+    return null;
+  }
+  function findPaneNode(node, paneId) {
+    if (!node) return null;
+    if (node.t === "pane") return node.paneId === paneId ? node : null;
+    return findPaneNode(node.a, paneId) || findPaneNode(node.b, paneId);
+  }
 
   // Show the host terminal's grid size (cols × rows) so its bounds are explicit.
   function updateDims() {
@@ -532,7 +572,7 @@
       function tabCluster(tab) {
         var group = document.createElement("div"); group.className = "ltab-group";
         var ps = []; panesInOrder(tab.tree, ps);
-        if (!summaryMode && tab.tree && tab.tree.t === "split") {
+        if ((!summaryMode || splitsAsTabs) && tab.tree && tab.tree.t === "split") {
           ps.forEach(function (pane) { group.appendChild(leftChip(tab, pane)); });
         } else {
           group.appendChild(leftChip(tab, null));
@@ -636,7 +676,7 @@
       if (layout) layout.tabs.forEach(function (tab) {
         var grp = document.createElement("div"); grp.className = "tab-group";
         var ps = []; panesInOrder(tab.tree, ps);
-        if (!summaryMode && tab.tree && tab.tree.t === "split") {
+        if ((!summaryMode || splitsAsTabs) && tab.tree && tab.tree.t === "split") {
           ps.forEach(function (pane) { grp.appendChild(topChip(tab, pane)); });
         } else {
           grp.appendChild(topChip(tab, null));
@@ -671,6 +711,7 @@
   function setClientFocus(paneId) {
     if (currentPaneId === paneId) return;
     currentPaneId = paneId;
+    if (splitsAsTabs) { renderTabBar(); renderStage(); return; } // shown pane follows focus
     refreshPaneFocus();
     renderTabBar(); // per-split sub-tab chip highlight follows the client's focus
   }
@@ -955,13 +996,19 @@
     // Keep the key-bar target on a pane that's actually visible in this tab.
     var ids = {}; collectPaneIds(tab.tree, ids);
     if (!currentPaneId || !ids[currentPaneId]) currentPaneId = defaultPaneId(tab.tree);
-    var root = buildNode(tab.tree);
-    if (tab.tree.t === "pane") {
+    // "Splits as tabs": show only the selected pane of a split, full-screen — the sub-tab
+    // chips switch between panes (each pane keeps its own xterm; nothing is lost).
+    var tree = tab.tree;
+    if (splitsAsTabs && tree && tree.t === "split") {
+      tree = findPaneNode(tree, currentPaneId) || tree;
+    }
+    var root = buildNode(tree);
+    if (tree.t === "pane") {
       // single pane → natural width, scrollable in #stage (don't stretch/clip)
       root.style.flex = "0 0 auto";
       root.style.height = "100%";
       root.style.overflow = "visible";
-      var sp = panes[tab.tree.paneId];
+      var sp = panes[tree.paneId];
       if (sp) { sp.host.style.overflow = "visible"; sp.host.style.height = "100%"; }
     } else {
       root.style.flex = "1 1 0"; // splits fill the stage

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -89,8 +89,8 @@
     if (currentPaneId && panes[currentPaneId]) { try { panes[currentPaneId].term.focus(); } catch (e) {} }
   }
   function sendKey(seq) {
-    if (!controlGranted || !currentPaneId) return;
-    sendMsg({ t: "input", paneId: currentPaneId, data: seq });
+    if (!currentPaneId) return;
+    sendInput(currentPaneId, seq);
   }
   function buildKeybar() {
     keybarEl.innerHTML = "";
@@ -267,7 +267,7 @@
     var canRead = controlGranted && navigator.clipboard && navigator.clipboard.readText;
     ctxEl.appendChild(ctxItem("Paste", canRead, function () {
       navigator.clipboard.readText().then(function (txt) {
-        if (txt) sendMsg({ t: "input", paneId: paneId, data: txt });
+        if (txt) sendInput(paneId, txt);
       }).catch(function () {});
     }));
     ctxEl.appendChild(ctxItem("Select all", true, function () { try { term.selectAll(); } catch (e) {} }));
@@ -480,11 +480,7 @@
       ta.setAttribute("spellcheck", "false");
     }
     if (viewerFont) { try { term.options.fontSize = viewerFont; } catch (e) {} }
-    term.onData(function (data) {
-      if (controlGranted && ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ t: "input", paneId: paneId, data: data }));
-      }
-    });
+    term.onData(function (data) { sendInput(paneId, data); });
     p = { term: term, host: host };
     panes[paneId] = p;
     return p;
@@ -705,6 +701,34 @@
     if (window.confirm("You're viewing this session read-only — this action needs control. Ask the host for it?"))
       sendMsg({ t: "requestControl" });
     return true;
+  }
+
+  // Typing prompt throttle: buffered keystrokes must not spam confirms — one prompt, then
+  // quiet for 30s (a grant clears the read-only state and re-enables input anyway).
+  var inputPromptQuietUntil = 0;
+  function promptControlForInput(tabId, name) {
+    var now = Date.now();
+    if (now < inputPromptQuietUntil) return;
+    inputPromptQuietUntil = now + 30000;
+    if (tabId) { requestUpstreamControl(tabId, name); return; }
+    if (window.confirm("You're viewing this session read-only — typing needs control. Ask the host for it?"))
+      sendMsg({ t: "requestControl" });
+  }
+  function tabOfPane(paneId) {
+    if (!layout) return null;
+    for (var i = 0; i < layout.tabs.length; i++) {
+      var ids = {}; collectPaneIds(layout.tabs[i].tree, ids);
+      if (ids[paneId]) return layout.tabs[i];
+    }
+    return null;
+  }
+  // Central input path: typing into a read-only context (no control, or the pane's tab is
+  // read-only via an upstream host) prompts to request control instead of vanishing.
+  function sendInput(paneId, data) {
+    if (!controlGranted) { promptControlForInput(null, null); return; }
+    var t = tabOfPane(paneId);
+    if (t && t.origin && t.originReadOnly) { promptControlForInput(t.id, t.originName || "remote"); return; }
+    sendMsg({ t: "input", paneId: paneId, data: data });
   }
 
   // kind: "v" = Split Left/Right (vertical divider), "h" = Split Top/Bottom (horizontal divider).

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -557,14 +557,13 @@
       });
       own.forEach(function (tab) { sidebarEl.appendChild(tabCluster(tab)); });
       // Action row mirroring the host's left bar: Split L/R, Split T/B, then New tab.
-      if (controlGranted) {
-        var actions = document.createElement("div");
-        actions.className = "ltab-actions";
-        actions.appendChild(splitButton("v"));
-        actions.appendChild(splitButton("h"));
-        actions.appendChild(newTabButton("+ New tab"));
-        sidebarEl.appendChild(actions);
-      }
+      // Always shown — when view-only, clicking offers to request control (viewOnlyGate).
+      var actions = document.createElement("div");
+      actions.className = "ltab-actions";
+      actions.appendChild(splitButton("v"));
+      actions.appendChild(splitButton("h"));
+      actions.appendChild(newTabButton("+ New tab"));
+      sidebarEl.appendChild(actions);
       // Upstream groups: tether + bordered box with header (name · via host, offline/read-only
       // badges, ✕ = ask host to disconnect it), chips, and a relayed action row.
       upOrder.forEach(function (key) {
@@ -593,48 +592,46 @@
           eye.onclick = function (ev) { ev.stopPropagation(); requestUpstreamControl(anchorTab(g).id, g.name || "remote"); };
           hd.appendChild(eye);
         }
-        if (controlGranted) {
-          var x = document.createElement("span");
-          x.textContent = "×"; x.title = "Ask the host to disconnect this upstream";
-          x.style.cssText = "cursor:pointer;color:#808080;padding:0 2px;";
-          x.onclick = function (ev) {
-            ev.stopPropagation();
-            if (window.confirm("Ask the host to disconnect from " + (g.name || "this upstream") + "?"))
-              sendMsg({ t: "disconnectUpstream", tabId: g.tabs[0].id });
-          };
-          hd.appendChild(x);
-        }
+        var x = document.createElement("span");
+        x.textContent = "×"; x.title = "Ask the host to disconnect this upstream";
+        x.style.cssText = "cursor:pointer;color:#808080;padding:0 2px;";
+        x.onclick = function (ev) {
+          ev.stopPropagation();
+          if (viewOnlyGate()) return;
+          if (window.confirm("Ask the host to disconnect from " + (g.name || "this upstream") + "?"))
+            sendMsg({ t: "disconnectUpstream", tabId: g.tabs[0].id });
+        };
+        hd.appendChild(x);
         box.appendChild(hd);
         g.tabs.forEach(function (tab) { box.appendChild(tabCluster(tab)); });
-        if (controlGranted) {
-          var act = document.createElement("div");
-          act.className = "ltab-actions";
-          act.appendChild(groupSplitButton("v", g));
-          act.appendChild(groupSplitButton("h", g));
-          var nt = document.createElement("div");
-          nt.className = "newtab"; nt.textContent = "+ New tab";
-          nt.title = "New tab in " + (g.name || "remote");
-          nt.onclick = function () {
-            if (g.readOnly) { requestUpstreamControl(anchorTab(g).id, g.name || "remote"); return; }
-            sendMsg({ t: "newTab", tabId: anchorTab(g).id });
-          };
-          act.appendChild(nt);
-          box.appendChild(act);
-        }
+        // Always shown; view-only clicks route to the request-control dialog (viewOnlyGate).
+        var act = document.createElement("div");
+        act.className = "ltab-actions";
+        act.appendChild(groupSplitButton("v", g));
+        act.appendChild(groupSplitButton("h", g));
+        var nt = document.createElement("div");
+        nt.className = "newtab"; nt.textContent = "+ New tab";
+        nt.title = "New tab in " + (g.name || "remote");
+        nt.onclick = function () {
+          if (viewOnlyGate()) return;
+          if (g.readOnly) { requestUpstreamControl(anchorTab(g).id, g.name || "remote"); return; }
+          sendMsg({ t: "newTab", tabId: anchorTab(g).id });
+        };
+        act.appendChild(nt);
+        box.appendChild(act);
         sidebarEl.appendChild(box);
       });
       // Bottom: ask the host to mirror another BossTerm share here (native "Add remote").
-      if (controlGranted) {
-        var add = document.createElement("div");
-        add.className = "newtab";
-        add.textContent = "☁ Add remote";
-        add.title = "Ask the host to mirror another BossTerm share link";
-        add.onclick = function () {
-          var link = window.prompt("Paste a BossTerm share link — the host will mirror its tabs:");
-          if (link && link.trim()) sendMsg({ t: "offerShare", link: link.trim() });
-        };
-        sidebarEl.appendChild(add);
-      }
+      var add = document.createElement("div");
+      add.className = "newtab";
+      add.textContent = "☁ Add remote";
+      add.title = "Ask the host to mirror another BossTerm share link";
+      add.onclick = function () {
+        if (viewOnlyGate()) return;
+        var link = window.prompt("Paste a BossTerm share link — the host will mirror its tabs:");
+        if (link && link.trim()) sendMsg({ t: "offerShare", link: link.trim() });
+      };
+      sidebarEl.appendChild(add);
     } else {
       tabbarEl.classList.remove("hidden");
       menubtnEl.classList.remove("show");
@@ -651,11 +648,10 @@
         tabbarEl.appendChild(grp);
       });
       // Split buttons sit just left of the new-tab (+), like the host's tab-bar actions.
-      if (controlGranted) {
-        tabbarEl.appendChild(splitButton("v"));
-        tabbarEl.appendChild(splitButton("h"));
-        tabbarEl.appendChild(newTabButton("+"));
-      }
+      // Always shown — when view-only, clicking offers to request control (viewOnlyGate).
+      tabbarEl.appendChild(splitButton("v"));
+      tabbarEl.appendChild(splitButton("h"));
+      tabbarEl.appendChild(newTabButton("+"));
     }
     updateViewPill(); // runs on layout/control/selection changes — keeps the pill current
   }
@@ -702,6 +698,15 @@
     if (currentPaneId) { var ids = {}; collectPaneIds(tab.tree, ids); if (ids[currentPaneId]) return currentPaneId; }
     return defaultPaneId(tab.tree);
   }
+  // View-only fallback for action buttons (the native client's confirm dialog): when we lack
+  // control, offer to request it instead of silently doing nothing. True = handled, caller bails.
+  function viewOnlyGate() {
+    if (controlGranted) return false;
+    if (window.confirm("You're viewing this session read-only — this action needs control. Ask the host for it?"))
+      sendMsg({ t: "requestControl" });
+    return true;
+  }
+
   // kind: "v" = Split Left/Right (vertical divider), "h" = Split Top/Bottom (horizontal divider).
   function splitButton(kind) {
     var b = document.createElement("div");
@@ -710,6 +715,7 @@
     b.innerHTML = kind === "v" ? SVG_VSPLIT : SVG_HSPLIT;
     b.onclick = function (ev) {
       ev.stopPropagation();
+      if (viewOnlyGate()) return;
       var tab = activeTabNode(), pid = activePaneId();
       if (!tab || !pid) return;
       sendMsg({ t: kind === "v" ? "splitVertical" : "splitHorizontal", tabId: tab.id, paneId: pid });
@@ -747,6 +753,7 @@
     b.innerHTML = kind === "v" ? SVG_VSPLIT : SVG_HSPLIT;
     b.onclick = function (ev) {
       ev.stopPropagation();
+      if (viewOnlyGate()) return;
       if (g.readOnly) { requestUpstreamControl(anchorTab(g).id, g.name || "remote"); return; }
       var tab = anchorTab(g);
       var pid = (tab.id === activeTabId ? activePaneId() : null) || defaultPaneId(tab.tree);
@@ -770,7 +777,10 @@
   function newTabButton(label) {
     var el = document.createElement("div");
     el.className = "newtab"; el.textContent = label; el.title = "New tab";
-    el.onclick = function () { sendMsg({ t: "newTab" }); };
+    el.onclick = function () {
+      if (viewOnlyGate()) return;
+      sendMsg({ t: "newTab" });
+    };
     return el;
   }
 
@@ -1017,6 +1027,7 @@
         }
         renderTabBar(); // show/hide the close + new-tab affordances
         buildKeybar();  // show/hide the on-screen control-key bar
+        updateViewPill(); // also directly, in case layout hasn't arrived yet
         break;
     }
   };

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -27,6 +27,31 @@
     if (window.confirm("You're viewing this session read-only. Ask the host for control?"))
       sendMsg({ t: "requestControl" });
   };
+  // Floating read-only pill over the stage (native parity): our own view-only connection, or
+  // — with control — an active tab whose upstream is read-only for the host. Click = request.
+  var viewPillEl = document.getElementById("viewpill");
+  function updateViewPill() {
+    if (!controlGranted) {
+      viewPillEl.textContent = "View only — click to request control";
+      viewPillEl.style.display = "";
+      viewPillEl.onclick = function () {
+        if (window.confirm("You're viewing this session read-only. Ask the host for control?"))
+          sendMsg({ t: "requestControl" });
+      };
+      return;
+    }
+    var t = null;
+    if (layout) for (var i = 0; i < layout.tabs.length; i++)
+      if (layout.tabs[i].id === activeTabId) { t = layout.tabs[i]; break; }
+    if (t && t.origin && t.originReadOnly) {
+      var name = t.originName || "remote";
+      viewPillEl.textContent = "View only — click to request control of " + name;
+      viewPillEl.style.display = "";
+      viewPillEl.onclick = function () { requestUpstreamControl(t.id, name); };
+      return;
+    }
+    viewPillEl.style.display = "none";
+  }
 
   var keybarEl = document.getElementById("keybar");
   var menubtnEl = document.getElementById("menubtn");
@@ -632,6 +657,7 @@
         tabbarEl.appendChild(newTabButton("+"));
       }
     }
+    updateViewPill(); // runs on layout/control/selection changes — keeps the pill current
   }
 
   // Panes of a tab in split-tree order (left/top before right/bottom).

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -18,6 +18,15 @@
   var stageEl = document.getElementById("stage");
   var presenceEl = document.getElementById("presence");
   var viewOnlyEl = document.getElementById("viewonly");
+  // The "view only" badge doubles as the request-control affordance (confirm-first, like
+  // the native client's dialog) — the host's user sees its approval toast.
+  viewOnlyEl.style.cursor = "pointer";
+  viewOnlyEl.title = "Request control";
+  viewOnlyEl.onclick = function () {
+    if (controlGranted) return;
+    if (window.confirm("You're viewing this session read-only. Ask the host for control?"))
+      sendMsg({ t: "requestControl" });
+  };
 
   var keybarEl = document.getElementById("keybar");
   var menubtnEl = document.getElementById("menubtn");
@@ -89,6 +98,9 @@
   }
 
   var controlGranted = false;
+  // An upstream control request queued until OUR control is granted (the host only relays
+  // upstream requests from controlling clients) — fired from the "control" handler.
+  var pendingUpstreamControlTab = null;
   var theme = null;               // last Theme message
   var layout = null;              // last Layout message
   var activeTabId = null;         // client-side selected tab
@@ -496,7 +508,7 @@
       sidebarEl.innerHTML = "";
       // One cluster per tab: per-pane sub-tab chips when the tab is split (and the host
       // isn't in summary mode), otherwise a single tab-level chip — like the host.
-      if (layout) layout.tabs.forEach(function (tab) {
+      function tabCluster(tab) {
         var group = document.createElement("div"); group.className = "ltab-group";
         var ps = []; panesInOrder(tab.tree, ps);
         if (!summaryMode && tab.tree && tab.tree.t === "split") {
@@ -504,8 +516,21 @@
         } else {
           group.appendChild(leftChip(tab, null));
         }
-        sidebarEl.appendChild(group);
+        return group;
+      }
+      // Partition like the native client: the host's own tabs render directly; tabs the host
+      // itself mirrors from OTHER sessions render as boxed "via host" groups below.
+      var own = [], upstreams = {}, upOrder = [];
+      if (layout) layout.tabs.forEach(function (t) {
+        if (t.origin) {
+          if (!upstreams[t.origin]) {
+            upstreams[t.origin] = { name: t.originName, readOnly: !!t.originReadOnly, offline: !!t.originOffline, tabs: [] };
+            upOrder.push(t.origin);
+          }
+          upstreams[t.origin].tabs.push(t);
+        } else own.push(t);
       });
+      own.forEach(function (tab) { sidebarEl.appendChild(tabCluster(tab)); });
       // Action row mirroring the host's left bar: Split L/R, Split T/B, then New tab.
       if (controlGranted) {
         var actions = document.createElement("div");
@@ -514,6 +539,76 @@
         actions.appendChild(splitButton("h"));
         actions.appendChild(newTabButton("+ New tab"));
         sidebarEl.appendChild(actions);
+      }
+      // Upstream groups: tether + bordered box with header (name · via host, offline/read-only
+      // badges, ✕ = ask host to disconnect it), chips, and a relayed action row.
+      upOrder.forEach(function (key) {
+        var g = upstreams[key];
+        var tether = document.createElement("div");
+        tether.style.cssText = "width:2px;height:10px;margin-left:13px;background:#4FC3F7;";
+        sidebarEl.appendChild(tether);
+        var box = document.createElement("div");
+        box.style.cssText = "border:1px solid #4FC3F7;border-radius:8px;padding:4px;display:flex;flex-direction:column;gap:4px;";
+        var hd = document.createElement("div");
+        hd.style.cssText = "display:flex;align-items:center;gap:4px;padding:2px;font-size:11px;color:#b0b0b0;";
+        var lbl = document.createElement("span");
+        lbl.style.cssText = "flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
+        lbl.textContent = "☁ " + (g.name || "remote") + " · via " + ((layout && layout.sessionName) || "host");
+        hd.appendChild(lbl);
+        if (g.offline) {
+          var off = document.createElement("span");
+          off.textContent = "· offline"; off.title = "The host lost its connection to this session — content is frozen";
+          off.style.cssText = "color:#E57373;font-size:10px;";
+          hd.appendChild(off);
+        }
+        if (g.readOnly) {
+          var eye = document.createElement("span");
+          eye.textContent = "👁"; eye.title = "Read-only via this host — click to request control";
+          eye.style.cursor = "pointer";
+          eye.onclick = function (ev) { ev.stopPropagation(); requestUpstreamControl(anchorTab(g).id, g.name || "remote"); };
+          hd.appendChild(eye);
+        }
+        if (controlGranted) {
+          var x = document.createElement("span");
+          x.textContent = "×"; x.title = "Ask the host to disconnect this upstream";
+          x.style.cssText = "cursor:pointer;color:#808080;padding:0 2px;";
+          x.onclick = function (ev) {
+            ev.stopPropagation();
+            if (window.confirm("Ask the host to disconnect from " + (g.name || "this upstream") + "?"))
+              sendMsg({ t: "disconnectUpstream", tabId: g.tabs[0].id });
+          };
+          hd.appendChild(x);
+        }
+        box.appendChild(hd);
+        g.tabs.forEach(function (tab) { box.appendChild(tabCluster(tab)); });
+        if (controlGranted) {
+          var act = document.createElement("div");
+          act.className = "ltab-actions";
+          act.appendChild(groupSplitButton("v", g));
+          act.appendChild(groupSplitButton("h", g));
+          var nt = document.createElement("div");
+          nt.className = "newtab"; nt.textContent = "+ New tab";
+          nt.title = "New tab in " + (g.name || "remote");
+          nt.onclick = function () {
+            if (g.readOnly) { requestUpstreamControl(anchorTab(g).id, g.name || "remote"); return; }
+            sendMsg({ t: "newTab", tabId: anchorTab(g).id });
+          };
+          act.appendChild(nt);
+          box.appendChild(act);
+        }
+        sidebarEl.appendChild(box);
+      });
+      // Bottom: ask the host to mirror another BossTerm share here (native "Add remote").
+      if (controlGranted) {
+        var add = document.createElement("div");
+        add.className = "newtab";
+        add.textContent = "☁ Add remote";
+        add.title = "Ask the host to mirror another BossTerm share link";
+        add.onclick = function () {
+          var link = window.prompt("Paste a BossTerm share link — the host will mirror its tabs:");
+          if (link && link.trim()) sendMsg({ t: "offerShare", link: link.trim() });
+        };
+        sidebarEl.appendChild(add);
       }
     } else {
       tabbarEl.classList.remove("hidden");
@@ -592,6 +687,44 @@
       var tab = activeTabNode(), pid = activePaneId();
       if (!tab || !pid) return;
       sendMsg({ t: kind === "v" ? "splitVertical" : "splitHorizontal", tabId: tab.id, paneId: pid });
+    };
+    return b;
+  }
+
+  // ---- upstream ("via host") group helpers — native-client parity ----
+
+  // Footer actions of an upstream group target the active tab when it's in the group, else
+  // the group's first tab (the host relays them to the origin session).
+  function anchorTab(g) {
+    for (var i = 0; i < g.tabs.length; i++) if (g.tabs[i].id === activeTabId) return g.tabs[i];
+    return g.tabs[0];
+  }
+
+  // Confirm-first control request for an upstream session. If we don't control the host yet,
+  // chain: request that first, then the relayed request fires when the grant arrives.
+  function requestUpstreamControl(tabId, name) {
+    if (!window.confirm("Ask for control of " + name + "? Each host along the path approves in turn.")) return;
+    if (!controlGranted) {
+      pendingUpstreamControlTab = tabId;
+      sendMsg({ t: "requestControl" });
+      return;
+    }
+    sendMsg({ t: "requestControl", tabId: tabId });
+  }
+
+  // Split button for an upstream group: relayed by the host to the origin; when the host is
+  // view-only on it, routes to the control request instead of a silent no-op.
+  function groupSplitButton(kind, g) {
+    var b = document.createElement("div");
+    b.className = "splitbtn";
+    b.title = kind === "v" ? "Split vertical (left / right)" : "Split horizontal (top / bottom)";
+    b.innerHTML = kind === "v" ? SVG_VSPLIT : SVG_HSPLIT;
+    b.onclick = function (ev) {
+      ev.stopPropagation();
+      if (g.readOnly) { requestUpstreamControl(anchorTab(g).id, g.name || "remote"); return; }
+      var tab = anchorTab(g);
+      var pid = (tab.id === activeTabId ? activePaneId() : null) || defaultPaneId(tab.tree);
+      if (pid) sendMsg({ t: kind === "v" ? "splitVertical" : "splitHorizontal", tabId: tab.id, paneId: pid });
     };
     return b;
   }
@@ -851,6 +984,11 @@
         controlGranted = !!m.granted;
         viewOnlyEl.style.display = controlGranted ? "none" : "";
         fithostEl.style.display = controlGranted ? "" : "none"; // resizing the host needs control
+        // Second hop of a chained upstream request (view-only → control → relay upstream).
+        if (controlGranted && pendingUpstreamControlTab) {
+          sendMsg({ t: "requestControl", tabId: pendingUpstreamControlTab });
+          pendingUpstreamControlTab = null;
+        }
         renderTabBar(); // show/hide the close + new-tab affordances
         buildKeybar();  // show/hide the on-screen control-key bar
         break;

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/remote/RemoteLinkParsingTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/remote/RemoteLinkParsingTest.kt
@@ -1,0 +1,58 @@
+package ai.rever.bossterm.compose.remote
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertFailsWith
+
+/**
+ * Pure-function coverage for the remote-client link parsing: `tokenOf` (share link → access
+ * token) and `RemoteSessionConnection.toWsUrl` (share link → WebSocket URL). No socket needed.
+ */
+class RemoteLinkParsingTest {
+
+    // toWsUrl is an instance method but pure over its argument; a throwaway connection is fine
+    // (the constructor's HttpClient is harmless and never dials in these tests).
+    private fun conn() = RemoteSessionConnection(
+        link = "https://h/?t=seed",
+        clientId = "c",
+        deviceName = "d",
+        keyProvider = { null },
+        onGrant = { _, _ -> },
+        onServerMessage = {},
+    )
+
+    @Test
+    fun `tokenOf extracts and url-decodes the t param`() {
+        assertEquals("abc123", tokenOf("https://host.trycloudflare.com/?t=abc123"))
+        assertEquals("a b/c", tokenOf("https://host/?t=a%20b%2Fc")) // %20 → space, %2F → /
+        assertEquals("tok", tokenOf("https://host/?foo=1&t=tok&bar=2")) // not the first param
+    }
+
+    @Test
+    fun `tokenOf is null when absent or malformed`() {
+        assertNull(tokenOf("https://host/"))        // no query
+        assertNull(tokenOf("https://host/?x=1"))     // no t=
+        assertNull(tokenOf("https://host/?t="))      // blank token
+        assertNull(tokenOf("::::not a uri::::"))     // unparseable
+    }
+
+    @Test
+    fun `toWsUrl maps https to wss and http to ws`() {
+        val c = conn()
+        assertEquals("wss://host/ws/tok", c.toWsUrl("https://host/?t=tok"))
+        assertEquals("ws://host/ws/tok", c.toWsUrl("http://host/?t=tok"))
+    }
+
+    @Test
+    fun `toWsUrl preserves an explicit port and decodes the token`() {
+        val c = conn()
+        assertEquals("ws://10.0.0.2:8080/ws/tok", c.toWsUrl("http://10.0.0.2:8080/?t=tok"))
+        assertEquals("wss://host/ws/a/b", c.toWsUrl("https://host/?t=a%2Fb"))
+    }
+
+    @Test
+    fun `toWsUrl rejects a hostless link instead of producing wss to null`() {
+        assertFailsWith<IllegalArgumentException> { conn().toWsUrl("file:///foo?t=tok") }
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -86,6 +86,27 @@ class ShareProtocolTest {
     }
 
     @Test
+    fun `native client decodes server messages (layout + paneOutput) and encodes hello`() {
+        // decodeServer is the client (native viewer) read path.
+        val layout = ShareProtocol.decodeServer(
+            """{"t":"layout","tabs":[{"id":"t1","title":"~","active":true,"tree":{"t":"pane","paneId":"p1","title":"zsh","cwd":"/home","focused":true}}],"activeTabId":"t1"}"""
+        )
+        assertIs<ServerMessage.Layout>(layout)
+        assertEquals("t1", layout.activeTabId)
+        val pane = layout.tabs[0].tree
+        assertIs<PaneTreeNode.Pane>(pane)
+        assertEquals("p1", pane.paneId)
+
+        val out = ShareProtocol.decodeServer("""{"t":"paneOutput","paneId":"p1","data":"hi"}""")
+        assertIs<ServerMessage.PaneOutput>(out)
+        assertEquals("hi", out.data)
+
+        // encodeClient is the client write path (handshake).
+        val hello = ShareProtocol.encodeClient(ClientMessage.Hello(name = "dev", clientId = "c1", key = null))
+        assertTrue(hello.contains("\"t\":\"hello\"") && hello.contains("\"clientId\":\"c1\""), hello)
+    }
+
+    @Test
     fun `split id serializes and is optional for forward-compat`() {
         val tree = PaneTreeNode.Split(
             "v", 0.5f,


### PR DESCRIPTION
A native in-app **client** for the session-sharing protocol — the reverse of the browser viewer. A new **Add remote** button in the left tab bar's bottom row takes another BossTerm's share link; that session's tabs then appear as local tabs, mirroring its split layouts, with **full control** (type into them once the host grants control).

## How it works
- **`RemoteSessionConnection`** — a Ktor WebSocket client (new `ktor-client-websockets` dep). Parses a share link `https://host/?t=TOKEN` → `wss://host/ws/TOKEN`, runs the same handshake as `viewer.js` (`Hello` → `Pending`/`Grant`/`Denied` → `Theme`/`Layout`/`PaneSnapshot`/`Control` → live `PaneOutput`/`PaneResize`), and reconnects (replaying the access key) on a transient drop. `ShareProtocol` gains symmetric `encodeClient`/`decodeServer`.
- **`RemoteSessionManager`** (per window, owned by `TabbedTerminalState`) — reconciles each `Layout` into local mirror tabs: creates/removes tabs, and (re)builds each tab's split tree from the pane tree via `SplitViewState.setTree` (reusing mirror sessions by remote paneId), self-healing if a mirror tab is closed externally. Routes `PaneSnapshot`/`PaneOutput` → the pane's `dataStream.append`, `PaneResize` → `terminal.resize`, and local keystrokes → `ClientMessage.Input` (only when control is granted).
- **PTY-less mirror sessions** — `TabController.createRemoteSession` builds the full terminal stack with **no process**, plus an emulator loop fed from the remote stream. `TerminalTab` gains `isRemote`/`remotePaneId`/`onUserInput` (so `writeUserInput` routes to the WebSocket); `TerminalSession` exposes `isRemote`; `ProperTerminal` renders remote tabs without a local connection and skips local auto-fit (their grid is the host's). The renderer/`SplitContainer` are otherwise unchanged — remote tabs reuse the whole pipeline.
- **UI** — left-bar bottom **Add remote**; `AddRemoteDialog` to paste a link and manage connections (live status, view-only vs control, **Request control**, **Disconnect**); remote tab chips marked cyan. Connections are torn down on window dispose.

## Tests
`ShareProtocolTest` adds client-side round-trips: `decodeServer` of `Layout`/`PaneOutput` and `encodeClient` of `Hello` (7 tests, all passing). `:compose-ui:compileKotlinDesktop` + `:bossterm-app:compileKotlinDesktop` green.

## Known v1 limitations (documented in code)
- Access keys are in-memory — you re-approve after an app restart (per-session reconnect uses the key).
- The remote `Theme` isn't applied per-tab; remote content renders with the local theme.
- A remote pane wider than the local view clips rather than scrolls (same constraint as the browser viewer's terminal area).

## Verify end-to-end
Instance A: **Share** a window (LAN/Cloudflare link). Instance B (or this one, sharing to itself): left bar → **Add remote** → paste A's link → approve on A → A's tabs (cyan) appear and mirror live; a split tab on A shows as a mirrored split on B; with control, typing on B reaches A; disconnect removes the mirror tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)