### PR TITLE
End-to-end encryption for session sharing

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
@@ -149,6 +149,11 @@ class RemoteSessionConnection(
                 send(Frame.Text(ShareProtocol.encodeKex(
                     Kex(v = 1, salt = SessionCrypto.encodeSecretB64Url(saltC)))))
                 val reply = (incoming.receive() as? Frame.Text)?.let { ShareProtocol.decodeKex(it.readText()) }
+                if (reply != null && reply.v != 1) {
+                    closedByUser = true // terminal — a newer host we can't speak to
+                    _status.value = RemoteStatus.Denied("This session uses a newer encryption version — update BossTerm.")
+                    return@webSocket
+                }
                 val saltS = reply?.salt?.let { runCatching { SessionCrypto.decodeSecretB64Url(it) }.getOrNull() }
                 if (reply == null || saltS == null) {
                     _status.value = RemoteStatus.Failed("Encrypted handshake failed")

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionConnection.kt
@@ -1,7 +1,9 @@
 package ai.rever.bossterm.compose.remote
 
 import ai.rever.bossterm.compose.share.ClientMessage
+import ai.rever.bossterm.compose.share.Kex
 import ai.rever.bossterm.compose.share.ServerMessage
+import ai.rever.bossterm.compose.share.SessionCrypto
 import ai.rever.bossterm.compose.share.ShareProtocol
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
@@ -77,6 +79,9 @@ class RemoteSessionConnection(
 
     // Best-effort: a malformed link must not crash construction — it just fails to connect.
     private val wsUrl: String = runCatching { toWsUrl(link) }.getOrDefault(link)
+    // E2E secret from the link's `#k=` fragment (never sent to the relay). Null → plaintext
+    // (a legacy / plain-LAN link). When present, the connection runs the encrypted handshake.
+    private val sessionSecret: ByteArray? = runCatching { secretOf(link) }.getOrNull()
     // Host portion only — safe to log (the token, a bearer credential, must never hit logs).
     private val safeUrl: String = wsUrl.substringBefore("/ws/").substringBefore("?").ifBlank { "remote" } + "/…"
 
@@ -84,6 +89,14 @@ class RemoteSessionConnection(
     val status: StateFlow<RemoteStatus> = _status.asStateFlow()
 
     fun start() {
+        // An https link must carry its `#k` secret — without it we'd only be able to connect
+        // in plaintext through the relay, which defeats the point. Fail loudly instead.
+        if (sessionSecret == null && isHttpsLink(link)) {
+            _status.value = RemoteStatus.Failed(
+                "This link is missing its encryption key. Re-copy the full link from BossTerm (including the part after #)."
+            )
+            return
+        }
         scope.launch { runWithReconnect() }
     }
 
@@ -123,19 +136,58 @@ class RemoteSessionConnection(
             // so messages queued while disconnected aren't replayed stale on reconnect.
             val box = kotlinx.coroutines.channels.Channel<ClientMessage>(kotlinx.coroutines.channels.Channel.BUFFERED)
             outbox = box
-            // Handshake first, ahead of any queued input.
-            send(Frame.Text(ShareProtocol.encodeClient(
-                ClientMessage.Hello(name = deviceName, clientId = clientId, key = keyProvider()))))
+
+            // E2E handshake (issue: end-to-end encryption). When the link carried a `#k` secret,
+            // exchange salts (plaintext Kex), derive per-connection AES-GCM keys, and verify the
+            // host's key-confirmation tag before sending anything sensitive. Fresh salt each
+            // connection → keys rotate on every reconnect even though the secret is stable.
+            var clientCipher: SessionCrypto.FrameCipher? = null
+            var serverCipher: SessionCrypto.FrameCipher? = null
+            val secret = sessionSecret
+            if (secret != null) {
+                val saltC = SessionCrypto.randomSalt()
+                send(Frame.Text(ShareProtocol.encodeKex(
+                    Kex(v = 1, salt = SessionCrypto.encodeSecretB64Url(saltC)))))
+                val reply = (incoming.receive() as? Frame.Text)?.let { ShareProtocol.decodeKex(it.readText()) }
+                val saltS = reply?.salt?.let { runCatching { SessionCrypto.decodeSecretB64Url(it) }.getOrNull() }
+                if (reply == null || saltS == null) {
+                    _status.value = RemoteStatus.Failed("Encrypted handshake failed")
+                    return@webSocket
+                }
+                val keys = SessionCrypto.deriveKeys(secret, saltC, saltS)
+                if (!SessionCrypto.confirmMatches(keys.confirm, reply.confirm)) {
+                    // Wrong/missing key — terminal, no point retrying with the same bad secret.
+                    closedByUser = true
+                    _status.value = RemoteStatus.Denied(
+                        "This link's encryption key is wrong. Re-copy the full link from BossTerm."
+                    )
+                    return@webSocket
+                }
+                clientCipher = SessionCrypto.FrameCipher(keys.kC2s, SessionCrypto.DIR_C2S)
+                serverCipher = SessionCrypto.FrameCipher(keys.kS2c, SessionCrypto.DIR_S2C)
+            }
+            val cc = clientCipher
+            val scph = serverCipher
+
+            // Handshake first, ahead of any queued input (encrypted when E2E).
+            val helloText = ShareProtocol.encodeClient(
+                ClientMessage.Hello(name = deviceName, clientId = clientId, key = keyProvider()))
+            if (cc != null) send(Frame.Binary(true, cc.encrypt(helloText))) else send(Frame.Text(helloText))
             val writer = launch {
-                for (m in box) runCatching { send(Frame.Text(ShareProtocol.encodeClient(m))) }
-                    .onFailure { log.debug("ws send failed: {}", it.message) }
+                for (m in box) runCatching {
+                    val t = ShareProtocol.encodeClient(m)
+                    if (cc != null) send(Frame.Binary(true, cc.encrypt(t))) else send(Frame.Text(t))
+                }.onFailure { log.debug("ws send failed: {}", it.message) }
             }
             try {
                 for (frame in incoming) {
-                    if (frame is Frame.Text) {
-                        val msg = runCatching { ShareProtocol.decodeServer(frame.readText()) }.getOrNull() ?: continue
-                        handle(msg)
-                    }
+                    val text = when {
+                        scph != null && frame is Frame.Binary -> runCatching { scph.decrypt(frame.data) }.getOrNull()
+                        scph == null && frame is Frame.Text -> frame.readText()
+                        else -> null
+                    } ?: continue
+                    val msg = runCatching { ShareProtocol.decodeServer(text) }.getOrNull() ?: continue
+                    handle(msg)
                 }
             } finally {
                 outbox = null
@@ -186,6 +238,18 @@ class RemoteSessionConnection(
         val port = if (uri.port != -1) ":${uri.port}" else ""
         return "$wsScheme://$host$port/ws/$token"
     }
+
+    // Visible for tests. The E2E secret lives in the link's `#k=` fragment (never transmitted to
+    // any server); null when absent (a legacy / plain-LAN link). `toWsUrl` ignores the fragment.
+    internal fun secretOf(link: String): ByteArray? {
+        val frag = URI(link.trim()).fragment ?: return null
+        val k = frag.split("&").firstOrNull { it.startsWith("k=") }?.substringAfter("k=")?.takeIf { it.isNotBlank() }
+            ?: return null
+        return runCatching { SessionCrypto.decodeSecretB64Url(k) }.getOrNull()
+    }
+
+    private fun isHttpsLink(link: String): Boolean =
+        runCatching { URI(link.trim()).scheme?.equals("https", ignoreCase = true) == true }.getOrDefault(false)
 
     private companion object {
         const val MAX_RECONNECTS = 5

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -58,6 +58,13 @@ class MirrorShare(
     val viewToken: String = secureToken()
     val controlToken: String = secureToken()
 
+    // E2E session secret (issue: end-to-end encryption). One per share, shared by the view +
+    // control links — it travels ONLY in the link's URL fragment (`#k=`), which the relay never
+    // sees, and each connection derives fresh AES-GCM keys from it ([SessionCrypto]). Role
+    // (view/control) stays enforced server-side by which token is presented.
+    val sessionSecret: ByteArray = SessionCrypto.newSessionSecret()
+    val sessionSecretB64: String = SessionCrypto.encodeSecretB64Url(sessionSecret)
+
     // Observable so the layout observer re-emits when the scope is toggled live
     // (Tab ↔ Window) — same tokens/viewers, just a different set of mirrored tabs.
     private var scopeVar by mutableStateOf(initialScope)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionCrypto.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionCrypto.kt
@@ -1,0 +1,135 @@
+package ai.rever.bossterm.compose.share
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.Mac
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * End-to-end encryption for session sharing.
+ *
+ * The relay (e.g. a Cloudflare quick-tunnel) terminates TLS, so `wss` alone is not
+ * end-to-end — the relay sees plaintext. We close that gap with a pre-shared secret that
+ * travels in the share link's **URL fragment** (`#k=…`), which browsers never transmit to
+ * any server, so the relay never sees it. From that secret each WebSocket connection
+ * derives fresh AES-256-GCM keys (HKDF-SHA256) and every frame is encrypted.
+ *
+ * Wire format of an encrypted frame (binary WebSocket frame):
+ *   nonce(12) || AES-256-GCM(ciphertext) || tag(16),  AAD = 1 direction byte.
+ *
+ * This mirrors exactly what the browser viewer does with WebCrypto (`crypto.subtle`):
+ * HKDF with `SHA-256`, info labels `bossterm-{c2s,s2c,kc}-v1`, and `AES-GCM` with a 12-byte
+ * IV / 128-bit tag / `additionalData` = the direction byte. Keep the two implementations in
+ * lock-step — `SessionCryptoTest` pins a cross-impl vector to catch divergence.
+ */
+object SessionCrypto {
+    const val NONCE_LEN = 12
+    const val TAG_BITS = 128
+    const val KEY_LEN = 32
+
+    /** AAD direction tags — bind each ciphertext to its direction so it can't be reflected. */
+    const val DIR_C2S: Byte = 0x00 // client → host
+    const val DIR_S2C: Byte = 0x01 // host → client
+
+    private val rng = SecureRandom()
+    private val b64UrlEnc = Base64.getUrlEncoder().withoutPadding()
+    private val b64UrlDec = Base64.getUrlDecoder()
+
+    /** A fresh 32-byte session secret (the `#k=` fragment value), per share. */
+    fun newSessionSecret(): ByteArray = ByteArray(KEY_LEN).also { rng.nextBytes(it) }
+
+    fun encodeSecretB64Url(secret: ByteArray): String = b64UrlEnc.encodeToString(secret)
+    fun decodeSecretB64Url(s: String): ByteArray = b64UrlDec.decode(s)
+
+    fun randomSalt(): ByteArray = ByteArray(16).also { rng.nextBytes(it) }
+
+    /**
+     * HKDF-SHA256 (RFC 5869): extract then expand. Matches WebCrypto `deriveBits({name:"HKDF",
+     * hash:"SHA-256", salt, info}, key, len*8)` — extract is deterministic, so deriving each
+     * label separately on the JS side yields identical bytes.
+     */
+    fun hkdf(ikm: ByteArray, salt: ByteArray, info: ByteArray, len: Int): ByteArray {
+        val prk = hmac(salt, ikm) // extract
+        val out = ByteArray(len)
+        var pos = 0
+        var counter = 1
+        var prev = ByteArray(0)
+        while (pos < len) {
+            val mac = Mac.getInstance("HmacSHA256").apply { init(SecretKeySpec(prk, "HmacSHA256")) }
+            mac.update(prev); mac.update(info); mac.update(counter.toByte())
+            prev = mac.doFinal()
+            val n = minOf(prev.size, len - pos)
+            System.arraycopy(prev, 0, out, pos, n)
+            pos += n; counter++
+        }
+        return out
+    }
+
+    private fun hmac(key: ByteArray, msg: ByteArray): ByteArray =
+        Mac.getInstance("HmacSHA256").apply {
+            // An all-zero key is invalid for HmacSHA256 init; HKDF allows an empty salt, but we
+            // always pass a non-empty salt here, so a plain SecretKeySpec is fine.
+            init(SecretKeySpec(if (key.isEmpty()) ByteArray(32) else key, "HmacSHA256"))
+        }.doFinal(msg)
+
+    /** Per-connection keys + a key-confirmation tag, derived from the session secret + both salts. */
+    class DerivedKeys(val kC2s: ByteArray, val kS2c: ByteArray, val confirm: ByteArray) {
+        val confirmB64: String get() = b64UrlEnc.encodeToString(confirm)
+    }
+
+    fun deriveKeys(secret: ByteArray, saltC: ByteArray, saltS: ByteArray): DerivedKeys {
+        val salt = saltC + saltS
+        return DerivedKeys(
+            kC2s = hkdf(secret, salt, "bossterm-c2s-v1".toByteArray(Charsets.UTF_8), KEY_LEN),
+            kS2c = hkdf(secret, salt, "bossterm-s2c-v1".toByteArray(Charsets.UTF_8), KEY_LEN),
+            confirm = hkdf(secret, salt, "bossterm-kc-v1".toByteArray(Charsets.UTF_8), KEY_LEN),
+        )
+    }
+
+    /** Constant-time compare for the key-confirmation tag (b64url). */
+    fun confirmMatches(expected: ByteArray, gotB64: String?): Boolean {
+        val got = runCatching { b64UrlDec.decode(gotB64 ?: return false) }.getOrNull() ?: return false
+        return MessageDigest.isEqual(expected, got)
+    }
+
+    /**
+     * Encrypts/decrypts one direction's frames with a fixed key + AAD direction byte. Not
+     * thread-safe across directions — use one instance per direction per connection (the host
+     * uses two, the clients each use two). Cipher is constructed per call (hardware AES → cheap).
+     */
+    class FrameCipher(key: ByteArray, private val dir: Byte) {
+        private val keySpec = SecretKeySpec(key, "AES")
+        private val aad = byteArrayOf(dir)
+
+        fun encrypt(plaintextUtf8: String): ByteArray {
+            val nonce = ByteArray(NONCE_LEN).also { rng.nextBytes(it) }
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, GCMParameterSpec(TAG_BITS, nonce))
+            cipher.updateAAD(aad)
+            val body = cipher.doFinal(plaintextUtf8.toByteArray(Charsets.UTF_8)) // ciphertext||tag
+            return nonce + body
+        }
+
+        /** @throws javax.crypto.AEADBadTagException on auth failure (wrong key / tamper). */
+        fun decrypt(frame: ByteArray): String {
+            require(frame.size > NONCE_LEN) { "frame too short" }
+            val nonce = frame.copyOfRange(0, NONCE_LEN)
+            val body = frame.copyOfRange(NONCE_LEN, frame.size)
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, GCMParameterSpec(TAG_BITS, nonce))
+            cipher.updateAAD(aad)
+            return String(cipher.doFinal(body), Charsets.UTF_8)
+        }
+    }
+
+    /**
+     * Short, human-comparable fingerprint of a session secret (first 8 hex of SHA-256). Shown
+     * on the host + each endpoint; matching codes confirm the same untampered key end-to-end.
+     */
+    fun fingerprint(secret: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(secret)
+            .take(4).joinToString("") { "%02x".format(it) }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -729,10 +729,14 @@ object SessionShareManager {
         } else {
             // A plaintext first-frame: allowed on LAN/loopback (no relay), but refused on a
             // public tunnel/Funnel share — there it'd stream unencrypted through the relay, so an
-            // old/keyless client must update rather than silently downgrade.
+            // old/keyless client must update rather than silently downgrade. Send a plaintext
+            // Denied first (old clients render its reason; a bare WS close shows nothing), then close.
             if (requireE2E()) {
-                ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT,
-                    "This shared session is end-to-end encrypted — update BossTerm to connect."))
+                runCatching {
+                    ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Denied(
+                        "This shared session is end-to-end encrypted. Update BossTerm to a version that supports it."))))
+                }
+                ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "Encryption required"))
                 return
             }
             hello = (first as? Frame.Text)?.let {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -247,6 +247,12 @@ object SessionShareManager {
         val secure: Boolean = true,
         /** Whether this share covers one tab or the whole window. */
         val scope: ShareScope = ShareScope.TAB,
+        /**
+         * Short verification code (first 8 hex of SHA-256 of the E2E secret) when the link is
+         * end-to-end encrypted; null when it's a plaintext link. Compare it against the code the
+         * viewer shows to confirm the same untampered key end-to-end.
+         */
+        val e2eCode: String? = null,
     )
 
     /** Begin observing settings. Idempotent. Call once from main(). */
@@ -307,7 +313,7 @@ object SessionShareManager {
         val share = sharesByTab[tabId] ?: return null
         val url = buildUrl(share.viewToken) ?: return null
         val controlUrl = buildUrl(share.controlToken) ?: url
-        return ShareInfo(tabId, url, share.viewToken, controlUrl, isSecureUrl(url), share.scope)
+        return ShareInfo(tabId, url, share.viewToken, controlUrl, isSecureUrl(url), share.scope, e2eCodeOf(url))
     }
 
     /**
@@ -338,7 +344,7 @@ object SessionShareManager {
                     url
                 )
             }
-            ShareInfo(tabId, url, share.viewToken, controlUrl, secure, share.scope)
+            ShareInfo(tabId, url, share.viewToken, controlUrl, secure, share.scope, e2eCodeOf(url))
         }
     }
 
@@ -686,8 +692,56 @@ object SessionShareManager {
         val share = ref.share
         val shareId = share.viewToken
 
-        // Handshake: the viewer's first frame carries its clientId + any prior access key.
-        val hello = readHello(ws)
+        // E2E handshake (issue: end-to-end encryption). The very first frame is either a
+        // plaintext Kex (a client that holds the link's `#k` secret → encrypt everything) or a
+        // plaintext Hello (a legacy / plain-LAN client → today's plaintext path). The host
+        // always knows the secret, so it follows whichever the client speaks — no per-share
+        // flag, and a relay can't force a downgrade (it never sees `#k`, can't forge a Kex).
+        val first = withTimeoutOrNull(10_000L) { runCatching { ws.incoming.receive() }.getOrNull() }
+        val kex = (first as? Frame.Text)?.let { ShareProtocol.decodeKex(it.readText()) }
+        var serverCipher: SessionCrypto.FrameCipher? = null
+        var clientCipher: SessionCrypto.FrameCipher? = null
+        val hello: ClientMessage.Hello?
+        if (kex != null) {
+            val saltC = runCatching { SessionCrypto.decodeSecretB64Url(kex.salt) }.getOrNull()
+            if (saltC == null) { ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "Bad handshake")); return }
+            val saltS = SessionCrypto.randomSalt()
+            val keys = SessionCrypto.deriveKeys(share.sessionSecret, saltC, saltS)
+            serverCipher = SessionCrypto.FrameCipher(keys.kS2c, SessionCrypto.DIR_S2C)
+            clientCipher = SessionCrypto.FrameCipher(keys.kC2s, SessionCrypto.DIR_C2S)
+            ws.send(Frame.Text(ShareProtocol.encodeKex(
+                Kex(v = 1, salt = SessionCrypto.encodeSecretB64Url(saltS), confirm = keys.confirmB64))))
+            // The next frame is the encrypted Hello; a decrypt failure ⇒ wrong/missing key.
+            val helloFrame = withTimeoutOrNull(10_000L) { runCatching { ws.incoming.receive() }.getOrNull() }
+            val helloText = (helloFrame as? Frame.Binary)?.let {
+                runCatching { clientCipher.decrypt(it.data) }.getOrNull()
+            }
+            if (helloText == null) {
+                ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "Wrong or missing encryption key"))
+                return
+            }
+            hello = runCatching { ShareProtocol.decodeClient(helloText) }.getOrNull() as? ClientMessage.Hello
+        } else {
+            hello = (first as? Frame.Text)?.let {
+                runCatching { ShareProtocol.decodeClient(it.readText()) }.getOrNull()
+            } as? ClientMessage.Hello
+        }
+
+        // Send/receive helpers: encrypted binary frames when a cipher was negotiated, else
+        // plaintext text frames (legacy). All the handshake/admit/stream code below funnels
+        // through these so the encryption seam lives in one place.
+        suspend fun send(m: ServerMessage) {
+            val text = ShareProtocol.encodeServer(m)
+            serverCipher?.let { ws.send(Frame.Binary(true, it.encrypt(text))) } ?: ws.send(Frame.Text(text))
+        }
+        fun decodeIncoming(frame: Frame): ClientMessage? = when {
+            clientCipher != null && frame is Frame.Binary ->
+                runCatching { ShareProtocol.decodeClient(clientCipher.decrypt(frame.data)) }.getOrNull()
+            clientCipher == null && frame is Frame.Text ->
+                runCatching { ShareProtocol.decodeClient(frame.readText()) }.getOrNull()
+            else -> null
+        }
+
         val clientId = hello?.clientId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
         var canControl = ref.canControl
 
@@ -700,8 +754,7 @@ object SessionShareManager {
                 existing.expiresAtMs = now + GRANT_TTL_MS
                 canControl = existing.canControl
                 accessKey = existing.key
-                ws.send(Frame.Text(ShareProtocol.encodeServer(
-                    ServerMessage.Grant(existing.key, existing.expiresAtMs, canControl))))
+                send(ServerMessage.Grant(existing.key, existing.expiresAtMs, canControl))
             } else {
                 hello?.key?.let { grants.remove(it) } // drop a stale/expired key
                 val req = PendingShareRequest(
@@ -712,11 +765,11 @@ object SessionShareManager {
                 )
                 _pendingRequests.value = _pendingRequests.value + req
                 notifyApprovalRequest(req)
-                runCatching { ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Pending))) }
+                runCatching { send(ServerMessage.Pending) }
                 val approved = withTimeoutOrNull(2 * 60_000L) { req.decision.await() } ?: false
                 _pendingRequests.value = _pendingRequests.value.filterNot { it.id == req.id }
                 if (!approved) {
-                    runCatching { ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Denied("Not approved")))) }
+                    runCatching { send(ServerMessage.Denied("Not approved")) }
                     ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "Not approved"))
                     return
                 }
@@ -725,25 +778,26 @@ object SessionShareManager {
                 grants[key] = Grant(key, shareId, clientId, ref.canControl, exp)
                 canControl = ref.canControl
                 accessKey = key
-                ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Grant(key, exp, canControl))))
+                send(ServerMessage.Grant(key, exp, canControl))
             }
         }
 
         // Admit: Theme + Layout + a PaneSnapshot per pane, THEN register so the outbox
         // only carries output produced after the snapshot (avoids double-rendering).
-        share.initialMessages().forEach { ws.send(Frame.Text(ShareProtocol.encodeServer(it))) }
-        ws.send(Frame.Text(ShareProtocol.encodeServer(ServerMessage.Control(granted = canControl))))
+        share.initialMessages().forEach { send(it) }
+        send(ServerMessage.Control(granted = canControl))
         val vc = share.addViewer(canControl, hello?.name?.takeIf { it.isNotBlank() } ?: "Viewer (${clientId.take(6)})")
         vc.grantKey = accessKey // lets an approved mid-session upgrade persist into the grant
+        val sc = serverCipher
         val writer = ws.launch {
-            for (text in vc.outbox) ws.send(Frame.Text(text))
+            for (text in vc.outbox) {
+                sc?.let { ws.send(Frame.Binary(true, it.encrypt(text))) } ?: ws.send(Frame.Text(text))
+            }
         }
         try {
             for (frame in ws.incoming) {
-                if (frame is Frame.Text) {
-                    val msg = runCatching { ShareProtocol.decodeClient(frame.readText()) }.getOrNull()
-                    if (msg != null) share.handleClient(vc, msg)  // input gated by role inside
-                }
+                val msg = decodeIncoming(frame)
+                if (msg != null) share.handleClient(vc, msg)  // input gated by role inside
             }
         } catch (_: Throwable) {
             // client gone
@@ -751,15 +805,6 @@ object SessionShareManager {
             writer.cancel()
             share.removeViewer(vc)
         }
-    }
-
-    /** Read the first frame as a [ClientMessage.Hello] (best-effort, short timeout). */
-    private suspend fun readHello(
-        ws: io.ktor.server.websocket.DefaultWebSocketServerSession
-    ): ClientMessage.Hello? {
-        val frame = withTimeoutOrNull(10_000L) { runCatching { ws.incoming.receive() }.getOrNull() } ?: return null
-        if (frame !is Frame.Text) return null
-        return runCatching { ShareProtocol.decodeClient(frame.readText()) }.getOrNull() as? ClientMessage.Hello
     }
 
     /**
@@ -770,11 +815,32 @@ object SessionShareManager {
      * WS scheme from the page.
      */
     private fun buildUrl(token: String): String? {
-        remoteUrl?.let { return "${it.trimEnd('/')}/?t=$token" }
-        val publicUrl = SettingsManager.instance.settings.value.sessionSharingPublicUrl
-        if (publicUrl.isNotBlank()) return "${publicUrl.trimEnd('/')}/?t=$token"
-        val port = boundPort ?: return null
-        return "http://${advertisedHost()}:$port/?t=$token"
+        val base = remoteUrl?.let { "${it.trimEnd('/')}/?t=$token" }
+            ?: SettingsManager.instance.settings.value.sessionSharingPublicUrl.takeIf { it.isNotBlank() }
+                ?.let { "${it.trimEnd('/')}/?t=$token" }
+            ?: boundPort?.let { "http://${advertisedHost()}:$it/?t=$token" }
+            ?: return null
+        // Append the E2E secret as a URL fragment — never transmitted to the relay — but only
+        // when the browser will have WebCrypto (a secure context: https tunnel/Tailscale, or
+        // loopback). Plain-LAN http (no relay, no crypto.subtle) stays plaintext as before.
+        // The native client uses #k whenever present, regardless of transport.
+        if (e2eCapable(base)) {
+            sharesByToken[token]?.share?.sessionSecretB64?.let { return "$base#k=$it" }
+        }
+        return base
+    }
+
+    /** The E2E verification code for a link that carries a `#k=` fragment, else null. */
+    private fun e2eCodeOf(url: String): String? {
+        val k = url.substringAfter("#k=", "").substringBefore('&').takeIf { it.isNotBlank() } ?: return null
+        return runCatching { SessionCrypto.fingerprint(SessionCrypto.decodeSecretB64Url(k)) }.getOrNull()
+    }
+
+    /** True when a browser at this URL would have `crypto.subtle` (https or loopback). */
+    private fun e2eCapable(url: String): Boolean {
+        if (url.startsWith("https://", ignoreCase = true)) return true
+        val h = hostOf(url).lowercase()
+        return h == "localhost" || h == "::1" || h.startsWith("127.")
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -703,6 +703,7 @@ object SessionShareManager {
         var clientCipher: SessionCrypto.FrameCipher? = null
         val hello: ClientMessage.Hello?
         if (kex != null) {
+            if (kex.v != 1) { ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "Unsupported encryption version")); return }
             val saltC = runCatching { SessionCrypto.decodeSecretB64Url(kex.salt) }.getOrNull()
             if (saltC == null) { ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "Bad handshake")); return }
             val saltS = SessionCrypto.randomSalt()
@@ -711,14 +712,18 @@ object SessionShareManager {
             clientCipher = SessionCrypto.FrameCipher(keys.kC2s, SessionCrypto.DIR_C2S)
             ws.send(Frame.Text(ShareProtocol.encodeKex(
                 Kex(v = 1, salt = SessionCrypto.encodeSecretB64Url(saltS), confirm = keys.confirmB64))))
-            // The next frame is the encrypted Hello; a decrypt failure ⇒ wrong/missing key.
+            // The next frame is the encrypted Hello. Distinguish the failure modes so the close
+            // reason is honest: a drop/late frame is a timeout, not a wrong key.
             val helloFrame = withTimeoutOrNull(10_000L) { runCatching { ws.incoming.receive() }.getOrNull() }
-            val helloText = (helloFrame as? Frame.Binary)?.let {
-                runCatching { clientCipher.decrypt(it.data) }.getOrNull()
+            if (helloFrame == null) {
+                ws.close(CloseReason(CloseReason.Codes.GOING_AWAY, "Handshake timeout")); return
             }
+            if (helloFrame !is Frame.Binary) {
+                ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "Expected an encrypted handshake")); return
+            }
+            val helloText = runCatching { clientCipher.decrypt(helloFrame.data) }.getOrNull()
             if (helloText == null) {
-                ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "Wrong or missing encryption key"))
-                return
+                ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "Wrong or missing encryption key")); return
             }
             hello = runCatching { ShareProtocol.decodeClient(helloText) }.getOrNull() as? ClientMessage.Hello
         } else {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -727,6 +727,14 @@ object SessionShareManager {
             }
             hello = runCatching { ShareProtocol.decodeClient(helloText) }.getOrNull() as? ClientMessage.Hello
         } else {
+            // A plaintext first-frame: allowed on LAN/loopback (no relay), but refused on a
+            // public tunnel/Funnel share — there it'd stream unencrypted through the relay, so an
+            // old/keyless client must update rather than silently downgrade.
+            if (requireE2E()) {
+                ws.close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT,
+                    "This shared session is end-to-end encrypted — update BossTerm to connect."))
+                return
+            }
             hello = (first as? Frame.Text)?.let {
                 runCatching { ShareProtocol.decodeClient(it.readText()) }.getOrNull()
             } as? ClientMessage.Hello
@@ -846,6 +854,20 @@ object SessionShareManager {
         if (url.startsWith("https://", ignoreCase = true)) return true
         val h = hostOf(url).lowercase()
         return h == "localhost" || h == "::1" || h.startsWith("127.")
+    }
+
+    /**
+     * Whether the host should REQUIRE end-to-end encryption (reject a plaintext handshake). True
+     * only when the session is reachable over a public tunnel/Funnel (or a configured public
+     * https URL): there the relay is the threat and every link we hand out carries `#k`, so a
+     * plaintext client is an out-of-date one that would otherwise stream unencrypted through the
+     * relay. Plain-LAN/loopback http has no relay, so plaintext stays allowed there.
+     */
+    private fun requireE2E(): Boolean {
+        val url = remoteUrl
+            ?: SettingsManager.instance.settings.value.sessionSharingPublicUrl.takeIf { it.isNotBlank() }
+            ?: return false
+        return e2eCapable(url)
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -33,6 +33,14 @@ object ShareProtocol {
     fun encodeClient(msg: ClientMessage): String = json.encodeToString(ClientMessage.serializer(), msg)
     fun decodeServer(text: String): ServerMessage = json.decodeFromString(ServerMessage.serializer(), text)
 
+    // ---- E2E key-exchange handshake ([SessionCrypto]) ----
+    // The ONLY plaintext frames once a connection is encrypted: client sends its salt, host
+    // replies with its salt + a key-confirmation tag. After this both sides derive per-connection
+    // AES-GCM keys and every subsequent frame is an encrypted binary frame. Sent/parsed on its own
+    // (not a Server/ClientMessage — those become the encrypted payloads).
+    fun encodeKex(k: Kex): String = json.encodeToString(Kex.serializer(), k)
+    fun decodeKex(text: String): Kex? = runCatching { json.decodeFromString(Kex.serializer(), text) }.getOrNull()
+
     /**
      * SHA-256 hex of [s]. Used as [TabNode.origin]: identifies which share a mirror tab came
      * from without leaking the share token itself to viewers.
@@ -41,6 +49,19 @@ object ShareProtocol {
         java.security.MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
             .joinToString("") { "%02x".format(it) }
 }
+
+/**
+ * E2E key-exchange frame ([SessionCrypto]). [v] = protocol version; [salt] = this side's 16-byte
+ * HKDF salt (base64url); [confirm] = the host's key-confirmation tag (base64url), null on the
+ * client's opening frame. Plaintext — it carries no secret (salts are public; the key lives only
+ * in the link fragment).
+ */
+@Serializable
+data class Kex(
+    val v: Int = 1,
+    val salt: String,
+    val confirm: String? = null,
+)
 
 /** Host → viewer messages. */
 @Serializable

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -245,6 +245,13 @@ fun ShareWindow(
                 Spacer(Modifier.height(20.dp))
 
                 ShareSection("Links", headerAction = headerActions) {
+                    info.e2eCode?.let { code ->
+                        Text(
+                            "🔒 End-to-end encrypted · code $code — the relay can't read this session. " +
+                                "The same code shows on the viewer; matching codes confirm the key end-to-end.",
+                            color = AccentColor, fontSize = 11.sp
+                        )
+                    }
                     LinkRow("View (read-only)", info.url, clipboard)
                     LinkRow("Control (can type)", info.controlUrl, clipboard)
                     Text(

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -164,6 +164,7 @@
     <div id="tabbar"></div>
     <span class="badge" id="viewonly">view only</span>
     <span class="badge" id="presence"></span>
+    <span class="badge" id="e2e" title="End-to-end encrypted — compare this code with the one in the host's Share dialog" style="display:none"></span>
     <span class="badge" id="dims" title="Host terminal size (columns × rows)"></span>
     <span id="zoom">
       <button id="splittabs" title="Show a split tab one pane at a time — switch panes via the sub-tab chips (on by default on phones)">⊞ Panes</button>

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -92,6 +92,14 @@
       el.style.display = "";
     }).catch(function () {});
   }
+  // Length-checked constant-time string compare for the key-confirmation tag (matches the
+  // host's MessageDigest.isEqual). No network oracle exists here, but it costs nothing.
+  function constantTimeEq(a, b) {
+    if (typeof a !== "string" || typeof b !== "string" || a.length !== b.length) return false;
+    var diff = 0;
+    for (var i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    return diff === 0;
+  }
   var cryptoFailed = false;
   function onCryptoFailure() {
     if (cryptoFailed) return;
@@ -172,7 +180,7 @@
     if (canE2E) {
       sendChain = sendChain.then(function () { return encryptFrame(JSON.stringify(o)); })
         .then(function (buf) { if (ws && ws.readyState === WebSocket.OPEN) ws.send(buf); })
-        .catch(function () {});
+        .catch(function () { onCryptoFailure(); }); // never silently drop a keystroke
     } else {
       ws.send(JSON.stringify(o));
     }
@@ -1507,8 +1515,14 @@
       if (typeof ev.data !== "string") return;
       var k; try { k = JSON.parse(ev.data); } catch (e) { return; }
       if (k.salt == null) return;
+      if (k.v && k.v !== 1) { // a newer host we can't speak to
+        sessionEnded = true;
+        showOverlay("Update BossTerm", "This session uses a newer encryption version than this viewer.", false);
+        try { ws.close(); } catch (e) {}
+        return;
+      }
       deriveSessionKeys(secretBytes, saltC, b64urlToBytes(k.salt)).then(function (keys) {
-        if (!k.confirm || keys.confirmB64 !== k.confirm) { onCryptoFailure(); return; }
+        if (!constantTimeEq(keys.confirmB64, k.confirm)) { onCryptoFailure(); return; }
         crypState.kc2s = keys.kc2s; crypState.ks2c = keys.ks2c; crypState.ready = true;
         showE2EBadge();
         if (!sentHello) sendHello();
@@ -1519,6 +1533,8 @@
     if (canE2E) {
       recvChain = recvChain.then(function () { return decryptFrame(ev.data); })
         .then(function (text) { var m; try { m = JSON.parse(text); } catch (e) { return; } dispatch(m); })
+        // A decrypt failure ends the session (onCryptoFailure closes the socket, so no further
+        // frames arrive); don't rethrow — that would leave a dangling unhandled rejection.
         .catch(function () { onCryptoFailure(); });
       return;
     }

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -12,6 +12,96 @@
   var params = new URLSearchParams(location.search);
   var token = params.get("t");
 
+  // ---- end-to-end encryption ----
+  // The session secret rides in the URL fragment (#k=…), which the browser never sends to any
+  // server — so the relay (e.g. a Cloudflare tunnel that terminates TLS) never sees it. From it
+  // we derive per-connection AES-GCM keys and encrypt every frame, exactly mirroring the host's
+  // SessionCrypto.kt. Requires a secure context (https / localhost) for crypto.subtle; a
+  // plain-LAN http link (no #k, no subtle) stays on the legacy plaintext path unchanged.
+  var hashParams = new URLSearchParams((location.hash || "").replace(/^#/, ""));
+  var secretB64 = hashParams.get("k");
+  var canE2E = !!(secretB64 && window.isSecureContext && window.crypto && crypto.subtle);
+  // Secure context + crypto, but the link lost its #k → a truncated link. A current host always
+  // mints #k for https, so this isn't an old-host case (the host serves this very script). Refuse
+  // rather than silently downgrade to plaintext over the relay.
+  var e2eMissing = !secretB64 && window.isSecureContext && !!(window.crypto && crypto.subtle);
+  var enc = new TextEncoder(), dec = new TextDecoder();
+  var crypState = { ready: false, kc2s: null, ks2c: null }; // AES-GCM CryptoKeys, post-handshake
+  var saltC = null, secretBytes = null;
+  var sendChain = Promise.resolve(), recvChain = Promise.resolve(); // ORDERING queues (see sendMsg/onmessage)
+  function b64urlToBytes(s) {
+    s = String(s).replace(/-/g, "+").replace(/_/g, "/");
+    while (s.length % 4) s += "=";
+    var bin = atob(s), b = new Uint8Array(bin.length);
+    for (var i = 0; i < bin.length; i++) b[i] = bin.charCodeAt(i);
+    return b;
+  }
+  function bytesToB64url(b) {
+    var s = "";
+    for (var i = 0; i < b.length; i++) s += String.fromCharCode(b[i]);
+    return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+  function randBytes(n) { var b = new Uint8Array(n); crypto.getRandomValues(b); return b; }
+  function concatBytes(a, b) { var c = new Uint8Array(a.length + b.length); c.set(a, 0); c.set(b, a.length); return c; }
+  function hkdf256(baseKey, salt, infoStr) {
+    return crypto.subtle.deriveBits(
+      { name: "HKDF", hash: "SHA-256", salt: salt, info: enc.encode(infoStr) }, baseKey, 256);
+  }
+  // Derive {kc2s, ks2c, confirm} from secret + both salts — same labels as the host.
+  function deriveSessionKeys(secret, sc, ss) {
+    var salt = concatBytes(sc, ss);
+    return crypto.subtle.importKey("raw", secret, "HKDF", false, ["deriveBits"]).then(function (base) {
+      return Promise.all([
+        hkdf256(base, salt, "bossterm-c2s-v1"),
+        hkdf256(base, salt, "bossterm-s2c-v1"),
+        hkdf256(base, salt, "bossterm-kc-v1"),
+      ]).then(function (r) {
+        return Promise.all([
+          crypto.subtle.importKey("raw", r[0], "AES-GCM", false, ["encrypt"]),
+          crypto.subtle.importKey("raw", r[1], "AES-GCM", false, ["decrypt"]),
+        ]).then(function (keys) {
+          return { kc2s: keys[0], ks2c: keys[1], confirmB64: bytesToB64url(new Uint8Array(r[2])) };
+        });
+      });
+    });
+  }
+  // Frame = nonce(12) || AES-256-GCM(ciphertext||tag), AAD = 1 direction byte (0x00 c2s, 0x01 s2c).
+  function encryptFrame(text) {
+    var iv = randBytes(12);
+    return crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: iv, additionalData: new Uint8Array([0x00]), tagLength: 128 },
+      crypState.kc2s, enc.encode(text)
+    ).then(function (ct) { return concatBytes(iv, new Uint8Array(ct)).buffer; });
+  }
+  function decryptFrame(buf) {
+    var u = new Uint8Array(buf), iv = u.subarray(0, 12), body = u.subarray(12);
+    return crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: iv, additionalData: new Uint8Array([0x01]), tagLength: 128 },
+      crypState.ks2c, body
+    ).then(function (pt) { return dec.decode(pt); });
+  }
+  // Show the verification code (first 8 hex of SHA-256 of the secret) so the user can compare
+  // it against the host's Share dialog — matching codes confirm the same untampered key.
+  function showE2EBadge() {
+    var el = document.getElementById("e2e");
+    if (!el || !secretBytes) return;
+    crypto.subtle.digest("SHA-256", secretBytes).then(function (h) {
+      var b = new Uint8Array(h), s = "";
+      for (var i = 0; i < 4; i++) s += ("0" + b[i].toString(16)).slice(-2);
+      el.textContent = "🔒 " + s;
+      el.style.display = "";
+    }).catch(function () {});
+  }
+  var cryptoFailed = false;
+  function onCryptoFailure() {
+    if (cryptoFailed) return;
+    cryptoFailed = true;
+    sessionEnded = true; // terminal — don't let "Disconnected" overwrite it
+    showOverlay("This link is missing its key",
+      "Re-copy the full share link from BossTerm — it must include the part after #.", false);
+    try { ws.close(); } catch (e) {}
+  }
+
   var statusEl = document.getElementById("status");
   var tabbarEl = document.getElementById("tabbar");
   var sidebarEl = document.getElementById("sidebar");
@@ -75,7 +165,18 @@
     if (tsaClearTimer) clearTimeout(tsaClearTimer);
     tsaClearTimer = setTimeout(function () { touchScrollActive = false; tsaClearTimer = null; }, 250);
   }
-  function sendMsg(o) { if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(o)); }
+  // Send a client message. E2E: encrypt then send, through an ORDERED promise chain so two
+  // rapid keystrokes can't be reordered by async encrypt resolution. Plaintext: send directly.
+  function sendMsg(o) {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    if (canE2E) {
+      sendChain = sendChain.then(function () { return encryptFrame(JSON.stringify(o)); })
+        .then(function (buf) { if (ws && ws.readyState === WebSocket.OPEN) ws.send(buf); })
+        .catch(function () {});
+    } else {
+      ws.send(JSON.stringify(o));
+    }
+  }
 
   // ☰ toggles the left tab drawer (phone); tapping a tab closes it (see selectPane).
   menubtnEl.onclick = function () { sidebarEl.classList.toggle("open"); };
@@ -1386,14 +1487,46 @@
   // ---- websocket ----
   var wsProto = location.protocol === "https:" ? "wss" : "ws";
   ws = new WebSocket(wsProto + "://" + location.host + "/ws/" + encodeURIComponent(token));
+  if (canE2E) { ws.binaryType = "arraybuffer"; secretBytes = b64urlToBytes(secretB64); saltC = randBytes(16); }
+  var sentHello = false;
+  function sendHello() { sentHello = true; sendMsg({ t: "hello", name: deviceName(), clientId: clientId, key: loadKey() }); }
 
   ws.onopen = function () {
+    if (e2eMissing) { onCryptoFailure(); return; } // truncated link — don't downgrade to plaintext
     setStatus("live");
-    ws.send(JSON.stringify({ t: "hello", name: deviceName(), clientId: clientId, key: loadKey() }));
+    // E2E: open with a plaintext Kex (our salt); the Hello waits until keys are derived from
+    // the host's reply. Plaintext: send the Hello immediately, as before.
+    if (canE2E) ws.send(JSON.stringify({ t: "kex", v: 1, salt: bytesToB64url(saltC) }));
+    else sendHello();
   };
 
   ws.onmessage = function (ev) {
+    // E2E handshake: the host's reply is a plaintext Kex (a string frame). Derive keys, verify
+    // its confirmation tag (wrong/missing #k ⇒ fail loudly), then send the encrypted Hello.
+    if (canE2E && !crypState.ready) {
+      if (typeof ev.data !== "string") return;
+      var k; try { k = JSON.parse(ev.data); } catch (e) { return; }
+      if (k.salt == null) return;
+      deriveSessionKeys(secretBytes, saltC, b64urlToBytes(k.salt)).then(function (keys) {
+        if (!k.confirm || keys.confirmB64 !== k.confirm) { onCryptoFailure(); return; }
+        crypState.kc2s = keys.kc2s; crypState.ks2c = keys.ks2c; crypState.ready = true;
+        showE2EBadge();
+        if (!sentHello) sendHello();
+      }).catch(function () { onCryptoFailure(); });
+      return;
+    }
+    // E2E steady state: decrypt (ORDERED, so PaneOutput applies in order) then dispatch.
+    if (canE2E) {
+      recvChain = recvChain.then(function () { return decryptFrame(ev.data); })
+        .then(function (text) { var m; try { m = JSON.parse(text); } catch (e) { return; } dispatch(m); })
+        .catch(function () { onCryptoFailure(); });
+      return;
+    }
     var m; try { m = JSON.parse(ev.data); } catch (e) { return; }
+    dispatch(m);
+  };
+
+  function dispatch(m) {
     switch (m.t) {
       case "pending":
         showOverlay("Waiting for host approval…",

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/remote/RemoteLinkParsingTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/remote/RemoteLinkParsingTest.kt
@@ -3,6 +3,7 @@ package ai.rever.bossterm.compose.remote
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.test.assertFailsWith
 
 /**
@@ -54,5 +55,22 @@ class RemoteLinkParsingTest {
     @Test
     fun `toWsUrl rejects a hostless link instead of producing wss to null`() {
         assertFailsWith<IllegalArgumentException> { conn().toWsUrl("file:///foo?t=tok") }
+    }
+
+    @Test
+    fun `secretOf extracts the e2e key from the fragment`() {
+        val secret = ai.rever.bossterm.compose.share.SessionCrypto.newSessionSecret()
+        val k = ai.rever.bossterm.compose.share.SessionCrypto.encodeSecretB64Url(secret)
+        val c = conn()
+        assertTrue(secret.contentEquals(c.secretOf("https://h/?t=tok#k=$k")))        // sole fragment param
+        assertTrue(secret.contentEquals(c.secretOf("https://h/?t=tok#x=1&k=$k")))    // mixed with others
+    }
+
+    @Test
+    fun `secretOf is null when the fragment is absent or has no k`() {
+        val c = conn()
+        assertNull(c.secretOf("https://h/?t=tok"))      // no fragment (plaintext / LAN link)
+        assertNull(c.secretOf("https://h/?t=tok#x=1"))   // fragment without k=
+        assertNull(c.secretOf("https://h/?t=tok#k="))    // blank key
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionCryptoTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionCryptoTest.kt
@@ -1,0 +1,105 @@
+package ai.rever.bossterm.compose.share
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import javax.crypto.AEADBadTagException
+
+/**
+ * Covers [SessionCrypto]: the HKDF derivation (pinned to an RFC 5869 vector so it can't silently
+ * diverge from the browser's WebCrypto HKDF), AES-GCM round-trips, and the wrong-key / wrong-
+ * direction failure paths the handshake relies on.
+ */
+class SessionCryptoTest {
+
+    private fun hex(s: String): ByteArray =
+        s.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    @Test
+    fun `hkdf matches RFC 5869 test case 1`() {
+        // The canonical HKDF-SHA256 vector — WebCrypto's deriveBits({name:"HKDF",hash:"SHA-256"})
+        // produces the same OKM, so this pins Kotlin↔JS key derivation parity.
+        val ikm = hex("0b".repeat(22))
+        val salt = hex("000102030405060708090a0b0c")
+        val info = hex("f0f1f2f3f4f5f6f7f8f9")
+        val okm = SessionCrypto.hkdf(ikm, salt, info, 42)
+        assertEquals(
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+            okm.joinToString("") { "%02x".format(it) },
+        )
+    }
+
+    @Test
+    fun `deriveKeys are distinct, deterministic, and salt-sensitive`() {
+        val secret = SessionCrypto.newSessionSecret()
+        val sc = SessionCrypto.randomSalt()
+        val ss = SessionCrypto.randomSalt()
+        val a = SessionCrypto.deriveKeys(secret, sc, ss)
+        val b = SessionCrypto.deriveKeys(secret, sc, ss)
+        // c2s != s2c (different info labels)
+        assertFalse(a.kC2s.contentEquals(a.kS2c))
+        // deterministic for the same inputs
+        assertTrue(a.kC2s.contentEquals(b.kC2s) && a.kS2c.contentEquals(b.kS2c) && a.confirm.contentEquals(b.confirm))
+        // different salts → different keys
+        val c = SessionCrypto.deriveKeys(secret, SessionCrypto.randomSalt(), ss)
+        assertFalse(a.kC2s.contentEquals(c.kC2s))
+    }
+
+    @Test
+    fun `frame cipher round-trips both directions incl multibyte`() {
+        val keys = SessionCrypto.deriveKeys(SessionCrypto.newSessionSecret(), SessionCrypto.randomSalt(), SessionCrypto.randomSalt())
+        val payload = "{\"t\":\"paneOutput\",\"data\":\"héllo [31mworld[0m 🌍 \"}"
+        // c2s
+        val c2s = SessionCrypto.FrameCipher(keys.kC2s, SessionCrypto.DIR_C2S)
+        assertEquals(payload, c2s.decrypt(c2s.encrypt(payload)))
+        // s2c
+        val s2c = SessionCrypto.FrameCipher(keys.kS2c, SessionCrypto.DIR_S2C)
+        assertEquals(payload, s2c.decrypt(s2c.encrypt(payload)))
+        // nonce is random → two encryptions of the same text differ
+        assertFalse(c2s.encrypt(payload).contentEquals(c2s.encrypt(payload)))
+    }
+
+    @Test
+    fun `wrong key fails authentication`() {
+        val k1 = SessionCrypto.deriveKeys(SessionCrypto.newSessionSecret(), SessionCrypto.randomSalt(), SessionCrypto.randomSalt())
+        val k2 = SessionCrypto.deriveKeys(SessionCrypto.newSessionSecret(), SessionCrypto.randomSalt(), SessionCrypto.randomSalt())
+        val frame = SessionCrypto.FrameCipher(k1.kS2c, SessionCrypto.DIR_S2C).encrypt("secret output")
+        assertFailsWith<AEADBadTagException> {
+            SessionCrypto.FrameCipher(k2.kS2c, SessionCrypto.DIR_S2C).decrypt(frame)
+        }
+    }
+
+    @Test
+    fun `wrong direction AAD fails authentication`() {
+        val keys = SessionCrypto.deriveKeys(SessionCrypto.newSessionSecret(), SessionCrypto.randomSalt(), SessionCrypto.randomSalt())
+        // Encrypt as c2s, try to decrypt with a c2s-keyed cipher but s2c direction byte.
+        val frame = SessionCrypto.FrameCipher(keys.kC2s, SessionCrypto.DIR_C2S).encrypt("x")
+        assertFailsWith<AEADBadTagException> {
+            SessionCrypto.FrameCipher(keys.kC2s, SessionCrypto.DIR_S2C).decrypt(frame)
+        }
+    }
+
+    @Test
+    fun `confirm tag matches only for the right secret`() {
+        val secret = SessionCrypto.newSessionSecret()
+        val sc = SessionCrypto.randomSalt(); val ss = SessionCrypto.randomSalt()
+        val host = SessionCrypto.deriveKeys(secret, sc, ss)
+        val client = SessionCrypto.deriveKeys(secret, sc, ss)
+        assertTrue(SessionCrypto.confirmMatches(client.confirm, host.confirmB64))
+        val wrong = SessionCrypto.deriveKeys(SessionCrypto.newSessionSecret(), sc, ss)
+        assertFalse(SessionCrypto.confirmMatches(wrong.confirm, host.confirmB64))
+        assertFalse(SessionCrypto.confirmMatches(client.confirm, null))
+    }
+
+    @Test
+    fun `secret b64url round-trips and fingerprint is stable`() {
+        val s = SessionCrypto.newSessionSecret()
+        assertTrue(s.contentEquals(SessionCrypto.decodeSecretB64Url(SessionCrypto.encodeSecretB64Url(s))))
+        assertEquals(SessionCrypto.fingerprint(s), SessionCrypto.fingerprint(s))
+        assertEquals(8, SessionCrypto.fingerprint(s).length)
+        assertNotEquals(SessionCrypto.fingerprint(s), SessionCrypto.fingerprint(SessionCrypto.newSessionSecret()))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -2,6 +2,8 @@ package ai.rever.bossterm.compose.share
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.assertIs
 
@@ -67,6 +69,23 @@ class ShareProtocolTest {
         val cw = ShareProtocol.decodeClient("""{"t":"closeWindow","windowId":"w1"}""")
         assertIs<ClientMessage.CloseWindow>(cw)
         assertEquals("w1", cw.windowId)
+    }
+
+    @Test
+    fun `decodeKex distinguishes a Kex from a Hello (the E2E vs plaintext fork)`() {
+        // The host's serveViewer relies entirely on decodeKex returning null for a non-Kex first
+        // frame to pick the legacy plaintext path. Lock that behavior down.
+        val kex = ShareProtocol.decodeKex("""{"t":"kex","v":1,"salt":"YWJjZGVm"}""")
+        assertNotNull(kex)
+        assertEquals(1, kex.v)
+        assertEquals("YWJjZGVm", kex.salt)
+
+        // A real Hello has no salt → must NOT decode as a Kex (→ plaintext path).
+        assertNull(ShareProtocol.decodeKex("""{"t":"hello","name":"phone","clientId":"c1"}"""))
+        // A saltless object likewise fails (salt is required, no default).
+        assertNull(ShareProtocol.decodeKex("""{"v":1}"""))
+        // Garbage / non-JSON is tolerated (null, not a throw).
+        assertNull(ShareProtocol.decodeKex("not json"))
     }
 
     @Test


### PR DESCRIPTION
## End-to-end encryption for session sharing

Tunnel shares (Cloudflare quick-tunnel, the default for remote access) terminate TLS **at the relay** — so `wss` alone let Cloudflare read the terminal stream and keystrokes. This adds true E2E so the relay carries only ciphertext.

### How it works
- A 32-byte session secret rides in the share link's **URL fragment** (`…#k=…`). Browsers never transmit fragments to any server, so the relay never sees the key. The `?t=` token still routes the connection and selects view/control role server-side (unchanged).
- Handshake: client sends a plaintext `Kex{salt}`; host replies `Kex{salt,confirm}`. Both derive per-connection keys via **HKDF-SHA256** (matches the browser's WebCrypto; pinned to the RFC-5869 vector in tests) → `kC2s`, `kS2c`, plus a key-confirmation tag. After that every frame is binary `nonce(12) ‖ AES-256-GCM ‖ tag(16)`, AAD = 1 direction byte, wrapping the **unchanged** ShareProtocol JSON. The reconnect grant key now travels encrypted too.
- **Per-connection gating:** a client holding `#k` speaks the encrypted handshake; the host follows. `#k` is minted only for browser-secure-context links (https tunnel/Tailscale or loopback); plain-LAN `http://` stays plaintext (no relay, no `crypto.subtle`).
- **Enforcement:** on a public tunnel/Funnel share, a plaintext first-frame is **rejected** (host sends a plaintext `Denied("update BossTerm…")` then closes) so an out-of-date client can't silently downgrade to unencrypted-through-the-relay. LAN/loopback shares still accept plaintext.
- **Verification code:** SHA-256 fingerprint of the secret shown in the host Share dialog and as a `🔒` badge in the viewer for out-of-band comparison.

### Clients
- **Native in-app client** — fully end-to-end (its code ships in the app). An https link missing its `#k` fails loudly.
- **Browser viewer** — does the handshake via WebCrypto with ordered async send/recv queues (keystroke + output ordering); a truncated link or wrong key shows a clear overlay instead of a silent downgrade.

### Known limitation (documented)
The host serves `viewer.js` through the same tunnel, so the browser viewer is E2E against a **passive** relay; an *active* relay could tamper the served JS. The native client has no such exposure. Trusted-origin viewer hosting is a future follow-up.

### Tests
`SessionCryptoTest` (RFC-5869 HKDF KAT, round-trips, wrong-key/wrong-direction auth failures, confirm tag), `ShareProtocolTest` (Kex round-trip + Kex-vs-Hello fork), `RemoteLinkParsingTest` (`secretOf`). Both modules compile; `viewer.js` syntax-checks; legacy plaintext path is regression-free.

### Verification
- Cloudflare share → link has `#k=`; browser (https) + native client connect encrypted; `🔒` codes match the dialog.
- DevTools → Network → WS: post-handshake frames are opaque binary (only the two `Kex` frames are readable).
- Strip the `#…` → loud "missing key"; flip a char in `#k` → wrong-key close.
- Old client on a tunnel link → "update BossTerm" message (no silent plaintext); LAN `http://` share → still works plaintext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
