### PR TITLE
Web viewer: Enter key + iOS soft-keyboard fixes for the on-screen key strip

### DIFF
--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -54,8 +54,12 @@
        pin it just above the soft keyboard (via the VisualViewport API). */
     #keybar { display: none; position: fixed; left: 0; right: 0; bottom: 0; z-index: 30; gap: 6px; padding: 6px 8px;
               background: #2b2b2b; border-top: 1px solid #404040; overflow-x: auto; -webkit-overflow-scrolling: touch; }
-    .keybtn { flex: 0 0 auto; min-width: 42px; padding: 9px 12px; border-radius: 6px; border: 1px solid #505050;
-              background: #1e1e1e; color: #ddd; font-size: 14px; cursor: pointer; -webkit-user-select: none; user-select: none; }
+    /* divs (not buttons) so tapping never blurs the terminal textarea / drops the iOS
+       keyboard; flex-centered since divs don't center text like a <button>. */
+    .keybtn { flex: 0 0 auto; min-width: 42px; box-sizing: border-box; display: inline-flex;
+              align-items: center; justify-content: center; padding: 9px 12px; border-radius: 6px;
+              border: 1px solid #505050; background: #1e1e1e; color: #ddd; font-size: 14px;
+              cursor: pointer; -webkit-user-select: none; user-select: none; }
     .keybtn:active { background: #4a90e2; color: #fff; border-color: #4a90e2; }
 
     /* zoom controls in the top bar (font size +/- and fit-to-width) */

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -288,46 +288,45 @@
       b.style.background = on ? "#4a90e2" : ""; b.style.color = on ? "#fff" : "";
       b.style.borderColor = on ? "#4a90e2" : "";
     }
+    function fire() { if (seq != null) sendKey(seq); focusCurrent(); }
     var sx = 0, sy = 0, moved = false, touched = false;
-    // iOS Safari: only preventDefault on the TOUCH events keeps focus on the terminal's
-    // hidden textarea — pointer/mouse preventDefault does NOT cancel the focus shift, so a
-    // tap blurs it and the keyboard drops. touchstart preventDefault also blocks the
-    // synthetic click; we send on touchend instead.
+    // The keys are <div>s, NOT <button>s: a non-focusable element doesn't steal focus from
+    // the terminal's hidden textarea on iOS, so the soft keyboard stays up WITHOUT a
+    // touchstart preventDefault — which means a horizontal swipe still scrolls the key bar
+    // natively (overflow-x). A 10px move-guard tells a swipe from a tap.
     b.addEventListener("touchstart", function (e) {
-      e.preventDefault();
       touched = true; moved = false;
       var t = e.touches[0]; if (t) { sx = t.clientX; sy = t.clientY; }
       hl(true);
-    }, { passive: false });
+    }, { passive: true });
     b.addEventListener("touchmove", function (e) {
       var t = e.touches[0]; if (!t) return;
-      if (Math.abs(t.clientX - sx) > 10 || Math.abs(t.clientY - sy) > 10) moved = true;
-    }, { passive: false });
+      if (Math.abs(t.clientX - sx) > 10 || Math.abs(t.clientY - sy) > 10) { moved = true; hl(false); }
+    }, { passive: true });
     b.addEventListener("touchend", function (e) {
-      e.preventDefault();
       hl(false);
-      if (!moved) { sendKey(seq); focusCurrent(); }
+      if (!moved) { e.preventDefault(); fire(); } // preventDefault stops the synthetic click
     }, { passive: false });
     b.addEventListener("touchcancel", function () { hl(false); });
-    // Desktop mouse: preventDefault on mousedown keeps focus; the click sends. (Suppressed
-    // after a touch sequence so a touch device doesn't double-fire via synthetic click.)
+    // Desktop mouse: keep focus on mousedown; the click fires. (Suppressed after a touch
+    // sequence so a touch device doesn't double-fire via the synthetic click.)
     b.addEventListener("mousedown", function (e) { e.preventDefault(); });
     b.addEventListener("click", function () {
       if (touched) { touched = false; return; }
-      sendKey(seq); focusCurrent();
+      fire();
     });
   }
   function buildKeybar() {
     keybarEl.innerHTML = "";
     if (!controlGranted) { keybarEl.style.display = "none"; layoutForKeyboard(); return; }
     keybarEl.style.display = "flex";
-    var kb = document.createElement("button");
+    var kb = document.createElement("div");
     kb.className = "keybtn"; kb.textContent = "⌨"; kb.title = "Show keyboard";
-    kb.onclick = focusCurrent;
+    wireKeyButton(kb, null); // null seq → just (re)focuses to summon the keyboard
     keybarEl.appendChild(kb);
     KEY_ROW.forEach(function (k) {
-      var b = document.createElement("button");
-      b.className = "keybtn"; b.textContent = k[0]; b.type = "button";
+      var b = document.createElement("div");
+      b.className = "keybtn"; b.textContent = k[0];
       wireKeyButton(b, k[1]);
       keybarEl.appendChild(b);
     });

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -265,6 +265,31 @@
     if (!currentPaneId) return;
     sendInput(currentPaneId, seq);
   }
+  // Wire a key-strip button so pressing it NEVER dismisses the soft keyboard: preventDefault
+  // on pointerdown stops the button from stealing focus off the terminal's hidden textarea
+  // (a plain click — esp. Enter/⏎ — otherwise blurs it and drops the keyboard). Fire on
+  // pointerup with a move-guard so a horizontal scroll of the bar doesn't send a key; refocus
+  // the textarea defensively to keep the keyboard up.
+  function wireKeyButton(b, seq) {
+    var px = 0, py = 0, moved = false;
+    b.addEventListener("pointerdown", function (e) {
+      e.preventDefault(); // keep focus on the terminal → keyboard stays up
+      px = e.clientX; py = e.clientY; moved = false;
+      b.style.background = "#4a90e2"; b.style.color = "#fff"; b.style.borderColor = "#4a90e2";
+    });
+    b.addEventListener("pointermove", function (e) {
+      if (Math.abs(e.clientX - px) > 10 || Math.abs(e.clientY - py) > 10) moved = true;
+    });
+    function clear() { b.style.background = ""; b.style.color = ""; b.style.borderColor = ""; }
+    b.addEventListener("pointerup", function (e) {
+      e.preventDefault();
+      clear();
+      if (!moved) { sendKey(seq); focusCurrent(); }
+    });
+    b.addEventListener("pointercancel", function () { clear(); moved = true; });
+    // Mouse fallback for any browser without pointer events.
+    if (!window.PointerEvent) b.onclick = function () { sendKey(seq); focusCurrent(); };
+  }
   function buildKeybar() {
     keybarEl.innerHTML = "";
     if (!controlGranted) { keybarEl.style.display = "none"; layoutForKeyboard(); return; }
@@ -275,10 +300,8 @@
     keybarEl.appendChild(kb);
     KEY_ROW.forEach(function (k) {
       var b = document.createElement("button");
-      b.className = "keybtn"; b.textContent = k[0];
-      // Don't steal focus from the terminal's input, so the soft keyboard stays up.
-      b.addEventListener("mousedown", function (e) { e.preventDefault(); });
-      b.onclick = function () { sendKey(k[1]); };
+      b.className = "keybtn"; b.textContent = k[0]; b.type = "button";
+      wireKeyButton(b, k[1]);
       keybarEl.appendChild(b);
     });
     layoutForKeyboard(); // reserve space + position above the keyboard

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -240,7 +240,12 @@
     }
     if (shift !== appliedShiftPx) {
       appliedShiftPx = shift;
+      // Transforming the focused textarea's ancestor blurs it on iOS (the keyboard drops —
+      // most visibly right after Enter advances the prompt). Re-assert focus afterward when
+      // the keyboard is up and the textarea was the active element.
+      var wasFocused = keyboardOpen && document.activeElement === activeTextarea();
       document.body.style.transform = shift ? "translateY(-" + shift + "px)" : "";
+      if (wasFocused) { var ta = activeTextarea(); if (ta) try { ta.focus({ preventScroll: true }); } catch (e) {} }
     }
     // The key bar rides the keyboard top regardless of how far the body shifted
     // (under a transform, fixed children position against the shifted body box).
@@ -258,8 +263,16 @@
     ["Esc", "\x1b"], ["Tab", "\t"], ["⏎", "\r"], ["^C", "\x03"], ["^D", "\x04"], ["^Z", "\x1a"], ["^L", "\x0c"],
     ["←", "\x1b[D"], ["↑", "\x1b[A"], ["↓", "\x1b[B"], ["→", "\x1b[C"]
   ];
+  function activeTextarea() {
+    var p = currentPaneId && panes[currentPaneId];
+    return p ? (p.term.textarea || p.host.querySelector(".xterm-helper-textarea")) : null;
+  }
   function focusCurrent() {
-    if (currentPaneId && panes[currentPaneId]) { try { panes[currentPaneId].term.focus(); } catch (e) {} }
+    // Focus the hidden textarea directly (term.focus() doesn't always re-summon the iOS
+    // soft keyboard); must run inside a user gesture for iOS to show the keyboard.
+    var ta = activeTextarea();
+    if (ta) { try { ta.focus({ preventScroll: true }); } catch (e) { try { ta.focus(); } catch (e2) {} } }
+    else if (currentPaneId && panes[currentPaneId]) { try { panes[currentPaneId].term.focus(); } catch (e) {} }
   }
   function sendKey(seq) {
     if (!currentPaneId) return;
@@ -271,24 +284,38 @@
   // pointerup with a move-guard so a horizontal scroll of the bar doesn't send a key; refocus
   // the textarea defensively to keep the keyboard up.
   function wireKeyButton(b, seq) {
-    var px = 0, py = 0, moved = false;
-    b.addEventListener("pointerdown", function (e) {
-      e.preventDefault(); // keep focus on the terminal → keyboard stays up
-      px = e.clientX; py = e.clientY; moved = false;
-      b.style.background = "#4a90e2"; b.style.color = "#fff"; b.style.borderColor = "#4a90e2";
-    });
-    b.addEventListener("pointermove", function (e) {
-      if (Math.abs(e.clientX - px) > 10 || Math.abs(e.clientY - py) > 10) moved = true;
-    });
-    function clear() { b.style.background = ""; b.style.color = ""; b.style.borderColor = ""; }
-    b.addEventListener("pointerup", function (e) {
+    function hl(on) {
+      b.style.background = on ? "#4a90e2" : ""; b.style.color = on ? "#fff" : "";
+      b.style.borderColor = on ? "#4a90e2" : "";
+    }
+    var sx = 0, sy = 0, moved = false, touched = false;
+    // iOS Safari: only preventDefault on the TOUCH events keeps focus on the terminal's
+    // hidden textarea — pointer/mouse preventDefault does NOT cancel the focus shift, so a
+    // tap blurs it and the keyboard drops. touchstart preventDefault also blocks the
+    // synthetic click; we send on touchend instead.
+    b.addEventListener("touchstart", function (e) {
       e.preventDefault();
-      clear();
+      touched = true; moved = false;
+      var t = e.touches[0]; if (t) { sx = t.clientX; sy = t.clientY; }
+      hl(true);
+    }, { passive: false });
+    b.addEventListener("touchmove", function (e) {
+      var t = e.touches[0]; if (!t) return;
+      if (Math.abs(t.clientX - sx) > 10 || Math.abs(t.clientY - sy) > 10) moved = true;
+    }, { passive: false });
+    b.addEventListener("touchend", function (e) {
+      e.preventDefault();
+      hl(false);
       if (!moved) { sendKey(seq); focusCurrent(); }
+    }, { passive: false });
+    b.addEventListener("touchcancel", function () { hl(false); });
+    // Desktop mouse: preventDefault on mousedown keeps focus; the click sends. (Suppressed
+    // after a touch sequence so a touch device doesn't double-fire via synthetic click.)
+    b.addEventListener("mousedown", function (e) { e.preventDefault(); });
+    b.addEventListener("click", function () {
+      if (touched) { touched = false; return; }
+      sendKey(seq); focusCurrent();
     });
-    b.addEventListener("pointercancel", function () { clear(); moved = true; });
-    // Mouse fallback for any browser without pointer events.
-    if (!window.PointerEvent) b.onclick = function () { sendKey(seq); focusCurrent(); };
   }
   function buildKeybar() {
     keybarEl.innerHTML = "";

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -255,7 +255,7 @@
 
   // ---- on-screen key bar (mobile control keys) ----
   var KEY_ROW = [
-    ["Esc", "\x1b"], ["Tab", "\t"], ["^C", "\x03"], ["^D", "\x04"], ["^Z", "\x1a"], ["^L", "\x0c"],
+    ["Esc", "\x1b"], ["Tab", "\t"], ["⏎", "\r"], ["^C", "\x03"], ["^D", "\x04"], ["^Z", "\x1a"], ["^L", "\x0c"],
     ["←", "\x1b[D"], ["↑", "\x1b[A"], ["↓", "\x1b[B"], ["→", "\x1b[C"]
   ];
   function focusCurrent() {


### PR DESCRIPTION
## Summary
Follow-ups to the phone-viewer work in #281, rebased onto current master (so it sits cleanly on top of the E2E work from #282 — no overlap).

- **Add an Enter (⏎) key** to the on-screen control-key strip (sends CR), between Tab and ^C — soft keyboards vary on how/whether they submit.
- **Key-strip taps no longer dismiss the iOS soft keyboard.** The keys are now `<div>`s instead of `<button>`s: a non-focusable element doesn't steal focus from the terminal's hidden textarea on iOS, so the keyboard stays up — *and* a horizontal swipe still scrolls the key bar natively (the earlier `touchstart` preventDefault that kept focus had blocked scrolling). A 10px move-guard distinguishes a swipe from a tap.
- **Fix the Enter aftershock on iOS.** When a command runs and the prompt advances, the cursor-aware keyboard-push rewrites `document.body`'s transform, and transforming the focused textarea's ancestor blurs it on iOS — the keyboard now re-asserts textarea focus right after the transform while it's open. `focusCurrent` targets the hidden textarea directly.

## Test plan
- `node --check viewer.js` passes; verified E2E (`encryptFrame`/`onCryptoFailure`/`sessionSecret`) is untouched.
- Manual (iOS Safari): tap ⏎/Esc/^C/arrows → fires and the keyboard stays up, including through the prompt advancing after Enter; swipe the key strip → scrolls horizontally; a swipe doesn't fire a key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)