### PR TITLE
Session sharing: embedder hook for "Fit host to my screen"

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -117,6 +117,8 @@ class MirrorShare(
         if (viewers.remove(vc)) {
             vc.outbox.close()
             broadcast(ServerMessage.Presence(viewers.size))
+            // Last viewer gone → undo any "fit host to my screen" resize.
+            if (viewers.isEmpty()) SessionShareManager.releaseEmbeddedFit(tabId)
         }
     }
 
@@ -303,6 +305,12 @@ class MirrorShare(
         val ch = tab.terminal.cellHeightPx
         if (cw <= 0f || ch <= 0f) return
         val cur = tab.display.termSize.value
+        // Embedded host (e.g. BossConsole): BossTerm doesn't own the OS window, so
+        // hand the resize to the embedder as a physical-px delta. It converts to its
+        // own units and resizes the window/pane (and restores it when the fit ends).
+        val dWpx = (cols - cur.columns) * cw
+        val dHpx = (rows - cur.rows) * ch
+        if (SessionShareManager.requestEmbeddedFit(tab.id, dWpx, dHpx)) return
         val tw = WindowManager.windows.firstOrNull { it.isWindowFocused.value && it.awtWindow != null }
             ?: WindowManager.windows.firstOrNull { it.awtWindow != null }
             ?: return

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -60,6 +60,49 @@ object SessionShareManager {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val mutex = Mutex()
 
+    /**
+     * Embedder hook for "Fit host to my screen" when BossTerm is hosted inside
+     * another app (e.g. BossConsole) and does NOT own its OS window — so
+     * [MirrorShare]'s own window-resize can't run (its [WindowManager] is
+     * empty). The embedder resizes its window/pane so the shared tab's grid
+     * approximates the viewer's, then restores it when the fit is released.
+     * Set once at startup by the embedder; left null in standalone bossterm-app
+     * (which resizes its real window directly).
+     */
+    interface FitHostEmbedder {
+        /** Grow/shrink the host so [tabId]'s grid ≈ the viewer's. Deltas are in
+         *  physical px (cellPx × grid-delta); the embedder converts to its own units. */
+        fun onFitHost(tabId: String, deltaWidthPx: Float, deltaHeightPx: Float)
+        /** Undo a prior [onFitHost] for [tabId] (sharing stopped / host interacted). */
+        fun onRestoreHostSize(tabId: String)
+    }
+
+    @Volatile
+    var fitHostEmbedder: FitHostEmbedder? = null
+    private val fitActiveTabs = ConcurrentHashMap.newKeySet<String>()
+
+    /**
+     * Apply an embedded "fit host" if an embedder is registered. Returns true if
+     * handled (caller skips the standalone window-resize path), false otherwise.
+     */
+    internal fun requestEmbeddedFit(tabId: String, deltaWidthPx: Float, deltaHeightPx: Float): Boolean {
+        val embedder = fitHostEmbedder ?: return false
+        fitActiveTabs.add(tabId)
+        runCatching { embedder.onFitHost(tabId, deltaWidthPx, deltaHeightPx) }
+        return true
+    }
+
+    /** Release a fit for [tabId] (if active) so the embedder restores its size. */
+    fun releaseEmbeddedFit(tabId: String) {
+        if (fitActiveTabs.remove(tabId)) {
+            runCatching { fitHostEmbedder?.onRestoreHostSize(tabId) }
+        }
+    }
+
+    /** Call from the terminal UI when the host user interacts with [tabId]; if a
+     *  remote-driven fit is active on that tab, it's released (window restores). */
+    fun notifyHostInteraction(tabId: String) = releaseEmbeddedFit(tabId)
+
     private var engine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
     @Volatile private var boundPort: Int? = null
     private var boundHost: String? = null
@@ -507,6 +550,7 @@ object SessionShareManager {
                 sharesByToken.remove(share.controlToken)
                 grants.values.removeIf { it.shareId == share.viewToken }
                 failPendingFor(tabId)
+                releaseEmbeddedFit(tabId) // sharing stopped → restore any fit-resized host window
                 share.stop()
                 _sharedTabIds.value = sharesByTab.keys.toSet()
                 if (sharesByTab.isEmpty()) stopEngineLocked()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -829,6 +829,11 @@ fun ProperTerminal(
     modifier = modifier
       .fillMaxSize()
       .onPreviewKeyEvent { keyEvent ->
+        if (keyEvent.type == KeyEventType.KeyDown) {
+          // The host user is interacting with this pane — release any remote
+          // "fit host to my screen" resize (no-op unless a fit is active here).
+          ai.rever.bossterm.compose.share.SessionShareManager.notifyHostInteraction(tab.id)
+        }
         // Handle Cmd+F toggle at the top level so it works regardless of which child has focus
         if (keyEvent.type == KeyEventType.KeyDown) {
           val action = actionRegistry.getAction("search")
@@ -914,6 +919,9 @@ fun ProperTerminal(
           // Skip if event was already consumed by an overlay (SearchBar, DebugPanel, etc.)
           if (change.isConsumed) return@onPointerEvent
           if (change.pressed && change.previousPressed.not()) {
+            // Host user clicked into this pane — release any remote "fit host"
+            // resize (no-op unless a fit is active here).
+            ai.rever.bossterm.compose.share.SessionShareManager.notifyHostInteraction(tab.id)
             // FIRST: Set pane focus before any other processing
             // This ensures split pane focus is set even when mouse events are
             // forwarded to terminal applications (like nvim with mouse reporting)


### PR DESCRIPTION
## Problem
When BossTerm is **embedded** (e.g. BossConsole) it doesn't own its OS window, so `WindowManager.windows` is empty and `MirrorShare.resizeHostWindow` hits its `?: return` — clicking **"Fit host to my screen"** in the web viewer does nothing to the visible shared pane.

## Change
Add a `SessionShareManager.FitHostEmbedder` seam the host sets once at startup:
```kotlin
interface FitHostEmbedder {
    fun onFitHost(tabId: String, deltaWidthPx: Float, deltaHeightPx: Float)
    fun onRestoreHostSize(tabId: String)
}
var fitHostEmbedder: FitHostEmbedder? = null
```
- `MirrorShare.resizeHostWindow` hands the embedded case to it as a **physical-px delta** (`cellPx × grid-delta`, same math the standalone window path uses), then returns. Standalone bossterm-app leaves the embedder null → unchanged (resizes its real window).
- Fit is **released** (embedder restores prior size) when: sharing stops / tab closes (`unshare`), the last viewer disconnects (`removeViewer`), or the host user types/clicks in the pane (`ProperTerminal` key/press → `notifyHostInteraction`, a cheap no-op unless a fit is active on that tab).

Pairs with BossConsole's new `WindowManager.fitWindowByDelta/restoreWindowSize` (risa-labs-inc/BossConsole#779) + a terminal-tab plugin change that implements `FitHostEmbedder` by reflecting into that host API.

## Testing
- `./gradlew :compose-ui:compileKotlinDesktop` ✅
- Behavioral verification lands once the plugin wires the embedder against a BossConsole with #779 (resize a shared pane from the viewer; revert on stop / local input).