### PR TITLE
MCP pill in the web viewer + 'Remote MCP' on remote groups (host parity)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1823,7 +1823,45 @@ fun TabbedTerminal(
                 tabController.activeTab?.id?.let { id -> s.upstreamFor(id)?.takeIf { it.readOnly } }
             }
         } else null
-        if (showMcpStatus || showSharingStatus || attachStatus != null || pendingShareRequests.isNotEmpty() ||
+        // "Remote MCP" pill: connected remote session(s) that reported their MCP state. Reading
+        // each session's mcpStatus Compose state here recomposes the strip when it changes.
+        val remoteMcpList = state?.remoteSessions?.sessions.orEmpty().mapNotNull { s ->
+            s.mcpStatus.value?.let { s to it }
+        }
+        val showRemoteMcp = remoteMcpList.isNotEmpty()
+        val remoteMcpOn = remoteMcpList.any { it.second.running }
+        // Build the toggle + Attach▸ items for one remote session (mirrors the local MCP menu
+        // minus the native "Settings…"); control-gated actions fall back to the request-control
+        // prompt when we're view-only on that remote.
+        fun remoteMcpItems(
+            s: ai.rever.bossterm.compose.remote.RemoteSession,
+            st: ai.rever.bossterm.compose.remote.RemoteSession.RemoteMcpStatus,
+        ): List<ai.rever.bossterm.compose.features.ContextMenuController.MenuElement> {
+            val attached = st.attached.toSet()
+            val gate: (() -> Unit) -> Unit = { act ->
+                if (s.canControlState.value) act() else requestControlPrompt = { s.requestControl() }
+            }
+            val attachSub = ai.rever.bossterm.compose.mcp.McpAttachTarget.entries.map { t ->
+                ai.rever.bossterm.compose.features.ContextMenuController.MenuItem(
+                    id = "rmcp_att_${t.persistenceKey}",
+                    label = (if (t.persistenceKey in attached) "✓ " else "") + t.displayName,
+                    enabled = true,
+                    action = { gate { s.attachRemoteMcp(t.persistenceKey) } },
+                )
+            }
+            return listOf(
+                ai.rever.bossterm.compose.features.ContextMenuController.MenuSubmenu(
+                    id = "rmcp_attach", label = "Attach", items = attachSub
+                ),
+                ai.rever.bossterm.compose.features.ContextMenuController.MenuItem(
+                    id = "rmcp_toggle",
+                    label = if (st.enabled) "Turn MCP off" else "Turn MCP on",
+                    enabled = true,
+                    action = { gate { s.setRemoteMcpEnabled(!st.enabled) } },
+                ),
+            )
+        }
+        if (showMcpStatus || showSharingStatus || showRemoteMcp || attachStatus != null || pendingShareRequests.isNotEmpty() ||
             viewOnlyRemote != null || upstreamReadOnly != null) {
             Column(
                 modifier = Modifier
@@ -1854,6 +1892,25 @@ fun TabbedTerminal(
                             onTurnOffRequest = { SettingsManager.instance.updateSetting { copy(mcpEnabled = false) } },
                             onTurnOnRequest = { SettingsManager.instance.updateSetting { copy(mcpEnabled = true) } },
                         ))
+                    },
+                    showRemoteMcp = showRemoteMcp,
+                    remoteMcpOn = remoteMcpOn,
+                    onRemoteMcpClick = {
+                        val items = if (remoteMcpList.size == 1) {
+                            val (s, st) = remoteMcpList.first()
+                            remoteMcpItems(s, st)
+                        } else {
+                            // Multiple remotes → one submenu per remote, labelled by its name.
+                            remoteMcpList.map { (s, st) ->
+                                ai.rever.bossterm.compose.features.ContextMenuController.MenuSubmenu(
+                                    id = "rmcp_sess_${s.link.hashCode()}",
+                                    label = s.customName.value ?: s.hostName.value
+                                        ?: runCatching { java.net.URI(s.link).host }.getOrNull() ?: "remote",
+                                    items = remoteMcpItems(s, st),
+                                )
+                            }
+                        }
+                        mcpMenu.showMenu(0f, 0f, items)
                     },
                     showSharing = showSharingStatus,
                     sharingCount = sharedTabIds.size,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1226,6 +1226,17 @@ fun TabbedTerminal(
                     onRequestControl = { session.requestControl() },
                     nested = nested,
                     windowSections = windowSections,
+                    // This remote's MCP — pill in the group header; click opens its toggle/attach
+                    // menu (control-gated, else the view-only request-control prompt).
+                    mcpShown = session.mcpStatus.value != null,
+                    mcpRunning = session.mcpStatus.value?.running == true,
+                    onMcpClick = {
+                        session.mcpStatus.value?.let { st ->
+                            mcpMenu.showMenu(0f, 0f, remoteMcpMenuItems(session, st) {
+                                requestControlPrompt = { session.requestControl() }
+                            })
+                        }
+                    },
                 )
             }
             // In summary mode the active tab's single chip carries the tab id; match it
@@ -1823,45 +1834,7 @@ fun TabbedTerminal(
                 tabController.activeTab?.id?.let { id -> s.upstreamFor(id)?.takeIf { it.readOnly } }
             }
         } else null
-        // "Remote MCP" pill: connected remote session(s) that reported their MCP state. Reading
-        // each session's mcpStatus Compose state here recomposes the strip when it changes.
-        val remoteMcpList = state?.remoteSessions?.sessions.orEmpty().mapNotNull { s ->
-            s.mcpStatus.value?.let { s to it }
-        }
-        val showRemoteMcp = remoteMcpList.isNotEmpty()
-        val remoteMcpOn = remoteMcpList.any { it.second.running }
-        // Build the toggle + Attach▸ items for one remote session (mirrors the local MCP menu
-        // minus the native "Settings…"); control-gated actions fall back to the request-control
-        // prompt when we're view-only on that remote.
-        fun remoteMcpItems(
-            s: ai.rever.bossterm.compose.remote.RemoteSession,
-            st: ai.rever.bossterm.compose.remote.RemoteSession.RemoteMcpStatus,
-        ): List<ai.rever.bossterm.compose.features.ContextMenuController.MenuElement> {
-            val attached = st.attached.toSet()
-            val gate: (() -> Unit) -> Unit = { act ->
-                if (s.canControlState.value) act() else requestControlPrompt = { s.requestControl() }
-            }
-            val attachSub = ai.rever.bossterm.compose.mcp.McpAttachTarget.entries.map { t ->
-                ai.rever.bossterm.compose.features.ContextMenuController.MenuItem(
-                    id = "rmcp_att_${t.persistenceKey}",
-                    label = (if (t.persistenceKey in attached) "✓ " else "") + t.displayName,
-                    enabled = true,
-                    action = { gate { s.attachRemoteMcp(t.persistenceKey) } },
-                )
-            }
-            return listOf(
-                ai.rever.bossterm.compose.features.ContextMenuController.MenuSubmenu(
-                    id = "rmcp_attach", label = "Attach", items = attachSub
-                ),
-                ai.rever.bossterm.compose.features.ContextMenuController.MenuItem(
-                    id = "rmcp_toggle",
-                    label = if (st.enabled) "Turn MCP off" else "Turn MCP on",
-                    enabled = true,
-                    action = { gate { s.setRemoteMcpEnabled(!st.enabled) } },
-                ),
-            )
-        }
-        if (showMcpStatus || showSharingStatus || showRemoteMcp || attachStatus != null || pendingShareRequests.isNotEmpty() ||
+        if (showMcpStatus || showSharingStatus || attachStatus != null || pendingShareRequests.isNotEmpty() ||
             viewOnlyRemote != null || upstreamReadOnly != null) {
             Column(
                 modifier = Modifier
@@ -1892,25 +1865,6 @@ fun TabbedTerminal(
                             onTurnOffRequest = { SettingsManager.instance.updateSetting { copy(mcpEnabled = false) } },
                             onTurnOnRequest = { SettingsManager.instance.updateSetting { copy(mcpEnabled = true) } },
                         ))
-                    },
-                    showRemoteMcp = showRemoteMcp,
-                    remoteMcpOn = remoteMcpOn,
-                    onRemoteMcpClick = {
-                        val items = if (remoteMcpList.size == 1) {
-                            val (s, st) = remoteMcpList.first()
-                            remoteMcpItems(s, st)
-                        } else {
-                            // Multiple remotes → one submenu per remote, labelled by its name.
-                            remoteMcpList.map { (s, st) ->
-                                ai.rever.bossterm.compose.features.ContextMenuController.MenuSubmenu(
-                                    id = "rmcp_sess_${s.link.hashCode()}",
-                                    label = s.customName.value ?: s.hostName.value
-                                        ?: runCatching { java.net.URI(s.link).host }.getOrNull() ?: "remote",
-                                    items = remoteMcpItems(s, st),
-                                )
-                            }
-                        }
-                        mcpMenu.showMenu(0f, 0f, items)
                     },
                     showSharing = showSharingStatus,
                     sharingCount = sharedTabIds.size,
@@ -2219,4 +2173,38 @@ private fun fitClientWindowToHost(focused: ai.rever.bossterm.compose.tabs.Termin
             if (attempt < 3) swingTimerOnce(420) { fitClientWindowToHost(focused, attempt + 1) }
         }
     }
+}
+
+/**
+ * Toggle + Attach▸ menu items for a connected remote's MCP (the "MCP" pill in its tab-group
+ * header). Mirrors the local MCP indicator menu minus the native "Settings…". Control-gated:
+ * when we're view-only on the remote, an action runs [onNeedControl] (the request-control
+ * prompt) instead. [st.attached] are McpAttachTarget persistence keys (✓-marked).
+ */
+private fun remoteMcpMenuItems(
+    s: ai.rever.bossterm.compose.remote.RemoteSession,
+    st: ai.rever.bossterm.compose.remote.RemoteSession.RemoteMcpStatus,
+    onNeedControl: () -> Unit,
+): List<ai.rever.bossterm.compose.features.ContextMenuController.MenuElement> {
+    val attached = st.attached.toSet()
+    fun gate(act: () -> Unit) { if (s.canControlState.value) act() else onNeedControl() }
+    val attachSub = ai.rever.bossterm.compose.mcp.McpAttachTarget.entries.map { t ->
+        ai.rever.bossterm.compose.features.ContextMenuController.MenuItem(
+            id = "rmcp_att_${t.persistenceKey}",
+            label = (if (t.persistenceKey in attached) "✓ " else "") + t.displayName,
+            enabled = true,
+            action = { gate { s.attachRemoteMcp(t.persistenceKey) } },
+        )
+    }
+    return listOf(
+        ai.rever.bossterm.compose.features.ContextMenuController.MenuSubmenu(
+            id = "rmcp_attach", label = "Attach", items = attachSub
+        ),
+        ai.rever.bossterm.compose.features.ContextMenuController.MenuItem(
+            id = "rmcp_toggle",
+            label = if (st.enabled) "Turn MCP off" else "Turn MCP on",
+            enabled = true,
+            action = { gate { s.setRemoteMcpEnabled(!st.enabled) } },
+        ),
+    )
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -2192,7 +2192,9 @@ private fun remoteMcpMenuItems(
         ai.rever.bossterm.compose.features.ContextMenuController.MenuItem(
             id = "rmcp_att_${t.persistenceKey}",
             label = (if (t.persistenceKey in attached) "✓ " else "") + t.displayName,
-            enabled = true,
+            // Attach is a no-op while the remote's MCP server is off — disable it (mirrors the
+            // host's local indicator menu) so the click isn't a silent nothing.
+            enabled = st.running,
             action = { gate { s.attachRemoteMcp(t.persistenceKey) } },
         )
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -111,6 +111,11 @@ class BossTermMcpManager(
     fun start() {
         if (watcherJob?.isActive == true) return
 
+        // Publish the embedder's server name/label to the registry so non-Compose readers
+        // (MirrorShare relaying a remote client's MCP attach/toggle) use the right values
+        // instead of the standalone defaults — matching the Compose LocalBossTermMcpConfig path.
+        registry.setServerInfo(config.serverName, config.displayName ?: "BossTerm")
+
         // Hydrate the runtime attached-targets set from persisted settings so
         // the indicator/menu reflect prior-session state immediately, and
         // the auto-reattach loop below has the right targets to refresh.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -111,6 +111,24 @@ object McpTerminalRegistry {
         _runningPort.value = null
     }
 
+    /**
+     * The embedder's MCP server name + display label (from [BossTermMcpConfig]). Defaults match
+     * the standalone app; an embedder's [BossTermMcpManager] overrides them at construction.
+     * Non-Compose readers (e.g. [ai.rever.bossterm.compose.share.MirrorShare] relaying a remote
+     * client's MCP toggle/attach) use these instead of the Compose-only `LocalBossTermMcpConfig`,
+     * so a customized embedder registers CLIs under the right name + broadcasts the right label.
+     */
+    @Volatile var mcpServerName: String = "bossterm"
+        private set
+    @Volatile var mcpServerLabel: String = "BossTerm"
+        private set
+
+    /** @suppress Manager-only. Publish the embedder's MCP server name/label. */
+    internal fun setServerInfo(name: String, label: String) {
+        mcpServerName = name
+        mcpServerLabel = label
+    }
+
     // -----------------------------------------------------------------
     // Attached-CLI tracking — written by McpCliAttacher's callers when an
     // attach succeeds; read by the Settings panel and the right-click menus

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -193,6 +193,22 @@ class RemoteSession internal constructor(
      */
     val statusState = androidx.compose.runtime.mutableStateOf<RemoteStatus>(RemoteStatus.Connecting)
 
+    /**
+     * The remote host's BossTerm-MCP state (from [ServerMessage.McpStatus]), or null until it
+     * arrives. Drives the "Remote MCP" pill in [ai.rever.bossterm.compose.share.StatusStrip].
+     */
+    val mcpStatus = androidx.compose.runtime.mutableStateOf<RemoteMcpStatus?>(null)
+
+    /** Toggle the remote host's MCP server (the pill's on/off). No-op when view-only. */
+    fun setRemoteMcpEnabled(enabled: Boolean) {
+        if (canControlState.value) conn.send(ClientMessage.SetMcpEnabled(enabled))
+    }
+
+    /** Attach a CLI on the remote host ([McpAttachTarget] persistence key). No-op when view-only. */
+    fun attachRemoteMcp(targetKey: String) {
+        if (canControlState.value) conn.send(ClientMessage.AttachMcp(targetKey))
+    }
+
     /** True if [s] is any of this session's mirrors — the containers or their pane mirrors. */
     fun ownsMirror(s: ai.rever.bossterm.compose.TerminalSession): Boolean =
         localTabByRemote.values.any { it === s } || sessionByPane.values.any { it === s }
@@ -227,6 +243,14 @@ class RemoteSession internal constructor(
      * [name] labels the section ("Window 2"). Absent for single-window hosts.
      */
     data class HostWindow(val key: String, val name: String?)
+
+    /** The remote host's MCP state for the "Remote MCP" pill. [attached] = persistence keys. */
+    data class RemoteMcpStatus(
+        val enabled: Boolean,
+        val running: Boolean,
+        val attached: List<String>,
+        val serverLabel: String?,
+    )
 
     // localTabId (container) → host-window identity; changes bump [upstreamRev] (the bar's
     // metadata-revision tick). Concurrent for the same reason as [upstreamByTab].
@@ -506,6 +530,12 @@ class RemoteSession internal constructor(
                         conn.send(ClientMessage.RequestControl(remoteTabIdFor(tabId)))
                     }
                 }
+            }
+            is ServerMessage.McpStatus -> {
+                mcpStatus.value = RemoteMcpStatus(
+                    enabled = msg.enabled, running = msg.running,
+                    attached = msg.attached, serverLabel = msg.serverLabel,
+                )
             }
             else -> {} // Theme/Presence/Pending/Grant/Denied handled in the connection
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -195,7 +195,8 @@ class RemoteSession internal constructor(
 
     /**
      * The remote host's BossTerm-MCP state (from [ServerMessage.McpStatus]), or null until it
-     * arrives. Drives the "Remote MCP" pill in [ai.rever.bossterm.compose.share.StatusStrip].
+     * arrives. Drives the "MCP" pill in this remote's tab-group header (rendered by
+     * [ai.rever.bossterm.compose.tabs.RemoteTabGroup] in the tab bar).
      */
     val mcpStatus = androidx.compose.runtime.mutableStateOf<RemoteMcpStatus?>(null)
 
@@ -244,12 +245,11 @@ class RemoteSession internal constructor(
      */
     data class HostWindow(val key: String, val name: String?)
 
-    /** The remote host's MCP state for the "Remote MCP" pill. [attached] = persistence keys. */
+    /** The remote host's MCP state for its group-header "MCP" pill. [attached] = persistence keys. */
     data class RemoteMcpStatus(
         val enabled: Boolean,
         val running: Boolean,
         val attached: List<String>,
-        val serverLabel: String?,
     )
 
     // localTabId (container) → host-window identity; changes bump [upstreamRev] (the bar's
@@ -533,8 +533,7 @@ class RemoteSession internal constructor(
             }
             is ServerMessage.McpStatus -> {
                 mcpStatus.value = RemoteMcpStatus(
-                    enabled = msg.enabled, running = msg.running,
-                    attached = msg.attached, serverLabel = msg.serverLabel,
+                    enabled = msg.enabled, running = msg.running, attached = msg.attached,
                 )
             }
             else -> {} // Theme/Presence/Pending/Grant/Denied handled in the connection

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -416,11 +416,12 @@ class MirrorShare(
     }
 
     companion object {
-        // MCP server name/label as the CLI attachers register it. The embedder's
-        // BossTermMcpConfig is a Compose CompositionLocal (unavailable here); these match its
-        // standalone-app defaults (BossTermMcpConfig.serverName / displayName fallback).
-        private const val MCP_SERVER_NAME = "bossterm"
-        private const val MCP_SERVER_LABEL = "BossTerm"
+        // MCP server name/label as the CLI attachers register it / as broadcast to viewers.
+        // The embedder's BossTermMcpConfig is a Compose CompositionLocal (unavailable in this
+        // non-Composable class), so BossTermMcpManager publishes the resolved values to the
+        // registry — read here so a customized embedder isn't forced to the standalone defaults.
+        private val MCP_SERVER_NAME get() = McpTerminalRegistry.mcpServerName
+        private val MCP_SERVER_LABEL get() = McpTerminalRegistry.mcpServerLabel
 
         /**
          * Resize a window programmatically. PREFER the Compose [WindowState] — Compose then

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import java.security.SecureRandom
@@ -82,6 +83,7 @@ class MirrorShare(
      */
     val sessionName = androidx.compose.runtime.mutableStateOf(SessionShareManager.defaultSessionName())
     private var observerJob: Job? = null
+    private var mcpJob: Job? = null
 
     private class TapEntry(val tab: TerminalTab, val listener: (String) -> Unit)
     private val taps = HashMap<String, TapEntry>()
@@ -92,10 +94,27 @@ class MirrorShare(
                 .distinctUntilChanged()
                 .collect { sig -> reconcile(sig) }
         }
+        // Push the host's MCP state (the "MCP" pill) to viewers whenever it changes —
+        // server on/off, the user's enable toggle, or the set of attached CLIs.
+        mcpJob = coro.launch {
+            combine(
+                SettingsManager.instance.settings,
+                McpTerminalRegistry.runningPort,
+                McpTerminalRegistry.attachedTargets,
+            ) { settings, port, attached ->
+                ServerMessage.McpStatus(
+                    enabled = settings.mcpEnabled,
+                    running = port != null,
+                    attached = attached.map { it.persistenceKey },
+                    serverLabel = MCP_SERVER_LABEL,
+                )
+            }.distinctUntilChanged().collect { broadcast(it) }
+        }
     }
 
     fun stop() {
         observerJob?.cancel()
+        mcpJob?.cancel()
         synchronized(taps) {
             taps.values.forEach { e -> runCatching { e.tab.dataStream.removeRawOutputListener(e.listener) } }
             taps.clear()
@@ -134,6 +153,7 @@ class MirrorShare(
         val sig = computeSignature()
         val out = ArrayList<ServerMessage>()
         out.add(themeMessage())
+        out.add(mcpStatusMessage())
         out.add(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft, sig.summaryMode, sig.sessionName))
         for ((id, tab) in paneTabMap()) {
             val sz = sig.sizes[id] ?: listOf(80, 24)
@@ -141,6 +161,14 @@ class MirrorShare(
         }
         return out
     }
+
+    /** Current host MCP state as a [ServerMessage.McpStatus] (snapshot for a new viewer). */
+    private fun mcpStatusMessage(): ServerMessage.McpStatus = ServerMessage.McpStatus(
+        enabled = SettingsManager.instance.settings.value.mcpEnabled,
+        running = McpTerminalRegistry.runningPort.value != null,
+        attached = McpTerminalRegistry.attachedTargets.value.map { it.persistenceKey },
+        serverLabel = MCP_SERVER_LABEL,
+    )
 
     /** Route viewer messages — input + tab close/new — to the host (controller role only). */
     /**
@@ -284,6 +312,23 @@ class MirrorShare(
                     ?.let { "$it (BossTerm)" }) ?: "BossTerm"
                 stateFor(null)?.remoteSessions?.connect(msg.link, name)
             }
+            // ---- MCP pill (mirrors the host's MCP indicator menu) ----
+            is ClientMessage.SetMcpEnabled ->
+                SettingsManager.instance.updateSetting { copy(mcpEnabled = msg.enabled) }
+            is ClientMessage.AttachMcp -> {
+                val target = ai.rever.bossterm.compose.mcp.McpAttachTarget.fromPersistenceKey(msg.target)
+                val port = McpTerminalRegistry.runningPort.value
+                if (target != null && port != null) {
+                    coro.launch {
+                        runCatching {
+                            val result = ai.rever.bossterm.compose.mcp.McpCliAttacher.attach(target, MCP_SERVER_NAME, port)
+                            if (result is ai.rever.bossterm.compose.mcp.McpAttachResult.Success) {
+                                McpTerminalRegistry.markAttached(target) // → re-broadcasts McpStatus
+                            }
+                        }
+                    }
+                }
+            }
             else -> {} // Hello / Focus: no-op (focus is viewer-side; RequestControl handled above)
         }
     }
@@ -362,6 +407,12 @@ class MirrorShare(
     }
 
     companion object {
+        // MCP server name/label as the CLI attachers register it. The embedder's
+        // BossTermMcpConfig is a Compose CompositionLocal (unavailable here); these match its
+        // standalone-app defaults (BossTermMcpConfig.serverName / displayName fallback).
+        private const val MCP_SERVER_NAME = "bossterm"
+        private const val MCP_SERVER_LABEL = "BossTerm"
+
         /**
          * Resize a window programmatically. PREFER the Compose [WindowState] — Compose then
          * moves the AWT frame and its Skia surface together, so no unpainted strip can

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -313,17 +313,26 @@ class MirrorShare(
                 stateFor(null)?.remoteSessions?.connect(msg.link, name)
             }
             // ---- MCP pill (mirrors the host's MCP indicator menu) ----
-            is ClientMessage.SetMcpEnabled ->
-                SettingsManager.instance.updateSetting { copy(mcpEnabled = msg.enabled) }
+            // tabId naming an upstream-mirrored tab → relay to that origin's MCP; else our own.
+            is ClientMessage.SetMcpEnabled -> {
+                val up = upstreamSession(msg.tabId)
+                if (up != null) up.setRemoteMcpEnabled(msg.enabled)
+                else SettingsManager.instance.updateSetting { copy(mcpEnabled = msg.enabled) }
+            }
             is ClientMessage.AttachMcp -> {
-                val target = ai.rever.bossterm.compose.mcp.McpAttachTarget.fromPersistenceKey(msg.target)
-                val port = McpTerminalRegistry.runningPort.value
-                if (target != null && port != null) {
-                    coro.launch {
-                        runCatching {
-                            val result = ai.rever.bossterm.compose.mcp.McpCliAttacher.attach(target, MCP_SERVER_NAME, port)
-                            if (result is ai.rever.bossterm.compose.mcp.McpAttachResult.Success) {
-                                McpTerminalRegistry.markAttached(target) // → re-broadcasts McpStatus
+                val up = upstreamSession(msg.tabId)
+                if (up != null) {
+                    up.attachRemoteMcp(msg.target)
+                } else {
+                    val target = ai.rever.bossterm.compose.mcp.McpAttachTarget.fromPersistenceKey(msg.target)
+                    val port = McpTerminalRegistry.runningPort.value
+                    if (target != null && port != null) {
+                        coro.launch {
+                            runCatching {
+                                val result = ai.rever.bossterm.compose.mcp.McpCliAttacher.attach(target, MCP_SERVER_NAME, port)
+                                if (result is ai.rever.bossterm.compose.mcp.McpAttachResult.Success) {
+                                    McpTerminalRegistry.markAttached(target) // → re-broadcasts McpStatus
+                                }
                             }
                         }
                     }
@@ -543,6 +552,9 @@ class MirrorShare(
                 // The upstream's own window for this tab (it shared ALL its windows) — forward
                 // it so OUR viewers can section the "via host" group per origin window.
                 val upstreamWindow = upstream?.windowFor(tab.id)
+                // The upstream's MCP state — forward so OUR viewers can show + manage it on the
+                // "via host" group (chain: viewer → us → upstream). Subscribed via the read.
+                val upstreamMcp = upstream?.mcpStatus?.value
                 tabNodes.add(
                     TabNode(
                         id = tab.id, title = tab.title.value, active = tab.id == activeId, tree = tree,
@@ -561,6 +573,9 @@ class MirrorShare(
                         windowName = windowName,
                         originWindowId = upstreamWindow?.key,
                         originWindowName = upstreamWindow?.name,
+                        originMcpEnabled = upstreamMcp?.enabled,
+                        originMcpRunning = upstreamMcp?.running,
+                        originMcpAttached = upstreamMcp?.attached ?: emptyList(),
                     )
                 )
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -111,6 +111,20 @@ sealed class ServerMessage {
     @SerialName("control")
     data class Control(val granted: Boolean) : ServerMessage()
 
+    /**
+     * The host's BossTerm-MCP state, so a client can show + manage it (the "MCP" pill).
+     * Broadcast on connect and whenever it changes. [attached] holds
+     * [ai.rever.bossterm.compose.mcp.McpAttachTarget] persistence keys the host has attached.
+     */
+    @Serializable
+    @SerialName("mcpStatus")
+    data class McpStatus(
+        val enabled: Boolean,
+        val running: Boolean,
+        val attached: List<String> = emptyList(),
+        val serverLabel: String? = null,
+    ) : ServerMessage()
+
     /** Host requires approval and this viewer's request is awaiting the host's decision. */
     @Serializable
     @SerialName("pending")
@@ -388,4 +402,17 @@ sealed class ClientMessage {
     @Serializable
     @SerialName("offerShare")
     data class OfferShare(val link: String) : ClientMessage()
+
+    /** Turn the host's BossTerm MCP server on/off (the MCP pill toggle). Controller role only. */
+    @Serializable
+    @SerialName("setMcpEnabled")
+    data class SetMcpEnabled(val enabled: Boolean) : ClientMessage()
+
+    /**
+     * Attach a CLI to the host's MCP server (the MCP pill's "Attach ▸"). [target] is an
+     * [ai.rever.bossterm.compose.mcp.McpAttachTarget] persistence key. Controller role only.
+     */
+    @Serializable
+    @SerialName("attachMcp")
+    data class AttachMcp(val target: String) : ClientMessage()
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -213,6 +213,14 @@ data class TabNode(
     val originWindowId: String? = null,
     /** When [originWindowId] != null: the upstream window's display label. */
     val originWindowName: String? = null,
+    /**
+     * When [origin] != null: the upstream session's MCP state, forwarded so a viewer can show +
+     * manage it on the "via host" group (chain: viewer → host → upstream). Null = the upstream
+     * never reported MCP (no pill). [originMcpAttached] = McpAttachTarget persistence keys.
+     */
+    val originMcpEnabled: Boolean? = null,
+    val originMcpRunning: Boolean? = null,
+    val originMcpAttached: List<String> = emptyList(),
 )
 
 /** Recursive split-layout node: either a binary split or a leaf pane. */
@@ -403,16 +411,21 @@ sealed class ClientMessage {
     @SerialName("offerShare")
     data class OfferShare(val link: String) : ClientMessage()
 
-    /** Turn the host's BossTerm MCP server on/off (the MCP pill toggle). Controller role only. */
+    /**
+     * Turn an MCP server on/off (the MCP pill toggle). Controller role only. [tabId] null →
+     * the host's own MCP; a [tabId] naming a tab the host mirrors from an upstream → relayed to
+     * that upstream (manage the origin's MCP on a "via host" group).
+     */
     @Serializable
     @SerialName("setMcpEnabled")
-    data class SetMcpEnabled(val enabled: Boolean) : ClientMessage()
+    data class SetMcpEnabled(val enabled: Boolean, val tabId: String? = null) : ClientMessage()
 
     /**
-     * Attach a CLI to the host's MCP server (the MCP pill's "Attach ▸"). [target] is an
-     * [ai.rever.bossterm.compose.mcp.McpAttachTarget] persistence key. Controller role only.
+     * Attach a CLI to an MCP server (the MCP pill's "Attach ▸"). [target] is an
+     * [ai.rever.bossterm.compose.mcp.McpAttachTarget] persistence key. [tabId] routes like
+     * [SetMcpEnabled] (null = host; upstream tab id = relayed). Controller role only.
      */
     @Serializable
     @SerialName("attachMcp")
-    data class AttachMcp(val target: String) : ClientMessage()
+    data class AttachMcp(val target: String, val tabId: String? = null) : ClientMessage()
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/StatusStrip.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/StatusStrip.kt
@@ -37,8 +37,12 @@ fun StatusStrip(
     sharingCount: Int,
     onSharingClick: () -> Unit,
     modifier: Modifier = Modifier,
+    /** "Remote MCP" segment — shown when this window is connected to a remote whose MCP we mirror. */
+    showRemoteMcp: Boolean = false,
+    remoteMcpOn: Boolean = false,
+    onRemoteMcpClick: () -> Unit = {},
 ) {
-    if (!showMcp && !showSharing) return
+    if (!showMcp && !showSharing && !showRemoteMcp) return
     Surface(
         modifier = modifier,
         color = Color(0xFF2B2B2B),
@@ -50,13 +54,19 @@ fun StatusStrip(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            // Tracks whether a divider is needed before the next segment.
+            var prior = false
             if (showMcp) {
                 Segment(dot = if (mcpOn) ON else OFF, label = "MCP", onClick = onMcpClick)
+                prior = true
             }
-            if (showMcp && showSharing) {
-                Text("|", color = Color(0xFF555555), fontSize = 12.sp)
+            if (showRemoteMcp) {
+                if (prior) Text("|", color = Color(0xFF555555), fontSize = 12.sp)
+                Segment(dot = if (remoteMcpOn) ON else OFF, label = "Remote MCP", onClick = onRemoteMcpClick)
+                prior = true
             }
             if (showSharing) {
+                if (prior) Text("|", color = Color(0xFF555555), fontSize = 12.sp)
                 val label = if (sharingCount > 1) "Sharing ($sharingCount)" else "Sharing"
                 Segment(dot = if (sharingCount > 0) ON else OFF, label = label, onClick = onSharingClick)
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/StatusStrip.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/StatusStrip.kt
@@ -37,12 +37,8 @@ fun StatusStrip(
     sharingCount: Int,
     onSharingClick: () -> Unit,
     modifier: Modifier = Modifier,
-    /** "Remote MCP" segment — shown when this window is connected to a remote whose MCP we mirror. */
-    showRemoteMcp: Boolean = false,
-    remoteMcpOn: Boolean = false,
-    onRemoteMcpClick: () -> Unit = {},
 ) {
-    if (!showMcp && !showSharing && !showRemoteMcp) return
+    if (!showMcp && !showSharing) return
     Surface(
         modifier = modifier,
         color = Color(0xFF2B2B2B),
@@ -54,19 +50,13 @@ fun StatusStrip(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            // Tracks whether a divider is needed before the next segment.
-            var prior = false
             if (showMcp) {
                 Segment(dot = if (mcpOn) ON else OFF, label = "MCP", onClick = onMcpClick)
-                prior = true
             }
-            if (showRemoteMcp) {
-                if (prior) Text("|", color = Color(0xFF555555), fontSize = 12.sp)
-                Segment(dot = if (remoteMcpOn) ON else OFF, label = "Remote MCP", onClick = onRemoteMcpClick)
-                prior = true
+            if (showMcp && showSharing) {
+                Text("|", color = Color(0xFF555555), fontSize = 12.sp)
             }
             if (showSharing) {
-                if (prior) Text("|", color = Color(0xFF555555), fontSize = 12.sp)
                 val label = if (sharingCount > 1) "Sharing ($sharingCount)" else "Sharing"
                 Segment(dot = if (sharingCount > 0) ON else OFF, label = label, onClick = onSharingClick)
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -153,6 +153,14 @@ data class RemoteTabGroup(
      * single-window host, [groups] renders flat. The sections' groups union == [groups].
      */
     val windowSections: List<RemoteWindowSection> = emptyList(),
+    /**
+     * This remote host's MCP state, when it reported one — drives the small "MCP" pill in the
+     * group header (green dot = the remote's MCP server is running). [onMcpClick] opens the
+     * toggle/attach menu (control-gated by the owner). Null/false = no pill.
+     */
+    val mcpShown: Boolean = false,
+    val mcpRunning: Boolean = false,
+    val onMcpClick: () -> Unit = {},
 )
 
 /**
@@ -515,6 +523,22 @@ fun TabBar(
                                         color = if (rg.statusError) Color(0xFFE57373) else Color(0xFFE0A030),
                                         fontSize = 10.sp, maxLines = 1
                                     )
+                                }
+                                if (rg.mcpShown) {
+                                    // This remote's MCP — dot (green = running) + "MCP"; click opens
+                                    // the toggle/attach menu (control-gated by the session).
+                                    Row(
+                                        modifier = Modifier.clip(RoundedCornerShape(4.dp))
+                                            .clickable(onClick = rg.onMcpClick).padding(horizontal = 3.dp, vertical = 1.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(3.dp)
+                                    ) {
+                                        Box(Modifier.size(6.dp).background(
+                                            if (rg.mcpRunning) Color(0xFF4CAF50) else Color(0xFF6B6B6B),
+                                            androidx.compose.foundation.shape.CircleShape
+                                        ))
+                                        Text("MCP", color = Color(0xFFB0B0B0), fontSize = 10.sp, maxLines = 1)
+                                    }
                                 }
                                 if (!rg.canControl) {
                                     // Read-only session: eye badge (right-click → Request Control).

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -21,6 +21,10 @@
     #bar::-webkit-scrollbar { display: none; }
     #status { width: 8px; height: 8px; border-radius: 50%; background: #888; flex: 0 0 auto; }
     #status.live { background: #4caf50; } #status.down { background: #f44336; }
+    /* host MCP pill — dot color mirrors the host StatusStrip (green=running, gray=off) */
+    #mcppill { cursor: pointer; display: inline-flex; align-items: center; gap: 5px; }
+    #mcppill .dot { width: 7px; height: 7px; border-radius: 50%; background: #6b6b6b; display: inline-block; }
+    #mcppill.on .dot { background: #4caf50; }
     #tabbar { display: flex; gap: 12px; overflow-x: auto; flex: 1 1 auto; align-items: center; }
     #tabbar.hidden { display: none; }
     /* one cluster per tab; panes of a tab sit tight together, tabs spaced apart */
@@ -167,6 +171,7 @@
     <button id="menubtn" title="Tabs">☰</button>
     <div id="tabbar"></div>
     <span class="badge" id="viewonly">view only</span>
+    <span class="badge" id="mcppill" style="display:none" title="Host MCP — click to manage"><span class="dot"></span>MCP</span>
     <span class="badge" id="presence"></span>
     <span class="badge" id="e2e" title="End-to-end encrypted — compare this code with the one in the host's Share dialog" style="display:none"></span>
     <span class="badge" id="dims" title="Host terminal size (columns × rows)"></span>

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -170,11 +170,9 @@
     <span id="status"></span>
     <button id="menubtn" title="Tabs">☰</button>
     <div id="tabbar"></div>
+    <!-- Control-centric items first (you act on them): request-control, MCP, zoom/fit. -->
     <span class="badge" id="viewonly">view only</span>
     <span class="badge" id="mcppill" style="display:none" title="Host MCP — click to manage"><span class="dot"></span>MCP</span>
-    <span class="badge" id="presence"></span>
-    <span class="badge" id="e2e" title="End-to-end encrypted — compare this code with the one in the host's Share dialog" style="display:none"></span>
-    <span class="badge" id="dims" title="Host terminal size (columns × rows)"></span>
     <span id="zoom">
       <button id="splittabs" title="Show a split tab one pane at a time — switch panes via the sub-tab chips (on by default on phones)">⊞ Panes</button>
       <button id="zoomout" title="Zoom out">A&minus;</button>
@@ -182,6 +180,10 @@
       <button id="zoomfit" title="Zoom so the terminal's full width fits your view (local only)">Fit view</button>
       <button id="fithost" title="Resize the host terminal to fit this screen" style="display:none">Fit host</button>
     </span>
+    <!-- Information-centric badges last (read-only): viewer count, terminal size, E2E code. -->
+    <span class="badge" id="presence"></span>
+    <span class="badge" id="dims" title="Host terminal size (columns × rows)"></span>
+    <span class="badge" id="e2e" title="End-to-end encrypted — compare this code with the one in the host's Share dialog" style="display:none"></span>
   </div>
   <div id="body">
     <div id="sidebar"></div>

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -116,6 +116,44 @@
   var stageEl = document.getElementById("stage");
   var presenceEl = document.getElementById("presence");
   var viewOnlyEl = document.getElementById("viewonly");
+  // Host MCP state (the "MCP" pill) — null until the host's mcpStatus arrives. Mirrors the
+  // host's StatusStrip: dot green when the MCP server is running; click (control only) opens
+  // a Turn on/off + Attach▸ menu relayed to the host. attached = McpAttachTarget persistence keys.
+  var mcp = null;
+  var mcpPillEl = document.getElementById("mcppill");
+  // Attach targets mirror the host's McpAttachTarget enum (persistenceKey → label).
+  var MCP_TARGETS = [
+    { key: "CLAUDE_CODE", label: "Claude Code" },
+    { key: "CODEX", label: "Codex" },
+    { key: "GEMINI", label: "Gemini CLI" },
+    { key: "OPENCODE", label: "OpenCode" },
+  ];
+  function updateMcpPill() {
+    if (!mcp) { mcpPillEl.style.display = "none"; return; }
+    mcpPillEl.style.display = "";
+    mcpPillEl.className = "badge" + (mcp.running ? " on" : "");
+  }
+  // Menu (reuses the context-menu primitives): Turn MCP on/off + Attach▸ targets (✓ attached).
+  function showMcpMenu(x, y) {
+    var attached = (mcp.attached || []);
+    ctxEl.innerHTML = "";
+    ctxEl.appendChild(ctxItem(mcp.enabled ? "Turn MCP off" : "Turn MCP on", true, function () {
+      sendMsg({ t: "setMcpEnabled", enabled: !mcp.enabled });
+    }));
+    ctxEl.appendChild(ctxSep());
+    MCP_TARGETS.forEach(function (t) {
+      var mark = attached.indexOf(t.key) >= 0 ? "✓ " : "";
+      ctxEl.appendChild(ctxItem(mark + "Attach " + t.label, true, function () {
+        sendMsg({ t: "attachMcp", target: t.key });
+      }));
+    });
+    positionMenu(x, y);
+  }
+  mcpPillEl.onclick = function (e) {
+    if (!mcp) return;
+    if (viewOnlyGate()) return; // view-only → request-control prompt
+    showMcpMenu(e.clientX, e.clientY);
+  };
   // The "view only" badge doubles as the request-control affordance (confirm-first, like
   // the native client's dialog) — the host's user sees its approval toast.
   viewOnlyEl.style.cursor = "pointer";
@@ -1687,6 +1725,8 @@
         break;
       case "presence":
         presenceEl.textContent = m.viewers === 1 ? "1 viewer" : m.viewers + " viewers"; break;
+      case "mcpStatus":
+        mcp = m; updateMcpPill(); break;
       case "control":
         controlGranted = !!m.granted;
         viewOnlyEl.style.display = controlGranted ? "none" : "";

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -154,6 +154,24 @@
     if (viewOnlyGate()) return; // view-only → request-control prompt
     showMcpMenu(e.clientX, e.clientY);
   };
+  // Same menu for an upstream "via host" group's MCP — toggle/attach are relayed by the host
+  // to the origin via the named tabId (anchorTab(g)).
+  function showUpstreamMcpMenu(x, y, g) {
+    var tabId = anchorTab(g).id;
+    var attached = (g.mcp.attached || []);
+    ctxEl.innerHTML = "";
+    ctxEl.appendChild(ctxItem(g.mcp.enabled ? "Turn MCP off" : "Turn MCP on", true, function () {
+      sendMsg({ t: "setMcpEnabled", enabled: !g.mcp.enabled, tabId: tabId });
+    }));
+    ctxEl.appendChild(ctxSep());
+    MCP_TARGETS.forEach(function (t) {
+      var mark = attached.indexOf(t.key) >= 0 ? "✓ " : "";
+      ctxEl.appendChild(ctxItem(mark + "Attach " + t.label, true, function () {
+        sendMsg({ t: "attachMcp", target: t.key, tabId: tabId });
+      }));
+    });
+    positionMenu(x, y);
+  }
   // The "view only" badge doubles as the request-control affordance (confirm-first, like
   // the native client's dialog) — the host's user sees its approval toast.
   viewOnlyEl.style.cursor = "pointer";
@@ -1039,7 +1057,13 @@
         tabs.forEach(function (t) {
           if (t.origin) {
             if (!upstreams[t.origin]) {
-              upstreams[t.origin] = { name: t.originName, readOnly: !!t.originReadOnly, offline: !!t.originOffline, tabs: [] };
+              upstreams[t.origin] = {
+                name: t.originName, readOnly: !!t.originReadOnly, offline: !!t.originOffline, tabs: [],
+                // The origin's MCP, forwarded by the host (null = never reported → no pill).
+                mcp: (typeof t.originMcpRunning === "boolean")
+                  ? { enabled: !!t.originMcpEnabled, running: !!t.originMcpRunning, attached: t.originMcpAttached || [] }
+                  : null,
+              };
               upOrder.push(t.origin);
             }
             upstreams[t.origin].tabs.push(t);
@@ -1092,6 +1116,24 @@
             off.textContent = "· offline"; off.title = "The host lost its connection to this session — content is frozen";
             off.style.cssText = "color:#E57373;font-size:10px;";
             hd.appendChild(off);
+          }
+          if (g.mcp) {
+            // This origin's MCP pill — dot (green = running) + "MCP"; click opens the
+            // toggle/attach menu relayed through the host to the origin. Read-only via the
+            // host → request control first.
+            var mp = document.createElement("span");
+            mp.style.cssText = "cursor:pointer;display:inline-flex;align-items:center;gap:4px;font-size:10px;color:#b0b0b0;";
+            var mpdot = document.createElement("span");
+            mpdot.style.cssText = "width:6px;height:6px;border-radius:50%;background:" + (g.mcp.running ? "#4caf50" : "#6b6b6b") + ";";
+            mp.appendChild(mpdot);
+            mp.appendChild(document.createTextNode("MCP"));
+            mp.onclick = function (ev) {
+              ev.stopPropagation();
+              if (viewOnlyGate()) return;
+              if (g.readOnly) { requestUpstreamControl(anchorTab(g).id, g.name || "remote"); return; }
+              showUpstreamMcpMenu(ev.clientX, ev.clientY, g);
+            };
+            hd.appendChild(mp);
           }
           if (g.readOnly) {
             var eye = document.createElement("span");

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -143,7 +143,8 @@
     ctxEl.appendChild(ctxSep());
     MCP_TARGETS.forEach(function (t) {
       var mark = attached.indexOf(t.key) >= 0 ? "✓ " : "";
-      ctxEl.appendChild(ctxItem(mark + "Attach " + t.label, true, function () {
+      // Attach is a no-op while the server is off — disable it (mirrors the host indicator).
+      ctxEl.appendChild(ctxItem(mark + "Attach " + t.label, !!mcp.running, function () {
         sendMsg({ t: "attachMcp", target: t.key });
       }));
     });
@@ -166,7 +167,7 @@
     ctxEl.appendChild(ctxSep());
     MCP_TARGETS.forEach(function (t) {
       var mark = attached.indexOf(t.key) >= 0 ? "✓ " : "";
-      ctxEl.appendChild(ctxItem(mark + "Attach " + t.label, true, function () {
+      ctxEl.appendChild(ctxItem(mark + "Attach " + t.label, !!g.mcp.running, function () {
         sendMsg({ t: "attachMcp", target: t.key, tabId: tabId });
       }));
     });

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -69,6 +69,34 @@ class ShareProtocolTest {
         val cw = ShareProtocol.decodeClient("""{"t":"closeWindow","windowId":"w1"}""")
         assertIs<ClientMessage.CloseWindow>(cw)
         assertEquals("w1", cw.windowId)
+
+        val setMcp = ShareProtocol.decodeClient("""{"t":"setMcpEnabled","enabled":true}""")
+        assertIs<ClientMessage.SetMcpEnabled>(setMcp)
+        assertEquals(true, setMcp.enabled)
+
+        val attach = ShareProtocol.decodeClient("""{"t":"attachMcp","target":"CLAUDE_CODE"}""")
+        assertIs<ClientMessage.AttachMcp>(attach)
+        assertEquals("CLAUDE_CODE", attach.target)
+    }
+
+    @Test
+    fun `McpStatus round-trips (the MCP pill state)`() {
+        val json = ShareProtocol.encodeServer(
+            ServerMessage.McpStatus(enabled = true, running = true, attached = listOf("CLAUDE_CODE", "CODEX"), serverLabel = "BossTerm")
+        )
+        assertTrue(json.contains("\"t\":\"mcpStatus\""), json)
+        val back = ShareProtocol.decodeServer(json)
+        assertIs<ServerMessage.McpStatus>(back)
+        assertEquals(true, back.enabled)
+        assertEquals(true, back.running)
+        assertEquals(listOf("CLAUDE_CODE", "CODEX"), back.attached)
+        assertEquals("BossTerm", back.serverLabel)
+
+        // Defaults tolerate an older/leaner host payload.
+        val lean = ShareProtocol.decodeServer("""{"t":"mcpStatus","enabled":false,"running":false}""")
+        assertIs<ServerMessage.McpStatus>(lean)
+        assertEquals(emptyList(), lean.attached)
+        assertEquals(null, lean.serverLabel)
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -77,6 +77,35 @@ class ShareProtocolTest {
         val attach = ShareProtocol.decodeClient("""{"t":"attachMcp","target":"CLAUDE_CODE"}""")
         assertIs<ClientMessage.AttachMcp>(attach)
         assertEquals("CLAUDE_CODE", attach.target)
+        assertEquals(null, attach.tabId) // null → host's own MCP
+
+        // tabId routes the action to an upstream "via host" group's origin MCP.
+        val attachUp = ShareProtocol.decodeClient("""{"t":"attachMcp","target":"CODEX","tabId":"t9"}""")
+        assertIs<ClientMessage.AttachMcp>(attachUp)
+        assertEquals("t9", attachUp.tabId)
+        val setUp = ShareProtocol.decodeClient("""{"t":"setMcpEnabled","enabled":false,"tabId":"t9"}""")
+        assertIs<ClientMessage.SetMcpEnabled>(setUp)
+        assertEquals("t9", setUp.tabId)
+    }
+
+    @Test
+    fun `TabNode forwards an upstream's MCP for the via-host group`() {
+        val tab = TabNode(
+            "t1", "~", active = true,
+            tree = PaneTreeNode.Pane("p1", "zsh", "/home", focused = true),
+            origin = "hash", originName = "C", originMcpEnabled = true, originMcpRunning = true,
+            originMcpAttached = listOf("CLAUDE_CODE"),
+        )
+        val back = ShareProtocol.decodeServer(ShareProtocol.encodeServer(ServerMessage.Layout(listOf(tab), "t1")))
+        assertIs<ServerMessage.Layout>(back)
+        assertEquals(true, back.tabs[0].originMcpRunning)
+        assertEquals(listOf("CLAUDE_CODE"), back.tabs[0].originMcpAttached)
+
+        // A non-mirror tab leaves them null/empty (no pill).
+        val own = ShareProtocol.decodeServer("""{"t":"layout","tabs":[{"id":"t1","title":"~","active":true,"tree":{"t":"pane","paneId":"p1","title":"z","cwd":null,"focused":true}}],"activeTabId":"t1"}""")
+        assertIs<ServerMessage.Layout>(own)
+        assertEquals(null, own.tabs[0].originMcpRunning)
+        assertEquals(emptyList(), own.tabs[0].originMcpAttached)
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -89,6 +89,14 @@ class ShareProtocolTest {
     }
 
     @Test
+    fun `MCP attach-target keys match the hardcoded set the web viewer mirrors`() {
+        // viewer.js can't read the Kotlin enum, so MCP_TARGETS there hardcodes these keys/labels.
+        // If a target is renamed/added/removed, this trips CI as a reminder to update viewer.js.
+        val keys = ai.rever.bossterm.compose.mcp.McpAttachTarget.entries.map { it.persistenceKey }.toSet()
+        assertEquals(setOf("CLAUDE_CODE", "CODEX", "GEMINI", "OPENCODE"), keys)
+    }
+
+    @Test
     fun `TabNode forwards an upstream's MCP for the via-host group`() {
         val tab = TabNode(
             "t1", "~", active = true,


### PR DESCRIPTION
## Summary

Surface and manage MCP from the remote clients, mirroring the host's MCP indicator with the same actions (toggle on/off, Attach ▸ a CLI), relayed back over the share protocol. Native-only 'Settings…' is dropped.

### Where the pill shows
- **Web viewer top bar** — an **MCP** pill for the connected host (green dot = host's MCP server running).
- **Web viewer 'via host' upstream groups** — each origin's MCP pill in the group header (chain-forwarded: viewer → host → origin).
- **Native client** — each connected remote's **tab-group header** gets an MCP pill (not the local status strip).

### Behavior
- Display mirrors the real host state — the host broadcasts `McpStatus` whenever its `mcpEnabled`/`runningPort`/`attachedTargets` change, so a pill reflects the actual result of any action (no optimistic local flip).
- Actions are **control-gated**; view-only → the existing request-control prompt.
- Old/new peer mismatches degrade to 'pill absent' (`ignoreUnknownKeys`).

## Protocol (ShareProtocol.kt)
- ServerMessage `McpStatus(enabled, running, attached[], serverLabel)` — broadcast on connect + on change.
- TabNode `originMcpEnabled/Running/Attached` — the upstream origin's MCP, forwarded for the 'via host' groups.
- ClientMessage `SetMcpEnabled(enabled, tabId?)` / `AttachMcp(target, tabId?)` — `tabId` null = host's own MCP; an upstream-mirrored tab id = relayed to that origin.

## Key files
- `share/ShareProtocol.kt`, `share/MirrorShare.kt` (broadcast + initialMessages + relay), `mcp/McpCliAttacher.kt` (attach reused)
- `remote/RemoteSessionManager.kt` (RemoteSession.mcpStatus + setters), `tabs/TabBar.kt` + `TabbedTerminal.kt` (Remote MCP pill in the group header)
- `share-viewer/viewer.js` + `index.html` (top-bar pill + upstream-group pill + menus; control-first / info-last bar ordering)
- `share/StatusStrip.kt` (unchanged behavior — local MCP/Sharing only)

## Test plan
- `:compose-ui:desktopTest` — `ShareProtocolTest`: `McpStatus` round-trip, `SetMcpEnabled`/`AttachMcp` decode incl. `tabId`, `TabNode` origin-MCP forwarding. Both modules compile; `node --check viewer.js`.
- Manual (rebuild jars, rerun `bossterm-dev-run`): web viewer pill toggles host MCP / attaches; with control the dot + ✓ update via the next `McpStatus`; native 'Add remote' shows the remote's MCP pill in its group; A→B→C shows C's MCP on the 'C · via B' box. View-only → request-control prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)