### PR TITLE
Auto-install cloudflared so session sharing needs no manual setup

### DIFF
--- a/bossterm-app/build.gradle.kts
+++ b/bossterm-app/build.gradle.kts
@@ -3,6 +3,13 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import java.util.Properties
 import javax.inject.Inject
 import org.gradle.process.ExecOperations
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.security.MessageDigest
+import java.time.Duration
 
 // Interface for injecting ExecOperations into tasks
 // Replaces deprecated project.exec() calls for Gradle 9.0 compatibility
@@ -185,12 +192,30 @@ compose.desktop {
 // above) bundles the staged dir into the .app / .deb / .rpm.
 val cliVersion = project.version.toString().removeSuffix("-SNAPSHOT")
 
+// cloudflared release pin — the SAME single source of truth the runtime reads
+// (compose-ui/.../resources/cloudflared-pin.properties). Used to fetch + bundle the binary into
+// the app so session sharing works offline; the runtime auto-downloads it elsewhere as a fallback.
+val cloudflaredPin = Properties().apply {
+    rootProject.file("compose-ui/src/desktopMain/resources/cloudflared-pin.properties")
+        .inputStream().use { load(it) }
+}
+val cloudflaredVersion: String = cloudflaredPin.getProperty("version")
+    ?: error("cloudflared-pin.properties is missing 'version'")
+// fetchCloudflaredBinary stages the verified binary here; processCliResources copies it into the
+// `common/` bucket alongside the CLI script. A SEPARATE dir (not common/) so the Sync stays the
+// single owner of common/ and can't clobber the binary.
+val cloudflaredStaging = layout.buildDirectory.dir("cloudflared-staging")
+
 tasks.register<Sync>("processCliResources") {
     description = "Stage cli-resources/ with @@BOSSTERM_VERSION@@ substituted to project.version"
     group = "build"
 
+    // Fetch cloudflared first, then fold its staging dir into common/ as an extra source — so the
+    // bundled binary survives this Sync's prune instead of being deleted by it.
+    dependsOn("fetchCloudflaredBinary")
     inputs.property("cliVersion", cliVersion)
     from(rootProject.file("cli-resources"))
+    from(cloudflaredStaging) // adds `cloudflared` (when bundled for this target) under common/
     // Stage under `common/`: Compose Desktop's appResourcesRootDir only bundles files inside
     // an OS bucket (`common` / `macos` / `linux` / `<os>-<arch>`) — files placed flat at the
     // root are silently dropped, so a packaged .app/.deb/.rpm never got the `bossterm` script
@@ -211,9 +236,117 @@ tasks.register<Sync>("processCliResources") {
 
 // `appResourcesRootDir` points at the staged dir, so prepareAppResources (the
 // gradle.plugin.compose Desktop task that copies into the bundle) depends on
-// processCliResources.
+// processCliResources (which itself dependsOn fetchCloudflaredBinary).
 tasks.matching { it.name == "prepareAppResources" }.configureEach {
     dependsOn("processCliResources")
+}
+
+// Download + SHA-256-verify the cloudflared binary for THIS build's target and stage it for
+// bundling, so a packaged BossTerm can open a Cloudflare quick tunnel offline with zero download.
+// Each CI runner builds natively (host arch == target arch). Unsupported OS/arch → bundle nothing
+// (the runtime auto-downloads instead); a SHA mismatch is always fatal. Hashes/version come from
+// cloudflared-pin.properties (shared with the runtime). Optionally hard-fail on RELEASE_BUILD so a
+// release never silently ships without the binary.
+tasks.register("fetchCloudflaredBinary") {
+    description = "Download + SHA-256-verify cloudflared for the host target and stage it for bundling"
+    group = "build"
+
+    val osNameProp = System.getProperty("os.name").lowercase()
+    val osArchProp = System.getProperty("os.arch").lowercase()
+    inputs.property("cloudflaredVersion", cloudflaredVersion)
+    inputs.property("osName", osNameProp)
+    inputs.property("osArch", osArchProp)
+    val outFile = cloudflaredStaging.map { it.file("cloudflared") }
+    outputs.file(outFile)
+
+    val pin = cloudflaredPin
+    val version = cloudflaredVersion
+    val cacheDirProvider = layout.buildDirectory.dir("cloudflared-cache")
+    val releaseBuild = System.getenv("RELEASE_BUILD") != null
+    val injected = project.objects.newInstance<InjectedExecOps>()
+
+    doLast {
+        fun sha256(f: File): String {
+            val md = MessageDigest.getInstance("SHA-256")
+            f.inputStream().use { input ->
+                val buf = ByteArray(64 * 1024)
+                while (true) { val n = input.read(buf); if (n < 0) break; md.update(buf, 0, n) }
+            }
+            return md.digest().joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        }
+        fun download(url: String, dest: File): Boolean {
+            val client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL) // github.com 302 → CDN
+                .connectTimeout(Duration.ofSeconds(20)).build()
+            repeat(3) { i ->
+                dest.delete()
+                try {
+                    val req = HttpRequest.newBuilder(URI.create(url))
+                        .timeout(Duration.ofMinutes(5)).header("User-Agent", "BossTerm-build").GET().build()
+                    val resp = client.send(req, HttpResponse.BodyHandlers.ofFile(dest.toPath()))
+                    val size = if (dest.exists()) dest.length() else 0L
+                    if (resp.statusCode() == 200 && size > 1_000_000L) return true
+                    logger.warn("cloudflared download attempt ${i + 1} failed (HTTP ${resp.statusCode()}, $size bytes)")
+                } catch (e: Exception) {
+                    logger.warn("cloudflared download attempt ${i + 1} error: ${e.message}")
+                }
+                if (i < 2) Thread.sleep(2_000)
+            }
+            return false
+        }
+
+        val stagingDir = outFile.get().asFile.parentFile.also { it.mkdirs() }
+        val staged = File(stagingDir, "cloudflared")
+        staged.delete() // a stale copy from a prior build target must not be bundled
+
+        val isMac = osNameProp.contains("mac")
+        val isLinux = osNameProp.contains("linux")
+        val arch = when (osArchProp) {            // mirror CloudflaredExposer.linuxArch/macArch
+            "amd64", "x86_64" -> "amd64"
+            "aarch64", "arm64" -> "arm64"
+            "arm", "armv7l", "armv7", "armhf" -> "arm"
+            "i386", "i486", "i586", "i686", "x86" -> "386"
+            else -> null
+        }
+        if (!isMac && !isLinux) {
+            logger.lifecycle("cloudflared: no bundle for OS '$osNameProp' (runtime auto-downloads); skipping"); return@doLast
+        }
+        if (arch == null) {
+            logger.lifecycle("cloudflared: unsupported arch '$osArchProp'; skipping (runtime auto-downloads)"); return@doLast
+        }
+        val asset = if (isMac) "cloudflared-darwin-$arch.tgz" else "cloudflared-linux-$arch"
+        val expectedSha = pin.getProperty("sha256.$asset")
+        if (expectedSha.isNullOrBlank()) {
+            if (releaseBuild) error("cloudflared: no pinned SHA for $asset (RELEASE_BUILD)")
+            logger.warn("cloudflared: no pinned SHA for $asset; skipping"); return@doLast
+        }
+        val url = "https://github.com/cloudflare/cloudflared/releases/download/$version/$asset"
+
+        val cacheDir = cacheDirProvider.get().asFile.also { it.mkdirs() }
+        val cached = File(cacheDir, "$version-$asset")
+        if (!(cached.isFile && sha256(cached).equals(expectedSha, ignoreCase = true))) {
+            logger.lifecycle("cloudflared: downloading $asset (v$version)…")
+            if (!download(url, cached)) {
+                cached.delete()
+                if (releaseBuild) error("cloudflared: download failed for $url (RELEASE_BUILD)")
+                logger.warn("cloudflared: download failed; skipping bundle (runtime auto-downloads)"); return@doLast
+            }
+            val actual = sha256(cached)
+            if (!actual.equals(expectedSha, ignoreCase = true)) {
+                cached.delete(); error("cloudflared: SHA-256 mismatch for $asset (expected $expectedSha, got $actual)")
+            }
+        }
+
+        if (isMac) {
+            // The .tgz holds a single `cloudflared` binary at its root → extracts to staging/cloudflared.
+            injected.execOps.exec { commandLine("tar", "-xzf", cached.absolutePath, "-C", stagingDir.absolutePath) }
+            require(staged.isFile) { "cloudflared: missing after extracting $asset" }
+        } else {
+            cached.copyTo(staged, overwrite = true)
+        }
+        staged.setExecutable(true, false)
+        logger.lifecycle("cloudflared: staged ${staged.absolutePath} (v$version)")
+    }
 }
 
 // Sign PTY4J native binaries with hardened runtime for macOS notarization
@@ -329,6 +462,27 @@ tasks.register("signPty4jBinaries") {
                 } finally {
                     // Clean up temp directory
                     tempDir.deleteRecursively()
+                }
+
+                // Sign the bundled cloudflared binary (if this target bundled one). It's a Mach-O
+                // executable inside a hardened-runtime, notarized bundle, so it MUST be signed with
+                // --options runtime or notarization rejects the app. Search the bundle (rather than
+                // hardcode a path) so we sign it wherever Compose placed the app resources. The
+                // --deep re-sign below then seals it. (pty4j is a hard dependency, so this branch
+                // always runs in practice.)
+                appFile.walkTopDown().filter { it.isFile && it.name == "cloudflared" }.forEach { cf ->
+                    println("  Signing bundled cloudflared: ${cf.relativeTo(appFile)}")
+                    cf.setExecutable(true)
+                    try {
+                        injected.execOps.exec {
+                            commandLine("codesign", "--force", "--options", "runtime",
+                                "--sign", developerId, "--timestamp", cf.absolutePath)
+                        }
+                        injected.execOps.exec { commandLine("codesign", "-vv", cf.absolutePath) }
+                        println("    ✅ Successfully signed cloudflared")
+                    } catch (e: Exception) {
+                        println("    ⚠️ Warning: Failed to sign cloudflared: ${e.message}")
+                    }
                 }
 
                 // CRITICAL: Re-sign the entire app bundle after modifying the JAR

--- a/bossterm-app/build.gradle.kts
+++ b/bossterm-app/build.gradle.kts
@@ -296,6 +296,9 @@ tasks.register("fetchCloudflaredBinary") {
         }
 
         val stagingDir = outFile.get().asFile.parentFile.also { it.mkdirs() }
+        // Always "cloudflared" (no extension) — only mac/linux are bundled today. NOTE: if Windows
+        // bundling is ever added, stage it as "cloudflared.exe" so it matches CloudflaredExposer's
+        // binName; otherwise the runtime's bundledBin() looks for the wrong name and silently misses it.
         val staged = File(stagingDir, "cloudflared")
         staged.delete() // a stale copy from a prior build target must not be bundled
 
@@ -315,6 +318,10 @@ tasks.register("fetchCloudflaredBinary") {
             logger.lifecycle("cloudflared: unsupported arch '$osArchProp'; skipping (runtime auto-downloads)"); return@doLast
         }
         val asset = if (isMac) "cloudflared-darwin-$arch.tgz" else "cloudflared-linux-$arch"
+        // Surface the resolved target on every run (cache hit or miss) so a mis-arched build — e.g.
+        // an x86/Rosetta JVM on Apple Silicon — is obvious in release logs. The app's bundled JRE
+        // follows this same build-JVM arch, so the binary always matches the app it ships in.
+        logger.lifecycle("cloudflared: bundling for os='$osNameProp' arch='$osArchProp' → $asset (v$version)")
         val expectedSha = pin.getProperty("sha256.$asset")
         if (expectedSha.isNullOrBlank()) {
             if (releaseBuild) error("cloudflared: no pinned SHA for $asset (RELEASE_BUILD)")
@@ -341,6 +348,9 @@ tasks.register("fetchCloudflaredBinary") {
             // The .tgz holds a single `cloudflared` binary at its root → extracts to staging/cloudflared.
             injected.execOps.exec { commandLine("tar", "-xzf", cached.absolutePath, "-C", stagingDir.absolutePath) }
             require(staged.isFile) { "cloudflared: missing after extracting $asset" }
+            // The archive is SHA-pinned (binary only), but prune any unexpected sibling entries so
+            // the Sync that folds this dir into common/ can only ever bundle the cloudflared binary.
+            stagingDir.listFiles()?.forEach { if (it != staged) it.deleteRecursively() }
         } else {
             cached.copyTo(staged, overwrite = true)
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/CloudflaredExposer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/CloudflaredExposer.kt
@@ -11,6 +11,7 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
 import java.time.Duration
+import java.util.Properties
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
@@ -42,15 +43,56 @@ object CloudflaredExposer {
 
     private val log = LoggerFactory.getLogger(CloudflaredExposer::class.java)
 
+    /** Binary name — Windows needs the `.exe` extension to be runnable. */
+    private val binName: String = if (ShellCustomizationUtils.isWindows()) "cloudflared.exe" else "cloudflared"
+
     /**
-     * BossTerm-managed cloudflared, dropped here by [linuxDirectInstall] so we never need
+     * BossTerm-managed cloudflared, dropped here by the direct-install paths so we never need
      * root or a package manager. Invoked by absolute path, so it needs no PATH entry.
      */
-    private val managedBin: File = File(System.getProperty("user.home"), ".bossterm/bin/cloudflared")
+    private val managedBin: File = File(System.getProperty("user.home"), ".bossterm/bin/$binName")
 
-    // "cloudflared" first (honors PATH), then our managed copy, then typical Homebrew locations.
-    private fun candidates(): List<String> =
-        listOf("cloudflared", managedBin.absolutePath, "/opt/homebrew/bin/cloudflared", "/usr/local/bin/cloudflared")
+    /**
+     * A cloudflared binary bundled INSIDE the packaged app — the build (bossterm-app) drops it
+     * into Compose Desktop's resources dir, so sharing works offline with zero download.
+     * Discovered exactly like [ai.rever.bossterm.compose.cli.CLIInstaller] reads its CLI script:
+     * Compose flattens the `common/` bucket into `compose.application.resources.dir`, but some
+     * dev/run setups leave it under `common/` — try both. Returns an *executable* absolute path
+     * or null when there's no bundled copy (Maven-library consumers, or a platform/arch the build
+     * didn't bundle — both fall through to the auto-download path).
+     *
+     * COORDINATION WITH THE BUILD: the bundled file must be named exactly [binName] and live in
+     * the `common` resources bucket, so it resolves at `<resourcesDir>/$binName`.
+     */
+    private fun bundledBin(): String? {
+        val dir = System.getProperty("compose.application.resources.dir") ?: return null
+        val found = File(dir, binName).takeIf { it.isFile }
+            ?: File(File(dir, "common"), binName).takeIf { it.isFile }
+            ?: return null
+        // The resources dir may be read-only / mounted noexec. Ensure an executable copy.
+        if (!ShellCustomizationUtils.isWindows() && !found.canExecute()) {
+            return runCatching {
+                managedBin.parentFile?.mkdirs()
+                if (!managedBin.exists() || managedBin.length() != found.length()) {
+                    Files.copy(found.toPath(), managedBin.toPath(), StandardCopyOption.REPLACE_EXISTING)
+                    managedBin.setExecutable(true, false)
+                }
+                managedBin.absolutePath
+            }.getOrNull()
+        }
+        return found.absolutePath
+    }
+
+    // Bundled copy first (zero download), then PATH, then our managed copy, then Homebrew (Unix only).
+    private fun candidates(): List<String> = buildList {
+        bundledBin()?.let { add(it) }
+        add(binName)
+        add(managedBin.absolutePath)
+        if (!ShellCustomizationUtils.isWindows()) {
+            add("/opt/homebrew/bin/cloudflared")
+            add("/usr/local/bin/cloudflared")
+        }
+    }
     private fun bin(): String? = candidates().firstOrNull { runCmd(listOf(it, "--version"), 5) != null }
 
     /** True if a working `cloudflared` CLI is present. Blocking — call off the UI thread. */
@@ -66,18 +108,43 @@ object CloudflaredExposer {
     fun canAutoInstall(): Boolean = when {
         ShellCustomizationUtils.isMacOS() -> brewAvailable() || macArch() != null
         ShellCustomizationUtils.isLinux() -> linuxArch() != null
+        ShellCustomizationUtils.isWindows() -> winArch() != null
         else -> false
     }
 
     /**
      * One-click install for the current platform. Blocking and slow (downloads) — call off
-     * the UI thread. Returns true on success (or if it's already installed). macOS prefers
-     * Homebrew when present (managed updates + on PATH); otherwise it downloads directly.
+     * the UI thread. Returns true on success (or if it's already installed).
+     *
+     * macOS prefers Homebrew when present (managed updates + on PATH); otherwise it downloads
+     * directly. Pass [preferManaged] = true for automatic/silent installs to skip Homebrew and
+     * go straight to the self-contained managed download — `brew install` is slow, global, and
+     * can stall, which is wrong for a background install the user didn't click.
      */
-    fun autoInstall(): Boolean = when {
-        ShellCustomizationUtils.isMacOS() -> if (brewAvailable()) brewInstall() else macDirectInstall()
+    fun autoInstall(preferManaged: Boolean = false): Boolean = when {
+        ShellCustomizationUtils.isMacOS() ->
+            if (!preferManaged && brewAvailable()) brewInstall() else macDirectInstall()
         ShellCustomizationUtils.isLinux() -> linuxDirectInstall()
+        ShellCustomizationUtils.isWindows() -> windowsDirectInstall()
         else -> false
+    }
+
+    private val ensureLock = Any()
+
+    /**
+     * Idempotent, silent-friendly "make sure cloudflared is usable". A no-op if a bundled / PATH /
+     * managed binary already runs; otherwise installs via the self-contained managed download
+     * (never Homebrew — see [autoInstall]). Serialized so a concurrent eager prefetch and a lazy
+     * share-time call don't both download the same ~tens of MB (the download itself is already
+     * atomic, so the lock only spares a redundant fetch). Blocking — call off the UI thread.
+     * Returns true if cloudflared is usable afterwards.
+     */
+    fun ensureInstalled(): Boolean {
+        if (isInstalled()) return true
+        synchronized(ensureLock) {
+            if (isInstalled()) return true // won the race against another caller
+            return autoInstall(preferManaged = true)
+        }
     }
 
     // Common Homebrew locations (Apple-silicon, Intel, then PATH).
@@ -100,24 +167,27 @@ object CloudflaredExposer {
     }
 
     /**
-     * The cloudflared release we install directly, with per-asset SHA-256.
+     * The cloudflared release we install directly + per-asset SHA-256, loaded from the bundled
+     * `cloudflared-pin.properties` (single source of truth, shared with the app build that bundles
+     * the binary — see that file for the security rationale and update steps).
      *
-     * cloudflared publishes no checksums/signatures on its GitHub releases, so transport TLS
-     * only guarantees "the bytes the CDN served" — not that they're the bytes Cloudflare built.
-     * We close that gap by pinning a known-good hash here at BUILD time (out-of-band from the
-     * download channel) and refusing to `chmod +x` / run anything that doesn't match. The
-     * hashes were verified against the published artifacts. Bump VERSION + the hashes together
-     * when updating cloudflared (auto-update is disabled in [start], so a pinned build is fine).
+     * cloudflared publishes no checksums/signatures on its GitHub releases, so transport TLS only
+     * guarantees "the bytes the CDN served" — not that they're the bytes Cloudflare built. We close
+     * that gap by pinning known-good hashes at BUILD time (compiled into the jar, out-of-band from
+     * the download channel) and refusing to `chmod +x` / run anything that doesn't match. If the
+     * resource is somehow missing, [PINNED_VERSION] / [pinnedSha] return empty/null so every install
+     * fails safely (we never run unverified bytes).
      */
-    private const val PINNED_VERSION = "2026.5.2"
-    private val PINNED_SHA256 = mapOf(
-        "cloudflared-linux-amd64"      to "5286698547f03df745adb2355f04c12dde52ef425491e81f433642d695521886",
-        "cloudflared-linux-arm64"      to "5a4e8ce2701105271412059f44b6a0bf1ae4542b4d98ff3180c0c019443a5815",
-        "cloudflared-linux-arm"        to "70a4c869a037bd69af6ce2ad0c4da4a7680d94fcfb8d4c70ecddae24d560762f",
-        "cloudflared-linux-386"        to "ad82d1dbed8bbb9d702807cbd97df932cc774d29e9da5c109b7a3c7f7aee2065",
-        "cloudflared-darwin-amd64.tgz" to "7240f709506bc2c1eb9da4d89cf2555499c60280ecb854b7d80e8f17d4b7903d",
-        "cloudflared-darwin-arm64.tgz" to "ba94054c9fd4297645093d59d51442e5e546d07bb0516120e694a13d5b216d38",
-    )
+    private val pin: Properties by lazy {
+        Properties().apply {
+            val res = CloudflaredExposer::class.java.classLoader
+                ?.getResourceAsStream("cloudflared-pin.properties")
+            if (res == null) log.error("cloudflared-pin.properties not on classpath; auto-install disabled")
+            else res.use { load(it) }
+        }
+    }
+    private val PINNED_VERSION: String get() = pin.getProperty("version", "")
+    private fun pinnedSha(asset: String): String? = pin.getProperty("sha256.$asset")?.takeIf { it.isNotBlank() }
     private fun assetUrl(name: String) =
         "https://github.com/cloudflare/cloudflared/releases/download/$PINNED_VERSION/$name"
 
@@ -138,6 +208,17 @@ object CloudflaredExposer {
     }
 
     /**
+     * cloudflared's Windows GitHub asset suffix for this CPU, or null if unsupported. cloudflared
+     * ships only `windows-amd64.exe` and `windows-386.exe` — there is no arm64 Windows build, so
+     * arm64 Windows returns null (no auto-install; the UI offers the manual download link).
+     */
+    private fun winArch(): String? = when (System.getProperty("os.arch").lowercase()) {
+        "amd64", "x86_64" -> "amd64"
+        "x86", "i386", "i486", "i586", "i686", "386" -> "386"
+        else -> null
+    }
+
+    /**
      * Seamless Linux install: download cloudflared's single static binary straight from its
      * GitHub releases into [managedBin], `chmod +x`, and verify it runs. No sudo, no package
      * manager, no PATH changes — works on any distro. Blocking and slow (downloads ~tens of
@@ -149,7 +230,7 @@ object CloudflaredExposer {
             log.warn("no cloudflared Linux binary for arch '{}'", System.getProperty("os.arch")); return false
         }
         val asset = "cloudflared-linux-$arch"
-        val sha = PINNED_SHA256[asset] ?: run { log.warn("no pinned hash for {}", asset); return false }
+        val sha = pinnedSha(asset) ?: run { log.warn("no pinned hash for {}", asset); return false }
         if (!downloadWithRetries(assetUrl(asset), managedBin, sha)) return false
         managedBin.setExecutable(true, false)
         val ok = isInstalled()
@@ -170,7 +251,7 @@ object CloudflaredExposer {
             log.warn("no cloudflared macOS binary for arch '{}'", System.getProperty("os.arch")); return false
         }
         val asset = "cloudflared-darwin-$arch.tgz"
-        val sha = PINNED_SHA256[asset] ?: run { log.warn("no pinned hash for {}", asset); return false }
+        val sha = pinnedSha(asset) ?: run { log.warn("no pinned hash for {}", asset); return false }
         val tgz = File(managedBin.parentFile, "cloudflared.tgz")
         if (!downloadWithRetries(assetUrl(asset), tgz, sha)) return false
         return try {
@@ -189,6 +270,26 @@ object CloudflaredExposer {
         } catch (e: Exception) {
             log.warn("cloudflared macOS extract error: {}", e.message); tgz.delete(); false
         }
+    }
+
+    /**
+     * Seamless Windows install: download cloudflared's single `.exe` straight from its GitHub
+     * releases into [managedBin] and verify it runs. No installer, no admin, no PATH changes.
+     * Blocking and slow (downloads ~tens of MB) — call off the UI thread. Returns true on success
+     * (or if it's already installed). (No `chmod` — Windows ignores the exec bit; the `--version`
+     * probe in [bin] is the real verification.)
+     */
+    fun windowsDirectInstall(): Boolean {
+        if (isInstalled()) return true
+        val arch = winArch() ?: run {
+            log.warn("no cloudflared Windows binary for arch '{}'", System.getProperty("os.arch")); return false
+        }
+        val asset = "cloudflared-windows-$arch.exe"
+        val sha = pinnedSha(asset) ?: run { log.warn("no pinned hash for {}", asset); return false }
+        if (!downloadWithRetries(assetUrl(asset), managedBin, sha)) return false
+        val ok = isInstalled()
+        log.info("cloudflared direct install {}", if (ok) "→ ${managedBin.absolutePath}" else "failed verification")
+        return ok
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/CloudflaredExposer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/CloudflaredExposer.kt
@@ -73,8 +73,14 @@ object CloudflaredExposer {
         if (!ShellCustomizationUtils.isWindows() && !found.canExecute()) {
             return runCatching {
                 managedBin.parentFile?.mkdirs()
-                if (!managedBin.exists() || managedBin.length() != found.length()) {
-                    Files.copy(found.toPath(), managedBin.toPath(), StandardCopyOption.REPLACE_EXISTING)
+                // Refresh when size OR mtime differs — length alone can collide across versions /
+                // a stale prior auto-download. COPY_ATTRIBUTES carries the source mtime over so the
+                // comparison stays stable and we don't re-copy ~tens of MB on every probe.
+                if (!managedBin.exists() ||
+                    managedBin.length() != found.length() ||
+                    managedBin.lastModified() != found.lastModified()) {
+                    Files.copy(found.toPath(), managedBin.toPath(),
+                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES)
                     managedBin.setExecutable(true, false)
                 }
                 managedBin.absolutePath

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -132,7 +132,7 @@ object SessionShareManager {
     val remoteUrlFlow: StateFlow<String?> = _remoteUrlFlow.asStateFlow()
 
     /** Lifecycle of the remote-access link, surfaced in the share dialog. */
-    enum class RemoteStatus { Off, Starting, Verifying, Active, Retrying, FellBack }
+    enum class RemoteStatus { Off, Starting, Installing, Verifying, Active, Retrying, FellBack }
 
     /** Remote-access status snapshot: phase + provider [mode] + retry progress. */
     data class RemoteState(
@@ -164,6 +164,11 @@ object SessionShareManager {
     val sharedTabIds: StateFlow<Set<String>> = _sharedTabIds.asStateFlow()
 
     private var watcherJob: Job? = null
+
+    // Eager cloudflared prefetch: when sharing is enabled in cloudflare mode we fetch the binary
+    // in the background so the first share is instant. @Volatile + the isActive guard keep it
+    // single-flight across rapid settings emissions.
+    @Volatile private var prefetchJob: Job? = null
 
     // ---- Approval handshake + 24h rolling access keys (issue #276) ----
 
@@ -303,9 +308,23 @@ object SessionShareManager {
         if (watcherJob?.isActive == true) return
         watcherJob = scope.launch {
             SettingsManager.instance.settings
-                .map { it.sessionSharingEnabled }
+                .map { it.sessionSharingEnabled to it.shareTailscaleMode }
                 .distinctUntilChanged()
-                .collect { enabled -> if (!enabled) stopAll() }
+                .collect { (enabled, mode) ->
+                    if (!enabled) { stopAll(); return@collect }
+                    // EAGER prefetch: as soon as cloudflare sharing is enabled, fetch cloudflared in
+                    // the background so the first share doesn't pay the download. No-op when a
+                    // bundled/PATH/managed binary already works; single-flight via prefetchJob.
+                    if (mode == "cloudflare" && prefetchJob?.isActive != true) {
+                        prefetchJob = scope.launch(Dispatchers.IO) {
+                            if (!CloudflaredExposer.isInstalled() && CloudflaredExposer.canAutoInstall()) {
+                                log.info("Prefetching cloudflared for session sharing…")
+                                val ok = CloudflaredExposer.ensureInstalled()
+                                log.info("cloudflared prefetch {}", if (ok) "ready" else "failed (will retry at share time)")
+                            }
+                        }
+                    }
+                }
         }
     }
 
@@ -488,6 +507,20 @@ object SessionShareManager {
      * failed attempt or a superseded op destroys its own tunnel, so nothing is ever leaked.
      */
     private suspend fun establishCloudflareVerified(port: Int, op: Int): String? {
+        // Make sure cloudflared is present before we try to start a tunnel. If the eager prefetch
+        // already installed it (or a bundled copy exists), this is an instant no-op; otherwise we
+        // install now — surfacing "installing…" — instead of silently dropping to the LAN link.
+        if (!CloudflaredExposer.isInstalled()) {
+            if (!isCurrentRemoteOp(op)) return null
+            if (!CloudflaredExposer.canAutoInstall()) return null // unsupported → LAN fallback (manual install offered in UI)
+            _remoteStateFlow.value = RemoteState(RemoteStatus.Installing, "cloudflare")
+            val installed = withContext(Dispatchers.IO) { CloudflaredExposer.ensureInstalled() }
+            if (!isCurrentRemoteOp(op)) return null
+            if (!installed) {
+                log.warn("cloudflared install failed; falling back to LAN link")
+                return null
+            }
+        }
         var refreshes = 0
         // Already runs on Dispatchers.IO (manager scope / caller's withContext), so the
         // blocking awaitUrl/awaitReady don't need their own withContext.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -402,6 +402,7 @@ private fun RemoteAccessSetupSection(
     val active = remote.status == SessionShareManager.RemoteStatus.Active
     // A switch/establish is in progress — don't let the picker queue a second one mid-flight.
     val busy = remote.status == SessionShareManager.RemoteStatus.Starting ||
+        remote.status == SessionShareManager.RemoteStatus.Installing ||
         remote.status == SessionShareManager.RemoteStatus.Verifying ||
         remote.status == SessionShareManager.RemoteStatus.Retrying
     val isCloudflare = mode == "cloudflare"
@@ -475,6 +476,7 @@ private fun RemoteAccessSetupSection(
                 when (remote.status) {
                     SessionShareManager.RemoteStatus.Off -> "LAN only"
                     SessionShareManager.RemoteStatus.Starting -> "${remote.mode} · starting…"
+                    SessionShareManager.RemoteStatus.Installing -> "${remote.mode} · installing…"
                     SessionShareManager.RemoteStatus.Verifying -> "${remote.mode} · verifying link…"
                     SessionShareManager.RemoteStatus.Retrying ->
                         "${remote.mode} · retrying (${remote.attempt}/${remote.maxAttempts})…"
@@ -563,7 +565,7 @@ private fun RemoteAccessSetupSection(
                     if (!active) {
                         Text(
                             "Not active yet — the links above still use the LAN address. " +
-                                if (isCloudflare) "Install cloudflared, then re-share." else "Finish the steps, then re-share.",
+                                if (isCloudflare) "Share to bring up the public link (cloudflared installs automatically)." else "Finish the steps, then re-share.",
                             color = TextMuted, fontSize = 11.sp
                         )
                     }
@@ -595,16 +597,20 @@ private fun ProviderInstallRow(
                 Text("1. $label", color = TextMuted, fontSize = 11.sp)
                 Text(
                     when {
-                        // cloudflared installs in-app on every platform (direct binary on Linux /
-                        // Homebrew-less macOS, Homebrew otherwise); Tailscale is Homebrew-only.
-                        installing -> if (isCloudflared) "Installing cloudflared… (this can take a minute)"
+                        // cloudflared is installed automatically (eager prefetch + at share time) on
+                        // every supported platform, so its copy reflects an automatic flow rather than
+                        // a manual step; Tailscale is still a manual Homebrew + sign-in.
+                        installing -> if (isCloudflared) "Installing cloudflared automatically… (this can take a minute)"
                                       else "Installing via Homebrew… (this can take a minute)"
                         installed == null -> "Checking…"
-                        installed == true -> if (isCloudflared) "Installed ✓ — ready (no sign-in needed)."
+                        installed == true -> if (isCloudflared) "Ready ✓ — installed automatically (no sign-in needed)."
                                              else "Installed ✓ — now sign in (menu-bar app, or `tailscale up`)."
-                        installFailed -> "Install failed — check your connection and Retry, or install manually."
-                        autoInstallOk -> if (isCloudflared) "Not found — install it." else "Not found — install it, then sign in."
-                        else -> "Not found — install manually."
+                        installFailed -> if (isCloudflared) "Automatic install failed — check your connection and Retry, or install manually."
+                                         else "Install failed — check your connection and Retry, or install manually."
+                        autoInstallOk -> if (isCloudflared) "Installs automatically when you share — no setup needed."
+                                         else "Not found — install it, then sign in."
+                        else -> if (isCloudflared) "Not supported on this platform — install manually."
+                                else "Not found — install manually."
                     },
                     color = when {
                         installed == true -> Color(0xFF4CAF50)
@@ -618,7 +624,12 @@ private fun ProviderInstallRow(
                     LinkText("Download $label →", downloadUrl)
                 }
             }
-            if (installed == false && autoInstallOk) {
+            // cloudflared installs itself (eager prefetch + at share time), so only surface the
+            // manual button if that automatic install actually failed. Tailscale always needs the
+            // explicit click (Homebrew install + sign-in).
+            val showInstallButton = installed == false && autoInstallOk &&
+                (if (isCloudflared) installFailed else true)
+            if (showInstallButton) {
                 Button(
                     onClick = onInstall,
                     enabled = !installing,

--- a/compose-ui/src/desktopMain/resources/cloudflared-pin.properties
+++ b/compose-ui/src/desktopMain/resources/cloudflared-pin.properties
@@ -1,0 +1,20 @@
+# Single source of truth for the cloudflared release BossTerm bundles / auto-installs.
+#
+# Read at BUILD time by bossterm-app/build.gradle.kts (to fetch + bundle the binary into the
+# packaged app) and at RUNTIME by CloudflaredExposer (to verify auto-downloads). cloudflared
+# publishes no checksums/signatures, so these hashes are pinned out-of-band: they are compiled
+# into the app/jar at build time, never fetched from the download channel, and anything that
+# doesn't match is refused before we chmod +x / run it.
+#
+# Bump `version` AND every sha256 together when updating cloudflared (auto-update is disabled
+# at runtime, so a pinned build is fine). Hashes verified against the published GitHub release
+# assets at https://github.com/cloudflare/cloudflared/releases/download/<version>/<asset>.
+version=2026.5.2
+sha256.cloudflared-linux-amd64=5286698547f03df745adb2355f04c12dde52ef425491e81f433642d695521886
+sha256.cloudflared-linux-arm64=5a4e8ce2701105271412059f44b6a0bf1ae4542b4d98ff3180c0c019443a5815
+sha256.cloudflared-linux-arm=70a4c869a037bd69af6ce2ad0c4da4a7680d94fcfb8d4c70ecddae24d560762f
+sha256.cloudflared-linux-386=ad82d1dbed8bbb9d702807cbd97df932cc774d29e9da5c109b7a3c7f7aee2065
+sha256.cloudflared-darwin-amd64.tgz=7240f709506bc2c1eb9da4d89cf2555499c60280ecb854b7d80e8f17d4b7903d
+sha256.cloudflared-darwin-arm64.tgz=ba94054c9fd4297645093d59d51442e5e546d07bb0516120e694a13d5b216d38
+sha256.cloudflared-windows-amd64.exe=20b9638f685333d623798e733effbad2487093f15ba592f6c7752360ff3b7ab7
+sha256.cloudflared-windows-386.exe=6736615e8d2b3b61e868e32907e85641b4ec7b2b8c26bd3361ec15e56e53e242

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/CloudflaredPinTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/CloudflaredPinTest.kt
@@ -1,0 +1,52 @@
+package ai.rever.bossterm.compose.share
+
+import java.util.Properties
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Drift guard for `cloudflared-pin.properties` — the single source of truth shared by the runtime
+ * ([CloudflaredExposer]) and the app build (bossterm-app bundles the binary from it). If the file
+ * goes missing, loses its version, or drops a hash for any platform/arch we install on, that
+ * platform's auto-install / bundle silently breaks — so assert the contract here at build time.
+ */
+class CloudflaredPinTest {
+
+    private val pin: Properties = Properties().apply {
+        val res = CloudflaredPinTest::class.java.classLoader
+            ?.getResourceAsStream("cloudflared-pin.properties")
+        assertNotNull(res, "cloudflared-pin.properties must be on the classpath (compose-ui resources)")
+        res.use { load(it) }
+    }
+
+    // Every asset CloudflaredExposer can download / the build can bundle. cloudflared ships no
+    // arm64 Windows build, so it is intentionally absent.
+    private val requiredAssets = listOf(
+        "cloudflared-linux-amd64",
+        "cloudflared-linux-arm64",
+        "cloudflared-linux-arm",
+        "cloudflared-linux-386",
+        "cloudflared-darwin-amd64.tgz",
+        "cloudflared-darwin-arm64.tgz",
+        "cloudflared-windows-amd64.exe",
+        "cloudflared-windows-386.exe",
+    )
+
+    @Test
+    fun `pin has a non-blank version`() {
+        val version = pin.getProperty("version")
+        assertNotNull(version, "missing 'version'")
+        assertTrue(version.isNotBlank(), "'version' must not be blank")
+    }
+
+    @Test
+    fun `pin has a valid sha256 for every supported asset`() {
+        val hex = Regex("[0-9a-fA-F]{64}")
+        for (asset in requiredAssets) {
+            val sha = pin.getProperty("sha256.$asset")
+            assertNotNull(sha, "missing sha256.$asset")
+            assertTrue(hex.matches(sha.trim()), "sha256.$asset must be 64 hex chars, got '$sha'")
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Session sharing uses a Cloudflare Quick Tunnel (default `shareTailscaleMode = "cloudflare"`), which needs the `cloudflared` CLI. Previously, if it wasn't installed, sharing silently fell back to a LAN-only link and the UI told the user to install it manually (and macOS preferred a slow global `brew install`). Windows had no auto-install at all.

This makes BossTerm provide `cloudflared` itself, with **no manual step on any platform**:

- **Bundled in the packaged app** — the build downloads + SHA-verifies the binary for the build target and bundles it, so sharing works **offline with zero download**.
- **Auto-download fallback** — for Maven-library consumers and any platform/arch the build didn't bundle (incl. Windows).
- **Eager prefetch** when session sharing is enabled (cloudflare mode), plus a lazy install at share time showing an "installing…" status — instead of silently dropping to the LAN link.

## Changes

- **`cloudflared-pin.properties`** (new) — single source of truth for version + per-asset SHA-256, read by both the runtime and the build. Real Windows hashes included.
- **`CloudflaredExposer`** — bundled-binary resolution first; Windows support (`winArch` + `windowsDirectInstall`); silent-friendly `ensureInstalled()` (single-flight, skips Homebrew); pins loaded from the properties resource.
- **`SessionShareManager`** — new `RemoteStatus.Installing`; eager prefetch in the settings watcher; install before starting the tunnel.
- **`ShareWindow`** — reflects the automatic install; manual button only surfaces on failure.
- **`bossterm-app/build.gradle.kts`** — `fetchCloudflaredBinary` (download + verify + stage), folded into the app via the existing `Sync` (so it can't be clobbered); bundled binary codesigned for macOS notarization.
- **`CloudflaredPinTest`** (new) — drift guard: pin has a version + valid SHA for every supported os/arch.

## Verification

- `compose-ui` main + tests compile; `CloudflaredPinTest` passes.
- `bossterm-app` build script configures cleanly.
- The build-time fetch was run end-to-end: downloaded `cloudflared 2026.5.2`, matched the pinned darwin-arm64 SHA, extracted a working Mach-O executable, and the `Sync` folded it into `common/` alongside `bossterm` with the exec bit intact.

## Not exercised here (needs a full packaging run / running app)

- DMG notarization with the bundled binary signed.
- Runtime UI flow (eager prefetch / "installing…" status).
- Windows isn't packaged in CI today, so there it's served purely by the (verified) auto-download path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
