### PR TITLE
fix(cli): create the bin dir instead of erroring when it's missing

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/cli/CLIInstaller.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/cli/CLIInstaller.kt
@@ -15,11 +15,22 @@ object CLIInstaller {
     private val isLinux = ShellCustomizationUtils.isLinux()
 
     /**
+     * Test-only seams (set by `:compose-ui:desktopTest`). [testInstallDir] redirects the
+     * mac/Linux install dir + path to a temp location so the dir-creation/write logic can be
+     * exercised without touching the real /usr/local; when [testScript] is non-null it stands
+     * in for the bundled CLI script (and signals test mode, so the MCP-helper/man-page side
+     * installs are skipped). Both default null = production behavior.
+     */
+    @Volatile internal var testInstallDir: String? = null
+    @Volatile internal var testScript: String? = null
+
+    /**
      * Get the install path based on platform.
      * Windows: %LOCALAPPDATA%\BossTerm\bossterm.cmd (no admin needed)
      * macOS/Linux: /usr/local/bin/bossterm
      */
     private fun getInstallPath(): String {
+        testInstallDir?.let { return "$it/$CLI_NAME" }
         return if (isWindows) {
             val localAppData = System.getenv("LOCALAPPDATA") ?: System.getProperty("user.home")
             "$localAppData\\BossTerm\\bossterm.cmd"
@@ -32,6 +43,7 @@ object CLIInstaller {
      * Get the install directory based on platform.
      */
     private fun getInstallDir(): String {
+        testInstallDir?.let { return it }
         return if (isWindows) {
             val localAppData = System.getenv("LOCALAPPDATA") ?: System.getProperty("user.home")
             "$localAppData\\BossTerm"
@@ -113,8 +125,9 @@ object CLIInstaller {
 
             // Try to write directly (might work if user has permissions)
             val targetFile = File(getInstallPath())
-            val mcpHelperContent = getMcpHelperScript()  // may be null on Windows-only setups
-            val manPageContent = getManPageContent()     // may be null on Windows
+            // In test mode skip the helper/man side-installs (they'd touch real user paths).
+            val mcpHelperContent = if (testScript != null) null else getMcpHelperScript()
+            val manPageContent = if (testScript != null) null else getManPageContent()
             try {
                 FileOutputStream(targetFile).use { out ->
                     out.write(scriptContent.toByteArray())
@@ -392,6 +405,7 @@ object CLIInstaller {
      * script doesn't cover it; that's tracked separately.
      */
     private fun getCLIScript(): String? {
+        testScript?.let { return it }
         if (isWindows) return EMBEDDED_WINDOWS_CLI_SCRIPT
         return findCliResource("bossterm")
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/cli/CLIInstaller.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/cli/CLIInstaller.kt
@@ -99,10 +99,16 @@ object CLIInstaller {
                 return installWindows(scriptContent)
             }
 
-            // macOS/Linux: Check if /usr/local/bin exists
+            // macOS/Linux: ensure the bin dir exists. On Apple Silicon Macs /usr/local/bin
+            // doesn't exist by default (Homebrew lives in /opt/homebrew) — create it rather
+            // than erroring. If we can't make it without elevation, hand off to the privileged
+            // installer (which mkdir -p's under sudo) instead of failing.
             val installDir = File(getInstallDir())
             if (!installDir.exists()) {
-                return InstallResult.Error("Directory ${getInstallDir()} does not exist")
+                runCatching { installDir.mkdirs() }
+                if (!installDir.exists()) {
+                    return installWithAdminPrivileges(scriptContent)
+                }
             }
 
             // Try to write directly (might work if user has permissions)
@@ -290,15 +296,18 @@ object CLIInstaller {
             tempFile.setExecutable(true)
 
             val installPath = getInstallPath()
+            val installDir = getInstallDir()
+            // mkdir -p the bin dir under elevation first — it may not exist (Apple Silicon
+            // has no /usr/local/bin by default), and creating it needs root just like the copy.
             val process = if (isMacOS) {
                 // macOS: Use osascript to run with admin privileges
                 val script = """
-                    do shell script "cp '${tempFile.absolutePath}' '$installPath' && chmod +x '$installPath'" with administrator privileges
+                    do shell script "mkdir -p '$installDir' && cp '${tempFile.absolutePath}' '$installPath' && chmod +x '$installPath'" with administrator privileges
                 """.trimIndent()
                 ProcessBuilder("osascript", "-e", script)
             } else if (isLinux) {
                 // Linux: Use pkexec (PolicyKit) for GUI privilege escalation
-                ProcessBuilder("pkexec", "sh", "-c", "cp '${tempFile.absolutePath}' '$installPath' && chmod +x '$installPath'")
+                ProcessBuilder("pkexec", "sh", "-c", "mkdir -p '$installDir' && cp '${tempFile.absolutePath}' '$installPath' && chmod +x '$installPath'")
             } else {
                 tempFile.delete()
                 return InstallResult.Error("Unsupported platform. Please manually copy the script to $installPath")

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/cli/CLIInstallerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/cli/CLIInstallerTest.kt
@@ -1,0 +1,69 @@
+package ai.rever.bossterm.compose.cli
+
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the mac/Linux CLI install dir handling — specifically the fix where a MISSING bin dir
+ * is created instead of erroring ("Directory /usr/local/bin does not exist" on Apple Silicon,
+ * where that dir doesn't exist by default). Uses [CLIInstaller.testInstallDir]/[testScript] to
+ * point the installer at a temp dir + a stub script, so nothing touches the real /usr/local.
+ */
+class CLIInstallerTest {
+
+    private val script = "#!/bin/bash\necho bossterm test cli\n"
+    private var tmp: File? = null
+
+    @AfterTest
+    fun cleanup() {
+        CLIInstaller.testInstallDir = null
+        CLIInstaller.testScript = null
+        tmp?.deleteRecursively()
+    }
+
+    // Windows takes the AppData/.cmd path; this fix is mac/Linux-only.
+    private fun skipOnWindows(): Boolean =
+        System.getProperty("os.name").orEmpty().lowercase().contains("win")
+
+    @Test
+    fun `install creates a missing bin dir and writes the executable script`() {
+        if (skipOnWindows()) return
+        val root = File.createTempFile("bossterm-cli-test", "").apply { delete(); mkdirs() }
+        tmp = root
+        val binDir = File(root, "nested/bin") // does NOT exist yet (parent is user-writable)
+        assertTrue(!binDir.exists(), "precondition: bin dir must be absent")
+
+        CLIInstaller.testInstallDir = binDir.absolutePath
+        CLIInstaller.testScript = script
+
+        val result = CLIInstaller.install()
+
+        assertEquals(CLIInstaller.InstallResult.Success, result)
+        assertTrue(binDir.isDirectory, "the missing bin dir should have been created")
+        val installed = File(binDir, "bossterm")
+        assertTrue(installed.isFile, "the script should be written")
+        assertEquals(script, installed.readText())
+        assertTrue(installed.canExecute(), "the script should be marked executable")
+    }
+
+    @Test
+    fun `install into an already-existing bin dir still works`() {
+        if (skipOnWindows()) return
+        val root = File.createTempFile("bossterm-cli-test", "").apply { delete(); mkdirs() }
+        tmp = root
+        val binDir = File(root, "bin").apply { mkdirs() } // already exists
+
+        CLIInstaller.testInstallDir = binDir.absolutePath
+        CLIInstaller.testScript = script
+
+        val result = CLIInstaller.install()
+
+        assertEquals(CLIInstaller.InstallResult.Success, result)
+        val installed = File(binDir, "bossterm")
+        assertTrue(installed.isFile)
+        assertEquals(script, installed.readText())
+    }
+}


### PR DESCRIPTION
## Problem

The in-app **Install Command Line Tool** dialog failed with:

> Error: Directory /usr/local/bin does not exist

`/usr/local/bin` doesn't exist by default on Apple Silicon Macs (Homebrew lives in `/opt/homebrew`), and `CLIInstaller.install()` hard-errored instead of creating it. (Companion to #287, which fixed the Welcome-wizard's Starship installer hitting the same missing dir.)

## Fix

- When the bin dir is missing, try to create it (`mkdirs()`); if that needs elevation, hand off to the privileged installer rather than erroring.
- The admin path (osascript on macOS / pkexec on Linux) now runs `mkdir -p '<bindir>'` before the copy, so the dir is created under sudo alongside the script + chmod.

## Test

- New `CLIInstallerTest` (`:compose-ui:desktopTest`) covers the fix **without touching the real /usr/local**: test-only seams (`testInstallDir`/`testScript`) redirect the mac/Linux install dir + script to a temp dir.
  - **create path**: a *missing* bin dir is created and the executable script written (the previously-erroring Apple Silicon case);
  - **regression**: an existing dir still works.
  - Skips on Windows (different AppData/.cmd path).
- Runs in CI on macOS + Ubuntu + Windows via the existing `test.yml` → `:compose-ui:desktopTest`.

Note: only reproducible manually on a machine that actually lacks `/usr/local/bin` (a clean Apple Silicon Mac / VM) — on a dev machine the dir already exists, so the unit test is the portable proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)