### PR TITLE
fix(onboarding): sudo npm when global prefix is root-owned + install-script test & live CI

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -431,8 +431,12 @@ jobs:
 
       - name: Verify the tools landed
         run: |
+          set -e
           export NVM_DIR="$HOME/.nvm"; [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" || true
           command -v starship && starship --version
           command -v git && git --version
-          # AI CLIs live under the npm global prefix; surface what installed (best-effort).
+          # AI CLIs install under the npm global prefix/bin — add it to PATH and assert at
+          # least one resolves, so this job truly proves the install produced runnable tools.
+          export PATH="$(npm prefix -g 2>/dev/null)/bin:$PATH"
           npm ls -g --depth=0 2>/dev/null || true
+          command -v claude && echo "✓ claude CLI installed"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - 'install.sh'
       - '.github/workflows/test-install.yml'
+      - 'compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/onboarding/**'
+      - 'compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/onboarding/**'
   pull_request:
     branches: [master]
     paths:
       - 'install.sh'
       - '.github/workflows/test-install.yml'
+      - 'compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/onboarding/**'
+      - 'compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/onboarding/**'
   workflow_dispatch:
     inputs:
       run_real_install:
@@ -388,3 +392,47 @@ jobs:
           needs.test-ubuntu.result == 'failure' ||
           needs.test-windows-ps.result == 'failure'
         run: exit 1
+
+  # ============================================================================
+  # Onboarding wizard: live install of the DEFAULT tool selection on Ubuntu.
+  # Non-blocking (continue-on-error) — npm/apt/github network flakiness must not
+  # gate merges; the deterministic OnboardingInstallScriptTest in test.yml is the
+  # required guard. This job proves the generated script actually runs end-to-end.
+  # ============================================================================
+  onboarding-install-ubuntu:
+    name: Onboarding tool install (Ubuntu, live)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Emit the wizard's default install script
+        run: |
+          BOSSTERM_EMIT_INSTALL_SCRIPT="$PWD/onboarding-install.sh" \
+            ./gradlew :compose-ui:desktopTest \
+            --tests "ai.rever.bossterm.compose.onboarding.OnboardingInstallScriptTest" --no-daemon
+          echo "----- generated script -----"
+          cat onboarding-install.sh
+
+      - name: Run the generated install script (Starship + git/gh + AI CLIs)
+        env:
+          BOSSTERM_SUDO_PWD: ""   # passwordless sudo on the runner; sudo -S ignores it
+        run: bash onboarding-install.sh
+
+      - name: Verify the tools landed
+        run: |
+          export NVM_DIR="$HOME/.nvm"; [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" || true
+          command -v starship && starship --version
+          command -v git && git --version
+          # AI CLIs live under the npm global prefix; surface what installed (best-effort).
+          npm ls -g --depth=0 2>/dev/null || true

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingWizard.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingWizard.kt
@@ -1063,14 +1063,22 @@ private fun buildInstallCommandInternal(selections: OnboardingSelections, instal
         val npmPackages = aiToInstall.joinToString(" ") { it.second }
         // Build cleanup command to remove any corrupted/partial npm installations (fixes ENOTEMPTY error)
         val packagesToClean = aiToInstall.map { it.second }
+        // $NPM_SUDO (set per-branch below) elevates only when npm's global dir isn't
+        // user-writable, so cleanup + install match the install's privilege level.
         val unixCleanup = packagesToClean.joinToString("; ") { pkg ->
-            "rm -rf \"\$(npm prefix -g 2>/dev/null)/lib/node_modules/$pkg\" 2>/dev/null || true"
+            "\$NPM_SUDO rm -rf \"\$(npm prefix -g 2>/dev/null)/lib/node_modules/$pkg\" 2>/dev/null || true"
         }
         val nodeCheckAndInstall = when {
             isMac -> {
                 "{ command -v npm >/dev/null 2>&1 || { echo 'Installing Node.js via Homebrew...' && brew install node; }; } && " +
+                // npm's global modules dir is root-owned when Node was installed via the
+                // official .pkg (prefix /usr/local) rather than Homebrew — `npm install -g`
+                // then EACCES'es. Use sudo ONLY when it isn't user-writable (creds are
+                // pre-authed; see needsSudo below). Homebrew prefixes stay sudo-free.
+                "NPM_MODULES=\"\$(npm prefix -g 2>/dev/null)/lib/node_modules\" && " +
+                "if [ -w \"\$NPM_MODULES\" ] || { [ ! -e \"\$NPM_MODULES\" ] && [ -w \"\$(dirname \"\$NPM_MODULES\")\" ]; }; then NPM_SUDO=''; else NPM_SUDO='sudo'; fi && " +
                 "echo 'Cleaning up any partial installations...' && $unixCleanup && " +
-                "npm install -g $npmPackages"
+                "\$NPM_SUDO npm install -g $npmPackages"
             }
             isWindows -> {
                 // Use winget or Chocolatey to install Node.js if npm is not available
@@ -1102,9 +1110,9 @@ private fun buildInstallCommandInternal(selections: OnboardingSelections, instal
                 "if [ \"\$NODE_VER\" != \"none\" ] && [ \"\$NODE_VER\" != \"system\" ]; then nvm uninstall \"\$NODE_VER\" 2>/dev/null; fi && " +
                 "nvm install --lts && nvm alias default node; " +
                 "fi && " +
-                "nvm use default && " +
+                "nvm use default && NPM_SUDO='' && " + // nvm's prefix (~/.nvm) is user-owned → no sudo
                 "echo 'Cleaning up any partial installations...' && $unixCleanup && " +
-                "npm install -g $npmPackages"
+                "\$NPM_SUDO npm install -g $npmPackages"
             }
         }
         userCommands.add(nodeCheckAndInstall)
@@ -1135,7 +1143,10 @@ private fun buildInstallCommandInternal(selections: OnboardingSelections, instal
     val allCommands = mutableListOf<String>()
 
     // Authenticate sudo upfront for Unix (Starship and other tools internally use sudo)
-    val needsSudo = !isWindows && (sudoCommands.isNotEmpty() || userCommands.any { it.contains("starship") })
+    // Pre-auth sudo when any step may need it: explicit sudo commands, Starship (creates
+    // /usr/local/bin), or mac AI installs (a root-owned npm global prefix → sudo npm).
+    val needsSudo = !isWindows && (sudoCommands.isNotEmpty() || userCommands.any { it.contains("starship") } ||
+        (isMac && aiToInstall.isNotEmpty()))
     if (needsSudo) {
         allCommands.add("echo '🔐 Authenticating administrator access...'")
         // Use sudo -S to read password from stdin (provided via env var)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingWizard.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingWizard.kt
@@ -1077,8 +1077,12 @@ private fun buildInstallCommandInternal(selections: OnboardingSelections, instal
                 // pre-authed; see needsSudo below). Homebrew prefixes stay sudo-free.
                 "NPM_MODULES=\"\$(npm prefix -g 2>/dev/null)/lib/node_modules\" && " +
                 "if [ -w \"\$NPM_MODULES\" ] || { [ ! -e \"\$NPM_MODULES\" ] && [ -w \"\$(dirname \"\$NPM_MODULES\")\" ]; }; then NPM_SUDO=''; else NPM_SUDO='sudo'; fi && " +
+                // Resolve npm's absolute path: `sudo npm` would otherwise fail with
+                // command-not-found, since macOS sudo's env_reset can drop /usr/local/bin
+                // from PATH — and that's exactly where the official .pkg's npm lives.
+                "NPM_BIN=\"\$(command -v npm)\" && " +
                 "echo 'Cleaning up any partial installations...' && $unixCleanup && " +
-                "\$NPM_SUDO npm install -g $npmPackages"
+                "\$NPM_SUDO \"\$NPM_BIN\" install -g $npmPackages"
             }
             isWindows -> {
                 // Use winget or Chocolatey to install Node.js if npm is not available
@@ -1111,8 +1115,9 @@ private fun buildInstallCommandInternal(selections: OnboardingSelections, instal
                 "nvm install --lts && nvm alias default node; " +
                 "fi && " +
                 "nvm use default && NPM_SUDO='' && " + // nvm's prefix (~/.nvm) is user-owned → no sudo
+                "NPM_BIN=\"\$(command -v npm)\" && " +
                 "echo 'Cleaning up any partial installations...' && $unixCleanup && " +
-                "\$NPM_SUDO npm install -g $npmPackages"
+                "\$NPM_SUDO \"\$NPM_BIN\" install -g $npmPackages"
             }
         }
         userCommands.add(nodeCheckAndInstall)
@@ -1120,8 +1125,10 @@ private fun buildInstallCommandInternal(selections: OnboardingSelections, instal
         // Add npm global bin to PATH if not already present
         if (!isWindows) {
             postInstallCommands.add(
-                "NPM_BIN=\$(npm bin -g 2>/dev/null) && " +
-                "if [ -n \"\$NPM_BIN\" ] && [ -d \"\$NPM_BIN\" ]; then " +
+                // `npm bin -g` was removed in npm v9 (returns empty) — derive the global bin
+                // from the prefix so the just-installed CLIs actually get onto PATH.
+                "NPM_BIN=\"\$(npm prefix -g 2>/dev/null)/bin\" && " +
+                "if [ -d \"\$NPM_BIN\" ]; then " +
                 "  SHELL_NAME=\$(basename \"\$SHELL\") && " +
                 "  if [ \"\$SHELL_NAME\" = \"zsh\" ]; then " +
                 "    grep -q \"\$NPM_BIN\" ~/.zshrc 2>/dev/null || grep -q \"\$NPM_BIN\" ~/.zprofile 2>/dev/null || " +

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingInstallScriptTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingInstallScriptTest.kt
@@ -51,11 +51,12 @@ class OnboardingInstallScriptTest {
             script.contains("[ -d /usr/local/bin ]"),
             "Starship install must guard /usr/local/bin existence:\n$script"
         )
-        // AI-CLI npm global install must go through the writability-gated \$NPM_SUDO, never a bare
-        // `npm install -g` (which EACCES'es on a root-owned global prefix).
+        // AI-CLI npm global install must go through the writability-gated \$NPM_SUDO with npm
+        // resolved to an absolute path (\$NPM_BIN) — a bare `npm install -g` EACCES'es on a
+        // root-owned prefix, and a bare `sudo npm` can hit command-not-found under env_reset.
         assertTrue(
-            script.contains("\$NPM_SUDO npm install -g"),
-            "AI-CLI npm install must use the \$NPM_SUDO guard:\n$script"
+            script.contains("\$NPM_SUDO \"\$NPM_BIN\" install -g"),
+            "AI-CLI npm install must use \$NPM_SUDO + resolved \$NPM_BIN:\n$script"
         )
         // Defaults include Starship → sudo is pre-authed so the guarded sudo calls run unattended.
         assertTrue(

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingInstallScriptTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingInstallScriptTest.kt
@@ -1,0 +1,78 @@
+package ai.rever.bossterm.compose.onboarding
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the onboarding wizard's generated tool-install script (the in-app "Welcome to BossTerm"
+ * flow). [buildInstallCommand] is platform-sensitive (it reads `os.name`), so on each CI OS this
+ * exercises that OS's branch with the wizard's default selections (Zsh + Starship + git + gh +
+ * all AI assistants) and nothing pre-installed — the realistic "accept defaults" install.
+ *
+ * Catches the class of bugs we've actually shipped: malformed shell (the bash that won't parse),
+ * the missing-`/usr/local/bin` Starship abort, and the AI-CLI `npm install -g` EACCES when npm's
+ * global prefix is root-owned. The companion CI job (.github/workflows/test-install.yml) actually
+ * RUNS the emitted script on Ubuntu; this test is the fast, deterministic, every-PR guard.
+ */
+class OnboardingInstallScriptTest {
+
+    private val isWindows = System.getProperty("os.name").orEmpty().lowercase().contains("win")
+
+    private fun defaultScript(): String =
+        buildInstallCommand(OnboardingSelections(), InstalledTools())
+
+    @Test
+    fun `default install script is syntactically valid`() {
+        val script = defaultScript()
+        assertTrue(script.isNotBlank(), "generated install script must not be empty")
+        if (isWindows) return // Windows emits an &&-joined PowerShell-flavored line, not bash.
+
+        assertTrue(script.startsWith("#!/bin/bash"), "unix script should start with a shebang:\n$script")
+        // `bash -n` parses without executing — the real guard against malformed commands.
+        val tmp = File.createTempFile("onboarding-install", ".sh")
+        try {
+            tmp.writeText(script)
+            val proc = ProcessBuilder("bash", "-n", tmp.absolutePath).redirectErrorStream(true).start()
+            val out = proc.inputStream.bufferedReader().readText()
+            assertEquals(0, proc.waitFor(), "bash -n rejected the generated script:\n$out\n---\n$script")
+        } finally {
+            tmp.delete()
+        }
+    }
+
+    @Test
+    fun `default install script keeps the known-bug guards`() {
+        if (isWindows) return
+        val script = defaultScript()
+        // Starship's installer aborts if /usr/local/bin is missing (Apple Silicon) — must be guarded.
+        assertTrue(
+            script.contains("[ -d /usr/local/bin ]"),
+            "Starship install must guard /usr/local/bin existence:\n$script"
+        )
+        // AI-CLI npm global install must go through the writability-gated \$NPM_SUDO, never a bare
+        // `npm install -g` (which EACCES'es on a root-owned global prefix).
+        assertTrue(
+            script.contains("\$NPM_SUDO npm install -g"),
+            "AI-CLI npm install must use the \$NPM_SUDO guard:\n$script"
+        )
+        // Defaults include Starship → sudo is pre-authed so the guarded sudo calls run unattended.
+        assertTrue(
+            script.contains("Authenticating administrator access"),
+            "script should authenticate sudo upfront when it contains sudo steps:\n$script"
+        )
+    }
+
+    /**
+     * Not an assertion — when `BOSSTERM_EMIT_INSTALL_SCRIPT` is set, writes the generated
+     * default install script to that path so the CI live-install job can execute it. A no-op
+     * (passes) otherwise, so it's harmless in the normal test run.
+     */
+    @Test
+    fun `emit install script for CI when requested`() {
+        val target = System.getenv("BOSSTERM_EMIT_INSTALL_SCRIPT") ?: return
+        File(target).writeText(defaultScript())
+        assertTrue(File(target).length() > 0)
+    }
+}


### PR DESCRIPTION
## Problem

The Welcome wizard's AI-CLI step failed on a user's Mac:

```
npm error code EACCES
npm error path /usr/local/lib/node_modules/@anthropic-ai
npm error Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules/@anthropic-ai'
```

It ran `npm install -g` as the user, but when Node was installed via the official `.pkg` the npm global prefix (`/usr/local/lib/node_modules`) is **root-owned** → EACCES. The Linux path already avoids this (nvm → user-owned prefix); the mac path assumed a writable Homebrew prefix.

## Fix

- The npm global install + cleanup now go through `$NPM_SUDO`, which is **sudo only when the global dir isn't user-writable** (Homebrew/nvm prefixes stay sudo-free). `needsSudo` pre-auths sudo for mac AI installs so the elevated `npm` runs unattended (the wizard's existing keepalive).

## Tests — both layers the request asked for

1. **Deterministic (every PR, mac+ubuntu+win)** — `OnboardingInstallScriptTest` generates the wizard's default-selection script (Zsh + Starship + git + gh + all AI assistants, nothing pre-installed; `buildInstallCommand` emits the per-OS branch) and asserts it's **valid bash (`bash -n`)** and keeps the known-bug guards: the `/usr/local/bin` Starship guard, the new `$NPM_SUDO npm install -g` guard, and the sudo preamble. Zero flakiness; runs in the existing `test.yml`.
2. **Live install (Ubuntu, non-blocking)** — new `onboarding-install-ubuntu` job in `test-install.yml` emits the default script and **actually runs it end-to-end** (Starship + git/gh + AI CLIs via npm), then verifies. `continue-on-error: true` so npm/apt/github network flakiness can't gate merges; triggered on onboarding-path changes + `workflow_dispatch`.

macOS/Windows can't run the wizard's script headlessly (mac uses `osascript … with administrator privileges`), so live-install is Ubuntu-only; mac/Windows get the deterministic check.

## Verification
- `:compose-ui:desktopTest` green locally (macOS — exercises the mac branch: bash -n clean, guards present).
- CI will run the deterministic test on all 3 OSes and the live install on Ubuntu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)