### PR TITLE
feat(auth): Sign In via BossConsole account in the Share menu

### DIFF
--- a/bossterm-app/build.gradle.kts
+++ b/bossterm-app/build.gradle.kts
@@ -135,6 +135,17 @@ compose.desktop {
                         <string>BossTerm needs permission to send notifications when commands complete.</string>
                         <key>NSUserNotificationAlertStyle</key>
                         <string>alert</string>
+                        <key>CFBundleURLTypes</key>
+                        <array>
+                            <dict>
+                                <key>CFBundleURLName</key>
+                                <string>ai.rever.bossterm</string>
+                                <key>CFBundleURLSchemes</key>
+                                <array>
+                                    <string>bossterm</string>
+                                </array>
+                            </dict>
+                        </array>
                     """.trimIndent()
                 }
             }
@@ -614,16 +625,40 @@ fun fixDesktopFileInDebPackage(packageDir: File, injected: InjectedExecOps) {
             commandLine("dpkg-deb", "-R", debFile.absolutePath, workDir.absolutePath)
         }
 
-        // Find and modify .desktop file
+        // Find and modify .desktop file. jpackage's generated entry has neither
+        // StartupWMClass (taskbar grouping) nor the bossterm:// scheme handler, so we patch
+        // both: add StartupWMClass, register MimeType=x-scheme-handler/bossterm, and ensure the
+        // Exec line passes the URL through with %U — without all three, the sign-in magic link
+        // (bossterm://auth/verify) has no handler on .deb installs. (RPM is not repacked below —
+        // see note; .rpm scheme registration remains unhandled.)
         var modified = false
         workDir.walkTopDown()
             .filter { it.isFile && it.name.endsWith(".desktop") }
             .forEach { desktopFile ->
                 var content = desktopFile.readText()
+                var changed = false
                 if (!content.contains("StartupWMClass")) {
                     content = content.trimEnd() + "\nStartupWMClass=bossterm\n"
+                    changed = true
+                }
+                if (!content.contains("x-scheme-handler/bossterm")) {
+                    content = if (Regex("(?m)^MimeType=").containsMatchIn(content)) {
+                        content.replace(Regex("(?m)^MimeType=(.*)$")) { m ->
+                            val v = m.groupValues[1].trimEnd(';')
+                            "MimeType=$v;x-scheme-handler/bossterm;"
+                        }
+                    } else {
+                        content.trimEnd() + "\nMimeType=x-scheme-handler/bossterm;\n"
+                    }
+                    changed = true
+                }
+                // The launcher must receive the URL: ensure the Exec line ends with %U.
+                content = content.replace(Regex("(?m)^(Exec=.*?)( %[UufF])?\\s*$")) { m ->
+                    if (m.groupValues[2].isBlank()) { changed = true; "${m.groupValues[1]} %U" } else m.value
+                }
+                if (changed) {
                     desktopFile.writeText(content)
-                    println("Added StartupWMClass to ${desktopFile.name}")
+                    println("Patched ${desktopFile.name} (StartupWMClass + bossterm:// scheme handler)")
                     modified = true
                 }
             }

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -61,12 +61,18 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
  *
  * This is the main entry point for the BossTerm application.
  */
-fun main() {
+fun main(args: Array<String>) {
     // Configure GPU rendering (must be before any Skiko/Compose initialization)
     configureGpuRendering()
 
     // Set WM_CLASS for Linux desktop integration (must be before any AWT init)
     setLinuxWMClass()
+
+    // bossterm:// deep links (sign-in callback). Must run before application{} so a
+    // cold-start URL is caught; returns true when this launch existed only to carry a
+    // deep link that was forwarded to an already-running instance — exit before any
+    // window opens. Also registers the scheme in HKCU on packaged Windows launches.
+    if (ai.rever.bossterm.compose.auth.DeepLinkHandler.install(args)) return
 
     // App-singleton MCP server. Constructed once before composition starts so
     // its lifetime spans every Window. Windows register their TabbedTerminalState

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -825,6 +825,26 @@ fun TabbedTerminal(
     var mcpAttaching by remember { mutableStateOf(false) }
     // Session sharing (issue #276): dialog state + live set of shared tab ids.
     var shareDialog by remember { mutableStateOf<ai.rever.bossterm.compose.share.SessionShareManager.ShareInfo?>(null) }
+    // Account sign-in (BossConsole Supabase backend) — window opened from the Share menus.
+    var showSignInWindow by remember { mutableStateOf(false) }
+    var signInFocusTick by remember { mutableStateOf(0) }
+    // "Signed in as …" toast for deep-link sign-ins that complete after the window was
+    // closed (the manager emits only on interactive verifies, not the startup restore).
+    // The collector must NOT block on the dismiss delay — otherwise a second sign-in during
+    // the window is dropped (signInEvents is a buffer-of-1 SharedFlow). Auto-dismiss runs in
+    // its own effect, keyed on the toast value, so each new toast restarts the timer.
+    var signInToast by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(Unit) {
+        ai.rever.bossterm.compose.auth.BossAccountManager.signInEvents.collect { email ->
+            signInToast = email
+        }
+    }
+    LaunchedEffect(signInToast) {
+        if (signInToast != null) {
+            kotlinx.coroutines.delay(5000)
+            signInToast = null
+        }
+    }
     // "Add remote": connect to another BossTerm's shared session (native client).
     var showAddRemote by remember { mutableStateOf(false) }
     // Pending "request control?" confirmation: a view-only group's split/new-tab click stores
@@ -954,6 +974,10 @@ fun TabbedTerminal(
         }
     }
     val mcpServerName = LocalBossTermMcpConfig.current?.serverName ?: "bossterm"
+    // Sign In appears only in standalone BossTerm: inside an embedder (e.g. BossConsole's
+    // terminal-tab plugin, which has its own account + owns the boss:// scheme) it's hidden.
+    val signInVisible = mcpServerName == "bossterm"
+    val openSignIn: () -> Unit = { showSignInWindow = true; signInFocusTick++ }
     val fireMcpAttach: (McpAttachTarget) -> Unit = { target ->
         // De-dupe: ignore clicks while an attach is in flight from any
         // right-click entry point. The Settings panel maintains its own
@@ -1335,6 +1359,7 @@ fun TabbedTerminal(
                 onShareAll = { index ->
                     tabController.tabs.getOrNull(index)?.let { startShare(it.id, ai.rever.bossterm.compose.share.ShareScope.ALL) }
                 },
+                onSignIn = if (signInVisible) openSignIn else null,
                 onStopShare = { index ->
                     tabController.tabs.getOrNull(index)?.let {
                         ai.rever.bossterm.compose.share.SessionShareManager.unshare(it.id)
@@ -1688,7 +1713,13 @@ fun TabbedTerminal(
                                         label = "All Windows…",
                                         action = { startShare(activeTab.id, ai.rever.bossterm.compose.share.ShareScope.ALL) }
                                     )
-                                )
+                                ) + (if (signInVisible) listOf(
+                                    ContextMenuItem(
+                                        id = "sign_in",
+                                        label = "Sign In…",
+                                        action = openSignIn
+                                    )
+                                ) else emptyList())
                             )
                         }
                     }
@@ -1889,13 +1920,34 @@ fun TabbedTerminal(
                                         id = "share_all", label = "Share All Windows", enabled = true,
                                         action = { startShare(active.id, ai.rever.bossterm.compose.share.ShareScope.ALL) }
                                     ),
-                                ))
+                                ) + (if (signInVisible) listOf(
+                                    ai.rever.bossterm.compose.features.ContextMenuController.MenuItem(
+                                        id = "sign_in", label = "Sign In…", enabled = true,
+                                        action = openSignIn
+                                    )
+                                ) else emptyList()))
                             }
                         }
                     },
                 )
                 attachStatus?.let { status ->
                     AttachToast(status = status)
+                }
+                // Account sign-in confirmation (auto-dismisses after a few seconds).
+                signInToast?.let { email ->
+                    Box(
+                        modifier = Modifier
+                            .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                            .background(Color(0xE6252526))
+                            .border(1.dp, Color(0xFF404040), androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                    ) {
+                        androidx.compose.material3.Text(
+                            "Signed in as $email",
+                            color = Color(0xFF81C784),
+                            fontSize = 11.sp,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                        )
+                    }
                 }
                 // Approval prompts (issue #276): one banner per waiting device.
                 pendingShareRequests.forEach { req ->
@@ -1946,6 +1998,14 @@ fun TabbedTerminal(
                 }
             }
         }
+    }
+
+    // Account sign-in window — a real top-level OS window like the share window.
+    if (showSignInWindow) {
+        ai.rever.bossterm.compose.auth.SignInWindow(
+            onDismiss = { showSignInWindow = false },
+            focusTick = signInFocusTick,
+        )
     }
 
     // Session sharing window (issue #276): a real top-level OS window (like Settings)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -835,6 +835,9 @@ fun TabbedTerminal(
     // its own effect, keyed on the toast value, so each new toast restarts the timer.
     var signInToast by remember { mutableStateOf<String?>(null) }
     LaunchedEffect(Unit) {
+        // Drain a cold-start sign-in (a deep link that launched the app and verified before any
+        // window was listening) so its toast isn't lost; then stream live interactive sign-ins.
+        ai.rever.bossterm.compose.auth.BossAccountManager.consumePendingSignInToast()?.let { signInToast = it }
         ai.rever.bossterm.compose.auth.BossAccountManager.signInEvents.collect { email ->
             signInToast = email
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -977,6 +977,13 @@ fun TabbedTerminal(
     // Sign In appears only in standalone BossTerm: inside an embedder (e.g. BossConsole's
     // terminal-tab plugin, which has its own account + owns the boss:// scheme) it's hidden.
     val signInVisible = mcpServerName == "bossterm"
+    // Once signed in, the menu item becomes an account row showing the email instead of
+    // "Sign In…" (clicking still opens the window, which then offers "Sign out"). The account
+    // glyph is drawn as a Swing Icon in ContextMenuController — NOT an emoji in the label,
+    // which corrupts AWT menu text metrics.
+    val accountState by ai.rever.bossterm.compose.auth.BossAccountManager.state.collectAsState()
+    val signInLabel = (accountState as? ai.rever.bossterm.compose.auth.BossAccountManager.AccountState.SignedIn)
+        ?.email ?: "Sign In…"
     val openSignIn: () -> Unit = { showSignInWindow = true; signInFocusTick++ }
     val fireMcpAttach: (McpAttachTarget) -> Unit = { target ->
         // De-dupe: ignore clicks while an attach is in flight from any
@@ -1360,6 +1367,7 @@ fun TabbedTerminal(
                     tabController.tabs.getOrNull(index)?.let { startShare(it.id, ai.rever.bossterm.compose.share.ShareScope.ALL) }
                 },
                 onSignIn = if (signInVisible) openSignIn else null,
+                signInLabel = signInLabel,
                 onStopShare = { index ->
                     tabController.tabs.getOrNull(index)?.let {
                         ai.rever.bossterm.compose.share.SessionShareManager.unshare(it.id)
@@ -1716,7 +1724,7 @@ fun TabbedTerminal(
                                 ) + (if (signInVisible) listOf(
                                     ContextMenuItem(
                                         id = "sign_in",
-                                        label = "Sign In…",
+                                        label = signInLabel,
                                         action = openSignIn
                                     )
                                 ) else emptyList())
@@ -1922,7 +1930,7 @@ fun TabbedTerminal(
                                     ),
                                 ) + (if (signInVisible) listOf(
                                     ai.rever.bossterm.compose.features.ContextMenuController.MenuItem(
-                                        id = "sign_in", label = "Sign In…", enabled = true,
+                                        id = "sign_in", label = signInLabel, enabled = true,
                                         action = openSignIn
                                     )
                                 ) else emptyList()))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
@@ -120,17 +120,30 @@ fun parseAuthInput(raw: String): AuthDeepLink? {
     return null
 }
 
-/** Value of `<name>=…` up to the next `&`, whitespace, `#`, or end — decoded; null if absent/blank. */
+/**
+ * Value of `<name>=…` up to the next `&`, whitespace, `#`, or end — decoded; null if absent/blank.
+ * The `<name>=` must sit at a real parameter boundary (start-of-string, or after `?`/`&`/`#`/whitespace)
+ * so `paramValue(s, "token")` can't latch onto the `token=` *inside* `access_token=`/`refresh_token=`
+ * — e.g. an implicit-flow callback fragment `#access_token=…&refresh_token=…&token=…` would otherwise
+ * yield the access token. Scans every occurrence and takes the first boundary-anchored one.
+ */
 private fun paramValue(s: String, name: String): String? {
     val key = "$name="
-    val at = s.indexOf(key)
-    if (at < 0) return null
-    val start = at + key.length
-    var end = start
-    while (end < s.length && s[end] != '&' && s[end] != '#' && !s[end].isWhitespace()) end++
-    val v = s.substring(start, end)
-    if (v.isBlank()) return null
-    return decodeQueryComponent(v)
+    var from = 0
+    while (from <= s.length) {
+        val at = s.indexOf(key, from)
+        if (at < 0) return null
+        val prev = if (at == 0) null else s[at - 1]
+        if (prev == null || prev == '?' || prev == '&' || prev == '#' || prev.isWhitespace()) {
+            val start = at + key.length
+            var end = start
+            while (end < s.length && s[end] != '&' && s[end] != '#' && !s[end].isWhitespace()) end++
+            val v = s.substring(start, end)
+            return if (v.isBlank()) null else decodeQueryComponent(v)
+        }
+        from = at + 1
+    }
+    return null
 }
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
@@ -93,6 +93,46 @@ fun parseAuthDeepLink(raw: String): AuthDeepLink? {
     return AuthDeepLink(tokenHash = tokenHash, type = params["type"]?.takeIf { it.isNotBlank() } ?: "magiclink")
 }
 
+/**
+ * Lenient parse for the MANUAL "paste the sign-in link" fallback — a superset of
+ * [parseAuthDeepLink] that pulls the token out of whatever the user pastes: the clean
+ * `bossterm://auth/verify` deep link (the redirect page's "Open BossTerm" link), the
+ * branded email's redirect URL, or the raw Supabase confirmation URL — percent-encoded
+ * or not. Returns null when no token is found.
+ *
+ * Like BossConsole's manual path, this is deliberate substring extraction rather than
+ * strict URI parsing: the email link's `?url=<ConfirmationURL>` embeds `token=…&type=…`
+ * and GoTrue's text/template emits it UNencoded, so the params sit at the top level —
+ * scanning for `token=` finds them in every shape. (Keep [parseAuthDeepLink] strict for
+ * the OS deep-link path; this is only for user-pasted input.)
+ */
+fun parseAuthInput(raw: String): AuthDeepLink? {
+    val trimmed = raw.trim()
+    if (trimmed.isEmpty()) return null
+    // Clean bossterm:// deep link first.
+    parseAuthDeepLink(trimmed)?.let { return it }
+    // Else scan the raw text, then a once-URL-decoded copy (covers a %26type%3D… email URL).
+    for (s in listOf(trimmed, runCatching { URLDecoder.decode(trimmed, StandardCharsets.UTF_8) }.getOrNull())) {
+        if (s == null) continue
+        val token = paramValue(s, "token_hash") ?: paramValue(s, "token")
+        if (token != null) return AuthDeepLink(tokenHash = token, type = paramValue(s, "type") ?: "magiclink")
+    }
+    return null
+}
+
+/** Value of `<name>=…` up to the next `&`, whitespace, `#`, or end — URL-decoded; null if absent/blank. */
+private fun paramValue(s: String, name: String): String? {
+    val key = "$name="
+    val at = s.indexOf(key)
+    if (at < 0) return null
+    val start = at + key.length
+    var end = start
+    while (end < s.length && s[end] != '&' && s[end] != '#' && !s[end].isWhitespace()) end++
+    val v = s.substring(start, end)
+    if (v.isBlank()) return null
+    return runCatching { URLDecoder.decode(v, StandardCharsets.UTF_8) }.getOrDefault(v)
+}
+
 // ---- Error mapping (pure; unit-tested) ----
 
 /** Map a GoTrue failure to the user-facing message shown in the sign-in window. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
@@ -84,7 +84,7 @@ fun parseAuthDeepLink(raw: String): AuthDeepLink? {
         .mapNotNull { p ->
             val i = p.indexOf('=')
             if (i <= 0) null
-            else p.take(i) to URLDecoder.decode(p.substring(i + 1), StandardCharsets.UTF_8)
+            else p.take(i) to decodeQueryComponent(p.substring(i + 1))
         }
         .toMap()
     val tokenHash = params["token_hash"]?.takeIf { it.isNotBlank() }
@@ -111,16 +111,16 @@ fun parseAuthInput(raw: String): AuthDeepLink? {
     if (trimmed.isEmpty()) return null
     // Clean bossterm:// deep link first.
     parseAuthDeepLink(trimmed)?.let { return it }
-    // Else scan the raw text, then a once-URL-decoded copy (covers a %26type%3D… email URL).
-    for (s in listOf(trimmed, runCatching { URLDecoder.decode(trimmed, StandardCharsets.UTF_8) }.getOrNull())) {
-        if (s == null) continue
+    // Else scan the raw text, then a once-decoded copy (covers a %26type%3D… email URL). The decode
+    // keeps '+' literal so a base64 token isn't corrupted (see [decodeQueryComponent]).
+    for (s in listOf(trimmed, decodeQueryComponent(trimmed))) {
         val token = paramValue(s, "token_hash") ?: paramValue(s, "token")
         if (token != null) return AuthDeepLink(tokenHash = token, type = paramValue(s, "type") ?: "magiclink")
     }
     return null
 }
 
-/** Value of `<name>=…` up to the next `&`, whitespace, `#`, or end — URL-decoded; null if absent/blank. */
+/** Value of `<name>=…` up to the next `&`, whitespace, `#`, or end — decoded; null if absent/blank. */
 private fun paramValue(s: String, name: String): String? {
     val key = "$name="
     val at = s.indexOf(key)
@@ -130,8 +130,19 @@ private fun paramValue(s: String, name: String): String? {
     while (end < s.length && s[end] != '&' && s[end] != '#' && !s[end].isWhitespace()) end++
     val v = s.substring(start, end)
     if (v.isBlank()) return null
-    return runCatching { URLDecoder.decode(v, StandardCharsets.UTF_8) }.getOrDefault(v)
+    return decodeQueryComponent(v)
 }
+
+/**
+ * Decode percent-escapes (%XX) in a URI query-component value while keeping `+` LITERAL.
+ * [URLDecoder.decode] applies `application/x-www-form-urlencoded` rules and turns `+` into a space —
+ * wrong for a generic URI query (RFC 3986) and, crucially, for auth tokens: a standard-base64
+ * `token_hash` can contain `+`, which a space would silently corrupt. We pre-escape literal `+` to
+ * `%2B` so the decoder leaves it intact (a real `%2B` is unaffected), and fall back to the raw
+ * string on a malformed escape. Tokens never legitimately contain a space, so nothing is lost.
+ */
+private fun decodeQueryComponent(s: String): String =
+    runCatching { URLDecoder.decode(s.replace("+", "%2B"), StandardCharsets.UTF_8) }.getOrDefault(s)
 
 // ---- Error mapping (pure; unit-tested) ----
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
@@ -1,0 +1,110 @@
+package ai.rever.bossterm.compose.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+// ---- GoTrue wire types (lenient — fields beyond what we read are ignored) ----
+
+@Serializable
+internal data class OtpRequest(
+    val email: String,
+    @SerialName("create_user") val createUser: Boolean = true,
+)
+
+@Serializable
+internal data class VerifyRequest(
+    /** GoTrue email_action_type, passed through VERBATIM from the deep link — a brand-new
+     *  user's first magic link arrives as `signup`, not `magiclink`. */
+    val type: String,
+    @SerialName("token_hash") val tokenHash: String,
+)
+
+@Serializable
+internal data class RefreshRequest(
+    @SerialName("refresh_token") val refreshToken: String,
+)
+
+@Serializable
+internal data class AuthUser(
+    val id: String = "",
+    val email: String = "",
+)
+
+@Serializable
+internal data class SessionResponse(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("refresh_token") val refreshToken: String,
+    @SerialName("expires_in") val expiresIn: Long = 3600,
+    val user: AuthUser? = null,
+)
+
+/** GoTrue error bodies vary by version — read every spelling, all optional. */
+@Serializable
+internal data class GoTrueError(
+    val msg: String? = null,
+    val message: String? = null,
+    @SerialName("error_description") val errorDescription: String? = null,
+    @SerialName("error_code") val errorCode: String? = null,
+) {
+    fun text(): String? = errorDescription ?: msg ?: message
+}
+
+// ---- Persisted session (~/.bossterm/auth.json) ----
+
+@Serializable
+data class StoredAuth(
+    val accessToken: String,
+    val refreshToken: String,
+    /** Absolute expiry (epoch seconds), computed from expires_in at issue time. */
+    val expiresAtEpochSec: Long,
+    val userId: String,
+    val email: String,
+)
+
+// ---- Deep link parsing (pure; unit-tested) ----
+
+/** The auth callback parsed out of `bossterm://auth/verify?token_hash=…&type=…`. */
+data class AuthDeepLink(val tokenHash: String, val type: String)
+
+/**
+ * Parse a `bossterm://auth/verify` deep link, or null when [raw] isn't one.
+ * NOTE `URI("bossterm://auth/verify")` parses as host=`auth`, path=`/verify` —
+ * the scheme's first segment is the authority, not part of the path.
+ * Accepts `token_hash` (the contract) and `token` (the param name BossConsole's
+ * current redirect function emits) interchangeably; `type` defaults to `magiclink`.
+ */
+fun parseAuthDeepLink(raw: String): AuthDeepLink? {
+    val uri = runCatching { java.net.URI(raw.trim()) }.getOrNull() ?: return null
+    if (!uri.scheme.equals("bossterm", ignoreCase = true)) return null
+    if (!uri.host.equals("auth", ignoreCase = true) || uri.path != "/verify") return null
+    val params = (uri.rawQuery ?: return null)
+        .split('&')
+        .mapNotNull { p ->
+            val i = p.indexOf('=')
+            if (i <= 0) null
+            else p.take(i) to URLDecoder.decode(p.substring(i + 1), StandardCharsets.UTF_8)
+        }
+        .toMap()
+    val tokenHash = params["token_hash"]?.takeIf { it.isNotBlank() }
+        ?: params["token"]?.takeIf { it.isNotBlank() }
+        ?: return null
+    return AuthDeepLink(tokenHash = tokenHash, type = params["type"]?.takeIf { it.isNotBlank() } ?: "magiclink")
+}
+
+// ---- Error mapping (pure; unit-tested) ----
+
+/** Map a GoTrue failure to the user-facing message shown in the sign-in window. */
+fun mapAuthError(status: Int, bodyText: String?, phase: AuthPhase): String = when {
+    status == 429 -> "Please wait a minute before requesting another link."
+    phase == AuthPhase.VERIFY && (status == 401 || status == 403) ->
+        "That link has expired or was already used. Request a new one."
+    else -> bodyText?.takeIf { it.isNotBlank() }
+        ?: when (phase) {
+            AuthPhase.SEND -> "Couldn't send the sign-in link. Check your connection and try again."
+            AuthPhase.VERIFY -> "Couldn't verify the sign-in link. Request a new one."
+        }
+}
+
+enum class AuthPhase { SEND, VERIFY }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
@@ -137,7 +137,9 @@ private fun paramValue(s: String, name: String): String? {
         if (prev == null || prev == '?' || prev == '&' || prev == '#' || prev.isWhitespace()) {
             val start = at + key.length
             var end = start
-            while (end < s.length && s[end] != '&' && s[end] != '#' && !s[end].isWhitespace()) end++
+            // Stop at any query/fragment delimiter. '?' too: a nested '?' never appears inside a
+            // real token (hex/base64url), so treating it as a boundary can only trim junk.
+            while (end < s.length && s[end] != '&' && s[end] != '?' && s[end] != '#' && !s[end].isWhitespace()) end++
             val v = s.substring(start, end)
             return if (v.isBlank()) null else decodeQueryComponent(v)
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthModels.kt
@@ -40,13 +40,14 @@ internal data class SessionResponse(
     val user: AuthUser? = null,
 )
 
-/** GoTrue error bodies vary by version — read every spelling, all optional. */
+/** GoTrue error bodies vary by version — read every spelling of the human-readable text, all
+ *  optional. (The machine `error_code` is intentionally not modelled: it's not user-facing and
+ *  unknown keys are ignored during decode.) */
 @Serializable
 internal data class GoTrueError(
     val msg: String? = null,
     val message: String? = null,
     @SerialName("error_description") val errorDescription: String? = null,
-    @SerialName("error_code") val errorCode: String? = null,
 ) {
     fun text(): String? = errorDescription ?: msg ?: message
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthStorage.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthStorage.kt
@@ -31,16 +31,29 @@ internal object AuthStorage {
 
     fun save(auth: StoredAuth, file: File = defaultFile()) {
         runCatching {
-            file.parentFile?.mkdirs()
-            val tmp = File.createTempFile("auth", ".json.tmp", file.parentFile)
+            // Stage the temp in the target's OWN directory so the ATOMIC_MOVE stays on one
+            // filesystem. Going through absoluteFile guarantees a non-null parent even for a
+            // bare-filename File — otherwise createTempFile would fall back to the system temp
+            // dir and the move would become cross-device and fail.
+            val dir = file.absoluteFile.parentFile
+            dir?.mkdirs()
+            val tmp = newOwnerOnlyTempFile(dir)
             tmp.writeText(json.encodeToString(StoredAuth.serializer(), auth))
-            restrictToOwner(tmp)
             Files.move(
                 tmp.toPath(), file.toPath(),
                 StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING
             )
         }.onFailure { log.warn("Could not persist auth state: {}", it.message) }
     }
+
+    /**
+     * Staging temp file for [save], chmod-600 (on POSIX) while still EMPTY. `File.createTempFile`
+     * honors the umask (commonly 0644), so restricting *before* the token is written closes the
+     * window where the token bytes would otherwise be group/world-readable on disk. On non-POSIX
+     * filesystems the user-profile ACL is the protection.
+     */
+    internal fun newOwnerOnlyTempFile(dir: File?): File =
+        File.createTempFile("auth", ".json.tmp", dir).also { restrictToOwner(it) }
 
     fun clear(file: File = defaultFile()) {
         runCatching { Files.deleteIfExists(file.toPath()) }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthStorage.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/AuthStorage.kt
@@ -1,0 +1,58 @@
+package ai.rever.bossterm.compose.auth
+
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.PosixFilePermission
+
+/**
+ * Persists the signed-in session to `~/.bossterm/auth.json` — deliberately a separate
+ * file from settings.json (which SettingsManager rewrites on every settings change and
+ * users paste into bug reports). Writes are atomic (temp file + ATOMIC_MOVE) and the
+ * file is chmod 600 where the filesystem supports POSIX permissions (on Windows the
+ * user-profile ACL is the protection). Tokens are never logged.
+ */
+internal object AuthStorage {
+
+    private val log = LoggerFactory.getLogger(AuthStorage::class.java)
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    fun defaultFile(): File = File(System.getProperty("user.home"), ".bossterm/auth.json")
+
+    fun load(file: File = defaultFile()): StoredAuth? {
+        if (!file.isFile) return null
+        return runCatching { json.decodeFromString<StoredAuth>(file.readText()) }
+            .onFailure { log.warn("Unreadable auth state ({}); signing out", it.javaClass.simpleName) }
+            .getOrNull()
+    }
+
+    fun save(auth: StoredAuth, file: File = defaultFile()) {
+        runCatching {
+            file.parentFile?.mkdirs()
+            val tmp = File.createTempFile("auth", ".json.tmp", file.parentFile)
+            tmp.writeText(json.encodeToString(StoredAuth.serializer(), auth))
+            restrictToOwner(tmp)
+            Files.move(
+                tmp.toPath(), file.toPath(),
+                StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING
+            )
+        }.onFailure { log.warn("Could not persist auth state: {}", it.message) }
+    }
+
+    fun clear(file: File = defaultFile()) {
+        runCatching { Files.deleteIfExists(file.toPath()) }
+    }
+
+    private fun restrictToOwner(file: File) {
+        if (!FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) return
+        runCatching {
+            Files.setPosixFilePermissions(
+                file.toPath(),
+                setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+            )
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/BossAccountManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/BossAccountManager.kt
@@ -144,8 +144,8 @@ object BossAccountManager {
             val resp = gotrue("verify", json.encodeToString(VerifyRequest.serializer(), VerifyRequest(type, tokenHash)))
             if (resp.status.value in 200..299) {
                 val session = json.decodeFromString<SessionResponse>(resp.bodyAsText())
-                adoptSession(session)
-                (state.value as? AccountState.SignedIn)?.let { _signInEvents.tryEmit(it.email) }
+                val email = adoptSession(session)
+                if (email.isNotBlank()) _signInEvents.tryEmit(email)
             } else {
                 _state.value = AccountState.Error(errorFrom(resp, AuthPhase.VERIFY))
             }
@@ -155,13 +155,14 @@ object BossAccountManager {
         }
     }
 
-    /** Sign out: best-effort server revoke, then always clear local state. */
+    /** Sign out: flip state immediately (called from a Compose onClick), then do the disk IO and
+     *  best-effort server revoke off the UI thread. */
     fun signOut() {
-        val stored = AuthStorage.load()
-        AuthStorage.clear()
         _state.value = AccountState.SignedOut
-        if (stored != null) scope.launch {
-            runCatching {
+        scope.launch {
+            val stored = AuthStorage.load()
+            AuthStorage.clear()
+            if (stored != null) runCatching {
                 http.post("${SupabaseAuthConfig.url}/auth/v1/logout") {
                     header("apikey", SupabaseAuthConfig.anonKey)
                     header("Authorization", "Bearer ${stored.accessToken}")
@@ -209,7 +210,9 @@ object BossAccountManager {
         }
     }
 
-    private fun adoptSession(session: SessionResponse, fallbackEmail: String = "", fallbackUserId: String = "") {
+    /** @return the adopted account email, so callers can emit it without re-reading the shared
+     *  [state] (which a concurrent transition on this multi-threaded scope could change). */
+    private fun adoptSession(session: SessionResponse, fallbackEmail: String = "", fallbackUserId: String = ""): String {
         val email = session.user?.email?.takeIf { it.isNotBlank() } ?: fallbackEmail
         val userId = session.user?.id?.takeIf { it.isNotBlank() } ?: fallbackUserId
         AuthStorage.save(
@@ -222,6 +225,7 @@ object BossAccountManager {
             )
         )
         _state.value = AccountState.SignedIn(email, userId)
+        return email
     }
 
     private suspend fun gotrue(pathAndQuery: String, body: String): HttpResponse =

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/BossAccountManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/BossAccountManager.kt
@@ -103,21 +103,42 @@ object BossAccountManager {
     fun handleAuthDeepLink(raw: String) {
         val link = parseAuthDeepLink(raw) ?: return
         _state.value = AccountState.Verifying
-        scope.launch {
-            try {
-                // Tokens are single-use: a 401/403 here is terminal for this link, never retried.
-                val resp = gotrue("verify", json.encodeToString(VerifyRequest.serializer(), VerifyRequest(link.type, link.tokenHash)))
-                if (resp.status.value in 200..299) {
-                    val session = json.decodeFromString<SessionResponse>(resp.bodyAsText())
-                    adoptSession(session)
-                    (state.value as? AccountState.SignedIn)?.let { _signInEvents.tryEmit(it.email) }
-                } else {
-                    _state.value = AccountState.Error(errorFrom(resp, AuthPhase.VERIFY))
-                }
-            } catch (e: Exception) {
-                log.warn("Magic-link verify failed: {}", e.message)
-                _state.value = AccountState.Error(mapAuthError(0, null, AuthPhase.VERIFY))
+        scope.launch { verify(link.tokenHash, link.type) }
+    }
+
+    /**
+     * Manual "paste the sign-in link" fallback (Sign In dialog): redeem whatever the user pastes —
+     * the bossterm:// deep link, the branded email's redirect URL, or the raw confirmation URL.
+     * Unlike [handleAuthDeepLink] (which silently ignores non-auth URIs from the OS), this surfaces
+     * a friendly error when no token can be found.
+     */
+    fun verifyPastedLink(raw: String) {
+        val link = parseAuthInput(raw)
+        if (link == null) {
+            _state.value = AccountState.Error(
+                "Couldn't find a sign-in token in that link — paste the whole link from the email."
+            )
+            return
+        }
+        _state.value = AccountState.Verifying
+        scope.launch { verify(link.tokenHash, link.type) }
+    }
+
+    /** POST /verify and adopt the session, or surface an error. Tokens are single-use: a 401/403
+     *  is terminal for this link and never retried. */
+    private suspend fun verify(tokenHash: String, type: String) {
+        try {
+            val resp = gotrue("verify", json.encodeToString(VerifyRequest.serializer(), VerifyRequest(type, tokenHash)))
+            if (resp.status.value in 200..299) {
+                val session = json.decodeFromString<SessionResponse>(resp.bodyAsText())
+                adoptSession(session)
+                (state.value as? AccountState.SignedIn)?.let { _signInEvents.tryEmit(it.email) }
+            } else {
+                _state.value = AccountState.Error(errorFrom(resp, AuthPhase.VERIFY))
             }
+        } catch (e: Exception) {
+            log.warn("Magic-link verify failed: {}", e.message)
+            _state.value = AccountState.Error(mapAuthError(0, null, AuthPhase.VERIFY))
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/BossAccountManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/BossAccountManager.kt
@@ -2,6 +2,7 @@ package ai.rever.bossterm.compose.auth
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -53,7 +54,19 @@ object BossAccountManager {
     private val log = LoggerFactory.getLogger(BossAccountManager::class.java)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
-    private val http by lazy { HttpClient(CIO) { expectSuccess = false } }
+    // A stuck request must not strand the UI on "Signing you in…" / "Check your email"
+    // forever — bound it so a hung server resolves to the mapAuthError(0, …) path. Mirrors
+    // DesktopUpdateService's API client timeouts.
+    private val http by lazy {
+        HttpClient(CIO) {
+            expectSuccess = false
+            install(HttpTimeout) {
+                requestTimeoutMillis = 30_000
+                connectTimeoutMillis = 15_000
+                socketTimeoutMillis = 15_000
+            }
+        }
+    }
 
     private val _state = MutableStateFlow<AccountState>(AccountState.SignedOut)
     val state: StateFlow<AccountState> = _state.asStateFlow()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/BossAccountManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/BossAccountManager.kt
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * BossTerm's account session against BossConsole's Supabase backend (one shared user
@@ -76,8 +77,25 @@ object BossAccountManager {
     private val _signInEvents = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val signInEvents: SharedFlow<String> = _signInEvents.asSharedFlow()
 
+    // A deep link that LAUNCHES the app verifies in main() before any window subscribes to
+    // signInEvents (replay = 0), so that emit would be dropped and the cold-start sign-in would
+    // never toast. Stash it here for the first UI collector to drain exactly once — using replay
+    // instead would re-toast the stale email on every newly opened window.
+    private val pendingToast = AtomicReference<String?>(null)
+
     init {
         scope.launch { restoreSession() }
+    }
+
+    /** Email of a sign-in that completed before the UI was listening, drained ONCE by the first
+     *  collector at startup; null for later windows. Live sign-ins flow through [signInEvents]. */
+    fun consumePendingSignInToast(): String? = pendingToast.getAndSet(null)
+
+    /** Route a completed-sign-in email to a live collector, or stash it for the first one to come. */
+    internal fun emitSignIn(email: String) {
+        if (email.isBlank()) return
+        if (_signInEvents.subscriptionCount.value > 0) _signInEvents.tryEmit(email)
+        else pendingToast.set(email)
     }
 
     /**
@@ -144,8 +162,7 @@ object BossAccountManager {
             val resp = gotrue("verify", json.encodeToString(VerifyRequest.serializer(), VerifyRequest(type, tokenHash)))
             if (resp.status.value in 200..299) {
                 val session = json.decodeFromString<SessionResponse>(resp.bodyAsText())
-                val email = adoptSession(session)
-                if (email.isNotBlank()) _signInEvents.tryEmit(email)
+                emitSignIn(adoptSession(session))
             } else {
                 _state.value = AccountState.Error(errorFrom(resp, AuthPhase.VERIFY))
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/BossAccountManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/BossAccountManager.kt
@@ -1,0 +1,204 @@
+package ai.rever.bossterm.compose.auth
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+/**
+ * BossTerm's account session against BossConsole's Supabase backend (one shared user
+ * pool) — magic-link sign-in over plain GoTrue REST, no Supabase SDK.
+ *
+ * Flow: [sendMagicLink] → GoTrue emails a link → the link's redirect step opens
+ * `bossterm://auth/verify?token_hash=…&type=…` → [handleAuthDeepLink] redeems the
+ * single-use token for a session → persisted via [AuthStorage], surfaced on [state].
+ * On startup [state] restores from disk, refreshing the access token when stale.
+ *
+ * Until the backend ticket (risa-labs-inc/BossConsole#787) ships, the email is BOSS
+ * Console-branded and its link opens BossConsole — the client side here is complete
+ * and testable by opening the deep link manually.
+ */
+object BossAccountManager {
+
+    sealed class AccountState {
+        object SignedOut : AccountState()
+        /** Magic link sent; waiting for the user to open it. */
+        data class EmailSent(val email: String) : AccountState()
+        /** Deep link received; token exchange in flight. */
+        object Verifying : AccountState()
+        data class SignedIn(val email: String, val userId: String) : AccountState()
+        data class Error(val message: String) : AccountState()
+    }
+
+    private val log = LoggerFactory.getLogger(BossAccountManager::class.java)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+    private val http by lazy { HttpClient(CIO) { expectSuccess = false } }
+
+    private val _state = MutableStateFlow<AccountState>(AccountState.SignedOut)
+    val state: StateFlow<AccountState> = _state.asStateFlow()
+
+    // Emits the email on a COMPLETED interactive sign-in (deep-link verify) only — not on
+    // the silent session restore at startup — so the UI can toast exactly once.
+    private val _signInEvents = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val signInEvents: SharedFlow<String> = _signInEvents.asSharedFlow()
+
+    init {
+        scope.launch { restoreSession() }
+    }
+
+    /**
+     * Email the user a sign-in link. Drives [state] to EmailSent / Error.
+     * @return false when the email failed local validation and NO request was made —
+     *   the UI must not start its resend cooldown then.
+     */
+    fun sendMagicLink(rawEmail: String): Boolean {
+        val email = rawEmail.trim().lowercase()
+        if (!email.matches(Regex("""[^@\s]+@[^@\s]+\.[^@\s]+"""))) {
+            _state.value = AccountState.Error("Enter a valid email address.")
+            return false
+        }
+        scope.launch {
+            try {
+                val redirect = URLEncoder.encode(SupabaseAuthConfig.REDIRECT_URI, StandardCharsets.UTF_8)
+                val resp = gotrue("otp?redirect_to=$redirect", json.encodeToString(OtpRequest.serializer(), OtpRequest(email)))
+                if (resp.status.value in 200..299) {
+                    _state.value = AccountState.EmailSent(email)
+                } else {
+                    _state.value = AccountState.Error(errorFrom(resp, AuthPhase.SEND))
+                }
+            } catch (e: Exception) {
+                log.warn("Magic-link send failed: {}", e.message)
+                _state.value = AccountState.Error(mapAuthError(0, null, AuthPhase.SEND))
+            }
+        }
+        return true
+    }
+
+    /**
+     * Redeem an auth deep link (`bossterm://auth/verify?token_hash=…&type=…`).
+     * Safe to call with any URI string — non-auth links are ignored. Runs async
+     * (deep links arrive on the AWT event thread); returns immediately.
+     */
+    fun handleAuthDeepLink(raw: String) {
+        val link = parseAuthDeepLink(raw) ?: return
+        _state.value = AccountState.Verifying
+        scope.launch {
+            try {
+                // Tokens are single-use: a 401/403 here is terminal for this link, never retried.
+                val resp = gotrue("verify", json.encodeToString(VerifyRequest.serializer(), VerifyRequest(link.type, link.tokenHash)))
+                if (resp.status.value in 200..299) {
+                    val session = json.decodeFromString<SessionResponse>(resp.bodyAsText())
+                    adoptSession(session)
+                    (state.value as? AccountState.SignedIn)?.let { _signInEvents.tryEmit(it.email) }
+                } else {
+                    _state.value = AccountState.Error(errorFrom(resp, AuthPhase.VERIFY))
+                }
+            } catch (e: Exception) {
+                log.warn("Magic-link verify failed: {}", e.message)
+                _state.value = AccountState.Error(mapAuthError(0, null, AuthPhase.VERIFY))
+            }
+        }
+    }
+
+    /** Sign out: best-effort server revoke, then always clear local state. */
+    fun signOut() {
+        val stored = AuthStorage.load()
+        AuthStorage.clear()
+        _state.value = AccountState.SignedOut
+        if (stored != null) scope.launch {
+            runCatching {
+                http.post("${SupabaseAuthConfig.url}/auth/v1/logout") {
+                    header("apikey", SupabaseAuthConfig.anonKey)
+                    header("Authorization", "Bearer ${stored.accessToken}")
+                }
+            }
+        }
+    }
+
+    /** Back out of EmailSent / Error (e.g. "Use a different email"). No-op when signed in. */
+    fun reset() {
+        if (_state.value !is AccountState.SignedIn) _state.value = AccountState.SignedOut
+    }
+
+    // ---- internals ----
+
+    private suspend fun restoreSession() {
+        val stored = AuthStorage.load() ?: return
+        if (stored.expiresAtEpochSec > Instant.now().epochSecond + 60) {
+            _state.value = AccountState.SignedIn(stored.email, stored.userId)
+            return
+        }
+        // Stale access token → rotate via the refresh token; failure = silent sign-out
+        // (no startup error dialog for an expired session).
+        try {
+            val resp = gotrue(
+                "token?grant_type=refresh_token",
+                json.encodeToString(RefreshRequest.serializer(), RefreshRequest(stored.refreshToken))
+            )
+            if (resp.status.value in 200..299) {
+                val session = json.decodeFromString<SessionResponse>(resp.bodyAsText())
+                // Refresh responses may omit the user — keep the stored identity then.
+                adoptSession(session, fallbackEmail = stored.email, fallbackUserId = stored.userId)
+            } else {
+                log.info("Stored session no longer refreshable; signing out")
+                AuthStorage.clear()
+                _state.value = AccountState.SignedOut
+            }
+        } catch (e: Exception) {
+            // Offline at startup: keep the stored identity (UI shows signed-in) even though the
+            // access token may be expired. Nothing consumes the token yet, so this is harmless
+            // today. NOTE: the first feature to call an authenticated endpoint with this token
+            // MUST handle a 401 by refreshing (or signing out) — there is no refresh-on-401 here.
+            log.warn("Session refresh unavailable ({}); keeping cached identity", e.message)
+            _state.value = AccountState.SignedIn(stored.email, stored.userId)
+        }
+    }
+
+    private fun adoptSession(session: SessionResponse, fallbackEmail: String = "", fallbackUserId: String = "") {
+        val email = session.user?.email?.takeIf { it.isNotBlank() } ?: fallbackEmail
+        val userId = session.user?.id?.takeIf { it.isNotBlank() } ?: fallbackUserId
+        AuthStorage.save(
+            StoredAuth(
+                accessToken = session.accessToken,
+                refreshToken = session.refreshToken,
+                expiresAtEpochSec = Instant.now().epochSecond + session.expiresIn,
+                userId = userId,
+                email = email,
+            )
+        )
+        _state.value = AccountState.SignedIn(email, userId)
+    }
+
+    private suspend fun gotrue(pathAndQuery: String, body: String): HttpResponse =
+        http.post("${SupabaseAuthConfig.url}/auth/v1/$pathAndQuery") {
+            header("apikey", SupabaseAuthConfig.anonKey)
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+
+    private suspend fun errorFrom(resp: HttpResponse, phase: AuthPhase): String {
+        val text = runCatching { json.decodeFromString<GoTrueError>(resp.bodyAsText()).text() }.getOrNull()
+        return mapAuthError(resp.status.value, text, phase)
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/DeepLinkHandler.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/DeepLinkHandler.kt
@@ -1,0 +1,80 @@
+package ai.rever.bossterm.compose.auth
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.slf4j.LoggerFactory
+import java.awt.Desktop
+
+/**
+ * `bossterm://` deep links. Today the only route is the sign-in callback
+ * (`bossterm://auth/verify?token_hash=…&type=…` → [BossAccountManager]); anything else
+ * is buffered on [pendingUri] for future consumers.
+ *
+ * Delivery per platform:
+ *  - macOS: LaunchServices sends the URL to the running .app as an Apple Event;
+ *    [install] registers `Desktop.setOpenURIHandler`. The JDK buffers OpenURI events
+ *    that arrive before registration and replays them, so installing first thing in
+ *    main() also covers cold starts. (Dev `gradlew run` has no bundle, so the scheme
+ *    isn't registered with LaunchServices — test via createDistributable, or the
+ *    `-Dbossterm.debug.deeplink=<uri>` hook below.)
+ *  - Windows/Linux: the OS launches a NEW process with the URL in argv; [install]
+ *    forwards it to the running instance via [DeepLinkSocket] and tells the caller to
+ *    exit, or handles it locally when this is the only instance.
+ */
+object DeepLinkHandler {
+
+    private val log = LoggerFactory.getLogger(DeepLinkHandler::class.java)
+
+    private val _pendingUri = MutableStateFlow<String?>(null)
+    /** Last received non-auth deep link, for future routes. */
+    val pendingUri: StateFlow<String?> = _pendingUri.asStateFlow()
+
+    /**
+     * Wire up deep-link delivery. Call FIRST THING in main(), after Skiko/WM_CLASS setup
+     * but before `application {}` (this touches `Desktop`, which initializes AWT).
+     *
+     * @return true when this launch existed only to carry a deep link that was forwarded
+     *   to an already-running instance — the caller should return immediately.
+     */
+    fun install(args: Array<String>): Boolean {
+        // Dev hook: simulate an incoming link without OS scheme registration.
+        System.getProperty("bossterm.debug.deeplink")?.takeIf { it.isNotBlank() }?.let {
+            log.info("Handling debug deep link")
+            handle(it)
+        }
+
+        args.firstOrNull { it.startsWith("bossterm://") }?.let { uri ->
+            if (DeepLinkSocket.tryForward(uri)) {
+                log.info("Deep link forwarded to the running BossTerm instance")
+                return true
+            }
+            handle(uri) // we're the only instance — process it ourselves once init completes
+        }
+
+        // macOS: receive URLs in-process (also replays a buffered cold-start event).
+        runCatching {
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.APP_OPEN_URI)) {
+                Desktop.getDesktop().setOpenURIHandler { event -> handle(event.uri.toString()) }
+            }
+        }.onFailure { log.warn("OpenURI handler unavailable: {}", it.message) }
+
+        // Windows: make sure the scheme points at this packaged exe (HKCU, best-effort).
+        WindowsProtocolRegistrar.registerIfPackaged()
+
+        // Windows/Linux: accept forwards from later launches.
+        DeepLinkSocket.startPrimaryListener(::handle)
+        return false
+    }
+
+    /** Route one URI. Non-blocking — auth verification runs on the manager's own scope. */
+    private fun handle(uri: String) {
+        if (!uri.startsWith("bossterm://")) return
+        if (parseAuthDeepLink(uri) != null) {
+            BossAccountManager.handleAuthDeepLink(uri)
+        } else {
+            log.info("Unrouted deep link (host={})", runCatching { java.net.URI(uri).host }.getOrNull())
+            _pendingUri.value = uri
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/DeepLinkSocket.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/DeepLinkSocket.kt
@@ -19,11 +19,22 @@ import java.security.SecureRandom
  * newly launched instance with a deep-link argument forwards the URI there and exits
  * before any AWT/Compose init. A stale port file (dead listener) falls back to
  * handling the link locally.
+ *
+ * Trust model: the channel is loopback-only and `deeplink.port` is chmod-600, so the
+ * secret is readable only by THIS OS user. The assumption the design rests on is that any
+ * same-user local process is already inside the user's trust boundary — such a process can
+ * read the port file and inject an arbitrary `bossterm://` URI, but that buys it nothing: a
+ * forged `auth/verify` only redeems a single-use token the caller must already possess, so
+ * there is no privilege escalation. The secret + constant-time compare + bounded read exist
+ * to keep OTHER users (and unprivileged remote connects, which loopback binding already
+ * blocks) out, not to defend against the user's own processes.
  */
 internal object DeepLinkSocket {
 
     private val log = LoggerFactory.getLogger(DeepLinkSocket::class.java)
-    private val portFile = File(System.getProperty("user.home"), ".bossterm/deeplink.port")
+    // Injectable so tests can point it at a temp file; production uses ~/.bossterm/deeplink.port.
+    internal var portFile = File(System.getProperty("user.home"), ".bossterm/deeplink.port")
+    @Volatile private var listenerSocket: ServerSocket? = null
 
     /** Try to hand [uri] to an already-running instance. True = forwarded, caller exits. */
     fun tryForward(uri: String): Boolean {
@@ -60,6 +71,7 @@ internal object DeepLinkSocket {
         }
         runCatching {
             val server = ServerSocket(0, 4, InetAddress.getLoopbackAddress())
+            listenerSocket = server
             val secret = ByteArray(16).also { SecureRandom().nextBytes(it) }
                 .joinToString("") { "%02x".format(it) }
             val secretBytes = secret.toByteArray(Charsets.UTF_8)
@@ -87,6 +99,19 @@ internal object DeepLinkSocket {
                 }
             }.apply { isDaemon = true; name = "bossterm-deeplink"; start() }
         }.onFailure { log.warn("Deep-link listener unavailable: {}", it.message) }
+    }
+
+    /**
+     * Stop listening and drop the advertised port file. In production the listener is an
+     * app-lifetime singleton (a daemon thread that dies with the JVM, so no teardown is
+     * required); this exists so tests can release the loopback socket and so a future caller
+     * has an explicit shutdown path. Closing the [ServerSocket] unblocks the accept loop, which
+     * then sees `isClosed` and exits.
+     */
+    internal fun stop() {
+        runCatching { listenerSocket?.close() }
+        listenerSocket = null
+        runCatching { portFile.delete() }
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/DeepLinkSocket.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/DeepLinkSocket.kt
@@ -134,7 +134,9 @@ internal object DeepLinkSocket {
         }
     }
 
-    /** Read one line (up to [max] bytes), stopping at newline or cap — never reads unbounded. */
+    /** Read one line (up to [max] bytes), stopping at newline or cap — never reads unbounded.
+     *  Decodes byte-per-char (ASCII): the protocol is a hex secret + an ASCII `bossterm://` URI
+     *  (percent-encoded), so no multibyte input is expected; a multibyte URI would be mangled. */
     private fun readBoundedLine(input: java.io.InputStream, max: Int): String? {
         val buf = StringBuilder()
         var count = 0

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/DeepLinkSocket.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/DeepLinkSocket.kt
@@ -45,8 +45,19 @@ internal object DeepLinkSocket {
         }
     }
 
-    /** Become the primary: listen for forwarded URIs and pass each to [onUri]. Best-effort. */
+    /**
+     * Become the primary deep-link listener — but only if no live instance already is. Multiple
+     * BossTerm instances are allowed; exactly ONE should own routing. Without this guard every
+     * launch overwrote `deeplink.port` with its own port+secret (so the LAST launch won routing)
+     * AND registered `deleteOnExit`, so that launch's exit also tore routing down for instances
+     * still running. Probing first makes the FIRST live instance own routing for as long as it runs;
+     * later launches detect it and leave it be. Best-effort.
+     */
     fun startPrimaryListener(onUri: (String) -> Unit) {
+        if (liveListenerPresent()) {
+            log.info("Deep-link routing already owned by a running instance; not usurping it")
+            return
+        }
         runCatching {
             val server = ServerSocket(0, 4, InetAddress.getLoopbackAddress())
             val secret = ByteArray(16).also { SecureRandom().nextBytes(it) }
@@ -76,6 +87,26 @@ internal object DeepLinkSocket {
                 }
             }.apply { isDaemon = true; name = "bossterm-deeplink"; start() }
         }.onFailure { log.warn("Deep-link listener unavailable: {}", it.message) }
+    }
+
+    /**
+     * True if `deeplink.port` points at a still-listening socket. A successful TCP connect proves a
+     * listener is bound (we send nothing — its accept loop sees an empty line and ignores it). A
+     * refused connect means the file is stale (the owning instance died): delete it so we can claim
+     * ownership. Sequential launches (A then B) therefore don't usurp A; only a genuine cold start
+     * (no live owner) becomes primary.
+     */
+    private fun liveListenerPresent(): Boolean {
+        val lines = runCatching { portFile.readLines() }.getOrNull() ?: return false
+        val port = lines.getOrNull(0)?.trim()?.toIntOrNull() ?: return false
+        if (lines.getOrNull(1)?.trim().isNullOrEmpty()) return false
+        return runCatching {
+            Socket(InetAddress.getLoopbackAddress(), port).close()
+            true
+        }.getOrElse {
+            runCatching { portFile.delete() } // stale file from a dead instance — clear it
+            false
+        }
     }
 
     /** Read one line (up to [max] bytes), stopping at newline or cap — never reads unbounded. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/DeepLinkSocket.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/DeepLinkSocket.kt
@@ -1,0 +1,103 @@
+package ai.rever.bossterm.compose.auth
+
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+import java.security.SecureRandom
+
+/**
+ * Single-instance forwarding for deep links on Windows/Linux, where the OS launches a
+ * NEW process for a `bossterm://` URL (macOS routes the URL to the running app via
+ * Apple Events instead). BossTerm intentionally allows multiple instances, so this is
+ * scoped strictly to deep-link argv: the first instance listens on a loopback socket
+ * advertised in `~/.bossterm/deeplink.port` (port + random secret, owner-only); a
+ * newly launched instance with a deep-link argument forwards the URI there and exits
+ * before any AWT/Compose init. A stale port file (dead listener) falls back to
+ * handling the link locally.
+ */
+internal object DeepLinkSocket {
+
+    private val log = LoggerFactory.getLogger(DeepLinkSocket::class.java)
+    private val portFile = File(System.getProperty("user.home"), ".bossterm/deeplink.port")
+
+    /** Try to hand [uri] to an already-running instance. True = forwarded, caller exits. */
+    fun tryForward(uri: String): Boolean {
+        val lines = runCatching { portFile.readLines() }.getOrNull() ?: return false
+        val port = lines.getOrNull(0)?.trim()?.toIntOrNull() ?: return false
+        val secret = lines.getOrNull(1)?.trim().orEmpty()
+        if (secret.isEmpty()) return false
+        return runCatching {
+            Socket(InetAddress.getLoopbackAddress(), port).use { s ->
+                s.soTimeout = 2000
+                s.getOutputStream().write("$secret $uri\n".toByteArray(Charsets.UTF_8))
+                s.getOutputStream().flush()
+            }
+            true
+        }.getOrElse {
+            // Listener gone — stale file. Remove it and let the caller handle the link itself.
+            runCatching { portFile.delete() }
+            false
+        }
+    }
+
+    /** Become the primary: listen for forwarded URIs and pass each to [onUri]. Best-effort. */
+    fun startPrimaryListener(onUri: (String) -> Unit) {
+        runCatching {
+            val server = ServerSocket(0, 4, InetAddress.getLoopbackAddress())
+            val secret = ByteArray(16).also { SecureRandom().nextBytes(it) }
+                .joinToString("") { "%02x".format(it) }
+            val secretBytes = secret.toByteArray(Charsets.UTF_8)
+            portFile.parentFile?.mkdirs()
+            portFile.writeText("${server.localPort}\n$secret\n")
+            restrictToOwner(portFile)
+            portFile.deleteOnExit()
+            Thread {
+                while (!server.isClosed) {
+                    runCatching {
+                        server.accept().use { client ->
+                            client.soTimeout = 2000
+                            // Bound the read so a hostile local process can't stream an
+                            // unbounded line at the daemon thread; a real "<secret> <uri>" is tiny.
+                            val line = readBoundedLine(client.getInputStream(), 8192) ?: return@use
+                            val sep = line.indexOf(' ')
+                            if (sep <= 0) return@use
+                            // Constant-time secret compare (it's a security boundary, even if loopback-only).
+                            val presented = line.take(sep).toByteArray(Charsets.UTF_8)
+                            if (!java.security.MessageDigest.isEqual(presented, secretBytes)) return@use
+                            val uri = line.substring(sep + 1).trim()
+                            if (uri.startsWith("bossterm://")) onUri(uri)
+                        }
+                    }
+                }
+            }.apply { isDaemon = true; name = "bossterm-deeplink"; start() }
+        }.onFailure { log.warn("Deep-link listener unavailable: {}", it.message) }
+    }
+
+    /** Read one line (up to [max] bytes), stopping at newline or cap — never reads unbounded. */
+    private fun readBoundedLine(input: java.io.InputStream, max: Int): String? {
+        val buf = StringBuilder()
+        var count = 0
+        while (count < max) {
+            val b = input.read()
+            if (b == -1 || b == '\n'.code) break
+            buf.append(b.toChar())
+            count++
+        }
+        return buf.toString().trimEnd('\r').ifEmpty { null }
+    }
+
+    private fun restrictToOwner(file: File) {
+        if (!FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) return
+        runCatching {
+            Files.setPosixFilePermissions(
+                file.toPath(),
+                setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+            )
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/SignInWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/SignInWindow.kt
@@ -1,0 +1,177 @@
+package ai.rever.bossterm.compose.auth
+
+import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
+import ai.rever.bossterm.compose.settings.components.SettingsSection
+import ai.rever.bossterm.compose.settings.components.SettingsTextField
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.rememberWindowState
+import kotlinx.coroutines.delay
+
+private val Danger = Color(0xFFE57373)
+
+/**
+ * Account sign-in window — opened from the Share menus' 4th item. Magic-link flow
+ * against BossConsole's Supabase backend (see [BossAccountManager]): enter email →
+ * "check your email" → the link's `bossterm://` deep link completes the sign-in.
+ * Styled like [ai.rever.bossterm.compose.share.ShareWindow] (SettingsTheme).
+ */
+@Composable
+fun SignInWindow(
+    onDismiss: () -> Unit,
+    focusTick: Int = 0,
+) {
+    val accountState by BossAccountManager.state.collectAsState()
+    var email by remember { mutableStateOf("") }
+    // GoTrue rate-limits link requests (~60s per email) — mirror that client-side.
+    var cooldownUntil by remember { mutableStateOf(0L) }
+    var nowMs by remember { mutableStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(cooldownUntil) {
+        while (System.currentTimeMillis() < cooldownUntil) {
+            nowMs = System.currentTimeMillis()
+            delay(1000)
+        }
+        nowMs = System.currentTimeMillis()
+    }
+    val cooldownLeft = ((cooldownUntil - nowMs) / 1000).coerceAtLeast(0)
+    val send: (String) -> Unit = {
+        // Start the cooldown only when a request was actually launched — a locally
+        // rejected email must not lock the button for 60s.
+        if (BossAccountManager.sendMagicLink(it)) {
+            cooldownUntil = System.currentTimeMillis() + 60_000
+        }
+    }
+
+    Window(
+        onCloseRequest = onDismiss,
+        title = "BossTerm — Sign In",
+        resizable = false,
+        state = rememberWindowState(size = DpSize(440.dp, 420.dp))
+    ) {
+        // Raise an already-open window when the menu item is clicked again.
+        LaunchedEffect(focusTick) {
+            window.toFront()
+            window.requestFocus()
+        }
+        Surface(color = BackgroundColor, modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Column(modifier = Modifier.weight(1f).fillMaxWidth().padding(20.dp)) {
+                    Text("Sign in to BossTerm", color = TextPrimary, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        "One account across BossTerm and BOSS Console.",
+                        color = TextSecondary, fontSize = 12.sp
+                    )
+                    Spacer(Modifier.height(20.dp))
+
+                    when (val s = accountState) {
+                        is BossAccountManager.AccountState.SignedIn -> {
+                            SettingsSection("Account") {
+                                Text(s.email, color = TextPrimary, fontSize = 14.sp)
+                                Spacer(Modifier.height(8.dp))
+                                Text("You're signed in on this machine.", color = TextSecondary, fontSize = 12.sp)
+                                Spacer(Modifier.height(12.dp))
+                                TextButton(onClick = { BossAccountManager.signOut() }) {
+                                    Text("Sign out", color = Danger, fontSize = 13.sp)
+                                }
+                            }
+                        }
+
+                        is BossAccountManager.AccountState.EmailSent -> {
+                            SettingsSection("Check your email") {
+                                Text(
+                                    "We sent a sign-in link to ${s.email}. Open it on this computer and it will bring you back to BossTerm.",
+                                    color = TextPrimary, fontSize = 13.sp
+                                )
+                                Spacer(Modifier.height(6.dp))
+                                Text("The link expires in about an hour.", color = TextMuted, fontSize = 11.sp)
+                                Spacer(Modifier.height(14.dp))
+                                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    Button(
+                                        onClick = { send(s.email) },
+                                        enabled = cooldownLeft <= 0,
+                                        colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                                    ) {
+                                        Text(if (cooldownLeft > 0) "Resend (${cooldownLeft}s)" else "Resend link", fontSize = 13.sp)
+                                    }
+                                    TextButton(onClick = { BossAccountManager.reset() }) {
+                                        Text("Use a different email", color = AccentColor, fontSize = 13.sp)
+                                    }
+                                }
+                            }
+                        }
+
+                        is BossAccountManager.AccountState.Verifying -> {
+                            SettingsSection("Signing you in…") {
+                                Text("Verifying your sign-in link.", color = TextSecondary, fontSize = 13.sp)
+                            }
+                        }
+
+                        else -> { // SignedOut or Error → email entry (with the error surfaced above it)
+                            (s as? BossAccountManager.AccountState.Error)?.let { err ->
+                                Text(err.message, color = Danger, fontSize = 12.sp)
+                                Spacer(Modifier.height(12.dp))
+                            }
+                            SettingsTextField(
+                                label = "Email",
+                                value = email,
+                                onValueChange = { email = it },
+                                placeholder = "you@example.com",
+                            )
+                            Spacer(Modifier.height(6.dp))
+                            Text("We'll email you a link — no password needed.", color = TextMuted, fontSize = 11.sp)
+                            Spacer(Modifier.height(14.dp))
+                            Button(
+                                onClick = { send(email) },
+                                enabled = email.isNotBlank() && cooldownLeft <= 0,
+                                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                            ) {
+                                Text(if (cooldownLeft > 0) "Send sign-in link (${cooldownLeft}s)" else "Send sign-in link", fontSize = 13.sp)
+                            }
+                        }
+                    }
+                }
+                // Pinned footer
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    Button(
+                        onClick = onDismiss,
+                        colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                    ) { Text("Close", fontSize = 13.sp) }
+                }
+            }
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/SignInWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/SignInWindow.kt
@@ -7,6 +7,8 @@ import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 import ai.rever.bossterm.compose.settings.components.SettingsSection
 import ai.rever.bossterm.compose.settings.components.SettingsTextField
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -53,6 +55,9 @@ fun SignInWindow(
 ) {
     val accountState by BossAccountManager.state.collectAsState()
     var email by remember { mutableStateOf("") }
+    // Manual fallback: paste the sign-in link when the deep link can't open the app.
+    var showPaste by remember { mutableStateOf(false) }
+    var pastedLink by remember { mutableStateOf("") }
     // GoTrue rate-limits link requests (~60s per email) — mirror that client-side.
     var cooldownUntil by remember { mutableStateOf(0L) }
     var nowMs by remember { mutableStateOf(System.currentTimeMillis()) }
@@ -76,7 +81,7 @@ fun SignInWindow(
         onCloseRequest = onDismiss,
         title = "BossTerm — Sign In",
         resizable = false,
-        state = rememberWindowState(size = DpSize(440.dp, 420.dp))
+        state = rememberWindowState(size = DpSize(440.dp, 480.dp))
     ) {
         // Raise an already-open window when the menu item is clicked again.
         LaunchedEffect(focusTick) {
@@ -85,7 +90,7 @@ fun SignInWindow(
         }
         Surface(color = BackgroundColor, modifier = Modifier.fillMaxSize()) {
             Column(modifier = Modifier.fillMaxSize()) {
-                Column(modifier = Modifier.weight(1f).fillMaxWidth().padding(20.dp)) {
+                Column(modifier = Modifier.weight(1f).fillMaxWidth().verticalScroll(rememberScrollState()).padding(20.dp)) {
                     Text("Sign in to BossTerm", color = TextPrimary, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
                     Spacer(Modifier.height(4.dp))
                     Text(
@@ -128,6 +133,13 @@ fun SignInWindow(
                                         Text("Use a different email", color = AccentColor, fontSize = 13.sp)
                                     }
                                 }
+                                PasteLinkSection(
+                                    show = showPaste,
+                                    onToggle = { showPaste = !showPaste },
+                                    value = pastedLink,
+                                    onValueChange = { pastedLink = it },
+                                    onVerify = { BossAccountManager.verifyPastedLink(pastedLink) },
+                                )
                             }
                         }
 
@@ -158,6 +170,13 @@ fun SignInWindow(
                             ) {
                                 Text(if (cooldownLeft > 0) "Send sign-in link (${cooldownLeft}s)" else "Send sign-in link", fontSize = 13.sp)
                             }
+                            PasteLinkSection(
+                                show = showPaste,
+                                onToggle = { showPaste = !showPaste },
+                                value = pastedLink,
+                                onValueChange = { pastedLink = it },
+                                onVerify = { BossAccountManager.verifyPastedLink(pastedLink) },
+                            )
                         }
                     }
                 }
@@ -173,5 +192,42 @@ fun SignInWindow(
                 }
             }
         }
+    }
+}
+
+/**
+ * Collapsible manual fallback for when the bossterm:// link can't open the app (dev builds,
+ * unregistered scheme, another device): paste the link from the email — or the redirect page's
+ * "Open BossTerm" link — and verify it directly. Mirrors BossConsole's "paste magic link" flow.
+ */
+@Composable
+private fun PasteLinkSection(
+    show: Boolean,
+    onToggle: () -> Unit,
+    value: String,
+    onValueChange: (String) -> Unit,
+    onVerify: () -> Unit,
+) {
+    Spacer(Modifier.height(14.dp))
+    TextButton(onClick = onToggle, contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp)) {
+        Text(
+            if (show) "Hide" else "Link didn't open the app? Paste it here",
+            color = TextMuted, fontSize = 12.sp,
+        )
+    }
+    if (show) {
+        Spacer(Modifier.height(8.dp))
+        SettingsTextField(
+            label = "Sign-in link",
+            value = value,
+            onValueChange = onValueChange,
+            placeholder = "Paste the link from the email",
+        )
+        Spacer(Modifier.height(10.dp))
+        Button(
+            onClick = onVerify,
+            enabled = value.isNotBlank(),
+            colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White),
+        ) { Text("Verify link", fontSize = 13.sp) }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/SupabaseAuthConfig.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/SupabaseAuthConfig.kt
@@ -1,0 +1,36 @@
+package ai.rever.bossterm.compose.auth
+
+/**
+ * Supabase (GoTrue) endpoint for BossTerm sign-in. This is **BossConsole's backend** —
+ * both apps share one user pool at api.risaboss.com; BossTerm talks to it over plain
+ * GoTrue REST (no Supabase SDK dependency).
+ *
+ * Resolution order mirrors BossConsole's SupabaseClientConfig: environment variable →
+ * system property → production fallback. The anon key is public by design (it ships in
+ * every client; Row Level Security is the real gate) — the override order keeps it
+ * rotatable without a code change.
+ */
+object SupabaseAuthConfig {
+
+    private fun resolve(name: String): String? =
+        System.getenv(name)?.takeIf { it.isNotBlank() }
+            ?: System.getProperty(name)?.takeIf { it.isNotBlank() }
+
+    val url: String by lazy {
+        resolve("BOSSTERM_SUPABASE_URL") ?: "https://api.risaboss.com"
+    }
+
+    val anonKey: String by lazy {
+        resolve("BOSSTERM_SUPABASE_ANON_KEY")
+            ?: ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+                "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBjbndxYW1xZG5zYWRyYW51Zmp2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTkxMDUwMzMsImV4cCI6MjA3NDY4MTAzM30." +
+                "WZ6jSKuqM2EMyZLgoGJnI8Bn_Sdwk6plW0PkVNLIYVY")
+    }
+
+    /**
+     * The deep link GoTrue is asked to redirect to (`redirect_to`). Until the backend
+     * allow-lists it (risa-labs-inc/BossConsole#787) GoTrue silently falls back to its
+     * site_url — harmless to send now, required for per-app email branding later.
+     */
+    const val REDIRECT_URI = "bossterm://auth/verify"
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/WindowsProtocolRegistrar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/WindowsProtocolRegistrar.kt
@@ -1,0 +1,33 @@
+package ai.rever.bossterm.compose.auth
+
+import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
+import org.slf4j.LoggerFactory
+
+/**
+ * Registers the `bossterm://` URL scheme on Windows (HKCU — no elevation needed) so
+ * sign-in links can open the app. Only runs in PACKAGED builds: `jpackage.app-path`
+ * is set by the jpackage launcher (absent under `gradlew run`) and conveniently IS
+ * the exe path the registry command must point at. macOS registers the scheme via
+ * Info.plist CFBundleURLTypes; Linux via the .desktop MimeType. Best-effort —
+ * failure just means links don't open the app on this machine.
+ */
+internal object WindowsProtocolRegistrar {
+
+    private val log = LoggerFactory.getLogger(WindowsProtocolRegistrar::class.java)
+
+    fun registerIfPackaged() {
+        if (!ShellCustomizationUtils.isWindows()) return
+        val exe = System.getProperty("jpackage.app-path") ?: return
+        runCatching {
+            reg("add", """HKCU\Software\Classes\bossterm""", "/ve", "/d", "URL:BossTerm Protocol", "/f")
+            reg("add", """HKCU\Software\Classes\bossterm""", "/v", "URL Protocol", "/d", "", "/f")
+            reg("add", """HKCU\Software\Classes\bossterm\shell\open\command""", "/ve", "/d", "\"$exe\" \"%1\"", "/f")
+            log.info("Registered bossterm:// URL scheme (HKCU)")
+        }.onFailure { log.warn("Could not register bossterm:// scheme: {}", it.message) }
+    }
+
+    private fun reg(vararg args: String) {
+        val code = ProcessBuilder(listOf("reg") + args).redirectErrorStream(true).start().waitFor()
+        check(code == 0) { "reg ${args.firstOrNull()} exited $code" }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/features/ContextMenuController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/features/ContextMenuController.kt
@@ -194,6 +194,13 @@ class ContextMenuController {
                             font = Font(".AppleSystemUIFont", Font.PLAIN, 13)
                             border = BorderFactory.createEmptyBorder(4, 12, 4, 12)
                             isOpaque = true
+                            // Signed-in account row (id "sign_in"/"custom_sign_in" with an email
+                            // label) gets a person glyph drawn in Java2D — NOT an emoji in the text,
+                            // which poisons the popup's font metrics and garbles every item.
+                            if (element.id.endsWith("sign_in") && element.label.contains('@')) {
+                                icon = AccountGlyphIcon
+                                iconTextGap = 8
+                            }
                             addActionListener { element.action() }
                         }
                         addToMenu(menu, menuItem)
@@ -259,6 +266,35 @@ class ContextMenuController {
         if (item != null && item.enabled) {
             item.action()
             hideMenu()
+        }
+    }
+}
+
+/**
+ * Small person silhouette (head + shoulders) drawn in Java2D for the signed-in account menu row.
+ * Java2D vector glyph, not a font character — so it can't trigger the emoji-font fallback that
+ * corrupts AWT menu text metrics.
+ */
+private val AccountGlyphIcon = object : javax.swing.Icon {
+    private val size = 14
+    override fun getIconWidth() = size
+    override fun getIconHeight() = size
+    override fun paintIcon(c: java.awt.Component?, g: java.awt.Graphics, x: Int, y: Int) {
+        val g2 = g.create() as java.awt.Graphics2D
+        try {
+            g2.setRenderingHint(
+                java.awt.RenderingHints.KEY_ANTIALIASING,
+                java.awt.RenderingHints.VALUE_ANTIALIAS_ON
+            )
+            g2.color = Color(0xCC, 0xCC, 0xCC)
+            // Head: a circle in the upper-middle.
+            g2.fill(java.awt.geom.Ellipse2D.Float(x + 4f, y + 1.5f, 6f, 6f))
+            // Shoulders: a half-disc clipped to the lower band so it reads as a torso, not a full circle.
+            val shoulders = java.awt.geom.Ellipse2D.Float(x + 1.5f, y + 8.5f, 11f, 11f)
+            g2.clip(java.awt.geom.Rectangle2D.Float(x.toFloat(), y.toFloat(), size.toFloat(), (size - 1).toFloat()))
+            g2.fill(shoulders)
+        } finally {
+            g2.dispose()
         }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -243,6 +243,8 @@ fun TabBar(
     onShareTab: (Int) -> Unit = {},
     onShareWindow: (Int) -> Unit = {},
     onShareAll: (Int) -> Unit = {},
+    /** Account sign-in (4th Share-submenu item). Null hides it (e.g. embedded builds). */
+    onSignIn: (() -> Unit)? = null,
     onStopShare: (Int) -> Unit = {},
     isSharing: (Int) -> Boolean = { false },
     onSplitVertical: () -> Unit = {},
@@ -293,7 +295,9 @@ fun TabBar(
                         ContextMenuController.MenuItem(id = "share_tab", label = "Tab…", enabled = true, action = { onShareTab(tabIndex) }),
                         ContextMenuController.MenuItem(id = "share_window", label = "Window…", enabled = true, action = { onShareWindow(tabIndex) }),
                         ContextMenuController.MenuItem(id = "share_all", label = "All Windows…", enabled = true, action = { onShareAll(tabIndex) })
-                    )
+                    ) + (onSignIn?.let { signIn ->
+                        listOf(ContextMenuController.MenuItem(id = "sign_in", label = "Sign In…", enabled = true, action = { signIn() }))
+                    } ?: emptyList())
                 )
             )
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -245,6 +245,8 @@ fun TabBar(
     onShareAll: (Int) -> Unit = {},
     /** Account sign-in (4th Share-submenu item). Null hides it (e.g. embedded builds). */
     onSignIn: (() -> Unit)? = null,
+    /** Label for the sign-in item — the account email once signed in, else "Sign In…". */
+    signInLabel: String = "Sign In…",
     onStopShare: (Int) -> Unit = {},
     isSharing: (Int) -> Boolean = { false },
     onSplitVertical: () -> Unit = {},
@@ -296,7 +298,7 @@ fun TabBar(
                         ContextMenuController.MenuItem(id = "share_window", label = "Window…", enabled = true, action = { onShareWindow(tabIndex) }),
                         ContextMenuController.MenuItem(id = "share_all", label = "All Windows…", enabled = true, action = { onShareAll(tabIndex) })
                     ) + (onSignIn?.let { signIn ->
-                        listOf(ContextMenuController.MenuItem(id = "sign_in", label = "Sign In…", enabled = true, action = { signIn() }))
+                        listOf(ContextMenuController.MenuItem(id = "sign_in", label = signInLabel, enabled = true, action = { signIn() }))
                     } ?: emptyList())
                 )
             )

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
@@ -206,6 +206,25 @@ class AuthModelsTest {
         }
     }
 
+    // ---- cold-start sign-in toast ----
+
+    @Test
+    fun `cold-start sign-in is stashed and drained exactly once`() {
+        // A deep link that verifies before any window subscribes must still toast on the first
+        // window — but exactly once, so later windows don't re-toast a stale email.
+        BossAccountManager.consumePendingSignInToast() // clear any residue from earlier tests
+        BossAccountManager.emitSignIn("cold@start.co") // no collectors → stashed as pending
+        assertEquals("cold@start.co", BossAccountManager.consumePendingSignInToast())
+        assertNull(BossAccountManager.consumePendingSignInToast())
+    }
+
+    @Test
+    fun `blank cold-start sign-in is not stashed`() {
+        BossAccountManager.consumePendingSignInToast()
+        BossAccountManager.emitSignIn("")
+        assertNull(BossAccountManager.consumePendingSignInToast())
+    }
+
     @Test
     fun `staging temp file is owner-only before any token bytes are written`() {
         // The window the final-file test can't see: File.createTempFile honors umask (commonly

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
@@ -128,6 +128,12 @@ class AuthModelsTest {
         assertEquals("HH", parseAuthInput("x?refresh_token=RR&token=HH")?.tokenHash)
     }
 
+    @Test
+    fun `parseAuthInput stops the value at a nested question mark`() {
+        // The value scan must treat '?' as a delimiter, else 'token=abc?foo=bar' captures the trailing junk.
+        assertEquals("abc", parseAuthInput("https://app/cb?token=abc?foo=bar")?.tokenHash)
+    }
+
     // ---- error mapping ----
 
     @Test
@@ -197,6 +203,30 @@ class AuthModelsTest {
             )
         } finally {
             file.delete(); dir.delete()
+        }
+    }
+
+    @Test
+    fun `staging temp file is owner-only before any token bytes are written`() {
+        // The window the final-file test can't see: File.createTempFile honors umask (commonly
+        // 0644), so the temp must be chmod 600 while still EMPTY — else the token is briefly
+        // group/world-readable between write and restrict.
+        val posix = java.nio.file.FileSystems.getDefault().supportedFileAttributeViews().contains("posix")
+        if (!posix) return // Windows ACLs protect the user profile; perms aren't applicable.
+        val dir = java.nio.file.Files.createTempDirectory("auth-tmp-perms").toFile()
+        val tmp = AuthStorage.newOwnerOnlyTempFile(dir)
+        try {
+            assertEquals(0L, tmp.length(), "staging temp must be empty when restricted")
+            assertEquals(
+                setOf(
+                    java.nio.file.attribute.PosixFilePermission.OWNER_READ,
+                    java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
+                ),
+                java.nio.file.Files.getPosixFilePermissions(tmp.toPath()),
+                "staging temp must be chmod 600 before the token is written"
+            )
+        } finally {
+            tmp.delete(); dir.delete()
         }
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
@@ -1,0 +1,134 @@
+package ai.rever.bossterm.compose.auth
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pure-logic guards for the sign-in flow: the `bossterm://auth/verify` deep-link
+ * contract (incl. the `token` → `token_hash` param compatibility), GoTrue error
+ * mapping, and the on-disk session round-trip. The network half is exercised
+ * manually against the live backend (see risa-labs-inc/BossConsole#787).
+ */
+class AuthModelsTest {
+
+    // ---- deep link parsing ----
+
+    @Test
+    fun `parses token_hash and type`() {
+        val l = parseAuthDeepLink("bossterm://auth/verify?token_hash=abc123&type=magiclink")
+        assertEquals(AuthDeepLink("abc123", "magiclink"), l)
+    }
+
+    @Test
+    fun `passes signup type through verbatim`() {
+        // New users' first magic link verifies as `signup` — hardcoding magiclink breaks them.
+        val l = parseAuthDeepLink("bossterm://auth/verify?token_hash=h&type=signup")
+        assertEquals("signup", l?.type)
+    }
+
+    @Test
+    fun `accepts legacy token param as the hash`() {
+        // BossConsole's current redirect function emits token=, the contract says token_hash=.
+        val l = parseAuthDeepLink("bossterm://auth/verify?token=tok&type=magiclink")
+        assertEquals("tok", l?.tokenHash)
+    }
+
+    @Test
+    fun `type defaults to magiclink`() {
+        assertEquals("magiclink", parseAuthDeepLink("bossterm://auth/verify?token_hash=h")?.type)
+    }
+
+    @Test
+    fun `url-decodes parameter values`() {
+        val l = parseAuthDeepLink("bossterm://auth/verify?token_hash=a%2Bb%3D&type=magiclink")
+        assertEquals("a+b=", l?.tokenHash)
+    }
+
+    @Test
+    fun `rejects non-auth links and malformed input`() {
+        // URI("bossterm://auth/verify") parses host="auth", path="/verify" — wrong host/path/scheme must all fail.
+        assertNull(parseAuthDeepLink("bossterm://workspace/open?id=1"))
+        assertNull(parseAuthDeepLink("boss://auth/verify?token_hash=h"))
+        assertNull(parseAuthDeepLink("bossterm://auth/other?token_hash=h"))
+        assertNull(parseAuthDeepLink("bossterm://auth/verify"))            // no query
+        assertNull(parseAuthDeepLink("bossterm://auth/verify?type=magiclink")) // no token
+        assertNull(parseAuthDeepLink("bossterm://auth/verify?token_hash="))    // blank token
+        assertNull(parseAuthDeepLink("::not a uri::"))
+        assertNull(parseAuthDeepLink(""))
+    }
+
+    // ---- error mapping ----
+
+    @Test
+    fun `rate limit maps to cooldown message`() {
+        assertTrue(mapAuthError(429, "over_email_send_rate_limit", AuthPhase.SEND).contains("wait a minute"))
+    }
+
+    @Test
+    fun `expired verify token maps to terminal message`() {
+        // Tokens are single-use: 401/403 on verify must read as expired/used, never retried.
+        for (status in listOf(401, 403)) {
+            assertTrue(mapAuthError(status, "otp_expired", AuthPhase.VERIFY).contains("expired"))
+        }
+    }
+
+    @Test
+    fun `server text wins for other errors, fallbacks otherwise`() {
+        assertEquals("Signups not allowed", mapAuthError(400, "Signups not allowed", AuthPhase.SEND))
+        assertTrue(mapAuthError(0, null, AuthPhase.SEND).contains("connection"))
+        assertTrue(mapAuthError(500, "", AuthPhase.VERIFY).contains("Request a new one"))
+    }
+
+    // ---- stored session round-trip ----
+
+    @Test
+    fun `stored auth round-trips through disk`() {
+        val file = File.createTempFile("auth-test", ".json").also { it.delete() }
+        try {
+            val auth = StoredAuth("at", "rt", 1_900_000_000L, "uid", "a@b.co")
+            AuthStorage.save(auth, file)
+            assertEquals(auth, AuthStorage.load(file))
+            AuthStorage.clear(file)
+            assertNull(AuthStorage.load(file))
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun `corrupted auth file loads as signed out`() {
+        val file = File.createTempFile("auth-test", ".json")
+        try {
+            file.writeText("{ not json !!")
+            assertNull(AuthStorage.load(file))
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun `saved auth file is owner-only on posix`() {
+        val posix = java.nio.file.FileSystems.getDefault().supportedFileAttributeViews().contains("posix")
+        if (!posix) return // Windows ACLs protect the user profile; perms aren't applicable.
+        val dir = java.nio.file.Files.createTempDirectory("auth-perms").toFile()
+        val file = File(dir, "auth.json")
+        try {
+            AuthStorage.save(StoredAuth("at", "rt", 1_900_000_000L, "uid", "a@b.co"), file)
+            val perms = java.nio.file.Files.getPosixFilePermissions(file.toPath())
+            // Tokens at rest must not be group/world readable.
+            assertEquals(
+                setOf(
+                    java.nio.file.attribute.PosixFilePermission.OWNER_READ,
+                    java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
+                ),
+                perms,
+                "auth.json must be chmod 600, was $perms"
+            )
+        } finally {
+            file.delete(); dir.delete()
+        }
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
@@ -48,6 +48,14 @@ class AuthModelsTest {
     }
 
     @Test
+    fun `keeps a literal plus in the token literal (not a form-encoded space)`() {
+        // A URI query component is RFC-3986, not form-encoded — '+' is literal. A standard-base64
+        // token_hash can contain '+'; turning it into a space would silently corrupt the token.
+        val l = parseAuthDeepLink("bossterm://auth/verify?token_hash=aB+cd/ef=&type=magiclink")
+        assertEquals("aB+cd/ef=", l?.tokenHash)
+    }
+
+    @Test
     fun `rejects non-auth links and malformed input`() {
         // URI("bossterm://auth/verify") parses host="auth", path="/verify" — wrong host/path/scheme must all fail.
         assertNull(parseAuthDeepLink("bossterm://workspace/open?id=1"))
@@ -81,6 +89,14 @@ class AuthModelsTest {
         val l = parseAuthInput("https://api.risaboss.com/functions/v1/redirect?url=https%3A%2F%2Fp.co%2Fverify%3Ftoken%3DTOK9%26type%3Dsignup")
         assertEquals("TOK9", l?.tokenHash)
         assertEquals("signup", l?.type)
+    }
+
+    @Test
+    fun `parseAuthInput preserves a literal plus in a pasted token`() {
+        // The footgun: URLDecoder's form semantics turn '+' into a space. A pasted confirmation URL
+        // whose token contains a literal '+' (standard base64) must come through intact.
+        val l = parseAuthInput("https://api.risaboss.com/auth/v1/verify?token=aB+cd/ef=&type=magiclink")
+        assertEquals("aB+cd/ef=", l?.tokenHash)
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
@@ -112,6 +112,22 @@ class AuthModelsTest {
         assertNull(parseAuthInput("token="))
     }
 
+    @Test
+    fun `parseAuthInput does not mistake access_token or refresh_token for the hash`() {
+        // An implicit-flow callback fragment carries access_token=/refresh_token= before token=.
+        // A bare indexOf("token=") would latch onto the FIRST '*token=' (access_token) and POST the
+        // wrong value to /verify; the match must be anchored to a real param boundary.
+        val l = parseAuthInput("https://app/cb#access_token=AAA&refresh_token=RRR&token=TTT&type=signup")
+        assertEquals("TTT", l?.tokenHash)
+        assertEquals("signup", l?.type)
+    }
+
+    @Test
+    fun `parseAuthInput finds token even when only refresh_token precedes it`() {
+        // No clean 'token=' decoy other than the substring inside refresh_token=.
+        assertEquals("HH", parseAuthInput("x?refresh_token=RR&token=HH")?.tokenHash)
+    }
+
     // ---- error mapping ----
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/AuthModelsTest.kt
@@ -60,6 +60,42 @@ class AuthModelsTest {
         assertNull(parseAuthDeepLink(""))
     }
 
+    // ---- lenient paste parsing (manual "paste the sign-in link" fallback) ----
+
+    @Test
+    fun `parseAuthInput accepts the clean bossterm deep link`() {
+        val l = parseAuthInput("  bossterm://auth/verify?token_hash=abc&type=signup  ")
+        assertEquals(AuthDeepLink("abc", "signup"), l)
+    }
+
+    @Test
+    fun `parseAuthInput extracts token + type from a confirmation URL`() {
+        val l = parseAuthInput("https://api.risaboss.com/auth/v1/verify?token=HASH123&type=magiclink&redirect_to=bossterm://auth/verify")
+        assertEquals("HASH123", l?.tokenHash)
+        assertEquals("magiclink", l?.type)
+    }
+
+    @Test
+    fun `parseAuthInput handles the percent-encoded redirect URL (decode fallback)`() {
+        // The email button href: /redirect?url=<encoded ConfirmationURL with token%3D…%26type%3Dsignup>
+        val l = parseAuthInput("https://api.risaboss.com/functions/v1/redirect?url=https%3A%2F%2Fp.co%2Fverify%3Ftoken%3DTOK9%26type%3Dsignup")
+        assertEquals("TOK9", l?.tokenHash)
+        assertEquals("signup", l?.type)
+    }
+
+    @Test
+    fun `parseAuthInput prefers token_hash and defaults type to magiclink`() {
+        assertEquals("xyz", parseAuthInput("foo?token_hash=xyz&token=other")?.tokenHash)
+        assertEquals("magiclink", parseAuthInput("anything?token=t")?.type)
+    }
+
+    @Test
+    fun `parseAuthInput returns null for junk with no token`() {
+        assertNull(parseAuthInput("https://example.com/nothing-here"))
+        assertNull(parseAuthInput("   "))
+        assertNull(parseAuthInput("token="))
+    }
+
     // ---- error mapping ----
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/DeepLinkSocketTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/auth/DeepLinkSocketTest.kt
@@ -1,0 +1,120 @@
+package ai.rever.bossterm.compose.auth
+
+import java.io.File
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Single-owner / forwarding state machine for [DeepLinkSocket] — the most intricate new auth code
+ * and the source of two prior bugs (last-launch-wins routing, premature teardown). Drives the real
+ * loopback sockets through an injectable port file: claim, forward round-trip, stale cleanup,
+ * no-usurp, and the secret + scheme guards on the listener.
+ */
+class DeepLinkSocketTest {
+
+    private lateinit var tmpDir: File
+    private lateinit var originalPortFile: File
+
+    @BeforeTest
+    fun setUp() {
+        originalPortFile = DeepLinkSocket.portFile
+        tmpDir = java.nio.file.Files.createTempDirectory("deeplink-test").toFile()
+        DeepLinkSocket.portFile = File(tmpDir, "deeplink.port")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        DeepLinkSocket.stop()            // closes the loopback socket; the accept loop then exits
+        DeepLinkSocket.portFile = originalPortFile
+        tmpDir.deleteRecursively()
+    }
+
+    private fun collector(latch: CountDownLatch, sink: MutableList<String>): (String) -> Unit =
+        { uri -> sink.add(uri); latch.countDown() }
+
+    @Test
+    fun `claims ownership when no listener exists and forwards a deep link`() {
+        val sink = CopyOnWriteArrayList<String>()
+        val latch = CountDownLatch(1)
+        DeepLinkSocket.startPrimaryListener(collector(latch, sink))
+        assertTrue(DeepLinkSocket.portFile.isFile, "primary should advertise a port file")
+
+        val uri = "bossterm://auth/verify?token_hash=abc&type=magiclink"
+        assertTrue(DeepLinkSocket.tryForward(uri), "forward to a live listener should succeed")
+        assertTrue(latch.await(3, TimeUnit.SECONDS), "listener should receive the forwarded uri")
+        assertEquals(listOf(uri), sink.toList())
+    }
+
+    @Test
+    fun `tryForward returns false when there is no port file`() {
+        assertFalse(DeepLinkSocket.portFile.exists())
+        assertFalse(DeepLinkSocket.tryForward("bossterm://auth/verify?token_hash=x"))
+    }
+
+    @Test
+    fun `tryForward deletes a stale port file and returns false`() {
+        // Advertise a port nothing listens on: bind then close to obtain a free (refused) port.
+        val freePort = ServerSocket(0, 1, InetAddress.getLoopbackAddress()).use { it.localPort }
+        DeepLinkSocket.portFile.writeText("$freePort\ndeadbeefdeadbeefdeadbeefdeadbeef\n")
+        assertFalse(DeepLinkSocket.tryForward("bossterm://auth/verify?token_hash=x"))
+        assertFalse(DeepLinkSocket.portFile.exists(), "a stale port file must be cleared")
+    }
+
+    @Test
+    fun `does not usurp a live listener`() {
+        DeepLinkSocket.startPrimaryListener { }
+        val claimed = DeepLinkSocket.portFile.readText()
+        // A second launch must detect the live owner and leave the advertised port untouched.
+        DeepLinkSocket.startPrimaryListener { }
+        assertEquals(claimed, DeepLinkSocket.portFile.readText(), "second launch must not overwrite routing")
+    }
+
+    @Test
+    fun `rejects a forward presenting the wrong secret`() {
+        val sink = CopyOnWriteArrayList<String>()
+        val latch = CountDownLatch(1)
+        DeepLinkSocket.startPrimaryListener(collector(latch, sink))
+        val port = DeepLinkSocket.portFile.readLines()[0].trim().toInt()
+
+        // Hand-craft a connection with a bogus secret — must be ignored by the constant-time check.
+        Socket(InetAddress.getLoopbackAddress(), port).use { s ->
+            s.getOutputStream().write("wrongsecret bossterm://auth/verify?token_hash=evil\n".toByteArray(Charsets.UTF_8))
+            s.getOutputStream().flush()
+        }
+        // A legitimate forward afterward should be the ONLY thing routed.
+        val good = "bossterm://auth/verify?token_hash=good"
+        assertTrue(DeepLinkSocket.tryForward(good))
+        assertTrue(latch.await(3, TimeUnit.SECONDS))
+        assertEquals(listOf(good), sink.toList(), "the wrong-secret line must not be routed")
+    }
+
+    @Test
+    fun `listener ignores a non-bossterm uri`() {
+        val sink = CopyOnWriteArrayList<String>()
+        val latch = CountDownLatch(1)
+        DeepLinkSocket.startPrimaryListener(collector(latch, sink))
+        val lines = DeepLinkSocket.portFile.readLines()
+        val port = lines[0].trim().toInt()
+        val secret = lines[1].trim()
+
+        // Correct secret but a non-bossterm scheme — must be dropped by the scheme filter.
+        Socket(InetAddress.getLoopbackAddress(), port).use { s ->
+            s.getOutputStream().write("$secret http://evil.example/exfil\n".toByteArray(Charsets.UTF_8))
+            s.getOutputStream().flush()
+        }
+        val good = "bossterm://auth/verify?token_hash=good"
+        assertTrue(DeepLinkSocket.tryForward(good))
+        assertTrue(latch.await(3, TimeUnit.SECONDS))
+        assertEquals(listOf(good), sink.toList(), "a non-bossterm uri must not be routed")
+    }
+}

--- a/snap/gui/bossterm.desktop
+++ b/snap/gui/bossterm.desktop
@@ -10,4 +10,4 @@ Categories=System;TerminalEmulator;Utility;
 Keywords=terminal;shell;console;command;prompt;
 StartupWMClass=bossterm
 StartupNotify=true
-MimeType=application/x-terminal-emulator;
+MimeType=application/x-terminal-emulator;x-scheme-handler/bossterm;


### PR DESCRIPTION
Adds **Sign In** as the 4th item in the Share menus, against BossConsole's shared Supabase backend (one user pool) over raw GoTrue REST — no Supabase SDK, reusing the existing ktor client. Magic-link flow: enter email → GoTrue emails a link → BossConsole's redirect function emits `bossterm://auth/verify?token_hash=…&type=…` → BossTerm verifies and persists the session. Hidden in embedded builds (`serverName != "bossterm"`).

Backend half: **risa-labs-inc/BossConsole#789** (closes #787). Until that ships, the email is BOSS-Console-branded and its link opens BossConsole — the client here is complete and testable via a manually-opened deep link.

## New `compose-ui/.../auth/` package
- **BossAccountManager** — `StateFlow<AccountState>`; `sendMagicLink` (`POST /auth/v1/otp`, `redirect_to=bossterm://auth/verify`), `handleAuthDeepLink` (`POST /auth/v1/verify` with `token_hash` + verbatim `type`), `signOut`, refresh-on-startup.
- **AuthModels / AuthStorage** — DTOs + `parseAuthDeepLink` + error mapping; session in `~/.bossterm/auth.json` (atomic write, chmod 600 on POSIX, never logged).
- **DeepLinkHandler / DeepLinkSocket** — new `bossterm://` support: macOS `setOpenURIHandler` (installed before AWT), Windows/Linux argv + single-instance loopback forwarder (bounded read, constant-time secret compare), `-Dbossterm.debug.deeplink` dev hook.
- **WindowsProtocolRegistrar** — HKCU scheme registration on packaged Windows launches.
- **SignInWindow** — email → sent (60s resend cooldown) → verifying → signed-in.

## Wiring
`Main.kt` (`fun main(args)` + `DeepLinkHandler.install` first thing); macOS `CFBundleURLTypes`; `.deb` `.desktop` patch (MimeType + `%U`); snap `x-scheme-handler/bossterm`; "Sign In…" at all three Share menu sites; a deferred "Signed in as …" toast.

## Security (reviewed)
Anon key is byte-identical to BossConsole's already-public fallback (RLS is the gate); tokens chmod-600 + never logged; deeplink params go into a JSON body (no injection); socket secret is 128-bit, owner-only, constant-time-compared.

## Tests / verification
`:compose-ui:desktopTest` auth suite (deeplink parsing incl. `token`↔`token_hash` + verbatim `type`, error mapping, storage round-trip/corruption, **600-perms assertion**) green; full build green.

**Manual before release** (OS-delivery has no automated coverage): packaged `.app` cold-start `open "bossterm://auth/verify?token_hash=…&type=magiclink"`; a Linux `.deb` `.desktop` carries the MimeType + `%U`; Windows HKCU registration. **RPM scheme registration is a known gap** (jpackage `.rpm` isn't repacked).

Generated with [Claude Code](https://claude.com/claude-code)