### PR TITLE
perf + hotkeys: kill ~1-core idle drain; safer global hotkeys + show/hide toggle

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -390,7 +390,9 @@ object TerminalCanvasRenderer {
         val detectedHyperlinks = renderText(ctx, analysisCache)
         hyperlinksCache.putAll(detectedHyperlinks)
 
-        // Pass 3: Draw overlays (hyperlinks, search, cursor - but NOT selection)
+        // Pass 3: Draw overlays (hyperlinks, search - but NOT selection or cursor).
+        // The cursor is drawn in its own overlay Canvas (see renderCursorOverlay) so its
+        // blink doesn't re-run this whole pass.
         renderOverlays(ctx)
 
         return hyperlinksCache
@@ -963,10 +965,9 @@ object TerminalCanvasRenderer {
 
         // Selection highlight is now rendered in Pass 1.5 (before text) so text is visible on top
 
-        // Cursor
-        if (ctx.cursorVisible) {
-            renderCursor(ctx)
-        }
+        // Cursor is intentionally NOT drawn here. It lives in its own overlay Canvas
+        // (see ProperTerminal) so its blink only repaints a single small layer instead of
+        // re-running this whole text pass twice a second. See [renderCursorOverlay].
     }
 
     /**
@@ -1134,38 +1135,65 @@ object TerminalCanvasRenderer {
      * Cursor is rendered at its buffer position - when scrolled into history,
      * cursor will be below the visible area and won't be rendered.
      */
-    private fun DrawScope.renderCursor(ctx: RenderingContext) {
+    /**
+     * Draw just the cursor, into its own overlay [Canvas] stacked on top of the text canvas.
+     *
+     * Split out from the main render pass on purpose: the cursor is the only thing that
+     * changes on the ~0.5s blink, and Compose's Canvas has no partial invalidation — reading
+     * the blink flag inside the text pass forced a full re-render of every visible cell twice
+     * a second. Drawing the cursor in a dedicated layer means a blink repaints only this tiny
+     * Canvas. The cursor is a translucent overlay (it never inverts the glyph underneath), so
+     * stacking it in a separate layer is visually identical to drawing it last in one canvas.
+     *
+     * Parameters are passed explicitly (rather than via [RenderingContext]) so the cursor layer
+     * needs no buffer snapshot — only cheap, composition-scoped cursor state. [visibleRows] is
+     * derived from the DrawScope size, matching the text canvas's own bounds computation.
+     */
+    fun DrawScope.renderCursorOverlay(
+        cursorVisible: Boolean,
+        cursorBlinkVisible: Boolean,
+        cursorShape: CursorShape?,
+        cursorX: Int,
+        cursorY: Int,
+        scrollOffset: Int,
+        cellWidth: Float,
+        cellHeight: Float,
+        isFocused: Boolean,
+        cursorColor: Color?,
+    ) {
+        if (!cursorVisible) return
         // cursorY is 1-indexed in the screen buffer, adjust to 0-indexed
-        val bufferCursorY = (ctx.cursorY - 1).coerceAtLeast(0)
+        val bufferCursorY = (cursorY - 1).coerceAtLeast(0)
         // Convert buffer position to screen position by adding scrollOffset
         // scrollOffset=0 means viewing current screen, scrollOffset>0 means scrolled into history
         // When scrolled up, cursor (at bottom of buffer) will be below visible area
-        val cursorScreenRow = bufferCursorY + ctx.scrollOffset
+        val cursorScreenRow = bufferCursorY + scrollOffset
 
-        // Don't render cursor if outside visible area
-        if (cursorScreenRow < 0 || cursorScreenRow >= ctx.visibleRows) {
+        // Don't render cursor if outside the visible area (rows that fit this canvas).
+        val visibleRows = kotlin.math.ceil(size.height / cellHeight).toInt()
+        if (cursorScreenRow < 0 || cursorScreenRow >= visibleRows) {
             return
         }
 
-        val shouldShowCursor = when (ctx.cursorShape) {
-            CursorShape.BLINK_BLOCK, CursorShape.BLINK_UNDERLINE, CursorShape.BLINK_VERTICAL_BAR -> ctx.cursorBlinkVisible
+        val shouldShowCursor = when (cursorShape) {
+            CursorShape.BLINK_BLOCK, CursorShape.BLINK_UNDERLINE, CursorShape.BLINK_VERTICAL_BAR -> cursorBlinkVisible
             else -> true
         }
 
         if (!shouldShowCursor) return
 
-        val x = ctx.cursorX * ctx.cellWidth
-        val y = cursorScreenRow * ctx.cellHeight
+        val x = cursorX * cellWidth
+        val y = cursorScreenRow * cellHeight
         // Calculate size as difference to next cell to avoid floating-point gaps
-        val w = (ctx.cursorX + 1) * ctx.cellWidth - x
-        val h = (cursorScreenRow + 1) * ctx.cellHeight - y
-        val cursorAlpha = if (ctx.isFocused) 0.7f else 0.3f
-        val cursorColor = (ctx.cursorColor ?: Color.White).copy(alpha = cursorAlpha)
+        val w = (cursorX + 1) * cellWidth - x
+        val h = (cursorScreenRow + 1) * cellHeight - y
+        val cursorAlpha = if (isFocused) 0.7f else 0.3f
+        val drawColor = (cursorColor ?: Color.White).copy(alpha = cursorAlpha)
 
-        when (ctx.cursorShape) {
+        when (cursorShape) {
             CursorShape.BLINK_BLOCK, CursorShape.STEADY_BLOCK, null -> {
                 drawRect(
-                    color = cursorColor,
+                    color = drawColor,
                     topLeft = Offset(x, y),
                     size = Size(w, h)
                 )
@@ -1173,7 +1201,7 @@ object TerminalCanvasRenderer {
             CursorShape.BLINK_UNDERLINE, CursorShape.STEADY_UNDERLINE -> {
                 val underlineHeight = h * 0.2f
                 drawRect(
-                    color = cursorColor,
+                    color = drawColor,
                     topLeft = Offset(x, y + h - underlineHeight),
                     size = Size(w, underlineHeight)
                 )
@@ -1181,7 +1209,7 @@ object TerminalCanvasRenderer {
             CursorShape.BLINK_VERTICAL_BAR, CursorShape.STEADY_VERTICAL_BAR -> {
                 val barWidth = w * 0.15f
                 drawRect(
-                    color = cursorColor,
+                    color = drawColor,
                     topLeft = Offset(x, y),
                     size = Size(barWidth, h)
                 )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.*
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -655,28 +656,53 @@ fun ProperTerminal(
     terminal.setCellDimensions(cellWidth, cellHeight)
   }
 
-  // SLOW_BLINK animation timer (configurable via settings.slowTextBlinkMs)
-  // Wrapped with enableTextBlinking master toggle for accessibility
-  if (settings.enableTextBlinking) {
-    LaunchedEffect(settings.slowTextBlinkMs) {
-      while (true) {
-        delay(settings.slowTextBlinkMs.toLong())
-        slowBlinkVisible = !slowBlinkVisible
-      }
-    }
+  // Window focus + tab visibility gate every blink animation. The Canvas draw lambda
+  // reads cursorBlinkVisible / slowBlinkVisible / rapidBlinkVisible, so each toggle
+  // repaints the ENTIRE terminal canvas. Letting those loops run while the window is in
+  // the background — or for a tab that isn't the visible one — wakes the CPU/GPU twice a
+  // second forever for no visible benefit (a major battery drain). Gate them so an idle
+  // or backgrounded terminal produces zero periodic repaints, matching iTerm2/Terminal.app
+  // (the cursor stops blinking when the app isn't frontmost). When a loop is parked we
+  // freeze its flag to "visible" so the cursor shows solid and blink-attributed text stays
+  // readable; the renderer still draws the unfocused cursor style from `isFocused`.
+  val blinkActive = isActiveTab && LocalWindowInfo.current.isWindowFocused
 
-    // RAPID_BLINK animation timer (configurable via settings.rapidTextBlinkMs)
-    LaunchedEffect(settings.rapidTextBlinkMs) {
-      while (true) {
-        delay(settings.rapidTextBlinkMs.toLong())
-        rapidBlinkVisible = !rapidBlinkVisible
-      }
+  // SLOW_BLINK animation timer (configurable via settings.slowTextBlinkMs).
+  // enableTextBlinking is the master accessibility toggle. A non-positive interval means
+  // "no blink" (also guards against a delay(0) busy-loop pegging a core).
+  LaunchedEffect(blinkActive, settings.enableTextBlinking, settings.slowTextBlinkMs) {
+    if (!blinkActive || !settings.enableTextBlinking || settings.slowTextBlinkMs <= 0) {
+      slowBlinkVisible = true
+      return@LaunchedEffect
+    }
+    while (isActive) {
+      delay(settings.slowTextBlinkMs.toLong())
+      slowBlinkVisible = !slowBlinkVisible
     }
   }
 
-  // Cursor blink animation timer (configurable via settings.caretBlinkMs)
-  LaunchedEffect(settings.caretBlinkMs) {
-    while (true) {
+  // RAPID_BLINK animation timer (configurable via settings.rapidTextBlinkMs).
+  LaunchedEffect(blinkActive, settings.enableTextBlinking, settings.rapidTextBlinkMs) {
+    if (!blinkActive || !settings.enableTextBlinking || settings.rapidTextBlinkMs <= 0) {
+      rapidBlinkVisible = true
+      return@LaunchedEffect
+    }
+    while (isActive) {
+      delay(settings.rapidTextBlinkMs.toLong())
+      rapidBlinkVisible = !rapidBlinkVisible
+    }
+  }
+
+  // Cursor blink animation timer (configurable via settings.caretBlinkMs).
+  // caretBlinkMs <= 0 means "solid cursor, never blink" (the settings slider exposes 0 as
+  // "Off"); the old code turned that into delay(0) in a tight loop, which pegged a CPU
+  // core instead of disabling the blink. The guard now makes "Off" actually off.
+  LaunchedEffect(blinkActive, settings.caretBlinkMs) {
+    if (!blinkActive || settings.caretBlinkMs <= 0) {
+      cursorBlinkVisible = true
+      return@LaunchedEffect
+    }
+    while (isActive) {
       delay(settings.caretBlinkMs.toLong())
       cursorBlinkVisible = !cursorBlinkVisible
     }
@@ -1828,7 +1854,11 @@ fun ProperTerminal(
             cursorX = effectiveCursorX,
             cursorY = cursorY,
             cursorVisible = cursorVisible,
-            cursorBlinkVisible = cursorBlinkVisible,
+            // The text pass no longer draws the cursor (it lives in its own overlay Canvas
+            // below), so pass a constant here. Reading the real cursorBlinkVisible state in
+            // this draw lambda would re-subscribe the whole text canvas to the blink and
+            // defeat the optimization.
+            cursorBlinkVisible = true,
             cursorShape = cursorShape,
             cursorColor = baseCursorColor,
             isFocused = isFocused,
@@ -1852,6 +1882,35 @@ fun ProperTerminal(
             // Update cache for next frame
             cachedHyperlinks = detectedHyperlinks
             lastHyperlinkVersionHash = currentVersionHash
+          }
+        }
+
+        // Cursor overlay — drawn in its own Canvas, stacked on top of the text canvas above
+        // (same modifier, so coordinates line up exactly). This is the ONLY place that reads
+        // cursorBlinkVisible, so the ~0.5s blink invalidates just this tiny layer instead of
+        // re-running the full text render. Cursor position is read from the same
+        // composition-scoped snapshots the text canvas uses, so it stays in sync as content
+        // and scroll change. The cursor is a translucent overlay, so a separate layer is
+        // visually identical to drawing it last in one canvas.
+        Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
+          if (size.width < cellWidth || size.height < cellHeight) return@Canvas
+          val customCursorColor = terminal.cursorColor
+          val baseCursorColor = if (customCursorColor != null) {
+            Color(customCursorColor.red, customCursorColor.green, customCursorColor.blue)
+          } else null
+          with(TerminalCanvasRenderer) {
+            renderCursorOverlay(
+              cursorVisible = cursorVisible,
+              cursorBlinkVisible = cursorBlinkVisible,
+              cursorShape = cursorShape,
+              cursorX = effectiveCursorX,
+              cursorY = cursorY,
+              scrollOffset = scrollOffset,
+              cellWidth = cellWidth,
+              cellHeight = cellHeight,
+              isFocused = isFocused,
+              cursorColor = baseCursorColor,
+            )
           }
         }
 
@@ -2118,18 +2177,6 @@ fun ProperTerminal(
             TerminalDisplay.ProgressState.HIDDEN -> Color.Transparent
           }
 
-          // Animated offset for indeterminate gradient - seamless loop
-          val infiniteTransition = rememberInfiniteTransition(label = "progress")
-          val animatedOffset by infiniteTransition.animateFloat(
-            initialValue = -0.3f,
-            targetValue = 1.3f,
-            animationSpec = infiniteRepeatable(
-              animation = tween(2500, easing = LinearEasing),
-              repeatMode = RepeatMode.Restart
-            ),
-            label = "progressOffset"
-          )
-
           val progressAlignment = if (settings.progressBarPosition == "top") Alignment.TopStart else Alignment.BottomStart
           Box(
             modifier = Modifier
@@ -2139,7 +2186,22 @@ fun ProperTerminal(
               .background(progressColor.copy(alpha = 0.15f))
           ) {
             if (progressState == TerminalDisplay.ProgressState.INDETERMINATE) {
-              // Indeterminate: animated gradient bar with seamless loop
+              // Indeterminate: animated gradient bar with seamless loop.
+              // The infinite transition is created INSIDE this branch on purpose: it
+              // drives the Compose frame clock continuously (~60fps), so it must only run
+              // while an indeterminate bar is actually on screen. A determinate bar ignores
+              // animatedOffset entirely — keeping the transition in the outer scope pinned
+              // the compositor at 60fps for the bar's whole (possibly minutes-long) life.
+              val infiniteTransition = rememberInfiniteTransition(label = "progress")
+              val animatedOffset by infiniteTransition.animateFloat(
+                initialValue = -0.3f,
+                targetValue = 1.3f,
+                animationSpec = infiniteRepeatable(
+                  animation = tween(2500, easing = LinearEasing),
+                  repeatMode = RepeatMode.Restart
+                ),
+                label = "progressOffset"
+              )
               // Gradient width is 30% of bar, animates from -30% to 130% for smooth entry/exit
               Canvas(modifier = Modifier.fillMaxSize()) {
                 val gradientWidth = size.width * 0.35f

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/window/GlobalHotKeyManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/window/GlobalHotKeyManager.kt
@@ -461,11 +461,29 @@ object GlobalHotKeyManager {
             macRunLoopMode = cfApi.CFStringCreateWithCString(null, "kCFRunLoopDefaultMode", 0x08000100)
 
             // Process events using CFRunLoopRunInMode instead of RunApplicationEventLoop
-            // This allows us to periodically check if we should stop
+            // so we can periodically check whether we should stop.
+            //
+            // BATTERY-CRITICAL: CFRunLoopRunInMode only *blocks* for the timeout if the
+            // mode has at least one input source or timer to wait on. The Carbon hotkey
+            // events registered above are dispatched on the application's main run loop,
+            // not on this background thread, so THIS thread's mode is empty — and
+            // CFRunLoopRunInMode then returns kCFRunLoopRunFinished *immediately* instead
+            // of waiting. With the old unconditional 0.1s call that turned this `while`
+            // into a tight spin that pegged a full CPU core for the entire lifetime of the
+            // app, regardless of window focus (measured: ~1 core / ~1000 ms·s⁻¹ at idle).
+            //
+            // Fix: only treat the call as a real wait when it actually blocked
+            // (TimedOut) or did work (HandledSource). Any immediate return (Finished /
+            // Stopped / empty mode) means there was nothing to wait on, so sleep before
+            // re-checking isRunning. A longer timeout also lets a non-empty mode block
+            // efficiently and wake instantly on a delivered event.
             while (isRunning && !Thread.currentThread().isInterrupted) {
-                // Run the run loop for a short time (100ms)
-                // This will process any pending events including hotkey events
-                cfApi.CFRunLoopRunInMode(macRunLoopMode, 0.1, false)
+                val result = cfApi.CFRunLoopRunInMode(macRunLoopMode, 1.0, false)
+                if (result != CoreFoundationApi.kCFRunLoopRunTimedOut &&
+                    result != CoreFoundationApi.kCFRunLoopRunHandledSource) {
+                    // Returned without waiting — park briefly so we idle instead of spin.
+                    Thread.sleep(250)
+                }
             }
 
         } catch (e: Exception) {


### PR DESCRIPTION
Three commits on this branch — two perf fixes (the reason it started) and one global-hotkey improvement that fell out of the investigation.

## 1. `perf(macos)`: stop the global-hotkey CFRunLoop spinning a full core  ← the big one
The hotkey handler ran `while (isRunning) { CFRunLoopRunInMode(mode, 0.1, false) }`. That call only blocks for its timeout when the run-loop mode has an input source; the Carbon hotkey events go to the app's **main** run loop, so this background thread's mode is empty and the call returns *immediately* — a tight spin pegging a full core for the app's whole lifetime, regardless of focus.

Fix: sleep when the call returns without actually waiting (empty mode) instead of busy-looping.

**Measured (Apple Silicon, idle, unfocused, gradlew-run):** `origin/master` ~1015 ms/s (≈1 core) → **~0.5%**. The blink fix below didn't move idle CPU — measuring it is how this was found.

## 2. `perf`: cut idle/blink battery cost in the renderer
- Gate cursor + text blink on `isActiveTab && isWindowFocused` (backgrounded terminal → zero periodic repaints).
- Fix `caretBlinkMs = 0` ("Off") which became `delay(0)` and pegged a core → now a solid cursor.
- Draw the cursor in its own overlay `Canvas` so a blink invalidates one tiny layer, not every cell.
- Scope the indeterminate progress animation to the `INDETERMINATE` branch (a determinate bar was pinning ~60fps).

## 3. `feat(hotkeys)`: safer defaults + global show/hide toggle
Resolves the global vs in-app shortcut collision (global ⌃1–9 summon shadows in-app ⌃1–9 because the system-wide hotkey wins).
- **Two-modifier default** (Ctrl+Shift; Shift not Alt, to avoid AltGr on EU layouts) + a settings **warning** when only one modifier is set. The hard ≥1-modifier guard stays, so a bare-key global hotkey can't be registered.
- **Single show/hide toggle** (`globalHotkeyToggleEnabled`, default on): one hotkey = modifiers + `globalHotkeyKey` (e.g. Ctrl+Shift+\`) that shows/hides the active window from anywhere — drop-down-terminal style, independent of 1–9. Implemented on macOS/Win32/X11 under sentinel id 0; routes through the existing callback; UI switch added.

## Testing
All desktop targets compile; `:compose-ui` tests pass. Idle CPU verified on-device (`top`/`sample`/`powermetrics`). **Needs manual on-device checks:** (1) Cmd/Ctrl+number global window switching still works after the CFRunLoop change; (2) the new show/hide toggle fires and shows/hides correctly; (3) the X11 path (couldn't test Linux here).

## Follow-ups (not in this PR)
- Linux hotkey path still polls X11 every 10 ms (`Thread.sleep(10)`) — a blocking wait on the display fd would be the analogous fix.
- ~20 leftover `cloudflared` tunnel processes observed from prior share sessions — likely a separate cleanup-on-exit gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)