### PR TITLE
feat(hotkeys): safer two-modifier default, conflict warning, and global show/hide toggle

### DIFF
--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -1028,19 +1028,33 @@ private fun startGlobalHotKeyManager() {
 
     // Start the manager with window-specific callback
     GlobalHotKeyManager.start(config) { windowNumber ->
-        // Find the window with this number
-        val window = WindowManager.getWindowByNumber(windowNumber)
-        if (window != null) {
-            // Window exists - toggle its visibility
-            val awtWindow = window.awtWindow
-            if (awtWindow != null) {
-                WindowVisibilityController.toggleWindow(listOf(awtWindow))
-            }
-        } else {
-            // No window with this number - create one if it's window 1
-            if (windowNumber == 1) {
+        if (windowNumber == 0) {
+            // Single global show/hide toggle (modifiers + configured key). Toggle the
+            // active window — toggleWindow() prefers focused > visible > first — or create
+            // one if none exist yet, so the hotkey can also summon the app from cold.
+            val awtWindows = WindowManager.windows.mapNotNull { it.awtWindow }
+            if (awtWindows.isNotEmpty()) {
+                WindowVisibilityController.toggleWindow(awtWindows)
+            } else {
                 javax.swing.SwingUtilities.invokeLater {
                     WindowManager.createWindow()
+                }
+            }
+        } else {
+            // Find the window with this number
+            val window = WindowManager.getWindowByNumber(windowNumber)
+            if (window != null) {
+                // Window exists - toggle its visibility
+                val awtWindow = window.awtWindow
+                if (awtWindow != null) {
+                    WindowVisibilityController.toggleWindow(listOf(awtWindow))
+                }
+            } else {
+                // No window with this number - create one if it's window 1
+                if (windowNumber == 1) {
+                    javax.swing.SwingUtilities.invokeLater {
+                        WindowManager.createWindow()
+                    }
                 }
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -797,8 +797,12 @@ data class TerminalSettings(
 
     /**
      * Shift modifier for global hotkey.
+     * Defaults to true so the out-of-the-box global hotkey is a two-modifier chord
+     * (Ctrl+Shift), which is far less likely to shadow ordinary app shortcuts than a
+     * single modifier. Shift (not Alt) is the second default modifier on purpose:
+     * Ctrl+Alt is AltGr on many European layouts and would interfere with typing.
      */
-    val globalHotkeyShift: Boolean = false,
+    val globalHotkeyShift: Boolean = true,
 
     /**
      * Windows key modifier for global hotkey.
@@ -810,6 +814,14 @@ data class TerminalSettings(
      * Valid values: "GRAVE" (`), "SPACE", "ESCAPE", A-Z, 0-9, F1-F12
      */
     val globalHotkeyKey: String = "GRAVE",
+
+    /**
+     * Register a single global show/hide toggle hotkey: the configured modifiers +
+     * [globalHotkeyKey] (e.g. Ctrl+Shift+`). Summons or hides the active BossTerm window
+     * from anywhere — a lightweight "drop-down terminal" trigger that is independent of
+     * the per-window 1–9 hotkeys. Only takes effect while [globalHotkeyEnabled] is on.
+     */
+    val globalHotkeyToggleEnabled: Boolean = true,
 
     /**
      * Automatically inject shell integration (OSC 133) into new terminal sessions.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/GlobalHotkeySection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/GlobalHotkeySection.kt
@@ -68,6 +68,31 @@ fun GlobalHotkeySection(
                     status = registrationStatus,
                     isMacOS = isMacOS
                 )
+
+                // Nudge toward a two-modifier chord. A single modifier (e.g. ⌃1–9) collides
+                // with common app shortcuts, and because the global hotkey is registered
+                // system-wide it intercepts the keystroke before the focused app sees it.
+                if (currentConfig.modifierCount == 1) {
+                    Text(
+                        text = "⚠︎ One modifier can clash with app shortcuts (the global hotkey " +
+                            "wins system-wide). Add a second modifier for a conflict-free chord.",
+                        color = Color(0xFFE2B44A),
+                        fontSize = 12.sp,
+                        lineHeight = 16.sp,
+                        modifier = Modifier.padding(top = 6.dp)
+                    )
+                }
+
+                // Single show/hide toggle (modifiers + configured key, e.g. ⌃⇧`).
+                SettingsToggle(
+                    label = "Show/Hide Toggle Hotkey",
+                    checked = settings.globalHotkeyToggleEnabled,
+                    onCheckedChange = { onSettingsChange(settings.copy(globalHotkeyToggleEnabled = it)) },
+                    description = "Also register one hotkey (" +
+                        currentConfig.toDisplayString(useMacSymbols = isMacOS) +
+                        ") that shows/hides the active window from anywhere — a drop-down-terminal trigger.",
+                    enabled = settings.globalHotkeyEnabled
+                )
             }
 
             SettingsToggle(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/window/GlobalHotKeyManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/window/GlobalHotKeyManager.kt
@@ -39,6 +39,15 @@ enum class HotKeyRegistrationStatus {
 object GlobalHotKeyManager {
     private const val HOTKEY_SIGNATURE = 0x424F5353  // 'BOSS'
 
+    // Sentinel id for the single global show/hide toggle (modifiers + configured key).
+    // Per-window hotkeys use ids 1-9, so 0 is free; it routes through invokeCallback(0),
+    // which the app maps to "toggle the active window" rather than a specific window.
+    private const val TOGGLE_HOTKEY_ID = 0
+
+    // The toggle is skipped when the configured key is itself a window digit (1-9), since
+    // that key is already claimed by a per-window hotkey and would fail to register twice.
+    private fun toggleKeyConflictsWithWindows(key: String): Boolean = key.trim().toIntOrNull() in 1..9
+
     // Linux registration success threshold: if less than this fraction succeed,
     // treat as overall failure. 50% threshold chosen because:
     // - Allows 4-5 windows to work even if some hotkeys conflict
@@ -71,8 +80,11 @@ object GlobalHotKeyManager {
      * Start the global hotkey manager with the given base configuration.
      * Will register hotkeys for all existing windows and listen for new ones.
      *
-     * @param config Base hotkey configuration (modifiers only, key is ignored - numbers 1-9 are used)
-     * @param onWindowHotKeyPressed Callback with window number (1-9) when hotkey is pressed
+     * @param config Base hotkey configuration. Modifiers + numbers 1-9 drive per-window
+     *   summon; if [HotKeyConfig.toggleEnabled] is set, modifiers + [HotKeyConfig.key]
+     *   also register a single show/hide toggle reported as window number 0.
+     * @param onWindowHotKeyPressed Callback with window number 1-9 (summon that window) or
+     *   0 (the show/hide toggle) when the corresponding hotkey is pressed
      */
     @Synchronized
     fun start(config: HotKeyConfig, onWindowHotKeyPressed: (Int) -> Unit) {
@@ -268,6 +280,17 @@ object GlobalHotKeyManager {
             return
         }
 
+        // Optional single show/hide toggle: modifiers + configured key (e.g. Ctrl+Shift+`).
+        if (config.toggleEnabled && !toggleKeyConflictsWithWindows(config.key)) {
+            try {
+                if (api.RegisterHotKey(null, TOGGLE_HOTKEY_ID, modifiers, config.toVirtualKeyCode())) {
+                    println("GlobalHotKeyManager: Registered Windows show/hide toggle (${config.key})")
+                }
+            } catch (e: Exception) {
+                println("GlobalHotKeyManager: show/hide toggle registration failed: ${e.message}")
+            }
+        }
+
         println("GlobalHotKeyManager: Registered Windows hotkeys for windows 1-9")
         _registrationStatus.value = HotKeyRegistrationStatus.REGISTERED
 
@@ -282,7 +305,8 @@ object GlobalHotKeyManager {
 
                 if (msg.message == Win32HotKeyApi.WM_HOTKEY) {
                     val windowNum = msg.wParam.toInt()
-                    if (windowNum in 1..9) {
+                    // 1-9 = per-window summon; TOGGLE_HOTKEY_ID (0) = show/hide toggle.
+                    if (windowNum in 1..9 || windowNum == TOGGLE_HOTKEY_ID) {
                         invokeCallback(windowNum)
                     }
                 }
@@ -298,6 +322,11 @@ object GlobalHotKeyManager {
                 } catch (e: Exception) {
                     // Ignore
                 }
+            }
+            try {
+                api.UnregisterHotKey(null, TOGGLE_HOTKEY_ID)
+            } catch (e: Exception) {
+                // Ignore
             }
             // Note: winThreadId is cleared in stopWindows() after posting WM_QUIT
             registeredWindows.clear()
@@ -379,7 +408,8 @@ object GlobalHotKeyManager {
                         if (result == MacOSHotKeyApi.noErr) {
                             hotKeyID.read()
                             val windowNum = hotKeyID.id
-                            if (windowNum in 1..9) {
+                            // 1-9 = per-window summon; TOGGLE_HOTKEY_ID (0) = show/hide toggle.
+                            if (windowNum in 1..9 || windowNum == TOGGLE_HOTKEY_ID) {
                                 invokeCallback(windowNum)
                             }
                         }
@@ -448,6 +478,26 @@ object GlobalHotKeyManager {
                 _registrationStatus.value = HotKeyRegistrationStatus.FAILED
                 initializationLatch?.countDown()
                 return
+            }
+
+            // Optional single show/hide toggle: modifiers + configured key (e.g. ⌃⇧`).
+            // Registered under the sentinel id so it flows through the same event handler.
+            if (config.toggleEnabled && !toggleKeyConflictsWithWindows(config.key)) {
+                val toggleKeyCode = MacOSHotKeyApi.keyToVirtualKeyCode(config.key)
+                val toggleId = EventHotKeyID.ByReference()
+                toggleId.signature = HOTKEY_SIGNATURE
+                toggleId.id = TOGGLE_HOTKEY_ID
+                toggleId.write()
+                val toggleRef = PointerByReference()
+                val toggleResult = carbonApi.RegisterEventHotKey(
+                    toggleKeyCode, modifiers, toggleId, target, 0, toggleRef
+                )
+                if (toggleResult == MacOSHotKeyApi.noErr) {
+                    macHotKeyRefs[TOGGLE_HOTKEY_ID] = toggleRef.value
+                    println("GlobalHotKeyManager: Registered macOS show/hide toggle (${config.key})")
+                } else {
+                    println("GlobalHotKeyManager: show/hide toggle registration failed: $toggleResult")
+                }
             }
 
             println("GlobalHotKeyManager: Registered macOS hotkeys for windows 1-9")
@@ -643,6 +693,30 @@ object GlobalHotKeyManager {
                 _registrationStatus.value = HotKeyRegistrationStatus.FAILED
                 initializationLatch?.countDown()
                 return
+            }
+
+            // Optional single show/hide toggle: modifiers + configured key (e.g. Ctrl+Shift+`).
+            // Stored under the sentinel id; the event loop and ungrab loop below already iterate
+            // linuxKeycodes, so id 0 routes through invokeCallback(0) and is cleaned up with the rest.
+            if (config.toggleEnabled && !toggleKeyConflictsWithWindows(config.key)) {
+                val toggleKeysym = LinuxHotKeyApi.keyToKeysym(config.key)
+                val toggleKeycode = api.XKeysymToKeycode(display, NativeLong(toggleKeysym.toLong()))
+                if (toggleKeycode != 0) {
+                    linuxKeycodes[TOGGLE_HOTKEY_ID] = toggleKeycode
+                    try {
+                        for (mods in modifierVariants) {
+                            api.XGrabKey(
+                                display, toggleKeycode, mods, rootWindow, 1,
+                                LinuxHotKeyApi.GrabModeAsync, LinuxHotKeyApi.GrabModeAsync
+                            )
+                        }
+                        api.XSync(display, 0)
+                        println("GlobalHotKeyManager: Registered Linux show/hide toggle (${config.key})")
+                    } catch (e: Exception) {
+                        println("GlobalHotKeyManager: show/hide toggle registration failed: ${e.message}")
+                        linuxKeycodes.remove(TOGGLE_HOTKEY_ID)
+                    }
+                }
             }
 
             api.XSelectInput(display, rootWindow, NativeLong(LinuxHotKeyApi.KeyPressMask))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/window/HotKeyConfig.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/window/HotKeyConfig.kt
@@ -13,8 +13,15 @@ data class HotKeyConfig(
     val alt: Boolean,
     val shift: Boolean,
     val win: Boolean,
-    val key: String
+    val key: String,
+    /** Whether to also register the single show/hide toggle (modifiers + [key]). */
+    val toggleEnabled: Boolean = false
 ) {
+    /** Number of modifier keys selected. Single-modifier global hotkeys tend to
+     *  shadow ordinary app shortcuts, so the UI nudges toward two or more. */
+    val modifierCount: Int
+        get() = listOf(ctrl, alt, shift, win).count { it }
+
     /**
      * Convert modifier settings to Win32 modifier flags.
      */
@@ -191,7 +198,8 @@ data class HotKeyConfig(
                 alt = settings.globalHotkeyAlt,
                 shift = settings.globalHotkeyShift,
                 win = settings.globalHotkeyWin,
-                key = settings.globalHotkeyKey
+                key = settings.globalHotkeyKey,
+                toggleEnabled = settings.globalHotkeyToggleEnabled
             )
         }
 


### PR DESCRIPTION
Splits the global-hotkey improvements out of the (now-merged) perf PR #298 into their own change.

## Why
Global window hotkeys (⌃1–9) collide with in-app shortcuts (⌃1–9 tab switch): the global Carbon/Win32/X11 hotkey is registered **system-wide** and wins, silently shadowing the focused app. A single modifier is the root of the conflict.

## What

**Safer modifiers**
- Default the global hotkey to a **two-modifier chord (Ctrl+Shift)**. Shift, not Alt, is the second default on purpose — Ctrl+Alt is AltGr on many European layouts and would interfere with typing.
- Settings now **warn when only one modifier is selected** (single-modifier global hotkeys clash with app shortcuts). The existing hard requirement of ≥1 modifier stays, so a bare-key (0-modifier) global hotkey still can never be registered.

**Single show/hide toggle** (revives the previously-unused `globalHotkeyKey`)
- New `globalHotkeyToggleEnabled` (default on) registers **one** extra global hotkey — modifiers + `globalHotkeyKey` (e.g. **Ctrl+Shift+\`**) — that shows/hides the active window from anywhere: a drop-down-terminal trigger, independent of the per-window 1–9 hotkeys.
- Implemented on **macOS / Windows / Linux** under sentinel id `0` (window ids are 1–9): `RegisterEventHotKey` / `RegisterHotKey` / `XGrabKey`. It routes through the existing callback as window number 0; `Main` toggles the focused/primary window (creating one if none exist). Skipped if the configured key is itself a digit 1–9.
- Settings UI gains a **"Show/Hide Toggle Hotkey"** switch that shows the resolved chord.

## Compatibility
`globalHotkeyToggleEnabled` and the two-modifier default only affect **fresh installs**; existing `settings.json` is untouched (so current single-modifier users keep their config and now see the conflict warning).

## Testing
All desktop targets compile; `:compose-ui` tests pass. **Needs on-device verification:** (1) the new show/hide toggle fires and shows/hides correctly; (2) per-window ⌃+number still works; (3) the X11/Linux path (not testable here). Global hotkeys default off on macOS/Linux, so this only activates on opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)