### PR TITLE
feat(mcp): add show_image tool + fix split targeting to the agent's tab (#296)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -1,6 +1,5 @@
 package ai.rever.bossterm.compose.mcp
 
-import ai.rever.bossterm.compose.TabbedTerminalState
 import ai.rever.bossterm.compose.settings.SettingsManager
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
@@ -47,8 +46,8 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * The manager is meant to be constructed **once per JVM** in `fun main()` and
  * exposes tabs from every window via [McpTerminalRegistry]. Window-scoped
- * lifecycles only need to register/unregister their [TabbedTerminalState]
- * with the registry; they should not instantiate this class themselves.
+ * lifecycles only need to register/unregister their window state with the
+ * registry; they should not instantiate this class themselves.
  *
  * Behavior:
  *  - On [start] the manager begins observing [SettingsManager.settings] and
@@ -96,16 +95,16 @@ class BossTermMcpManager(
     private var disabledToolsWatcherJob: Job? = null
     private var preferredShellWatcherJob: Job? = null
 
-    // Caches caller-window resolution by the client's ephemeral TCP port. That
+    // Caches caller-tab resolution by the client's ephemeral TCP port. That
     // port is stable for a connection's lifetime and its owning PID can't
     // change without reconnecting, so one (possibly expensive) ProcessAncestry
     // resolution per socket suffices instead of one per request. Optional wraps
-    // the nullable result (a client outside any pane resolves to "no window")
+    // the nullable result (a client outside any pane resolves to "no tab")
     // since ConcurrentHashMap forbids null values. Cleared wholesale past
     // CLIENT_WINDOW_CACHE_MAX so recycled ephemeral ports can't accrete entries
-    // — a recycled port could briefly return a stale window, an acceptable
+    // — a recycled port could briefly return a stale tab, an acceptable
     // last-writer-wins miss already inherent to the multi-client design.
-    private val clientWindowByPort = ConcurrentHashMap<Int, Optional<TabbedTerminalState>>()
+    private val clientTabByPort = ConcurrentHashMap<Int, Optional<String>>()
 
     /** Begin observing settings. Idempotent. Safe to call multiple times. */
     fun start() {
@@ -411,7 +410,7 @@ class BossTermMcpManager(
                     // once per client connection.
                     if (call.request.httpMethod == HttpMethod.Post) {
                         val remotePort = call.request.local.remotePort
-                        val cached = clientWindowByPort[remotePort]
+                        val cached = clientTabByPort[remotePort]
                         val resolved = if (cached != null) {
                             cached.orElse(null)
                         } else {
@@ -420,18 +419,18 @@ class BossTermMcpManager(
                             // it never stalls a CIO selector thread. The small
                             // race where two first-POSTs on one port both
                             // resolve is harmless (same result, idempotent).
-                            if (clientWindowByPort.size > CLIENT_WINDOW_CACHE_MAX) {
-                                clientWindowByPort.clear()
+                            if (clientTabByPort.size > CLIENT_WINDOW_CACHE_MAX) {
+                                clientTabByPort.clear()
                             }
                             val r = withContext(Dispatchers.IO) {
                                 runCatching {
-                                    ProcessAncestry.resolveClientWindow(remotePort, registry)
+                                    ProcessAncestry.resolveClientTabId(remotePort, registry)
                                 }.getOrNull()
                             }
-                            clientWindowByPort[remotePort] = Optional.ofNullable(r)
+                            clientTabByPort[remotePort] = Optional.ofNullable(r)
                             r
                         }
-                        registry.setLastResolvedClientWindow(resolved)
+                        registry.setLastResolvedClientTab(resolved)
                     }
                 }
                 // SDK 0.8.3 quirk: both `Route.mcp { ... }` and
@@ -647,7 +646,7 @@ class BossTermMcpManager(
         private const val MAX_TCP_PORT = 65535
 
         /**
-         * Size at which [clientWindowByPort] is cleared wholesale. Caller-window
+         * Size at which [clientTabByPort] is cleared wholesale. Caller-tab
          * resolutions are keyed by ephemeral client port; this bounds the map so
          * recycled ports over a long-lived server can't accrete entries. Well
          * above the realistic concurrent-client count.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -7,7 +7,6 @@ import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.tabs.TerminalTab
 import ai.rever.bossterm.terminal.model.CommandStateListener
 import ai.rever.bossterm.terminal.model.TerminalTextBuffer
-import ai.rever.bossterm.terminal.model.image.ImageFormat
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.Base64
@@ -1050,6 +1049,7 @@ class BossTermMcpServer(
             val imageBytes: ByteArray = if (path != null) {
                 val file = File(path)
                 when {
+                    !file.isAbsolute -> return@addTool errorResult("`path` must be absolute: $path")
                     !file.exists() -> return@addTool errorResult("File not found: $path")
                     !file.isFile -> return@addTool errorResult("Not a file: $path")
                     file.length() > MAX_IMAGE_BYTES -> return@addTool errorResult(
@@ -1064,6 +1064,11 @@ class BossTermMcpServer(
             } else {
                 // Accept a bare base64 string or a `data:<mime>;base64,<...>` URL.
                 val raw = dataBase64!!.substringAfter("base64,").replace(Regex("\\s"), "")
+                // Bound the decoded size BEFORE allocating it (base64 expands ~4:3),
+                // so an oversized payload can't force a large allocation first.
+                if (raw.length.toLong() / 4 * 3 > MAX_IMAGE_BYTES) {
+                    return@addTool errorResult("Image too large (max $MAX_IMAGE_BYTES bytes).")
+                }
                 val decoded = try {
                     Base64.getDecoder().decode(raw)
                 } catch (e: Exception) {
@@ -1077,19 +1082,38 @@ class BossTermMcpServer(
                 decoded
             }
 
-            // --- 2. Validate it decodes to a raster image (clear error vs. silent no-op). ---
-            if (ImageFormat.detect(imageBytes) == ImageFormat.UNKNOWN) {
-                return@addTool errorResult(
-                    "Unrecognized image format (supported: PNG, JPEG, GIF, BMP, WebP)."
-                )
-            }
-            val bufferedImage = try {
-                ImageIO.read(ByteArrayInputStream(imageBytes))
+            // --- 2. Ensure the bytes can be PLACED. The emulator's OSC 1337 handler
+            //        reads intrinsic dimensions via ImageIO, which has no WebP reader in
+            //        a stock JDK. Gate on ImageIO; if it can't read the bytes, fall back
+            //        to Skia (the renderer's own decoder, which does handle WebP) and
+            //        transcode to PNG so placement and rendering stay on one decoder —
+            //        this is why a valid .webp still works even though ImageIO can't read it.
+            var bytesToSend = imageBytes
+            val imageIoReadable = try {
+                ImageIO.read(ByteArrayInputStream(imageBytes))?.let { it.width > 0 && it.height > 0 } ?: false
             } catch (e: Exception) {
-                null
+                false
             }
-            if (bufferedImage == null || bufferedImage.width <= 0 || bufferedImage.height <= 0) {
-                return@addTool errorResult("Failed to decode image dimensions.")
+            if (!imageIoReadable) {
+                val transcoded = try {
+                    org.jetbrains.skia.Image.makeFromEncoded(imageBytes).use { img ->
+                        img.encodeToData(org.jetbrains.skia.EncodedImageFormat.PNG)?.use { it.bytes }
+                    }
+                } catch (e: Throwable) {
+                    null
+                }
+                if (transcoded == null || transcoded.isEmpty()) {
+                    return@addTool errorResult(
+                        "Could not decode image — unsupported format or corrupt data " +
+                            "(supported: PNG, JPEG, GIF, BMP, WebP)."
+                    )
+                }
+                if (transcoded.size > MAX_IMAGE_BYTES) {
+                    return@addTool errorResult(
+                        "Image too large after transcode: ${transcoded.size} bytes (max $MAX_IMAGE_BYTES)."
+                    )
+                }
+                bytesToSend = transcoded
             }
 
             // --- 3. Resolve the owning window + tab. ---
@@ -1137,6 +1161,10 @@ class BossTermMcpServer(
                     freshlyCreated = true
                 }
                 "horizontal_split", "vertical_split" -> {
+                    // Each split creates a fresh pane for the image. Unlike run_command,
+                    // show_image deliberately does NOT chain via the scratch-pane cache —
+                    // an image is a one-shot display, not a reused command pane, so
+                    // consecutive split calls intentionally make independent panes.
                     val effectiveRatio = (args.optionalFloat("split_ratio")
                         ?: settingsManager.settings.value.mcpDefaultSplitRatio)
                         .coerceIn(0.05f, 0.95f)
@@ -1186,13 +1214,18 @@ class BossTermMcpServer(
                 }
 
                 val osc = buildOsc1337Image(
-                    bytes = imageBytes,
+                    bytes = bytesToSend,
                     name = path?.let { File(it).name },
                     widthSpec = widthSpec,
                     heightSpec = heightSpec
                 )
+                // Strip control characters so a caption can't smuggle its own escape /
+                // OSC sequences into the emulator; keep printable + non-C1 Unicode.
+                val safeCaption = caption
+                    ?.filter { it.code >= 0x20 && it.code != 0x7F && it.code !in 0x80..0x9F }
+                    ?.takeIf { it.isNotEmpty() }
                 val payload = buildString {
-                    if (!caption.isNullOrEmpty()) append(caption.replace("\n", " ")).append("\r\n")
+                    if (safeCaption != null) append(safeCaption).append("\r\n")
                     append(osc).append("\r\n")
                 }
                 tab.dataStream.append(payload)
@@ -2258,8 +2291,7 @@ class BossTermMcpServer(
         val ok: Boolean,
         val tabId: String,
         /** The pane the image was rendered into (== tabId for an unsplit tab). */
-        val paneId: String,
-        val error: String? = null
+        val paneId: String
     )
 
     @Serializable

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -7,6 +7,11 @@ import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.tabs.TerminalTab
 import ai.rever.bossterm.terminal.model.CommandStateListener
 import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import ai.rever.bossterm.terminal.model.image.ImageFormat
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.Base64
+import javax.imageio.ImageIO
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
@@ -121,7 +126,8 @@ class BossTermMcpServer(
         "send_input" to ::registerSendInput,
         "send_signal" to ::registerSendSignal,
         "run_in_panel" to ::registerRunInPanel,
-        "run_command" to ::registerRunCommand
+        "run_command" to ::registerRunCommand,
+        "show_image" to ::registerShowImage
     )
 
     /** Reserved tools that callers cannot disable. */
@@ -958,6 +964,267 @@ class BossTermMcpServer(
                     "Unknown panel: '$panel'. Expected one of: new_tab, horizontal_split, vertical_split."
                 )
             }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Tool: show_image
+    // -----------------------------------------------------------------
+
+    private fun registerShowImage(server: Server) {
+        server.addTool(
+            name = toolName("show_image"),
+            description = describe(
+                "show_image",
+                "Display an image inline in a terminal pane (iTerm2 OSC 1337). " +
+                        "Provide exactly one of `path` (a local image file) or `data_base64` " +
+                        "(raw base64, or a data: URL). Renders in the active pane by default, " +
+                        "or in a freshly created pane via `panel`: new_tab / horizontal_split / " +
+                        "vertical_split. Aspect ratio is preserved; `width`/`height` accept " +
+                        "cells ('80'), pixels ('200px'), or percent ('50%'). Returns " +
+                        "{ ok, tabId, paneId } — the image bytes are NEVER echoed back."
+            ),
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("path") {
+                        put("type", "string")
+                        put("description", "Absolute path to a local image file " +
+                                "(PNG/JPEG/GIF/BMP/WebP). Provide either this or data_base64.")
+                    }
+                    putJsonObject("data_base64") {
+                        put("type", "string")
+                        put("description", "Image bytes as base64, or a data:*;base64,... URL. " +
+                                "Provide either this or path.")
+                    }
+                    putJsonObject("panel") {
+                        put("type", "string")
+                        put("description", "Where to render: reuse (default — the active pane), " +
+                                "new_tab, horizontal_split, vertical_split.")
+                    }
+                    putJsonObject("width") {
+                        put("type", "string")
+                        put("description", "Optional width: cells ('80'), pixels ('200px'), or " +
+                                "percent ('50%'). Default fits the pane, preserving aspect ratio.")
+                    }
+                    putJsonObject("height") {
+                        put("type", "string")
+                        put("description", "Optional height: cells ('24'), pixels ('200px'), or " +
+                                "percent ('50%').")
+                    }
+                    putJsonObject("tab_id") {
+                        put("type", "string")
+                        put("description", "Optional target tab id. Defaults to the active tab " +
+                                "of the calling window.")
+                    }
+                    putJsonObject("pane_id") {
+                        put("type", "string")
+                        put("description", "Optional target pane id within tab_id (reuse mode).")
+                    }
+                    putJsonObject("caption") {
+                        put("type", "string")
+                        put("description", "Optional text printed on the line above the image.")
+                    }
+                    putJsonObject("split_ratio") {
+                        put("type", "number")
+                        put("description", "For split modes: fraction (0.05..0.95) of the parent " +
+                                "the NEW pane gets. Defaults to `mcpDefaultSplitRatio`.")
+                    }
+                },
+                required = emptyList()
+            )
+        ) { request ->
+            val args = request.arguments
+            val path = args.requireString("path")
+            val dataBase64 = args.requireString("data_base64")
+            val caption = args.requireString("caption")
+            val widthSpec = args.requireString("width")
+            val heightSpec = args.requireString("height")
+            val panel = (args.requireString("panel") ?: "reuse").lowercase()
+            val explicitPaneId = args.requireString("pane_id")
+            val requestedTabId = args.requireString("tab_id")
+
+            // --- 1. Resolve image bytes: exactly one of path / data_base64. ---
+            if ((path == null) == (dataBase64 == null)) {
+                return@addTool errorResult("Provide exactly one of `path` or `data_base64`.")
+            }
+            val imageBytes: ByteArray = if (path != null) {
+                val file = File(path)
+                when {
+                    !file.exists() -> return@addTool errorResult("File not found: $path")
+                    !file.isFile -> return@addTool errorResult("Not a file: $path")
+                    file.length() > MAX_IMAGE_BYTES -> return@addTool errorResult(
+                        "Image too large: ${file.length()} bytes (max $MAX_IMAGE_BYTES)."
+                    )
+                    else -> try {
+                        file.readBytes()
+                    } catch (e: Exception) {
+                        return@addTool errorResult("Failed to read $path: ${e.message}")
+                    }
+                }
+            } else {
+                // Accept a bare base64 string or a `data:<mime>;base64,<...>` URL.
+                val raw = dataBase64!!.substringAfter("base64,").replace(Regex("\\s"), "")
+                val decoded = try {
+                    Base64.getDecoder().decode(raw)
+                } catch (e: Exception) {
+                    return@addTool errorResult("Invalid base64 in data_base64: ${e.message}")
+                }
+                if (decoded.size > MAX_IMAGE_BYTES) {
+                    return@addTool errorResult(
+                        "Image too large: ${decoded.size} bytes (max $MAX_IMAGE_BYTES)."
+                    )
+                }
+                decoded
+            }
+
+            // --- 2. Validate it decodes to a raster image (clear error vs. silent no-op). ---
+            if (ImageFormat.detect(imageBytes) == ImageFormat.UNKNOWN) {
+                return@addTool errorResult(
+                    "Unrecognized image format (supported: PNG, JPEG, GIF, BMP, WebP)."
+                )
+            }
+            val bufferedImage = try {
+                ImageIO.read(ByteArrayInputStream(imageBytes))
+            } catch (e: Exception) {
+                null
+            }
+            if (bufferedImage == null || bufferedImage.width <= 0 || bufferedImage.height <= 0) {
+                return@addTool errorResult("Failed to decode image dimensions.")
+            }
+
+            // --- 3. Resolve the owning window + tab. ---
+            val state: TabbedTerminalState = if (requestedTabId != null) {
+                registry.findState(requestedTabId)
+                    ?: return@addTool errorResult("Unknown tab_id: $requestedTabId")
+            } else {
+                registry.lastResolvedClientWindow()
+                    ?: registry.primaryState()
+                    ?: return@addTool errorResult("No registered terminal window")
+            }
+            val tabId = requestedTabId
+                ?: registry.lastResolvedClientTabId()
+                ?: state.activeTabId
+                ?: return@addTool errorResult("No active tab")
+
+            // --- 4. Resolve or create the target pane. Unlike run_command, `reuse`
+            //        targets the active pane directly (no scratch-pane decay) so the
+            //        image lands where the user is looking. ---
+            var resolvedTabId = tabId
+            val session: TerminalSession
+            val resolvedPaneId: String
+            var freshlyCreated = false
+
+            if (explicitPaneId != null) {
+                session = state.findSession(tabId, explicitPaneId)
+                    ?: return@addTool errorResult("Unknown pane_id '$explicitPaneId' in tab '$tabId'")
+                resolvedPaneId = explicitPaneId
+            } else when (panel) {
+                "reuse" -> {
+                    val s = state.findSession(tabId)
+                        ?: return@addTool errorResult("No active pane in tab '$tabId'")
+                    session = s
+                    resolvedPaneId = s.id
+                }
+                "new_tab" -> {
+                    val newId = state.createTab(workingDir = null, initialCommand = null)
+                        ?: return@addTool errorResult("Failed to create tab")
+                    resolvedTabId = newId
+                    // A freshly created tab is single-pane: pane id == tab id.
+                    resolvedPaneId = newId
+                    session = state.findSession(newId, newId)
+                        ?: state.findSession(newId)
+                        ?: return@addTool errorResult("Created tab $newId but cannot resolve session")
+                    freshlyCreated = true
+                }
+                "horizontal_split", "vertical_split" -> {
+                    val effectiveRatio = (args.optionalFloat("split_ratio")
+                        ?: settingsManager.settings.value.mcpDefaultSplitRatio)
+                        .coerceIn(0.05f, 0.95f)
+                    val newPaneId = if (panel == "horizontal_split") {
+                        state.splitHorizontal(
+                            tabId = tabId, ratio = effectiveRatio,
+                            initialCommand = null, preserveFocus = true
+                        )
+                    } else {
+                        state.splitVertical(
+                            tabId = tabId, ratio = effectiveRatio,
+                            initialCommand = null, preserveFocus = true
+                        )
+                    } ?: return@addTool errorResult("Split failed (terminal too small?)")
+                    resolvedPaneId = newPaneId
+                    session = state.findSession(tabId, newPaneId)
+                        ?: return@addTool errorResult(
+                            "Created pane $newPaneId but cannot resolve session"
+                        )
+                    freshlyCreated = true
+                }
+                else -> return@addTool errorResult(
+                    "Unknown panel: '$panel'. Expected one of: reuse, new_tab, " +
+                            "horizontal_split, vertical_split."
+                )
+            }
+
+            // dataStream is the designed, thread-safe entry point into the emulator
+            // (PTY → BlockingTerminalDataStream → BossEmulator). Feeding a synthesized
+            // OSC 1337 here reuses the full decode/place/render pipeline and serializes
+            // with all other PTY output on the emulator thread — calling
+            // processInlineImage() directly from this thread would race the cursor.
+            val tab = session as? TerminalTab
+                ?: return@addTool errorResult("Target pane does not support image output")
+
+            // Per-pane mutex serializes with concurrent run_command / run_in_panel /
+            // show_image calls on the same pane.
+            registry.paneMutex(resolvedPaneId).withLock {
+                // Freshly created panes haven't drawn their first prompt (or been laid
+                // out, which sets real cell metrics). Wait for OSC 133;A so placement
+                // sizes against the real grid and lands below a clean prompt.
+                if (freshlyCreated) {
+                    val shellReadyTimeoutMs = settingsManager.settings.value
+                        .mcpRunCommandShellReadyTimeoutMs
+                        .coerceIn(0, MAX_SHELL_READY_TIMEOUT_MS).toLong()
+                    if (shellReadyTimeoutMs > 0) awaitPromptReady(tab, shellReadyTimeoutMs)
+                }
+
+                val osc = buildOsc1337Image(
+                    bytes = imageBytes,
+                    name = path?.let { File(it).name },
+                    widthSpec = widthSpec,
+                    heightSpec = heightSpec
+                )
+                val payload = buildString {
+                    if (!caption.isNullOrEmpty()) append(caption.replace("\n", " ")).append("\r\n")
+                    append(osc).append("\r\n")
+                }
+                tab.dataStream.append(payload)
+            }
+
+            successJson(
+                json.encodeToString(
+                    ShowImageResult.serializer(),
+                    ShowImageResult(ok = true, tabId = resolvedTabId, paneId = resolvedPaneId)
+                )
+            )
+        }
+    }
+
+    /**
+     * Suspend until [session]'s shell signals OSC 133;A (prompt ready) or
+     * [timeoutMs] elapses. Used to defer image injection on freshly created
+     * panes until the pane is laid out and the prompt is drawn.
+     */
+    private suspend fun awaitPromptReady(session: TerminalSession, timeoutMs: Long) {
+        val terminal = session.terminal
+        val signal = CompletableDeferred<Unit>()
+        val listener = object : CommandStateListener {
+            override fun onPromptStarted() {
+                if (!signal.isCompleted) signal.complete(Unit)
+            }
+        }
+        terminal.addCommandStateListener(listener)
+        try {
+            withTimeoutOrNull(timeoutMs) { signal.await() }
+        } finally {
+            terminal.removeCommandStateListener(listener)
         }
     }
 
@@ -1987,6 +2254,15 @@ class BossTermMcpServer(
     )
 
     @Serializable
+    data class ShowImageResult(
+        val ok: Boolean,
+        val tabId: String,
+        /** The pane the image was rendered into (== tabId for an unsplit tab). */
+        val paneId: String,
+        val error: String? = null
+    )
+
+    @Serializable
     data class RunCommandResult(
         val ok: Boolean,
         val tabId: String,
@@ -2090,8 +2366,17 @@ class BossTermMcpServer(
             "send_input",
             "send_signal",
             "run_in_panel",
-            "run_command"
+            "run_command",
+            "show_image"
         )
+
+        /**
+         * Hard cap on a single `show_image` source. Bounds the transient base64
+         * string fed through the data stream and stays well under
+         * `TerminalImageStorage`'s 50 MB total budget. Diagrams/screenshots are
+         * far smaller; anything larger is almost certainly a mistake.
+         */
+        private const val MAX_IMAGE_BYTES: Long = 16L * 1024 * 1024
 
         /**
          * Tools that may never be disabled. `manage_tools` is the only escape hatch
@@ -2122,5 +2407,37 @@ class BossTermMcpServer(
                 "(long-running dev servers, REPLs). If `run_command` returns " +
                 "`error: \"TUI detected\"`, switch to `send_input` + `read_scrollback` to " +
                 "drive the program — do not retry the same command."
+    }
+}
+
+
+/**
+ * Build an iTerm2 OSC 1337;File inline-image escape. [widthSpec]/[heightSpec]
+ * are passed verbatim (the emulator's [ai.rever.bossterm.terminal.model.image.DimensionSpec]
+ * understands "80" (cells), "200px", and "50%"). base64 is pure ASCII so it passes
+ * through the data stream's grapheme handling untouched; BEL terminates and never
+ * appears in the base64 alphabet. Top-level + internal so unit tests can exercise
+ * the exact framing the emulator's OSC 1337 parser expects.
+ */
+internal fun buildOsc1337Image(
+    bytes: ByteArray,
+    name: String?,
+    widthSpec: String?,
+    heightSpec: String?
+): String {
+    val b64 = java.util.Base64.getEncoder().encodeToString(bytes)
+    return buildString {
+        append("\u001B]1337;File=inline=1")
+        append(";size=").append(bytes.size)
+        if (!name.isNullOrEmpty()) {
+            append(";name=").append(
+                java.util.Base64.getEncoder().encodeToString(name.toByteArray(Charsets.UTF_8))
+            )
+        }
+        if (!widthSpec.isNullOrBlank()) append(";width=").append(widthSpec)
+        if (!heightSpec.isNullOrBlank()) append(";height=").append(heightSpec)
+        append(";preserveAspectRatio=1")
+        append(":").append(b64)
+        append("\u0007")
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -913,6 +913,7 @@ class BossTermMcpServer(
                 }
                 "horizontal_split", "vertical_split" -> {
                     val targetTabId = requestedTabId
+                        ?: registry.lastResolvedClientTabId()
                         ?: state.activeTabId
                         ?: return@addTool errorResult("No active tab to split")
                     // Resolve effective ratio: per-call override > user setting > 0.3 fallback.
@@ -1045,6 +1046,7 @@ class BossTermMcpServer(
                     ?: return@addTool errorResult("No registered terminal window")
             }
             val tabId = requestedTabId
+                ?: registry.lastResolvedClientTabId()
                 ?: state.activeTabId
                 ?: return@addTool errorResult("No active tab")
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -244,7 +244,7 @@ object McpTerminalRegistry {
     /**
      * Sweep threshold for the opportunistic [gcStalePaneMutexes]. Set well
      * above the realistic concurrent-pane count (matching the
-     * `clientWindowByPort` cap heuristic) so a heavy multi-window session
+     * `clientTabByPort` cap heuristic) so a heavy multi-window session
      * doesn't trigger a full-state sweep on every pane creation, while still
      * bounding map growth for very long-lived processes.
      */
@@ -301,31 +301,43 @@ object McpTerminalRegistry {
     // call for a single request, never permanently.
     // -----------------------------------------------------------------
 
-    private val lastResolvedClient = AtomicReference<TabbedTerminalState?>(null)
+    private val lastResolvedClientTab = AtomicReference<String?>(null)
 
     /**
-     * Most recently resolved "calling-client window", or null if no
-     * request has been resolved yet OR the resolved state has been
-     * unregistered (window closed). Lazy invalidation: stale entries
-     * are detected on read and cleared.
+     * Tab id of the most recently resolved "calling-client pane" — the
+     * top-level tab whose shell PID is an ancestor of the MCP client process
+     * (ProcessAncestry walk) — or null if no request resolved yet OR the tab
+     * has since closed. Lazy invalidation: stale entries are detected on read
+     * and cleared.
+     *
+     * Tools default their `tab_id` to this so pane creation (splits, new
+     * scratch panes) lands on the tab the agent actually runs in, NOT the tab
+     * the human happens to have selected in the UI.
      */
-    internal fun lastResolvedClientWindow(): TabbedTerminalState? {
-        val cached = lastResolvedClient.get() ?: return null
-        if (cached !in states) {
-            lastResolvedClient.compareAndSet(cached, null)
+    internal fun lastResolvedClientTabId(): String? {
+        val tabId = lastResolvedClientTab.get() ?: return null
+        if (findState(tabId) == null) {
+            lastResolvedClientTab.compareAndSet(tabId, null)
             return null
         }
-        return cached
+        return tabId
     }
 
     /**
-     * Manager-only. Pass a resolved state to record it as the most-recent
-     * caller window. Null is a no-op — a non-resolving request (client
-     * running outside any BossTerm pane) shouldn't blow away the prior
-     * resolution from a request that DID resolve.
+     * Window (state) owning the most recently resolved calling-client tab, or
+     * null if unresolved / closed. Derived from [lastResolvedClientTabId] so the
+     * two can never disagree.
      */
-    internal fun setLastResolvedClientWindow(state: TabbedTerminalState?) {
-        if (state != null) lastResolvedClient.set(state)
+    internal fun lastResolvedClientWindow(): TabbedTerminalState? =
+        lastResolvedClientTabId()?.let { findState(it) }
+
+    /**
+     * Manager-only. Record the resolved calling-client tab id. Null is a no-op —
+     * a non-resolving request (client running outside any BossTerm pane)
+     * shouldn't blow away the prior resolution from a request that DID resolve.
+     */
+    internal fun setLastResolvedClientTab(tabId: String?) {
+        if (tabId != null) lastResolvedClientTab.set(tabId)
     }
 
     private fun persist(targets: Set<McpAttachTarget>) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/ProcessAncestry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/ProcessAncestry.kt
@@ -1,6 +1,5 @@
 package ai.rever.bossterm.compose.mcp
 
-import ai.rever.bossterm.compose.TabbedTerminalState
 import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -8,8 +7,8 @@ import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
 /**
- * Resolves which registered [TabbedTerminalState] (window) owns the MCP
- * client process connected on a given loopback TCP source port.
+ * Resolves which registered tab (and thus window) owns the MCP client
+ * process connected on a given loopback TCP source port.
  *
  * Tools that default to "the primary window" (e.g. `run_command`,
  * `run_in_panel`, `get_active_tab` called with no `tab_id`) want to target
@@ -54,22 +53,23 @@ internal object ProcessAncestry {
      * @param remotePort the client-side ephemeral port — i.e. what Ktor
      *   reports as `call.request.local.remotePort`.
      * @param registry source of truth for tracked panes' shell PIDs.
-     * @return the [TabbedTerminalState] containing the pane that owns the
-     *   client process, or null if no ancestor matches.
+     * @return the id of the tab whose shell owns (is an ancestor of) the client
+     *   process, or null if no ancestor matches. The owning window is
+     *   [McpTerminalRegistry.findState] of this id.
      */
-    fun resolveClientWindow(
+    fun resolveClientTabId(
         remotePort: Int,
         registry: McpTerminalRegistry
-    ): TabbedTerminalState? {
+    ): String? {
         if (remotePort <= 0) return null
-        val statesByShellPid = collectStateByShellPid(registry)
-        if (statesByShellPid.isEmpty()) return null
+        val tabIdByShellPid = collectTabIdByShellPid(registry)
+        if (tabIdByShellPid.isEmpty()) return null
 
         val clientPid = findClientPid(remotePort) ?: return null
         var pid = clientPid
         var hops = 0
         while (hops < MAX_PARENT_WALK) {
-            statesByShellPid[pid]?.let { return it }
+            tabIdByShellPid[pid]?.let { return it }
             val parent = parentPid(pid)
             if (parent == null || parent <= 1L || parent == pid) return null
             pid = parent
@@ -79,18 +79,18 @@ internal object ProcessAncestry {
     }
 
     /**
-     * Flatten every tracked tab's shell PID across every registered state
-     * into a single lookup map. Cheap and rebuilt per resolution so pane
+     * Flatten every tracked tab's shell PID across every registered state into
+     * a single PID → tab-id lookup. Cheap and rebuilt per resolution so pane
      * creation / closure is reflected immediately without a refresh hook.
      */
-    private fun collectStateByShellPid(
+    private fun collectTabIdByShellPid(
         registry: McpTerminalRegistry
-    ): Map<Long, TabbedTerminalState> {
-        val out = HashMap<Long, TabbedTerminalState>()
+    ): Map<Long, String> {
+        val out = HashMap<Long, String>()
         for (state in registry.allStates()) {
             for (tab in state.tabs) {
                 val pid = tab.processHandle.value?.getPid() ?: continue
-                out[pid] = state
+                out[pid] = tab.id
             }
         }
         return out

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -313,6 +313,7 @@ private fun toolDescription(name: String): String = when (name) {
         "Run a shell command in a visible pane and return its output + exit code. " +
             "Available for explicit use by default; see 'Use run_command as default " +
             "shell' above to make AI clients prefer it over their built-in shell."
+    "show_image" -> "Display an image (file or base64) inline in a terminal pane."
     else -> name
 }
 

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/ShowImageOscBuilderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/ShowImageOscBuilderTest.kt
@@ -12,11 +12,11 @@ import kotlin.test.assertTrue
  * Unit tests for the `show_image` MCP tool's pure pieces.
  *
  * Covers the OSC 1337 framing emitted by [buildOsc1337Image] (the bytes the tool
- * feeds into the pane's data stream) plus the two cross-module contracts the tool
- * relies on: that [DimensionSpec.parse] understands the width/height strings we
- * pass through verbatim, and that [ImageFormat.detect] recognizes the raster
- * headers we pre-validate with. A running server / PTY isn't needed — these are
- * all pure functions.
+ * feeds into the pane's data stream) plus two cross-module contracts the inline-
+ * image pipeline relies on: that [DimensionSpec.parse] understands the width/height
+ * strings we pass through verbatim, and that [ImageFormat.detect] recognizes the
+ * raster headers the emulator's OSC 1337 parser keys on. A running server / PTY
+ * isn't needed — these are all pure functions.
  *
  * ESC (0x1B) and BEL (0x07) are asserted via char codes so this source file
  * contains no control characters of its own.
@@ -79,7 +79,7 @@ class ShowImageOscBuilderTest {
     }
 
     @Test
-    fun imageFormatDetectsRasterHeadersWePreValidate() {
+    fun imageFormatDetectsCommonRasterHeaders() {
         val png = byteArrayOf(
             0x89.toByte(), 0x50.toByte(), 0x4E.toByte(), 0x47.toByte(),
             0x0D.toByte(), 0x0A.toByte(), 0x1A.toByte(), 0x0A.toByte()

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/ShowImageOscBuilderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/ShowImageOscBuilderTest.kt
@@ -1,0 +1,99 @@
+package ai.rever.bossterm.compose.mcp
+
+import ai.rever.bossterm.terminal.model.image.DimensionSpec
+import ai.rever.bossterm.terminal.model.image.ImageFormat
+import java.util.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the `show_image` MCP tool's pure pieces.
+ *
+ * Covers the OSC 1337 framing emitted by [buildOsc1337Image] (the bytes the tool
+ * feeds into the pane's data stream) plus the two cross-module contracts the tool
+ * relies on: that [DimensionSpec.parse] understands the width/height strings we
+ * pass through verbatim, and that [ImageFormat.detect] recognizes the raster
+ * headers we pre-validate with. A running server / PTY isn't needed — these are
+ * all pure functions.
+ *
+ * ESC (0x1B) and BEL (0x07) are asserted via char codes so this source file
+ * contains no control characters of its own.
+ */
+class ShowImageOscBuilderTest {
+
+    private fun decodeB64(value: String): ByteArray =
+        Base64.getDecoder().decode(value)
+
+    @Test
+    fun oscFramingHasEscBelAndInlineMarker() {
+        val payload = "PNGDATA".toByteArray()
+        val osc = buildOsc1337Image(payload, name = null, widthSpec = null, heightSpec = null)
+
+        // ESC introducer and BEL terminator.
+        assertEquals(27, osc.first().code, "OSC must start with ESC")
+        assertEquals(7, osc.last().code, "OSC must end with BEL")
+
+        assertTrue(osc.contains("]1337;File=inline=1"), "missing iTerm2 inline marker: $osc")
+        assertTrue(osc.contains(";size=${payload.size}"), "missing/incorrect size: $osc")
+        assertTrue(osc.contains(";preserveAspectRatio=1"), "aspect ratio not preserved: $osc")
+    }
+
+    @Test
+    fun oscBase64RoundTripsToOriginalBytes() {
+        val payload = byteArrayOf(1, 2, 3, 4, 5, 100, -1, -128, 127)
+        val osc = buildOsc1337Image(payload, name = "diagram.png", widthSpec = "80", heightSpec = null)
+
+        // Everything after the single ':' is base64 + the trailing BEL.
+        val afterColon = osc.substringAfter(":")
+        val b64 = afterColon.substring(0, afterColon.length - 1) // drop BEL
+        assertTrue(decodeB64(b64).contentEquals(payload), "base64 did not round-trip to the input bytes")
+    }
+
+    @Test
+    fun oscEncodesNameAsBase64AndOmitsAbsentDimensions() {
+        val osc = buildOsc1337Image("x".toByteArray(), name = "a.png", widthSpec = "80", heightSpec = null)
+
+        val expectedName = Base64.getEncoder().encodeToString("a.png".toByteArray())
+        assertTrue(osc.contains(";name=$expectedName"), "name not base64-encoded: $osc")
+        assertTrue(osc.contains(";width=80"), "width spec not passed through: $osc")
+        assertFalse(osc.contains(";height="), "height should be omitted when null: $osc")
+    }
+
+    @Test
+    fun oscPassesWidthAndHeightVerbatim() {
+        val osc = buildOsc1337Image("x".toByteArray(), name = null, widthSpec = "200px", heightSpec = "50%")
+        assertTrue(osc.contains(";width=200px"), "px width not verbatim: $osc")
+        assertTrue(osc.contains(";height=50%"), "percent height not verbatim: $osc")
+    }
+
+    @Test
+    fun dimensionSpecUnderstandsToolWidthHeightForms() {
+        // The tool forwards width/height strings untouched; the emulator parses them.
+        assertEquals(DimensionSpec.Cells(80), DimensionSpec.parse("80"))
+        assertEquals(DimensionSpec.Pixels(200), DimensionSpec.parse("200px"))
+        assertEquals(DimensionSpec.Percent(50), DimensionSpec.parse("50%"))
+        assertEquals(DimensionSpec.Auto, DimensionSpec.parse("auto"))
+        assertEquals(DimensionSpec.Auto, DimensionSpec.parse(null))
+    }
+
+    @Test
+    fun imageFormatDetectsRasterHeadersWePreValidate() {
+        val png = byteArrayOf(
+            0x89.toByte(), 0x50.toByte(), 0x4E.toByte(), 0x47.toByte(),
+            0x0D.toByte(), 0x0A.toByte(), 0x1A.toByte(), 0x0A.toByte()
+        )
+        val jpeg = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 0, 0, 0, 0)
+        val gif = byteArrayOf(
+            0x47.toByte(), 0x49.toByte(), 0x46.toByte(), 0x38.toByte(),
+            0x39.toByte(), 0x61.toByte(), 0, 0
+        )
+        val garbage = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+
+        assertEquals(ImageFormat.PNG, ImageFormat.detect(png))
+        assertEquals(ImageFormat.JPEG, ImageFormat.detect(jpeg))
+        assertEquals(ImageFormat.GIF, ImageFormat.detect(gif))
+        assertEquals(ImageFormat.UNKNOWN, ImageFormat.detect(garbage))
+    }
+}


### PR DESCRIPTION
## Summary

Two related MCP changes:

### 1. `feat(mcp): add built-in show_image tool` — closes #296
A default-enabled `show_image` tool that displays an image inline in a terminal pane in one call, instead of hand-crafting an OSC 1337 escape through `run_in_panel` / `run_command`.

- **Params:** `path` | `data_base64` (exactly one; `data:` URLs accepted), `panel` (`reuse` [default, active pane] / `new_tab` / `horizontal_split` / `vertical_split`), `width`/`height` (cells / `Npx` / `N%`), `tab_id`, `pane_id`, `caption`, `split_ratio`.
- **Returns** `{ ok, tabId, paneId }` — the image bytes are never echoed back.
- **How:** synthesizes an OSC 1337 escape and feeds it through the pane's `BlockingTerminalDataStream.append()` — the thread-safe entry point into the emulator — reusing the entire existing decode/place/render pipeline. Calling `processInlineImage()` directly would race the emulator thread (there's no public hook to run on it). `width`/`height` map 1:1 to the specs `DimensionSpec.parse` already understands. Bytes are pre-validated (`ImageFormat.detect` + `ImageIO`) so bad input returns a clear error. Fresh panes wait for OSC 133;A before injection so placement sizes against the real grid.
- Registered as a write tool; the settings toggle and `manage_tools` gating pick it up automatically. One MCP server → covers `bossterm-app` and the embedded/tabbed examples.

### 2. `fix(mcp): target the calling agent's tab for splits, not the UI-selected tab`
`run_command` / `run_in_panel` opened their split under whichever tab the **user** had selected, not the tab the **agent** runs in.

Root cause: `ProcessAncestry` already finds the exact tab whose shell owns the client process, but it returned only the owning *window*, so tools fell back to `state.activeTabId`. Now the resolved **tab id** is threaded through (`resolveClientTabId` → `registry.lastResolvedClientTabId()`), and the pane-creating tools default `tab_id` to it. Falls back to the active tab when the client runs outside any BossTerm pane (e.g. Claude Desktop) — no regression.

## Test plan
- `./gradlew :compose-ui:desktopTest` → **BUILD SUCCESSFUL**, 230 tests pass (incl. 6 new `ShowImageOscBuilderTest` cases covering OSC framing + the `DimensionSpec`/`ImageFormat` contracts).
- Manual (run the app): `tools/list` shows `show_image`; `show_image { path: "/abs/x.png" }` renders in the active pane; `panel: new_tab` / splits render in a fresh pane and return its ids; with a different tab selected, an agent `run_command` now splits in the agent's tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
