### PR TITLE
feat: background-tab title updates + MCP split-pane/get_active_tab targeting

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1468,7 +1468,12 @@ fun TabbedTerminal(
                 sharedFont = sharedFont,
                 isActiveTab = isActive,
                 onTabTitleChange = { newTitle ->
-                    activeTab.title.value = newTitle
+                    // A user rename (customTitle) always wins; otherwise track the
+                    // app's OSC title. Matches the background-tab collector in
+                    // TabController.wireCwdTitle so active and background tabs behave alike.
+                    if (activeTab.customTitle.value == null) {
+                        activeTab.title.value = newTitle
+                    }
                 },
                 onNewTab = {
                     // New tabs always start in home directory (no working dir inheritance)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -313,8 +313,10 @@ class BossTermMcpServer(
             name = toolName("get_active_tab"),
             description = describe(
                 "get_active_tab",
-                "Return the active tab of the primary window (the first window opened " +
-                        "that is still alive), or null if no tab is active."
+                "Return the calling client's own tab (the tab whose process tree the MCP " +
+                        "client runs in) when it can be resolved, otherwise the active tab of " +
+                        "the primary window; null if no tab is available. The `isActive` field " +
+                        "reports whether that tab is the window's currently-focused one."
             ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
@@ -335,7 +337,13 @@ class BossTermMcpServer(
             // ancestor matches a tracked pane.
             val primary = registry.lastResolvedClientWindow() ?: registry.primaryState()
             val activeId = primary?.activeTabId
-            val info = primary?.activeTab?.toTabInfo(activeId)
+            // Within that window, prefer the caller's OWN tab over the window's
+            // focused tab; isActive (id == activeId) still tells the client
+            // whether its tab is the currently-focused one.
+            val callerTabId = registry.lastResolvedClientTabId()
+                ?.takeIf { primary?.getTabById(it) != null }
+            val targetTab = callerTabId?.let { primary?.getTabById(it) } ?: primary?.activeTab
+            val info = targetTab?.toTabInfo(activeId)
             // The literal JSON `null` is valid output — clients calling
             // JSON.parse get a real null. Cheaper than wrapping in `{tab: null}`.
             val text = when {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/ProcessAncestry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/ProcessAncestry.kt
@@ -79,9 +79,11 @@ internal object ProcessAncestry {
     }
 
     /**
-     * Flatten every tracked tab's shell PID across every registered state into
-     * a single PID → tab-id lookup. Cheap and rebuilt per resolution so pane
-     * creation / closure is reflected immediately without a refresh hook.
+     * Flatten every tracked pane's shell PID across every registered state into
+     * a single PID → tab-id lookup. Includes split panes, not just each tab's
+     * primary session, so a client running in a NON-primary pane still resolves
+     * to its owning tab. Cheap and rebuilt per resolution so pane creation /
+     * closure is reflected immediately without a refresh hook.
      */
     private fun collectTabIdByShellPid(
         registry: McpTerminalRegistry
@@ -89,8 +91,14 @@ internal object ProcessAncestry {
         val out = HashMap<Long, String>()
         for (state in registry.allStates()) {
             for (tab in state.tabs) {
-                val pid = tab.processHandle.value?.getPid() ?: continue
-                out[pid] = tab.id
+                // Primary session PID (also covers a single-pane tab).
+                tab.processHandle.value?.getPid()?.let { out[it] = tab.id }
+                // Split-pane session PIDs — all map back to the owning tab id.
+                for (snapshot in state.getPaneSnapshots(tab.id)) {
+                    val pid = state.findSession(tab.id, snapshot.id)
+                        ?.processHandle?.value?.getPid() ?: continue
+                    out[pid] = tab.id
+                }
             }
         }
         return out

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -106,6 +106,19 @@ class TabController(
         session.terminal.addCommandStateListener(titleResetListener)
         session.commandStateListeners.add(titleResetListener)
 
+        // Mirror an app's OSC 0/1 icon title (e.g. "claude") onto the tab name so the
+        // LEFT TAB BAR reflects title changes even for BACKGROUND (unfocused) tabs.
+        // ProperTerminal also collects this, but only for the active tab's mounted
+        // Composable; this runs for the session's whole life regardless of focus.
+        // customTitle (Rename…) always wins and is re-asserted by the snapshotFlow above.
+        session.coroutineScope.launch {
+            session.display.iconTitleFlow.collect { newTitle ->
+                if (newTitle.isNotEmpty() && session.customTitle.value == null) {
+                    session.title.value = newTitle
+                }
+            }
+        }
+
         // Track the git branch of the working directory for the left tab-bar's
         // third chip line (Warp-style title / cwd / branch). Debounced + collectLatest
         // so a rapid `cd` cancels the stale lookup; null outside a repository.


### PR DESCRIPTION
## Summary

Two tab-UX improvements, rebased onto latest master (which now includes #300's caller-tab split fix and the `show_image` tool).

### 1. Background tabs update their name from OSC title changes
The left tab bar updated a tab's name from an app's OSC icon title (e.g. `claude`) **only for the focused tab**. Every tab runs its own emulator in the background and already tracks the title, but the `iconTitle → tab.title` sync lived inside `ProperTerminal` — a Composable mounted only for the active tab. So background tabs computed the new title and never showed it.

- `TabController.wireCwdTitle` (called by every session-creation path) gains a per-session background collector mirroring `display.iconTitleFlow → session.title` for the session's whole lifetime, gated on `customTitle == null` so user renames win.
- The active-tab `onTabTitleChange` callback is now also gated on `customTitle`, so active and background tabs behave identically and a rename isn't clobbered by a later OSC title.

Power impact is nil — the emulator/PTY work already runs for background tabs; this only consumes an already-emitted, conflated `StateFlow`.

### 2. MCP caller-tab resolution: split panes + `get_active_tab`
Master's #300 made `run_in_panel`/`run_command`/`show_image` default to the calling agent's tab, but only matched each tab's **primary** session PID and left `get_active_tab` on the window's active tab. This builds on that:

- `ProcessAncestry.collectTabIdByShellPid` now also maps each **split pane's** session PID to its owning tab. A client running in a non-primary pane previously fell back to the window's active tab; now it pins the correct tab.
- `get_active_tab` returns the calling client's **own** tab when resolvable (`isActive` still reports whether it's the focused one).

## Testing
- `./gradlew :compose-ui:compileKotlinDesktop` — clean build.
- The MCP change takes effect only in an instance running this build; relaunch the instance hosting the `bossterm` MCP server, then a no-`tab_id` split from a split pane lands on the calling session's own tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
