### PR TITLE
perf: park idle repaints, fix per-tab display leak, cut render churn

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -66,6 +66,9 @@ class BossTerminal(
 
   private val myWindowTitlesStack = Stack<String>()
     private val myIconTitlesStack = Stack<String>()
+    // Bound the XTPUSHTITLE (CSI 22 t) stacks: a program that only ever pushes and never
+    // pops (CSI 23 t) would otherwise grow these without limit. xterm caps the same way.
+    private val maxTitleStackDepth = 10
 
     private val myTabulator: Tabulator
 
@@ -324,6 +327,9 @@ class BossTerminal(
 
     override fun saveWindowTitleOnStack() {
         val title = myDisplay.windowTitle
+        if (myWindowTitlesStack.size >= maxTitleStackDepth) {
+            myWindowTitlesStack.removeAt(0) // drop oldest to keep the stack bounded
+        }
         myWindowTitlesStack.push(title)
     }
 
@@ -340,6 +346,9 @@ class BossTerminal(
 
     override fun saveIconTitleOnStack() {
         val title = myDisplay.iconTitle
+        if (myIconTitlesStack.size >= maxTitleStackDepth) {
+            myIconTitlesStack.removeAt(0) // drop oldest to keep the stack bounded
+        }
         myIconTitlesStack.push(title)
     }
 
@@ -1350,6 +1359,10 @@ class BossTerminal(
 
         cursorPosition(1, 1)
         cursorShapeNullable(null)
+
+        // Drop any saved (XTPUSHTITLE) titles so they don't survive a full reset.
+        myWindowTitlesStack.clear()
+        myIconTitlesStack.clear()
     }
 
     private fun initMouseModes() {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Compose implementation of TerminalDisplay interface with adaptive debouncing.
@@ -65,10 +64,6 @@ class ComposeTerminalDisplay : TerminalDisplay {
     // Mode transition tracking
     private var lastModeSwitch = System.currentTimeMillis()
     private var returnToInteractiveJob: Job? = null
-
-    // ===== PERFORMANCE METRICS =====
-    private val redrawCount = AtomicLong(0)
-    private val skippedRedraws = AtomicLong(0) // Count of coalesced redraws
 
     init {
         // Start redraw processor coroutine
@@ -426,11 +421,9 @@ class ComposeTerminalDisplay : TerminalDisplay {
             }
         }
 
-        val sent = redrawChannel.trySend(RedrawRequest(priority = RedrawPriority.NORMAL))
-        if (!sent.isSuccess) {
-            // Channel is full (CONFLATED), request was coalesced
-            skippedRedraws.incrementAndGet()
-        }
+        // Conflated channel: a full channel simply coalesces this request into the
+        // pending one, which is the intended debouncing behaviour.
+        redrawChannel.trySend(RedrawRequest(priority = RedrawPriority.NORMAL))
     }
 
     /**
@@ -520,7 +513,6 @@ class ComposeTerminalDisplay : TerminalDisplay {
      * Perform the actual redraw by updating Compose state.
      */
     private fun actualRedraw() {
-        redrawCount.incrementAndGet()
         _redrawTrigger.value += 1
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.util.concurrent.atomic.AtomicLong
-import kotlin.concurrent.timer
 
 /**
  * Compose implementation of TerminalDisplay interface with adaptive debouncing.
@@ -70,18 +69,10 @@ class ComposeTerminalDisplay : TerminalDisplay {
     // ===== PERFORMANCE METRICS =====
     private val redrawCount = AtomicLong(0)
     private val skippedRedraws = AtomicLong(0) // Count of coalesced redraws
-    private val startTime = System.currentTimeMillis()
-    private var lastMetricsReport = System.currentTimeMillis()
-    private val metricsReportInterval = 5000L // Report every 5 seconds
 
     init {
         // Start redraw processor coroutine
         startRedrawProcessor()
-
-        // Start metrics reporting timer
-        timer("RedrawMetrics", daemon = true, period = metricsReportInterval) {
-            reportMetrics()
-        }
     }
     // Non-reactive cursor state - only redrawTrigger controls recomposition
     // This prevents flickering caused by Compose State updates racing with debounced redraws
@@ -533,24 +524,20 @@ class ComposeTerminalDisplay : TerminalDisplay {
         _redrawTrigger.value += 1
     }
 
-    // ===== METRICS REPORTING =====
-    private fun reportMetrics() {
-        val now = System.currentTimeMillis()
-        val totalTime = (now - startTime) / 1000.0
-        val intervalTime = (now - lastMetricsReport) / 1000.0
-        val totalRedraws = redrawCount.get()
-        val totalSkipped = skippedRedraws.get()
-        val totalRequests = totalRedraws + totalSkipped
-        val efficiencyPercent = if (totalRequests > 0) {
-            (totalSkipped.toDouble() / totalRequests * 100)
-        } else 0.0
-
-        // Performance metrics reporting removed
-
-        lastMetricsReport = now
-    }
-
-    fun printFinalMetrics() {
-        // Final metrics reporting removed
+    /**
+     * Release everything started in [init]. Must be called when the owning
+     * tab / split pane is closed.
+     *
+     * Without this the redraw coroutine stays parked on [redrawChannel] forever
+     * and [redrawScope] is never cancelled, so the display (and the render state
+     * it captures) can never be collected — one leaked Main-dispatcher coroutine
+     * per tab/pane ever opened. Idempotent: cancelling an already-cancelled scope
+     * and closing an already-closed channel are both no-ops.
+     */
+    fun dispose() {
+        returnToInteractiveJob?.cancel()
+        redrawJob?.cancel()
+        redrawScope.cancel()
+        redrawChannel.close()
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -340,6 +340,10 @@ fun EmbeddableTerminal(
 
         // Register as CommandStateListener to track shell prompt state (OSC 133)
         session.terminal.addCommandStateListener(interceptor)
+        // Track it so TerminalTab.dispose() detaches it from the terminal; otherwise
+        // the interceptor stays registered for the terminal's life and pins the AI
+        // detector/launcher state after the session is gone.
+        session.commandStateListeners.add(interceptor)
 
         // Store reference in session for ProperTerminal to access
         session.aiCommandInterceptor = interceptor

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -724,6 +724,10 @@ fun TabbedTerminal(
 
             // Register as CommandStateListener to track shell prompt state (OSC 133)
             tab.terminal.addCommandStateListener(interceptor)
+            // Track it so TerminalTab.dispose() detaches it from the terminal; otherwise
+            // the interceptor stays registered for the terminal's life and pins the AI
+            // detector/launcher state after the tab is gone.
+            tab.commandStateListeners.add(interceptor)
 
             // Store reference in tab for ProperTerminal to access
             tab.aiCommandInterceptor = interceptor

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -884,8 +884,13 @@ object TerminalCanvasRenderer {
 
                 // Report blink-attributed text in the visible region so the caller can
                 // park the blink toggle loops when none is present (no blinking text =>
-                // no periodic full-canvas repaints on a focused, idle terminal).
-                if (isSlowBlink || isRapidBlink) {
+                // no periodic full-canvas repaints on a focused, idle terminal). Only a
+                // cell that actually draws a glyph counts: a blink-attributed space,
+                // NUL, or HIDDEN cell toggles nothing visible, so arming the loop for it
+                // would be exactly the idle repaint this avoids. (isBlinkVisible is
+                // deliberately not part of this check — it's the current blink phase, so
+                // gating on it would be circular.)
+                if ((isSlowBlink || isRapidBlink) && !isHidden && char != ' ' && char != '\u0000') {
                     ctx.blinkProbe?.let {
                         if (isSlowBlink) it[0] = true
                         if (isRapidBlink) it[1] = true

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -85,6 +85,13 @@ data class RenderingContext(
     val slowBlinkVisible: Boolean,
     val rapidBlinkVisible: Boolean,
 
+    // Optional write-back probe so the caller can learn whether the visible
+    // region actually contains blink-attributed text this frame, without a
+    // second scan. Index 0 = a SLOW_BLINK cell was drawn, index 1 = a
+    // RAPID_BLINK cell was drawn. The caller resets it before each render and
+    // reads it after; left null by callers that don't care (e.g. tests).
+    val blinkProbe: BooleanArray? = null,
+
     // Cell-based image rendering (images flow with text)
     val imageDataCache: ImageDataCache? = null,
     val terminalWidthCells: Int = 80,
@@ -250,10 +257,29 @@ fun analyzeCharacter(
 }
 
 /**
- * Cache for CharacterAnalysis results to avoid redundant analysis between render passes.
- * Key: (row, col) pair, Value: CharacterAnalysis result
+ * Per-frame cache of [CharacterAnalysis] so the text pass can reuse the analysis the
+ * background pass already computed, indexed by (row, col).
+ *
+ * Backed by a flat array rather than a `Map<Pair<Int,Int>, …>`: the old map allocated a
+ * boxed `Pair` (plus two boxed Ints) and a HashMap node for every visible cell on every
+ * frame — thousands of short-lived allocations per redraw during bulk output. A new
+ * instance is allocated per render call (so it stays thread-safe on the shared renderer
+ * object, and starts all-null with no reset needed), but that is a single array
+ * allocation instead of per-cell churn. `row`/`col` are always within
+ * `[0, visibleRows) × [0, visibleCols)` on the hot path; out-of-range access is treated
+ * as a miss so callers fall back to recomputing, exactly like the old map.
  */
-private typealias AnalysisCache = MutableMap<Pair<Int, Int>, CharacterAnalysis>
+private class AnalysisCache(private val rows: Int, private val cols: Int) {
+    private val data: Array<CharacterAnalysis?> =
+        arrayOfNulls(if (rows > 0 && cols > 0) rows * cols else 0)
+
+    operator fun set(row: Int, col: Int, analysis: CharacterAnalysis) {
+        if (row in 0 until rows && col in 0 until cols) data[row * cols + col] = analysis
+    }
+
+    operator fun get(row: Int, col: Int): CharacterAnalysis? =
+        if (row in 0 until rows && col in 0 until cols) data[row * cols + col] else null
+}
 
 /**
  * Cache key for text measurements (issue #147 - special character rendering optimization).
@@ -371,7 +397,7 @@ object TerminalCanvasRenderer {
     fun DrawScope.renderTerminal(ctx: RenderingContext): Map<Int, List<Hyperlink>> {
         val hyperlinksCache = mutableMapOf<Int, List<Hyperlink>>()
         // Cache character analysis to avoid redundant computation between passes
-        val analysisCache: AnalysisCache = mutableMapOf()
+        val analysisCache = AnalysisCache(ctx.visibleRows, ctx.visibleCols)
 
         // Pass 1: Draw backgrounds and populate analysis cache
         renderBackgrounds(ctx, analysisCache)
@@ -540,7 +566,7 @@ object TerminalCanvasRenderer {
 
                 // Use shared character analysis helper and cache the result
                 val analysis = analyzeCharacter(char, line, col, ctx.visibleCols, ctx.ambiguousCharsAreDoubleWidth)
-                analysisCache[lineIndex to col] = analysis
+                analysisCache[row, col] = analysis
 
                 // Get attributes
                 val isInverse = style?.hasOption(BossTextStyle.Option.INVERSE) ?: false
@@ -668,6 +694,14 @@ object TerminalCanvasRenderer {
         val hyperlinksCache: Map<Int, List<Hyperlink>> = ctx.precomputedHyperlinks
             ?: detectAllHyperlinks(ctx)
 
+        // Memoize TextStyle for the duration of this frame, keyed by foreground color
+        // (raw ULong, lossless) with the 4 bold/italic combinations in a small array.
+        // fontFamily/fontSize are constant for the whole render, so they need not be in
+        // the key. Without this, flushBatch() built a fresh TextStyle (and its internal
+        // SpanStyle/ParagraphStyle) for every style run on every row on every frame.
+        // Frame-local so it stays thread-safe on the shared renderer object.
+        val textStyleCache = HashMap<Long, Array<TextStyle?>>()
+
         for (row in 0 until ctx.visibleRows) {
             val lineIndex = row - ctx.scrollOffset
             val line = snapshot.getLine(lineIndex)
@@ -686,14 +720,19 @@ object TerminalCanvasRenderer {
                     val x = batchStartCol * ctx.cellWidth
                     val y = row * ctx.cellHeight
 
-                    val textStyle = TextStyle(
-                        color = batchFgColor ?: ctx.settings.defaultForegroundColor,
+                    val resolvedColor = batchFgColor ?: ctx.settings.defaultForegroundColor
+                    val variants = textStyleCache.getOrPut(resolvedColor.value.toLong()) {
+                        arrayOfNulls(4)
+                    }
+                    val variantIndex = (if (batchIsBold) 2 else 0) or (if (batchIsItalic) 1 else 0)
+                    val textStyle = variants[variantIndex] ?: TextStyle(
+                        color = resolvedColor,
                         fontFamily = ctx.measurementFontFamily,
                         fontSize = ctx.fontSize.sp,
                         fontWeight = if (batchIsBold) FontWeight.Bold else FontWeight.Normal,
                         fontStyle = if (batchIsItalic) androidx.compose.ui.text.font.FontStyle.Italic
                             else androidx.compose.ui.text.font.FontStyle.Normal
-                    )
+                    ).also { variants[variantIndex] = it }
 
                     drawText(
                         textMeasurer = ctx.textMeasurer,
@@ -818,10 +857,9 @@ object TerminalCanvasRenderer {
 
                 val x = visualCol * ctx.cellWidth
                 val y = row * ctx.cellHeight
-                val lineIndex = row - ctx.scrollOffset
 
                 // Use cached analysis from renderBackgrounds, or compute if not found
-                val analysis = analysisCache[lineIndex to col]
+                val analysis = analysisCache[row, col]
                     ?: analyzeCharacter(char, line, col, snapshot.width, ctx.ambiguousCharsAreDoubleWidth)
 
                 // Get nextChar for rendering emoji with variation selectors
@@ -843,6 +881,16 @@ object TerminalCanvasRenderer {
                 val isHidden = style?.hasOption(BossTextStyle.Option.HIDDEN) ?: false
                 val isSlowBlink = style?.hasOption(BossTextStyle.Option.SLOW_BLINK) ?: false
                 val isRapidBlink = style?.hasOption(BossTextStyle.Option.RAPID_BLINK) ?: false
+
+                // Report blink-attributed text in the visible region so the caller can
+                // park the blink toggle loops when none is present (no blinking text =>
+                // no periodic full-canvas repaints on a focused, idle terminal).
+                if (isSlowBlink || isRapidBlink) {
+                    ctx.blinkProbe?.let {
+                        if (isSlowBlink) it[0] = true
+                        if (isRapidBlink) it[1] = true
+                    }
+                }
 
                 // Calculate colors
                 val baseFg = style?.foreground?.let { ColorUtils.convertTerminalColor(it) }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -485,6 +485,15 @@ data class TerminalTab(
         // Cancel all coroutines in this scope (including writeConsumerJob)
         coroutineScope.cancel()
 
+        // Tear down the display: cancels its redraw scope, closes the redraw
+        // channel, and stops the parked redraw coroutine. Without this every
+        // closed tab/pane leaks a Main-dispatcher coroutine and pins the display.
+        try {
+            display.dispose()
+        } catch (e: Exception) {
+            System.err.println("WARN: Failed to dispose display: ${e.message}")
+        }
+
         // Terminal cleanup (if needed)
         // terminal.close() may not be available in all BossTerm versions
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -333,6 +333,14 @@ fun ProperTerminal(
   var slowBlinkVisible by remember { mutableStateOf(true) }
   var rapidBlinkVisible by remember { mutableStateOf(true) }
 
+  // Whether blink-attributed text is actually present in the visible region. The
+  // renderer writes this back each frame via `blinkProbe` (no extra scan), and the
+  // blink toggle loops below gate on it: with no blinking text on screen, a focused
+  // idle terminal produces zero periodic repaints instead of ~3 full-canvas redraws/sec.
+  var hasSlowBlinkText by remember { mutableStateOf(false) }
+  var hasRapidBlinkText by remember { mutableStateOf(false) }
+  val blinkProbe = remember { BooleanArray(2) }
+
   // Drag state for text selection
   var isDragging by remember { mutableStateOf(false) }
   var dragStartPos by remember { mutableStateOf<Offset?>(null) }  // Track initial mouse position for drag detection
@@ -670,8 +678,12 @@ fun ProperTerminal(
   // SLOW_BLINK animation timer (configurable via settings.slowTextBlinkMs).
   // enableTextBlinking is the master accessibility toggle. A non-positive interval means
   // "no blink" (also guards against a delay(0) busy-loop pegging a core).
-  LaunchedEffect(blinkActive, settings.enableTextBlinking, settings.slowTextBlinkMs) {
-    if (!blinkActive || !settings.enableTextBlinking || settings.slowTextBlinkMs <= 0) {
+  // Also gate on hasSlowBlinkText: if nothing on screen carries the SLOW_BLINK
+  // attribute, there is nothing to animate, so park the loop (and freeze the flag
+  // to "visible") instead of repainting the whole text canvas once a second for
+  // no visible change.
+  LaunchedEffect(blinkActive, hasSlowBlinkText, settings.enableTextBlinking, settings.slowTextBlinkMs) {
+    if (!blinkActive || !hasSlowBlinkText || !settings.enableTextBlinking || settings.slowTextBlinkMs <= 0) {
       slowBlinkVisible = true
       return@LaunchedEffect
     }
@@ -682,8 +694,8 @@ fun ProperTerminal(
   }
 
   // RAPID_BLINK animation timer (configurable via settings.rapidTextBlinkMs).
-  LaunchedEffect(blinkActive, settings.enableTextBlinking, settings.rapidTextBlinkMs) {
-    if (!blinkActive || !settings.enableTextBlinking || settings.rapidTextBlinkMs <= 0) {
+  LaunchedEffect(blinkActive, hasRapidBlinkText, settings.enableTextBlinking, settings.rapidTextBlinkMs) {
+    if (!blinkActive || !hasRapidBlinkText || !settings.enableTextBlinking || settings.rapidTextBlinkMs <= 0) {
       rapidBlinkVisible = true
       return@LaunchedEffect
     }
@@ -1829,9 +1841,15 @@ fun ProperTerminal(
             emptyList()
           }
 
+          // Reset the per-frame blink probe; renderText() sets an entry true if it
+          // draws a SLOW_BLINK / RAPID_BLINK cell in the visible region this frame.
+          blinkProbe[0] = false
+          blinkProbe[1] = false
+
           // Build rendering context with all state
           val renderingContext = RenderingContext(
             bufferSnapshot = bufferSnapshot,
+            blinkProbe = blinkProbe,
             cellWidth = cellWidth,
             cellHeight = cellHeight,
             baseCellHeight = baseCellHeight,
@@ -1883,6 +1901,13 @@ fun ProperTerminal(
             cachedHyperlinks = detectedHyperlinks
             lastHyperlinkVersionHash = currentVersionHash
           }
+
+          // Reflect the renderer's blink-presence findings into composition state. Only
+          // an actual change notifies (mutableStateOf uses structural equality), so this
+          // re-arms/parks the blink loops on transitions and is a no-op otherwise — no
+          // per-frame recomposition. Reads here are in the draw phase, not composition.
+          if (hasSlowBlinkText != blinkProbe[0]) hasSlowBlinkText = blinkProbe[0]
+          if (hasRapidBlinkText != blinkProbe[1]) hasRapidBlinkText = blinkProbe[1]
         }
 
         // Cursor overlay — drawn in its own Canvas, stacked on top of the text canvas above


### PR DESCRIPTION
## Summary

Follow-ups to the idle-battery work merged in #298/#299, found by a fresh audit of `master`. These are the issues that survived that work — one real leak, one residual idle repaint, and some render-path allocation churn. **No behaviour or visual change**; idle CPU and per-tab/per-frame allocations drop.

7 files, +132/−42. `:compose-ui:compileKotlinDesktop` + test sources compile (BUILD SUCCESSFUL). App not run.

## What & why

### 🔴 HIGH — `ComposeTerminalDisplay` was never disposed (leak + idle wakeup)
Every tab **and** every split pane constructs a `ComposeTerminalDisplay`, but `TerminalTab.dispose()` never tore it down. Each closed tab/pane leaked:
- a **Main-dispatcher redraw coroutine** parked forever on a conflated channel, and
- a **`RedrawMetrics` `java.util.Timer`** whose `TimerTask` captured the display as a **GC root** — so the display (and its captured render state) could never be collected. Its `reportMetrics()` had already been gutted to a no-op, so the timer was also a pointless 0.2 Hz idle wakeup per display that defeated CPU idle.

**Fix:** add `ComposeTerminalDisplay.dispose()` (cancel scope + jobs, close channel), call it from `TerminalTab.dispose()` — the single chokepoint both the tabbed and embeddable paths route through — and delete the dead metrics timer entirely.

### 🔴 HIGH — text-blink loops repainted the whole canvas ~3×/sec on a focused idle terminal
The `SLOW_BLINK`/`RAPID_BLINK` loops were gated only on window focus, not on whether any **visible** cell actually carries a blink attribute (and `enableTextBlinking` defaults on). So a focused terminal sitting at a bare prompt did ~3 full-canvas repaints/sec for nothing.

**Fix:** the renderer reports blink-cell presence via a reused `BooleanArray` probe that **piggybacks on the existing per-cell attribute check (zero extra iteration)**; the loops park (and freeze "visible") when no blinking text is on screen — mirroring how the cursor blink was already isolated.

### 🟠 MED — render hot-path allocations
- Replaced the per-frame `Map<Pair<Int,Int>, CharacterAnalysis>` (a boxed `Pair` + `HashMap` node per visible cell, **every frame**) with a per-frame **flat array** keyed by `(row, col)`.
- Memoized `TextStyle` per `(color, bold, italic)` within a frame instead of rebuilding it per style-run per row in `flushBatch`.

Both caches are render-call-local, so the shared `TerminalCanvasRenderer` object stays thread-safe.

### 🟠 MED — AI interceptor not removed on dispose
The AI `CommandStateListener` was registered on the terminal but never tracked, so it stayed attached for the terminal's life. Added it to `commandStateListeners` so `TerminalTab.dispose()` detaches it.

### 🟡 LOW — unbounded XTPUSHTITLE stacks
Bounded the window/icon title stacks (`CSI 22 t`) at 10 (drop-oldest) and clear them on a full reset.

## Deliberately out of scope
- **Listener symmetry** (`addCustomCommandListener`/title/clipboard): the audit confirmed these are added once per tab on the per-tab `BossTerminal` (`CopyOnWriteArrayList`) and collected with the terminal — they don't grow across tab cycles, so adding core API + dispose plumbing would be risk without benefit.
- **`McpTerminalRegistry` host concern:** lives in **BossConsole** (the embedding host), not this repo. The standalone app and `tabbed-example` correctly pair `register`/`unregister`; worth verifying BossConsole does too on window close.
- **`IncrementalSnapshotBuilder` micro-iteration:** profiling-gated and on the lock-free snapshot path — not worth the regression risk for a LOW.

## How to validate at runtime
- **HIGH-1:** `jcmd <pid> Thread.print | grep -c RedrawMetrics` → now `0` and stays 0 across tab/split churn (the timer thread is gone); heap/thread totals stay flat over open/close cycles.
- **HIGH-2:** focus a terminal at a bare prompt and run `top -pid <pid> -l 30 -stats pid,cpu,idlew` → idle wakeups drop to ~0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
