### PR TITLE
Design: BOSS Operator terminal theme + palette (default)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -95,9 +95,9 @@ data class TerminalSettings(
 
     /**
      * Selection highlight color (serialized as ARGB hex).
-     * Default matches VS Code Dark / BossEditor style.
+     * Default matches the BOSS Operator theme so a fresh install is self-consistent.
      */
-    val selectionColor: String = "0xFF214283",
+    val selectionColor: String = "0xFF21405A",
 
     /**
      * Selection highlight opacity (0.0 to 1.0).
@@ -109,12 +109,12 @@ data class TerminalSettings(
     /**
      * Search result highlight color (serialized as ARGB hex)
      */
-    val foundPatternColor: String = "0xFFE6DB74",
+    val foundPatternColor: String = "0xFFF0B429",
 
     /**
      * Hyperlink color (serialized as ARGB hex)
      */
-    val hyperlinkColor: String = "0xFF66D9EF",
+    val hyperlinkColor: String = "0xFF56C7E0",
 
     /**
      * Active theme ID.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -86,12 +86,12 @@ data class TerminalSettings(
     /**
      * Default foreground color (serialized as ARGB hex)
      */
-    val defaultForeground: String = "0xFFF8F8F2",
+    val defaultForeground: String = "0xFFD7DEE6",
 
     /**
      * Default background color (serialized as ARGB hex)
      */
-    val defaultBackground: String = "0xFF272822",
+    val defaultBackground: String = "0xFF0E1217",
 
     /**
      * Selection highlight color (serialized as ARGB hex).
@@ -121,7 +121,7 @@ data class TerminalSettings(
      * References a theme from BuiltinThemes or a custom theme.
      * When a theme is applied, the color settings above are updated to match.
      */
-    val activeThemeId: String = "monokai",
+    val activeThemeId: String = "boss-operator",
 
     /**
      * Active color palette ID.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinColorPalettes.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinColorPalettes.kt
@@ -387,26 +387,11 @@ object BuiltinColorPalettes {
      * BOSS Operator — the ANSI 16 of the unified "Operator's Console" identity.
      * Mix over any theme to carry the BOSS palette into terminal apps.
      */
-    val BOSS_OPERATOR = ColorPalette(
+    // ANSI derived from the BOSS Operator theme so the two never drift; id/name
+    // are preserved so this stays a selectable builtin palette.
+    val BOSS_OPERATOR = ColorPalette.fromTheme(BuiltinThemes.BOSS_OPERATOR).copy(
         id = "boss-operator",
         name = "BOSS Operator",
-        black = "0xFF15202B",
-        red = "0xFFF2685F",
-        green = "0xFF6FD08C",
-        yellow = "0xFFF2A93B",
-        blue = "0xFF5C9FE0",
-        magenta = "0xFFC792EA",
-        cyan = "0xFF56C7E0",
-        white = "0xFFC7D1DB",
-        brightBlack = "0xFF3A4B5C",
-        brightRed = "0xFFFF8A80",
-        brightGreen = "0xFF8FE0A6",
-        brightYellow = "0xFFFFC560",
-        brightBlue = "0xFF82B7F0",
-        brightMagenta = "0xFFDDB0F5",
-        brightCyan = "0xFF7FD9EE",
-        brightWhite = "0xFFE9EEF3",
-        isBuiltin = true
     )
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinColorPalettes.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinColorPalettes.kt
@@ -384,9 +384,36 @@ object BuiltinColorPalettes {
     )
 
     /**
+     * BOSS Operator — the ANSI 16 of the unified "Operator's Console" identity.
+     * Mix over any theme to carry the BOSS palette into terminal apps.
+     */
+    val BOSS_OPERATOR = ColorPalette(
+        id = "boss-operator",
+        name = "BOSS Operator",
+        black = "0xFF15202B",
+        red = "0xFFF2685F",
+        green = "0xFF6FD08C",
+        yellow = "0xFFF2A93B",
+        blue = "0xFF5C9FE0",
+        magenta = "0xFFC792EA",
+        cyan = "0xFF56C7E0",
+        white = "0xFFC7D1DB",
+        brightBlack = "0xFF3A4B5C",
+        brightRed = "0xFFFF8A80",
+        brightGreen = "0xFF8FE0A6",
+        brightYellow = "0xFFFFC560",
+        brightBlue = "0xFF82B7F0",
+        brightMagenta = "0xFFDDB0F5",
+        brightCyan = "0xFF7FD9EE",
+        brightWhite = "0xFFE9EEF3",
+        isBuiltin = true
+    )
+
+    /**
      * All built-in color palettes.
      */
     val ALL = listOf(
+        BOSS_OPERATOR,
         XTERM,
         TANGO,
         UBUNTU,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinThemes.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinThemes.kt
@@ -348,9 +348,48 @@ object BuiltinThemes {
     )
 
     /**
+     * BOSS Operator — the unified "Operator's Console" identity.
+     *
+     * Shares the BossConsole host floor (ink #0E1217) so the terminal and the
+     * chrome around it read as one continuous surface. The cursor is the amber
+     * signal — the single "live / now" color of the whole design system.
+     */
+    val BOSS_OPERATOR = Theme(
+        id = "boss-operator",
+        name = "BOSS Operator",
+        foreground = "0xFFD7DEE6",
+        background = "0xFF0E1217",   // shared `ink` floor
+        cursor = "0xFFF2A93B",       // amber signal — the signature
+        cursorText = "0xFF0E1217",
+        selection = "0xFF21405A",
+        selectionText = "0xFFE9EEF3",
+        searchMatch = "0xFFF0B429",
+        hyperlink = "0xFF56C7E0",    // cyan `data`
+        // ANSI 16 — tuned to sit calmly on the ink floor
+        black = "0xFF15202B",
+        red = "0xFFF2685F",
+        green = "0xFF6FD08C",
+        yellow = "0xFFF2A93B",
+        blue = "0xFF5C9FE0",
+        magenta = "0xFFC792EA",
+        cyan = "0xFF56C7E0",
+        white = "0xFFC7D1DB",
+        brightBlack = "0xFF3A4B5C",
+        brightRed = "0xFFFF8A80",
+        brightGreen = "0xFF8FE0A6",
+        brightYellow = "0xFFFFC560",
+        brightBlue = "0xFF82B7F0",
+        brightMagenta = "0xFFDDB0F5",
+        brightCyan = "0xFF7FD9EE",
+        brightWhite = "0xFFE9EEF3",
+        isBuiltin = true
+    )
+
+    /**
      * All built-in themes.
      */
     val ALL = listOf(
+        BOSS_OPERATOR,
         DEFAULT,
         DRACULA,
         NORD,
@@ -369,7 +408,7 @@ object BuiltinThemes {
     fun getById(id: String): Theme? = ALL.find { it.id == id }
 
     /**
-     * Default theme ID.
+     * Default theme ID — the unified BOSS identity.
      */
-    const val DEFAULT_THEME_ID = "monokai"
+    const val DEFAULT_THEME_ID = "boss-operator"
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/ThemeManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/ThemeManager.kt
@@ -215,7 +215,11 @@ class ThemeManager private constructor(
      */
     private fun loadActiveTheme() {
         val activeThemeId = settingsManager.settings.value.activeThemeId
-        val theme = getThemeById(activeThemeId) ?: BuiltinThemes.DEFAULT
+        // Unknown id falls back to the product default (boss-operator), not the
+        // stark black/white BuiltinThemes.DEFAULT.
+        val theme = getThemeById(activeThemeId)
+            ?: getThemeById(BuiltinThemes.DEFAULT_THEME_ID)
+            ?: BuiltinThemes.DEFAULT
         _currentTheme.value = theme
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/ThemeManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/ThemeManager.kt
@@ -36,7 +36,7 @@ class ThemeManager private constructor(
      */
     val customThemes: StateFlow<List<Theme>> = _customThemes.asStateFlow()
 
-    private val _currentTheme = MutableStateFlow(BuiltinThemes.MONOKAI)
+    private val _currentTheme = MutableStateFlow(BuiltinThemes.BOSS_OPERATOR)
 
     /**
      * Currently active theme.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -2,7 +2,6 @@ package ai.rever.bossterm.compose.tabs
 
 import ai.rever.bossterm.compose.features.ContextMenuController
 import ai.rever.bossterm.compose.settings.theme.ThemeManager
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -34,6 +33,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -1,6 +1,8 @@
 package ai.rever.bossterm.compose.tabs
 
 import ai.rever.bossterm.compose.features.ContextMenuController
+import ai.rever.bossterm.compose.settings.theme.ThemeManager
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -401,16 +403,24 @@ fun TabBar(
         }
     }
 
+    // Tab-bar chrome follows the active terminal theme, so the left panel
+    // re-styles live when the theme/palette is switched (collectAsState recomposes).
+    val tabBarTheme by ThemeManager.instance.currentTheme.collectAsState()
+    val barBg = tabBarTheme.backgroundColorValue
+    val barFg = tabBarTheme.foregroundColor
+    val barMuted = barFg.copy(alpha = 0.62f)
+    val barDivider = barFg.copy(alpha = 0.10f)
+
     val newTabButton: @Composable () -> Unit = {
         IconButton(onClick = onNewTab, modifier = Modifier.size(36.dp)) {
-            Icon(imageVector = Icons.Default.Add, contentDescription = "New Tab", tint = Color.White)
+            Icon(imageVector = Icons.Default.Add, contentDescription = "New Tab", tint = barFg)
         }
     }
 
     // A single compact action button for the left bar's top toolbar.
     val barButton: @Composable (ImageVector, String, () -> Unit) -> Unit = { icon, desc, onClick ->
         IconButton(onClick = onClick, modifier = Modifier.size(30.dp)) {
-            Icon(imageVector = icon, contentDescription = desc, tint = Color(0xFFB0B0B0), modifier = Modifier.size(16.dp))
+            Icon(imageVector = icon, contentDescription = desc, tint = barMuted, modifier = Modifier.size(16.dp))
         }
     }
 
@@ -463,7 +473,7 @@ fun TabBar(
             if (vertical) Modifier.fillMaxHeight().width(verticalWidth)
             else Modifier.fillMaxWidth().height(TabBarHeight)
         ),
-        color = Color(0xFF1E1E1E),
+        color = barBg,
         shadowElevation = 2.dp
     ) {
         if (vertical) {
@@ -471,7 +481,7 @@ fun TabBar(
                 // Action toolbar pinned at the top, then a divider…
                 actionBar()
                 Spacer(Modifier.height(6.dp))
-                Box(Modifier.fillMaxWidth().height(1.dp).background(Color(0xFF333333)))
+                Box(Modifier.fillMaxWidth().height(1.dp).background(barDivider))
                 Spacer(Modifier.height(8.dp))
                 // …with scrollable tab/pane chips filling the rest.
                 Column(
@@ -727,7 +737,7 @@ fun TabBar(
                 }
                 // Bottom bar — connect to another BossTerm's shared session.
                 Spacer(Modifier.height(8.dp))
-                Box(Modifier.fillMaxWidth().height(1.dp).background(Color(0xFF333333)))
+                Box(Modifier.fillMaxWidth().height(1.dp).background(barDivider))
                 Spacer(Modifier.height(6.dp))
                 Row(
                     modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp))
@@ -794,6 +804,14 @@ private fun TabItem(
     modifier: Modifier = Modifier
 ) {
     val accent = parseTabColor(colorHex)
+    // Chip colors follow the active terminal theme (re-style live on theme switch).
+    val itemTheme by ThemeManager.instance.currentTheme.collectAsState()
+    val itemBg = itemTheme.backgroundColorValue
+    val itemFg = itemTheme.foregroundColor
+    val itemRaised = lerp(itemBg, itemFg, 0.12f)   // active chip surface
+    val itemAccent = itemTheme.cursorColor          // active chip border
+    val itemMuted = itemFg.copy(alpha = 0.62f)      // inactive text
+    val itemSubtle = itemFg.copy(alpha = 0.20f)     // inactive border
     Surface(
         modifier = modifier
             .then(if (multiLine) Modifier.heightIn(min = 36.dp) else Modifier.height(36.dp))
@@ -810,13 +828,13 @@ private fun TabItem(
                     }
             ),
         shape = RoundedCornerShape(6.dp),
-        color = if (isActive) Color(0xFF2B2B2B) else Color(0xFF1E1E1E),
+        color = if (isActive) itemRaised else itemBg,
         border = androidx.compose.foundation.BorderStroke(
             1.dp,
             when {
                 isActive && accent != null -> accent
-                isActive -> Color(0xFF4A90E2)
-                else -> Color(0xFF404040)
+                isActive -> itemAccent
+                else -> itemSubtle
             }
         )
     ) {
@@ -835,7 +853,7 @@ private fun TabItem(
                 // Tab title - use Monospace font (Menlo on macOS) for monochrome symbols
                 Text(
                     text = title,
-                    color = if (isActive) Color.White else Color(0xFFB0B0B0),
+                    color = if (isActive) itemFg else itemMuted,
                     fontSize = 13.sp,
                     fontFamily = FontFamily.Monospace,  // Menlo has monochrome Dingbats (✳, ❯, etc.)
                     maxLines = 1,
@@ -851,7 +869,7 @@ private fun TabItem(
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = "Close Tab",
-                        tint = if (isActive) Color(0xFFB0B0B0) else Color(0xFF707070),
+                        tint = if (isActive) itemMuted else itemSubtle,
                         modifier = Modifier.size(14.dp)
                     )
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.compose.tabs
 
 import ai.rever.bossterm.compose.features.ContextMenuController
+import ai.rever.bossterm.compose.settings.theme.Theme
 import ai.rever.bossterm.compose.settings.theme.ThemeManager
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -409,7 +410,7 @@ fun TabBar(
     val barBg = tabBarTheme.backgroundColorValue
     val barFg = tabBarTheme.foregroundColor
     val barMuted = barFg.copy(alpha = 0.62f)
-    val barDivider = barFg.copy(alpha = 0.10f)
+    val barDivider = barFg.copy(alpha = 0.14f)
 
     val newTabButton: @Composable () -> Unit = {
         IconButton(onClick = onNewTab, modifier = Modifier.size(36.dp)) {
@@ -448,6 +449,7 @@ fun TabBar(
             subtitle = pane.subtitle,
             branch = pane.branch,
             multiLine = vertical,
+            tabTheme = tabBarTheme,
             isActive = group.tabIndex == activeTabIndex && pane.paneId == focusedPaneId,
             colorHex = pane.colorHex,
             isEditing = pane.paneId == editingPaneId,
@@ -790,6 +792,7 @@ fun TabBar(
 private fun TabItem(
     title: String,
     isActive: Boolean,
+    tabTheme: Theme,
     colorHex: String?,
     isEditing: Boolean,
     onSelected: () -> Unit,
@@ -804,14 +807,15 @@ private fun TabItem(
     modifier: Modifier = Modifier
 ) {
     val accent = parseTabColor(colorHex)
-    // Chip colors follow the active terminal theme (re-style live on theme switch).
-    val itemTheme by ThemeManager.instance.currentTheme.collectAsState()
-    val itemBg = itemTheme.backgroundColorValue
-    val itemFg = itemTheme.foregroundColor
-    val itemRaised = lerp(itemBg, itemFg, 0.12f)   // active chip surface
-    val itemAccent = itemTheme.cursorColor          // active chip border
-    val itemMuted = itemFg.copy(alpha = 0.62f)      // inactive text
-    val itemSubtle = itemFg.copy(alpha = 0.20f)     // inactive border
+    // Chip colors derive from the active theme, collected once in TabBar and
+    // passed in (one subscriber for the whole bar, not one per tab).
+    val itemBg = tabTheme.backgroundColorValue
+    val itemFg = tabTheme.foregroundColor
+    val itemRaised = lerp(itemBg, itemFg, 0.12f)    // active chip surface
+    val itemAccent = tabTheme.cursorColor           // active chip border
+    val itemMuted = itemFg.copy(alpha = 0.62f)      // inactive text / active close-icon
+    val itemSubtle = itemFg.copy(alpha = 0.22f)     // inactive border (hairline)
+    val itemIcon = itemFg.copy(alpha = 0.42f)       // inactive close-icon — readable on the dark floor
     Surface(
         modifier = modifier
             .then(if (multiLine) Modifier.heightIn(min = 36.dp) else Modifier.height(36.dp))
@@ -869,7 +873,7 @@ private fun TabItem(
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = "Close Tab",
-                        tint = if (isActive) itemMuted else itemSubtle,
+                        tint = if (isActive) itemMuted else itemIcon,
                         modifier = Modifier.size(14.dp)
                     )
                 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ThemeDefaultsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ThemeDefaultsTest.kt
@@ -1,0 +1,47 @@
+package ai.rever.bossterm.compose.theme
+
+import ai.rever.bossterm.compose.settings.theme.BuiltinColorPalettes
+import ai.rever.bossterm.compose.settings.theme.BuiltinThemes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Locks in two invariants around the default identity:
+ *  1. DEFAULT_THEME_ID always resolves to a real builtin (catches an id rename
+ *     that would otherwise silently fall back at runtime).
+ *  2. The BOSS Operator palette's ANSI 16 stays identical to the theme's, so the
+ *     "derive the palette from the theme" wiring can never drift.
+ */
+class ThemeDefaultsTest {
+
+    @Test
+    fun `default theme id resolves to a builtin theme`() {
+        assertNotNull(
+            BuiltinThemes.getById(BuiltinThemes.DEFAULT_THEME_ID),
+            "DEFAULT_THEME_ID '${BuiltinThemes.DEFAULT_THEME_ID}' must resolve to a builtin theme",
+        )
+    }
+
+    @Test
+    fun `boss-operator palette ANSI matches the theme`() {
+        val t = BuiltinThemes.BOSS_OPERATOR
+        val p = BuiltinColorPalettes.BOSS_OPERATOR
+        assertEquals(t.black, p.black)
+        assertEquals(t.red, p.red)
+        assertEquals(t.green, p.green)
+        assertEquals(t.yellow, p.yellow)
+        assertEquals(t.blue, p.blue)
+        assertEquals(t.magenta, p.magenta)
+        assertEquals(t.cyan, p.cyan)
+        assertEquals(t.white, p.white)
+        assertEquals(t.brightBlack, p.brightBlack)
+        assertEquals(t.brightRed, p.brightRed)
+        assertEquals(t.brightGreen, p.brightGreen)
+        assertEquals(t.brightYellow, p.brightYellow)
+        assertEquals(t.brightBlue, p.brightBlue)
+        assertEquals(t.brightMagenta, p.brightMagenta)
+        assertEquals(t.brightCyan, p.brightCyan)
+        assertEquals(t.brightWhite, p.brightWhite)
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ThemeDefaultsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ThemeDefaultsTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.theme
 
+import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.settings.theme.BuiltinColorPalettes
 import ai.rever.bossterm.compose.settings.theme.BuiltinThemes
 import kotlin.test.Test
@@ -43,5 +44,18 @@ class ThemeDefaultsTest {
         assertEquals(t.brightMagenta, p.brightMagenta)
         assertEquals(t.brightCyan, p.brightCyan)
         assertEquals(t.brightWhite, p.brightWhite)
+    }
+
+    @Test
+    fun `terminal settings color defaults match the boss-operator theme`() {
+        // A fresh install renders these TerminalSettings defaults until a theme is
+        // applied via updateSetting, so they must equal the default theme's colors.
+        val t = BuiltinThemes.BOSS_OPERATOR
+        val s = TerminalSettings()
+        assertEquals(t.foreground, s.defaultForeground)
+        assertEquals(t.background, s.defaultBackground)
+        assertEquals(t.selection, s.selectionColor)
+        assertEquals(t.searchMatch, s.foundPatternColor)
+        assertEquals(t.hyperlink, s.hyperlinkColor)
     }
 }


### PR DESCRIPTION
Adds the **BOSS "Operator"** terminal identity, matching the BossConsole design system.

- New builtin `boss-operator` `Theme` + `ColorPalette` — shares the host `ink` floor (`#0E1217`) with an amber signal cursor (`#F2A93B`) and a tuned ANSI 16 set.
- Set as the default: `BuiltinThemes.DEFAULT_THEME_ID`, `TerminalSettings.activeThemeId`, and the default terminal fg/bg (`#D7DEE6` / `#0E1217`).

Verified: `:compose-ui:compileKotlinDesktop` succeeds. Existing saved settings keep their current theme; only fresh installs pick up the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)