### PR TITLE
fix(tabs): keep split-pane titles on their own chips + window title follows focused pane

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1398,9 +1398,12 @@ fun TabbedTerminal(
             val activeTab = tabController.tabs[tabController.activeTabIndex]
             val splitState = getOrCreateSplitState(activeTab)
 
-            // Update window title when active tab's title changes
-            LaunchedEffect(activeTab) {
-                activeTab.display.windowTitleFlow.collect { newTitle ->
+            // Update the OS window title from the FOCUSED pane's window title.
+            // Re-subscribe when focus moves between split panes so the window title
+            // follows the active pane instead of always the root/first pane.
+            LaunchedEffect(activeTab, splitState.focusedPaneId) {
+                val focused = splitState.getFocusedSession() ?: activeTab
+                focused.display.windowTitleFlow.collect { newTitle ->
                     if (newTitle.isNotEmpty()) {
                         onWindowTitleChange(newTitle)
                     }
@@ -1509,9 +1512,13 @@ fun TabbedTerminal(
                 isActiveTab = isActive,
                 onTabTitleChange = { newTitle ->
                     // A user rename (customTitle) always wins; otherwise track the
-                    // app's OSC title. Matches the background-tab collector in
-                    // TabController.wireCwdTitle so active and background tabs behave alike.
-                    if (activeTab.customTitle.value == null) {
+                    // app's OSC title. Only for a SINGLE-pane tab: when the tab is
+                    // split, `activeTab` is the ROOT pane's session, so writing the
+                    // focused pane's title here would land it on the root pane's chip.
+                    // Each split pane already tracks its own title via
+                    // TabController.wireCwdTitle, so the active tab only drives its
+                    // own title when it is not split.
+                    if (activeTab.customTitle.value == null && splitState.isSinglePane) {
                         activeTab.title.value = newTitle
                     }
                 },


### PR DESCRIPTION
## Summary

Builds on #301. That PR made each session track its own OSC icon title via `TabController.wireCwdTitle`, and the left tab bar already renders **one chip per split pane** reading `pane.session.title` (`TabbedTerminal.kt:1087`). Two split-pane title defects remained:

### 1. A focused split pane's title landed on the ROOT pane's chip
The active-tab `onTabTitleChange` callback wrote the focused pane's OSC title into `activeTab.title`. But `activeTab` **is the root pane's session**, so focusing any non-root pane made its title show up on the **first/root chip** — the "all titles update just the first entry" symptom.

Fix: gate that write to single-pane tabs (`splitState.isSinglePane`). Split panes already track their own titles via `wireCwdTitle`, so the active tab only drives its own title when it isn't split. A user rename (`customTitle`) still always wins.

### 2. The OS window title followed the root pane, not the focused pane
`activeTab.display.windowTitleFlow` is the root pane's flow. In a split, focusing another pane left the window title stuck on the first pane.

Fix: collect the **focused** pane's `windowTitleFlow`, re-subscribing when `focusedPaneId` changes.

## Testing
- `./gradlew :compose-ui:compileKotlinDesktop` — clean build.
- Manual (in the sidebar / `tabbed-example`): split a tab, set a distinct title in each pane (e.g. `printf '\033]0;PANE-B\007'`); each pane's chip should show its own title and the root chip should keep the root pane's title. Focus a non-root pane and confirm the OS window title follows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)