### PR TITLE
Enable session daemon by default + document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ cd BossTerm
 - **Session Sharing** - Watch or control a tab / window / all windows from any device — self-hosted, with a QR code and a mobile-friendly web viewer (LAN, Tailscale, or a zero-config Cloudflare tunnel)
 - **Remote Control** - End-to-end encrypted; viewers get typing access on approval, or connect from another BossTerm as a native remote client
 - **AI / MCP Server** - Built-in [Model Context Protocol](https://modelcontextprotocol.io) server exposes your terminals to Claude Code, Codex, Gemini CLI, and OpenCode
+- **Session Daemon** - Opt-in tmux-style background process keeps your sessions, MCP server, and shares alive after the GUI closes — reopen to reattach; optional start-at-login
 - **Embeddable** - Drop the terminal into your own Kotlin/Compose Desktop app as a library (`com.risaboss:bossterm-compose`)
 
 ## Keyboard Shortcuts
@@ -599,6 +600,34 @@ modules demonstrate both hooks.
 See [docs/mcp-server.md](docs/mcp-server.md) for the full reference —
 every built-in tool's JSON schema, the `manage_tools` meta-tool, the
 `BossTermMcpConfig` field-by-field table, and troubleshooting.
+
+## Session Daemon
+
+A tmux-style background process that **owns your terminal sessions, MCP server, and shares** so they
+keep running after you close the GUI — reopen BossTerm and it reattaches to the live sessions. Opt-in
+and **off by default**; with the daemon off, BossTerm is byte-for-byte the same as before.
+
+- **Survives the GUI**: sessions live in the daemon, not the window. Close the app (or all its
+  windows) and your shells keep running — long builds, SSH sessions, and `run_command` agents don't
+  die. The next launch mirrors them straight back as tabs.
+- **Thin-client GUI**: when enabled, each window attaches to the daemon over a loopback WebSocket and
+  renders its sessions; keystrokes and resizes flow back to the daemon, which owns the PTYs. If the
+  daemon is unreachable, the GUI falls back to local tabs so you're never stuck.
+- **MCP + sharing stay live headless**: the daemon hosts the [MCP server](#bossterm-mcp) and
+  [session sharing](#session-sharing), so agents and share links keep working with no window open. A
+  menu-bar / tray icon shows it's running and lets you open the GUI or quit the daemon.
+- **Start at login** (optional, on by default when you enable the daemon): installs a per-OS login
+  service (launchd LaunchAgent / systemd user unit / Windows Run key) so the daemon is available even
+  before BossTerm is first opened or after a reboot. The separate toggle turns this off without
+  disabling the daemon. On a shared/multi-user host, note the loopback MCP endpoint is then reachable
+  by any process running as you whenever you're logged in.
+- **Secure by construction**: loopback-only, gated by a 256-bit per-launch secret (constant-time
+  compare, sent in a header — never the query string), DNS-rebinding `Host` guards on every server,
+  owner-only (`0600`) discovery/secret files in a `0700` base dir, and a `FileChannel.tryLock`
+  single-spawn guard. SESSION-scoped shares are write-isolated to their one session.
+
+Enable it under **Settings → Session Daemon** (takes effect after restarting BossTerm). The daemon
+never stops when you close the GUI — only via **Quit daemon**, or OS logout.
 
 ## Technology Stack
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ cd BossTerm
 - **Session Sharing** - Watch or control a tab / window / all windows from any device — self-hosted, with a QR code and a mobile-friendly web viewer (LAN, Tailscale, or a zero-config Cloudflare tunnel)
 - **Remote Control** - End-to-end encrypted; viewers get typing access on approval, or connect from another BossTerm as a native remote client
 - **AI / MCP Server** - Built-in [Model Context Protocol](https://modelcontextprotocol.io) server exposes your terminals to Claude Code, Codex, Gemini CLI, and OpenCode
-- **Session Daemon** - Opt-in tmux-style background process keeps your sessions, MCP server, and shares alive after the GUI closes — reopen to reattach; optional start-at-login
+- **Session Daemon** - tmux-style background process (on by default) keeps your sessions, MCP server, and shares alive after the GUI closes — reopen to reattach; starts at login
 - **Embeddable** - Drop the terminal into your own Kotlin/Compose Desktop app as a library (`com.risaboss:bossterm-compose`)
 
 ## Keyboard Shortcuts
@@ -604,8 +604,9 @@ every built-in tool's JSON schema, the `manage_tools` meta-tool, the
 ## Session Daemon
 
 A tmux-style background process that **owns your terminal sessions, MCP server, and shares** so they
-keep running after you close the GUI — reopen BossTerm and it reattaches to the live sessions. Opt-in
-and **off by default**; with the daemon off, BossTerm is byte-for-byte the same as before.
+keep running after you close the GUI — reopen BossTerm and it reattaches to the live sessions. **On by
+default**; turn it off under Settings → Session Daemon to fall back to the pre-daemon behavior
+(in-process MCP/sharing, sessions die with the window), a path that's preserved byte-for-byte.
 
 - **Survives the GUI**: sessions live in the daemon, not the window. Close the app (or all its
   windows) and your shells keep running — long builds, SSH sessions, and `run_command` agents don't
@@ -616,18 +617,18 @@ and **off by default**; with the daemon off, BossTerm is byte-for-byte the same 
 - **MCP + sharing stay live headless**: the daemon hosts the [MCP server](#bossterm-mcp) and
   [session sharing](#session-sharing), so agents and share links keep working with no window open. A
   menu-bar / tray icon shows it's running and lets you open the GUI or quit the daemon.
-- **Start at login** (optional, on by default when you enable the daemon): installs a per-OS login
-  service (launchd LaunchAgent / systemd user unit / Windows Run key) so the daemon is available even
-  before BossTerm is first opened or after a reboot. The separate toggle turns this off without
-  disabling the daemon. On a shared/multi-user host, note the loopback MCP endpoint is then reachable
-  by any process running as you whenever you're logged in.
+- **Starts at login** (on by default): installs a per-OS login service (launchd LaunchAgent / systemd
+  user unit / Windows Run key) so the daemon is available even before BossTerm is first opened or after
+  a reboot. A separate **Start daemon at login** toggle turns this off without disabling the daemon. On
+  a shared/multi-user host, note the loopback MCP endpoint is then reachable by any process running as
+  you whenever you're logged in.
 - **Secure by construction**: loopback-only, gated by a 256-bit per-launch secret (constant-time
   compare, sent in a header — never the query string), DNS-rebinding `Host` guards on every server,
   owner-only (`0600`) discovery/secret files in a `0700` base dir, and a `FileChannel.tryLock`
   single-spawn guard. SESSION-scoped shares are write-isolated to their one session.
 
-Enable it under **Settings → Session Daemon** (takes effect after restarting BossTerm). The daemon
-never stops when you close the GUI — only via **Quit daemon**, or OS logout.
+Manage it under **Settings → Session Daemon** (toggles take effect after restarting BossTerm). The
+daemon never stops when you close the GUI — only via **Quit daemon**, or OS logout.
 
 ## Technology Stack
 

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -106,9 +106,9 @@ fun main(args: Array<String>) {
     }
 
     // Session daemon (tmux-style): when enabled, a long-lived background process owns the MCP
-    // server (and, in later phases, sessions + sharing) so they survive the GUI closing. The GUI
-    // then does NOT host the in-process MCP — the daemon owns the loopback endpoint + mcp.port.
-    // Default off: BossTerm behaves exactly as before until the user opts in.
+    // server, sessions, and sharing so they survive the GUI closing. The GUI then does NOT host the
+    // in-process MCP — the daemon owns the loopback endpoint + mcp.port. On by default; set
+    // daemonEnabled=false to fall back to the pre-daemon path (in-process, sessions die with the window).
     val daemonEnabled = SettingsManager.instance.settings.value.daemonEnabled
     val daemonScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     val daemonClient = if (daemonEnabled) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -906,13 +906,13 @@ data class TerminalSettings(
 
     /**
      * Master switch for the BossTerm session daemon — a long-lived background process that owns
-     * terminal sessions, the MCP server, and (later) session sharing, so they survive the GUI
-     * closing. Defaults to false for opt-in safety: when off, BossTerm behaves exactly as before
-     * (in-process MCP/sharing, sessions die with the window). When on, the GUI spawns/connects the
-     * daemon and hosts MCP there instead. The daemon is started on-demand by the GUI; see also
-     * [startDaemonAtLogin] for an always-on service.
+     * terminal sessions, the MCP server, and session sharing, so they survive the GUI closing.
+     * Defaults to true: the GUI spawns/connects the daemon and hosts MCP there, and sessions outlive
+     * the window. Set to false to fall back to the pre-daemon behavior (in-process MCP/sharing,
+     * sessions die with the window) — that path is preserved byte-for-byte. The daemon is started
+     * on-demand by the GUI; see also [startDaemonAtLogin] for an always-on at-login service.
      */
-    val daemonEnabled: Boolean = false,
+    val daemonEnabled: Boolean = true,
 
     /**
      * Install a per-OS login service (macOS LaunchAgent / Linux systemd user unit / Windows Run

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/DaemonSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/DaemonSettingsSection.kt
@@ -34,8 +34,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
- * Session-daemon settings: opt into the tmux-style background daemon, install it as a login
- * service, and see/control its status. The daemon owns terminal sessions + MCP (+ later sharing)
+ * Session-daemon settings: toggle the tmux-style background daemon (on by default), install/remove
+ * its login service, and see/control its status. The daemon owns terminal sessions + MCP + sharing
  * so they survive the GUI closing. [TerminalSettings.daemonEnabled] is read at app startup, so
  * toggling it needs a restart — surfaced in the note.
  */


### PR DESCRIPTION
Follow-up to #297 (merged). Two changes that landed after that PR was squash-merged:

## Enable the session daemon by default
- `TerminalSettings.daemonEnabled` flipped `false → true` (`startDaemonAtLogin` already defaults `true`). A fresh install now runs the tmux-style daemon — sessions, MCP, and sharing survive the GUI closing — and installs the at-login service on first launch.
- Setting `daemonEnabled=false` falls back to the pre-daemon in-process path, which stays **byte-for-byte unchanged**.
- Updated the now-stale "off by default / opt-in" wording in `TerminalSettings`, `Main.kt`, and `DaemonSettingsSection`.

## Document the session daemon in the README
- New **Session Daemon** section + a Features bullet: survives-the-GUI sessions, the thin-client GUI model, MCP + sharing staying live headless, start-at-login, and the loopback/secret/`Host`-guard/scope-isolation security posture.

### Note on the default
This intentionally reverses the off-by-default posture from #297. Implications, by design:
- Fresh installs spawn a background daemon and install an OS login service (launchd / systemd user unit / Windows Run key) on first launch — always-on across reboots.
- On shared/multi-user hosts, the loopback MCP endpoint is reachable by any same-user process while you're logged in (documented in the README caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)