### PR TITLE
feat: Supabase Realtime update source with GitHub backup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -502,6 +502,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Publish release to Supabase Storage
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          BOSSTERM_UPDATE_BUCKET: ${{ vars.BOSSTERM_UPDATE_BUCKET }}
+          VERSION: ${{ needs.prepare-version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Non-breaking: until the Supabase service-role secret is configured this
+          # step is a silent no-op, so adding it can't break existing releases.
+          if [[ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
+            echo "ℹ️  SUPABASE_SERVICE_ROLE_KEY not set; skipping Supabase publish."
+            exit 0
+          fi
+          export SUPABASE_URL="${SUPABASE_URL:-https://api.risaboss.com}"
+          BUCKET="${BOSSTERM_UPDATE_BUCKET:-app-releases}"
+
+          echo "📤 Publishing BossTerm $VERSION to Supabase bucket '$BUCKET'"
+          # release.yml publishes stable releases (prerelease: false).
+          bash scripts/publish-supabase-release.sh bossterm "$VERSION" stable release-assets "$BUCKET"
+
   update-homebrew:
     needs: [prepare-version, create-release]
     # Run if: not publish_only AND create-release succeeded

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,6 +508,8 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           BOSSTERM_UPDATE_BUCKET: ${{ vars.BOSSTERM_UPDATE_BUCKET }}
           VERSION: ${{ needs.prepare-version.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -519,6 +521,11 @@ jobs:
           fi
           export SUPABASE_URL="${SUPABASE_URL:-https://api.risaboss.com}"
           BUCKET="${BOSSTERM_UPDATE_BUCKET:-app-releases}"
+
+          # Capture the just-created GitHub release body so app_releases.release_notes
+          # isn't blank (release.yml builds the body inline, not into a file).
+          gh release view "v$VERSION" --repo "$REPO" --json body --jq .body \
+            > release-assets/release-body.txt 2>/dev/null || true
 
           echo "📤 Publishing BossTerm $VERSION to Supabase bucket '$BUCKET'"
           # release.yml publishes stable releases (prerelease: false).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ env:
   JAVA_VERSION: '17'
   JAVA_DISTRIBUTION: 'temurin'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.caching=true'
+  # Baked into the packaged app launcher (see bossterm-app/build.gradle.kts) so the
+  # self-updater uses the Supabase update source at runtime. Absent in local/dev builds
+  # -> the updater falls back to GitHub. The anon key is the public, RLS-gated key.
+  SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
 
 jobs:
   prepare-version:

--- a/bossterm-app/build.gradle.kts
+++ b/bossterm-app/build.gradle.kts
@@ -183,6 +183,18 @@ compose.desktop {
                 "-Dawt.useSystemAAFontSettings=on",
                 "-Dsun.java2d.xrender=true"
             )
+
+            // Bake the Supabase config into the packaged app launcher so the self-updater
+            // can use the Supabase update source at runtime (UpdateSourceConfig reads these
+            // as system properties). CI provides them from repo secrets via env; local/dev
+            // builds leave them unset, so the updater falls back to GitHub. The anon key is
+            // the public, RLS-gated key, so embedding it in the distributed binary is expected.
+            System.getenv("SUPABASE_ANON_KEY")?.takeIf { it.isNotBlank() }?.let {
+                jvmArgs += "-DSUPABASE_ANON_KEY=$it"
+            }
+            System.getenv("SUPABASE_URL")?.takeIf { it.isNotBlank() }?.let {
+                jvmArgs += "-DSUPABASE_URL=$it"
+            }
         }
 
         // ProGuard configuration for release builds

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -367,7 +367,10 @@ fun main(args: Array<String>) {
                         }
                     }
 
-                    // Check for updates on first window launch
+                    // Check for updates on first window launch, then subscribe to
+                    // Supabase Realtime so later releases push an update check
+                    // instantly (no polling). The startup check is the catch-up for
+                    // releases published while the app was closed.
                     var hasCheckedForUpdates by remember { mutableStateOf(false) }
                     LaunchedEffect(Unit) {
                         if (!hasCheckedForUpdates) {
@@ -375,6 +378,7 @@ fun main(args: Array<String>) {
                             if (updateManager.shouldCheckForUpdates()) {
                                 updateManager.checkForUpdates()
                             }
+                            updateManager.startRealtimePush()
                         }
                     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,11 @@
 plugins {
-    kotlin("jvm") version "2.1.21" apply false
+    // Kotlin 2.2.20: bumped from 2.1.21 so this module can consume supabase-kt 3.6.0
+    // (its 2.3.0 metadata is readable by a 2.2.x compiler). Compose Multiplatform stays
+    // on 1.9.3 — only the Kotlin/Compose-compiler version moves, so the Compose runtime
+    // API surface is unchanged.
+    kotlin("jvm") version "2.2.20" apply false
     id("org.jetbrains.compose") version "1.9.3" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.1.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.20" apply false
     id("com.android.library") version "8.5.2" apply false
     id("com.vanniktech.maven.publish") version "0.30.0" apply false
 }

--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     kotlin("multiplatform")
     id("org.jetbrains.compose")
     id("org.jetbrains.kotlin.plugin.compose")
-    kotlin("plugin.serialization") version "2.1.21"
+    kotlin("plugin.serialization") version "2.2.20"
     id("com.vanniktech.maven.publish")
 }
 
@@ -117,6 +117,12 @@ kotlin {
                 implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
                 // WebSocket client — native viewer that connects to a remote BossTerm share.
                 implementation("io.ktor:ktor-client-websockets:$ktorVersion")
+
+                // Supabase Realtime — push notifications for new app releases so the
+                // self-updater learns about them instantly instead of polling GitHub.
+                // Realtime only; the release catalog is fetched via plain Ktor REST.
+                // 3.6.0 matches BossConsole; requires the Kotlin 2.2.x bump above.
+                implementation("io.github.jan-tennert.supabase:realtime-kt:3.6.0")
 
                 // MCP (Model Context Protocol) server + Ktor CIO server backend.
                 // `api` for the SDK because BossTermMcpConfig's additionalTools

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/AppUpdateRealtimeService.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/AppUpdateRealtimeService.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Pushes BossTerm release notifications via Supabase Realtime so the app learns
@@ -32,8 +33,9 @@ class AppUpdateRealtimeService(
 ) {
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
-    private var client: SupabaseClient? = null
-    private var channel: RealtimeChannel? = null
+    // Touched from start()/stop() and the subscribe + triggerCheck coroutines.
+    @Volatile private var client: SupabaseClient? = null
+    @Volatile private var channel: RealtimeChannel? = null
 
     /**
      * Invoked when a release row for [appId] changes, and once on every successful
@@ -60,8 +62,8 @@ class AppUpdateRealtimeService(
             println("[update] starting realtime push: $fullUrl")
             client = createSupabaseClient(supabaseUrl = fullUrl, supabaseKey = anonKey) {
                 install(Realtime) {
-                    heartbeatInterval = kotlin.time.Duration.parse("30s")
-                    reconnectDelay = kotlin.time.Duration.parse("7s")
+                    heartbeatInterval = 30.seconds
+                    reconnectDelay = 7.seconds
                 }
             }
             subscribe()
@@ -79,12 +81,13 @@ class AppUpdateRealtimeService(
                 try {
                     val c = client ?: return@launch
 
-                    channel = c.channel("app-releases-changes")
-                    val changeFlow = channel!!.postgresChangeFlow<PostgresAction>(schema = "public") {
+                    val ch = c.channel("app-releases-changes")
+                    channel = ch
+                    val changeFlow = ch.postgresChangeFlow<PostgresAction>(schema = "public") {
                         table = "app_releases"
                     }
 
-                    channel!!.subscribe()
+                    ch.subscribe()
                     backoffMs = 5_000L
                     println("[update] subscribed to app_releases changes")
 
@@ -98,15 +101,19 @@ class AppUpdateRealtimeService(
                             else -> {}
                         }
                     }
+                    println("[update] app_releases subscription closed; will resubscribe")
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    println("[update] app_releases subscription lost, reconnecting in ${backoffMs}ms: ${e.message}")
-                    try { channel?.unsubscribe() } catch (_: Exception) {}
-                    channel = null
-                    delay(backoffMs)
-                    backoffMs = (backoffMs * 2).coerceAtMost(maxBackoffMs)
+                    println("[update] app_releases subscription lost: ${e.message}")
                 }
+                // Normal close OR error: unsubscribe the old channel (don't leak it) and
+                // back off before reconnecting so a repeatedly-completing flow can't busy-spin.
+                try { channel?.unsubscribe() } catch (_: Exception) {}
+                channel = null
+                if (!isActive) break
+                delay(backoffMs)
+                backoffMs = (backoffMs * 2).coerceAtMost(maxBackoffMs)
             }
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/AppUpdateRealtimeService.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/AppUpdateRealtimeService.kt
@@ -1,0 +1,152 @@
+package ai.rever.bossterm.compose.update
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.realtime.PostgresAction
+import io.github.jan.supabase.realtime.Realtime
+import io.github.jan.supabase.realtime.RealtimeChannel
+import io.github.jan.supabase.realtime.channel
+import io.github.jan.supabase.realtime.postgresChangeFlow
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Pushes BossTerm release notifications via Supabase Realtime so the app learns
+ * about new versions instantly instead of polling. Subscribes to `postgres_changes`
+ * on the shared `app_releases` table (filtered client-side by app id) and invokes
+ * [onReleaseChanged] on each INSERT/UPDATE and on every (re)connect (catch-up).
+ *
+ * Dedicated, isolated Realtime client with exponential-backoff reconnect. Disabled
+ * unless a Supabase anon key is configured (see [UpdateSourceConfig]).
+ */
+class AppUpdateRealtimeService(
+    private val supabaseUrl: String = UpdateSourceConfig.supabaseUrl,
+    private val anonKey: String = UpdateSourceConfig.anonKey,
+    private val appId: String = UpdateSourceConfig.appId
+) {
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    private var client: SupabaseClient? = null
+    private var channel: RealtimeChannel? = null
+
+    /**
+     * Invoked when a release row for [appId] changes, and once on every successful
+     * (re)connect. Wire this to UpdateManager.checkForUpdates().
+     */
+    var onReleaseChanged: (suspend () -> Unit)? = null
+
+    companion object {
+        val instance: AppUpdateRealtimeService by lazy { AppUpdateRealtimeService() }
+    }
+
+    fun start() {
+        if (!UpdateSourceConfig.supabaseEnabled) {
+            println("[update] realtime disabled (no Supabase anon key or source=github)")
+            return
+        }
+        if (client != null) return
+        try {
+            val fullUrl = if (supabaseUrl.startsWith("http://") || supabaseUrl.startsWith("https://")) {
+                supabaseUrl
+            } else {
+                "https://$supabaseUrl"
+            }
+            println("[update] starting realtime push: $fullUrl")
+            client = createSupabaseClient(supabaseUrl = fullUrl, supabaseKey = anonKey) {
+                install(Realtime) {
+                    heartbeatInterval = kotlin.time.Duration.parse("30s")
+                    reconnectDelay = kotlin.time.Duration.parse("7s")
+                }
+            }
+            subscribe()
+        } catch (e: Exception) {
+            println("[update] failed to start realtime: ${e.message}")
+        }
+    }
+
+    private fun subscribe() {
+        scope.launch {
+            var backoffMs = 5_000L
+            val maxBackoffMs = 60_000L
+
+            while (isActive) {
+                try {
+                    val c = client ?: return@launch
+
+                    channel = c.channel("app-releases-changes")
+                    val changeFlow = channel!!.postgresChangeFlow<PostgresAction>(schema = "public") {
+                        table = "app_releases"
+                    }
+
+                    channel!!.subscribe()
+                    backoffMs = 5_000L
+                    println("[update] subscribed to app_releases changes")
+
+                    // Catch-up for releases published while disconnected/closed.
+                    triggerCheck()
+
+                    changeFlow.collect { action ->
+                        when (action) {
+                            is PostgresAction.Insert -> handleRecord(action.record["app"], action.record["version"])
+                            is PostgresAction.Update -> handleRecord(action.record["app"], action.record["version"])
+                            else -> {}
+                        }
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    println("[update] app_releases subscription lost, reconnecting in ${backoffMs}ms: ${e.message}")
+                    try { channel?.unsubscribe() } catch (_: Exception) {}
+                    channel = null
+                    delay(backoffMs)
+                    backoffMs = (backoffMs * 2).coerceAtMost(maxBackoffMs)
+                }
+            }
+        }
+    }
+
+    private fun handleRecord(appElement: Any?, versionElement: Any?) {
+        val app = appElement?.toString()?.removeSurrounding("\"")
+        if (app != null && app != appId) return  // shared table: ignore other apps
+        val version = versionElement?.toString()?.removeSurrounding("\"") ?: ""
+        println("[update] release change received: $version")
+        triggerCheck()
+    }
+
+    private fun triggerCheck() {
+        scope.launch {
+            try {
+                onReleaseChanged?.invoke()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                println("[update] error running update check from realtime event: ${e.message}")
+            }
+        }
+    }
+
+    fun stop() {
+        scope.launch {
+            try {
+                channel?.unsubscribe()
+                client?.close()
+            } catch (e: Exception) {
+                println("[update] error stopping realtime: ${e.message}")
+            } finally {
+                channel = null
+                client = null
+            }
+        }
+    }
+
+    fun dispose() {
+        stop()
+        scope.cancel()
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/DesktopUpdateService.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/DesktopUpdateService.kt
@@ -36,6 +36,9 @@ class DesktopUpdateService {
     /** Supabase primary, GitHub backup (overridable via BOSSTERM_UPDATE_PRIMARY_SOURCE). */
     private val source: UpdateSource = buildSource()
 
+    /** Dedicated GitHub source used only to recover a download if the primary URL fails. */
+    private val gitHubSource = GitHubUpdateSource()
+
     private fun buildSource(): UpdateSource {
         val src = when {
             UpdateSourceConfig.primarySource == "github" || !UpdateSourceConfig.supabaseEnabled -> GitHubUpdateSource()
@@ -160,30 +163,53 @@ class DesktopUpdateService {
     }
 
     /**
-     * Download an update.
+     * Download an update. Tries the source-provided URL (Supabase Storage when Supabase
+     * is primary); if that fails, recovers via the GitHub asset for the same version.
      */
     suspend fun downloadUpdate(
         updateInfo: UpdateInfo,
         onProgress: (progress: Float) -> Unit
     ): String? {
-        return try {
-            val downloadUrl = updateInfo.downloadUrl ?: return null
+        val primaryUrl = updateInfo.downloadUrl ?: return null
 
-            println("Starting download from: $downloadUrl")
+        downloadFrom(primaryUrl, updateInfo.assetName, updateInfo.assetSize, updateInfo.sha256, onProgress)
+            ?.let { return it }
+
+        // The fallback chain is metadata-only: once Supabase serves the catalog, the
+        // download URL is a Storage URL with no recovery. If that fails (e.g. the bucket
+        // isn't public/reachable) recover via the GitHub asset for the same version.
+        val gitHubUrl = gitHubAssetUrlFor(updateInfo.latestVersion)
+        if (gitHubUrl != null && gitHubUrl != primaryUrl) {
+            println("[update] primary download failed; falling back to GitHub asset")
+            return downloadFrom(gitHubUrl, updateInfo.assetName, updateInfo.assetSize, sha256 = null, onProgress)
+        }
+        return null
+    }
+
+    /** Download [url] to a temp file, verifying [sha256] when provided. Returns the path or null. */
+    private suspend fun downloadFrom(
+        url: String,
+        assetName: String,
+        assetSize: Long,
+        sha256: String?,
+        onProgress: (progress: Float) -> Unit
+    ): String? {
+        return try {
+            println("Starting download from: $url")
 
             val tempDir = File(System.getProperty("java.io.tmpdir"), "bossterm-updates")
             tempDir.mkdirs()
 
-            val downloadFile = File(tempDir, updateInfo.assetName)
+            val downloadFile = File(tempDir, assetName)
             if (downloadFile.exists()) {
                 downloadFile.delete()
             }
 
-            streamToFile(downloadUrl, updateInfo.assetSize, downloadFile, onProgress)
+            streamToFile(url, assetSize, downloadFile, onProgress)
 
             if (downloadFile.exists() && downloadFile.length() > 0) {
-                if (!verifyChecksum(downloadFile, updateInfo.sha256)) {
-                    println("❌ Checksum mismatch; discarding download: ${updateInfo.assetName}")
+                if (!verifyChecksum(downloadFile, sha256)) {
+                    println("❌ Checksum mismatch; discarding download: $assetName")
                     downloadFile.delete()
                     return null
                 }
@@ -198,7 +224,25 @@ class DesktopUpdateService {
         }
     }
 
-    /** Verify [file] against [expectedSha] (lowercase hex). No-op when null/blank. */
+    /** Resolve the GitHub Releases asset URL for [version] — the download-time backup. */
+    private suspend fun gitHubAssetUrlFor(version: Version): String? = try {
+        val expected = getExpectedAssetName(version)
+        gitHubSource.listReleases()
+            .firstOrNull { Version.parse(it.tag_name) == version }
+            ?.assets?.firstOrNull { it.name.equals(expected, ignoreCase = true) }
+            ?.browser_download_url
+    } catch (e: Exception) {
+        println("[update] could not resolve GitHub fallback asset: ${e.message}")
+        null
+    }
+
+    /**
+     * Verify [file] against [expectedSha] (lowercase hex). No-op when null/blank.
+     *
+     * Integrity check, not authenticity: the hash and the download URL come from the
+     * same app_releases row, so this catches Storage/CDN corruption, not a compromised
+     * catalog. Update authenticity still rests on OS code-signing.
+     */
     private fun verifyChecksum(file: File, expectedSha: String?): Boolean {
         if (expectedSha.isNullOrBlank()) return true
         val actual = sha256Of(file)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/DesktopUpdateService.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/DesktopUpdateService.kt
@@ -1,40 +1,29 @@
 package ai.rever.bossterm.compose.update
 
+import ai.rever.bossterm.compose.update.source.FallbackUpdateSource
+import ai.rever.bossterm.compose.update.source.GitHubUpdateSource
+import ai.rever.bossterm.compose.update.source.SupabaseUpdateSource
+import ai.rever.bossterm.compose.update.source.UpdateSource
 import io.ktor.client.*
-import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
-import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
-import io.ktor.serialization.kotlinx.json.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import java.io.File
+import java.security.MessageDigest
 
 /**
- * Desktop implementation of update service using GitHub Releases API.
+ * Desktop update service. Release metadata comes from the configured [UpdateSource]
+ * — Supabase primary (Realtime-fed `app_releases` catalog), GitHub Releases backup —
+ * while binaries are streamed from whichever URL the chosen source provides.
  */
 class DesktopUpdateService {
-
-    private val apiClient = HttpClient(CIO) {
-        install(ContentNegotiation) {
-            json(Json {
-                ignoreUnknownKeys = true
-                isLenient = true
-            })
-        }
-        install(HttpTimeout) {
-            requestTimeoutMillis = 30_000
-            connectTimeoutMillis = 15_000
-            socketTimeoutMillis = 15_000
-        }
-    }
 
     private val downloadClient = HttpClient(CIO) {
         install(HttpTimeout) {
@@ -44,50 +33,43 @@ class DesktopUpdateService {
         }
     }
 
-    companion object {
-        private const val GITHUB_API_BASE = "https://api.github.com"
-        private const val RELEASES_REPO = "kshivang/BossTerm"
-        private const val RELEASES_ENDPOINT = "$GITHUB_API_BASE/repos/$RELEASES_REPO/releases"
+    /** Supabase primary, GitHub backup (overridable via BOSSTERM_UPDATE_PRIMARY_SOURCE). */
+    private val source: UpdateSource = buildSource()
+
+    private fun buildSource(): UpdateSource {
+        val src = when {
+            UpdateSourceConfig.primarySource == "github" || !UpdateSourceConfig.supabaseEnabled -> GitHubUpdateSource()
+            UpdateSourceConfig.primarySource == "supabase-only" -> SupabaseUpdateSource()
+            else -> FallbackUpdateSource(primary = SupabaseUpdateSource(), backup = GitHubUpdateSource())
+        }
+        println("[update] source configured: ${src.name}")
+        return src
     }
 
+    private fun upToDate(): UpdateInfo = UpdateInfo(
+        available = false,
+        currentVersion = Version.CURRENT,
+        latestVersion = Version.CURRENT,
+        releaseNotes = ""
+    )
+
     /**
-     * Fetch all available releases from GitHub.
-     * Used for version selection in About section.
+     * Fetch all available releases (for version selection in About). Filtering and
+     * sorting happen here so the underlying source stays format-only.
      */
     suspend fun getAllReleases(includePreReleases: Boolean = false): Result<List<GitHubRelease>> {
         return try {
-            val response = apiClient.get(RELEASES_ENDPOINT) {
-                headers {
-                    append("Accept", "application/vnd.github.v3+json")
-                    append("User-Agent", "BossTerm-Desktop-${Version.CURRENT}")
-                    GitHubConfig.token?.let { append("Authorization", "Bearer $it") }
-                }
-            }
-
-            if (response.status.value !in 200..299) {
-                val errorBody = response.bodyAsText()
-                val errorMessage = when {
-                    errorBody.contains("rate limit", ignoreCase = true) ->
-                        "GitHub API rate limit exceeded. Please try again later."
-                    else -> "Unable to fetch releases (HTTP ${response.status.value})"
-                }
-                return Result.failure(Exception(errorMessage))
-            }
-
-            val releases = response.body<List<GitHubRelease>>()
-            val filteredReleases = releases
+            val filtered = source.listReleases()
                 .filter { !it.draft && (includePreReleases || !it.prerelease) }
                 .sortedByDescending { Version.parse(it.tag_name) }
-
-            Result.success(filteredReleases)
+            Result.success(filtered)
         } catch (e: Exception) {
             Result.failure(e)
         }
     }
 
     /**
-     * Download a specific release version.
-     * Returns the path to the downloaded file.
+     * Download a specific release version. Returns the path to the downloaded file.
      */
     suspend fun downloadRelease(
         release: GitHubRelease,
@@ -115,6 +97,10 @@ class DesktopUpdateService {
             streamToFile(downloadUrl, asset.size, downloadFile, onProgress)
 
             if (downloadFile.exists() && downloadFile.length() > 0) {
+                if (!verifyChecksum(downloadFile, asset.sha256)) {
+                    downloadFile.delete()
+                    return Result.failure(Exception("Checksum verification failed for ${asset.name}"))
+                }
                 Result.success(downloadFile.absolutePath)
             } else {
                 Result.failure(Exception("Download failed: file is empty"))
@@ -129,37 +115,7 @@ class DesktopUpdateService {
      */
     suspend fun checkForUpdates(): UpdateInfo {
         return try {
-            if (GitHubConfig.hasToken) {
-                println("✅ Using authenticated GitHub API (5,000 requests/hour)")
-            } else {
-                println("⚠️ Using unauthenticated GitHub API (60 requests/hour)")
-            }
-
-            val response = apiClient.get(RELEASES_ENDPOINT) {
-                headers {
-                    append("Accept", "application/vnd.github.v3+json")
-                    append("User-Agent", "BossTerm-Desktop-${Version.CURRENT}")
-                    GitHubConfig.token?.let { append("Authorization", "Bearer $it") }
-                }
-            }
-
-            if (response.status.value !in 200..299) {
-                val errorBody = response.bodyAsText()
-                val errorMessage = when {
-                    errorBody.contains("rate limit", ignoreCase = true) ->
-                        "GitHub API rate limit exceeded. Please try again later."
-                    else -> "Unable to check for updates (HTTP ${response.status.value})"
-                }
-                println("Update check failed: $errorMessage")
-                return UpdateInfo(
-                    available = false,
-                    currentVersion = Version.CURRENT,
-                    latestVersion = Version.CURRENT,
-                    releaseNotes = ""
-                )
-            }
-
-            val releases = response.body<List<GitHubRelease>>()
+            val releases = source.listReleases()
 
             val latestRelease = releases
                 .filter { !it.draft && !it.prerelease }
@@ -168,24 +124,9 @@ class DesktopUpdateService {
                 }
                 .maxByOrNull { it.second }
                 ?.first
+                ?: return upToDate()
 
-            if (latestRelease == null) {
-                return UpdateInfo(
-                    available = false,
-                    currentVersion = Version.CURRENT,
-                    latestVersion = Version.CURRENT,
-                    releaseNotes = ""
-                )
-            }
-
-            val latestVersion = Version.parse(latestRelease.tag_name)
-                ?: return UpdateInfo(
-                    available = false,
-                    currentVersion = Version.CURRENT,
-                    latestVersion = Version.CURRENT,
-                    releaseNotes = ""
-                )
-
+            val latestVersion = Version.parse(latestRelease.tag_name) ?: return upToDate()
             val isUpdateAvailable = latestVersion.isNewerThan(Version.CURRENT)
 
             val expectedAssetName = getExpectedAssetName(latestVersion)
@@ -209,16 +150,12 @@ class DesktopUpdateService {
                 releaseNotes = latestRelease.body,
                 downloadUrl = asset?.browser_download_url,
                 assetSize = asset?.size ?: 0,
-                assetName = asset?.name ?: ""
+                assetName = asset?.name ?: "",
+                sha256 = asset?.sha256
             )
         } catch (e: Exception) {
             println("Error checking for updates: ${e.message}")
-            UpdateInfo(
-                available = false,
-                currentVersion = Version.CURRENT,
-                latestVersion = Version.CURRENT,
-                releaseNotes = ""
-            )
+            upToDate()
         }
     }
 
@@ -245,6 +182,11 @@ class DesktopUpdateService {
             streamToFile(downloadUrl, updateInfo.assetSize, downloadFile, onProgress)
 
             if (downloadFile.exists() && downloadFile.length() > 0) {
+                if (!verifyChecksum(downloadFile, updateInfo.sha256)) {
+                    println("❌ Checksum mismatch; discarding download: ${updateInfo.assetName}")
+                    downloadFile.delete()
+                    return null
+                }
                 println("Update downloaded successfully: ${downloadFile.absolutePath}")
                 downloadFile.absolutePath
             } else {
@@ -254,6 +196,32 @@ class DesktopUpdateService {
             println("Error downloading update: ${e.message}")
             null
         }
+    }
+
+    /** Verify [file] against [expectedSha] (lowercase hex). No-op when null/blank. */
+    private fun verifyChecksum(file: File, expectedSha: String?): Boolean {
+        if (expectedSha.isNullOrBlank()) return true
+        val actual = sha256Of(file)
+        val ok = actual.equals(expectedSha, ignoreCase = true)
+        if (ok) {
+            println("✅ Checksum verified for ${file.name}")
+        } else {
+            println("❌ Checksum mismatch for ${file.name}: expected $expectedSha, got $actual")
+        }
+        return ok
+    }
+
+    private fun sha256Of(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(8192)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateManager.kt
@@ -71,6 +71,24 @@ class UpdateManager {
     }
 
     /**
+     * Start Supabase Realtime push so a newly published release triggers an update
+     * check the moment it lands — no polling. Idempotent; a no-op unless a Supabase
+     * anon key is configured (otherwise update checks rely on the GitHub backup).
+     * Call once at app startup.
+     */
+    fun startRealtimePush() {
+        AppUpdateRealtimeService.instance.onReleaseChanged = { checkForUpdates() }
+        AppUpdateRealtimeService.instance.start()
+    }
+
+    /**
+     * Stop the Realtime push subscription.
+     */
+    fun stopRealtimePush() {
+        AppUpdateRealtimeService.instance.dispose()
+    }
+
+    /**
      * Manually check for updates.
      */
     suspend fun checkForUpdates(): UpdateResult {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateManager.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.compose.update
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -82,20 +83,33 @@ class UpdateManager {
     }
 
     /**
-     * Stop the Realtime push subscription.
-     */
-    fun stopRealtimePush() {
-        AppUpdateRealtimeService.instance.dispose()
-    }
-
-    /**
      * Manually check for updates.
      */
     suspend fun checkForUpdates(): UpdateResult {
         return checkForUpdatesInternal()
     }
 
+    // Coalesces concurrent checks: the startup check and the Realtime on-connect
+    // catch-up fire near-simultaneously, and each Realtime event launches its own.
+    private val checkMutex = Mutex()
+
     private suspend fun checkForUpdatesInternal(): UpdateResult {
+        if (!checkMutex.tryLock()) {
+            val info = _updateInfo.value
+            return if (info != null && info.isNewerVersionAvailable) {
+                UpdateResult.UpdateAvailable(info)
+            } else {
+                UpdateResult.NoUpdateAvailable
+            }
+        }
+        return try {
+            runCheck()
+        } finally {
+            checkMutex.unlock()
+        }
+    }
+
+    private suspend fun runCheck(): UpdateResult {
         return try {
             _updateState.value = UpdateState.CheckingForUpdates
             _lastCheckTime.value = System.currentTimeMillis()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateService.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateService.kt
@@ -21,7 +21,11 @@ data class GitHubAsset(
     val name: String,
     val browser_download_url: String? = null,
     val size: Long = 0,
-    val content_type: String = ""
+    val content_type: String = "",
+    // Optional integrity hash. GitHub releases don't provide this (stays null);
+    // the Supabase source populates it from the `app_releases` row so the download
+    // can be verified.
+    val sha256: String? = null
 )
 
 /**
@@ -34,7 +38,10 @@ data class UpdateInfo(
     val releaseNotes: String,
     val downloadUrl: String? = null,
     val assetSize: Long = 0,
-    val assetName: String = ""
+    val assetName: String = "",
+    // Optional integrity hash (populated by the Supabase source). When present the
+    // download is verified against it before install.
+    val sha256: String? = null
 ) {
     val isNewerVersionAvailable: Boolean
         get() = available && latestVersion.isNewerThan(currentVersion)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateSourceConfig.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateSourceConfig.kt
@@ -1,0 +1,58 @@
+package ai.rever.bossterm.compose.update
+
+import java.io.File
+import java.util.Properties
+
+/**
+ * Configuration for BossTerm's update source (Supabase primary, GitHub backup).
+ *
+ * Values resolve through env var → system property → local.properties → default,
+ * mirroring [GitHubConfig].
+ *
+ * NOTE: BossTerm is a public repository, so no Supabase anon key is embedded here.
+ * The Supabase path is enabled only when SUPABASE_ANON_KEY is provided (CI/release
+ * builds inject it; local devs can set it in local.properties). When absent, update
+ * checks fall back to the GitHub Releases API automatically.
+ *
+ * Keys:
+ * - SUPABASE_URL                  (default https://api.risaboss.com)
+ * - SUPABASE_ANON_KEY             (default empty → Supabase disabled, GitHub-only)
+ * - BOSSTERM_UPDATE_BUCKET        (default "app-releases")
+ * - BOSSTERM_UPDATE_APP_ID        (default "bossterm")
+ * - BOSSTERM_UPDATE_PRIMARY_SOURCE: "supabase" (default), "github", "supabase-only"
+ */
+object UpdateSourceConfig {
+
+    private fun config(key: String, default: String): String =
+        resolve(key)?.takeIf { it.isNotBlank() } ?: default
+
+    private fun resolve(key: String): String? {
+        System.getenv(key)?.takeIf { it.isNotBlank() }?.let { return it }
+        System.getProperty(key)?.takeIf { it.isNotBlank() }?.let { return it }
+        try {
+            val localProps = File("local.properties")
+            if (localProps.exists()) {
+                val props = Properties()
+                localProps.inputStream().use { props.load(it) }
+                props.getProperty(key)?.takeIf { it.isNotBlank() }?.let { return it }
+            }
+        } catch (_: Exception) {
+            // Ignore errors reading local.properties
+        }
+        return null
+    }
+
+    val supabaseUrl: String by lazy { config("SUPABASE_URL", "https://api.risaboss.com") }
+    val anonKey: String by lazy { config("SUPABASE_ANON_KEY", "") }
+    val bucket: String by lazy { config("BOSSTERM_UPDATE_BUCKET", "app-releases") }
+    val appId: String by lazy { config("BOSSTERM_UPDATE_APP_ID", "bossterm") }
+    val primarySource: String by lazy { config("BOSSTERM_UPDATE_PRIMARY_SOURCE", "supabase").lowercase() }
+
+    /** True when Supabase can serve as a source (key present and not forced to GitHub). */
+    val supabaseEnabled: Boolean
+        get() = anonKey.isNotBlank() && primarySource != "github"
+
+    /** PostgREST base, e.g. https://api.risaboss.com/rest/v1 */
+    val restBaseUrl: String
+        get() = "${supabaseUrl.trimEnd('/')}/rest/v1"
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/source/FallbackUpdateSource.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/source/FallbackUpdateSource.kt
@@ -1,0 +1,41 @@
+package ai.rever.bossterm.compose.update.source
+
+import ai.rever.bossterm.compose.update.GitHubRelease
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Tries [primary] first; on a thrown error OR an empty result, falls back to
+ * [backup]. If the backup also fails, returns an empty list (treated as "up to
+ * date"). Cancellation propagates. Used as Supabase-primary / GitHub-backup.
+ */
+class FallbackUpdateSource(
+    private val primary: UpdateSource,
+    private val backup: UpdateSource
+) : UpdateSource {
+
+    override val name: String = "${primary.name}->${backup.name}"
+
+    override suspend fun listReleases(): List<GitHubRelease> {
+        try {
+            val releases = primary.listReleases()
+            if (releases.isNotEmpty()) {
+                println("[update] releases served by ${primary.name} (${releases.size})")
+                return releases
+            }
+            println("[update] ${primary.name} returned no releases; falling back to ${backup.name}")
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            println("[update] ${primary.name} failed (${e.message}); falling back to ${backup.name}")
+        }
+
+        return try {
+            backup.listReleases()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            println("[update] both update sources failed (${backup.name}: ${e.message})")
+            emptyList()
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/source/GitHubUpdateSource.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/source/GitHubUpdateSource.kt
@@ -1,0 +1,62 @@
+package ai.rever.bossterm.compose.update.source
+
+import ai.rever.bossterm.compose.update.GitHubConfig
+import ai.rever.bossterm.compose.update.GitHubRelease
+import ai.rever.bossterm.compose.update.Version
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.json.Json
+
+/**
+ * Backup [UpdateSource] backed by the GitHub Releases API (kshivang/BossTerm).
+ * The relocated single-GET fetch from DesktopUpdateService; non-2xx responses are
+ * surfaced as [UpdateSourceException] so [FallbackUpdateSource] can react.
+ */
+class GitHubUpdateSource(
+    private val apiClient: HttpClient = defaultApiClient()
+) : UpdateSource {
+
+    override val name: String = "github"
+
+    companion object {
+        private const val GITHUB_API_BASE = "https://api.github.com"
+        private const val RELEASES_REPO = "kshivang/BossTerm"
+        private const val RELEASES_ENDPOINT = "$GITHUB_API_BASE/repos/$RELEASES_REPO/releases"
+
+        private fun defaultApiClient(): HttpClient = HttpClient(CIO) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    isLenient = true
+                })
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 30_000
+                connectTimeoutMillis = 15_000
+                socketTimeoutMillis = 15_000
+            }
+        }
+    }
+
+    override suspend fun listReleases(): List<GitHubRelease> {
+        val response = apiClient.get(RELEASES_ENDPOINT) {
+            headers {
+                append("Accept", "application/vnd.github.v3+json")
+                append("User-Agent", "BossTerm-Desktop-${Version.CURRENT}")
+                GitHubConfig.token?.let { append("Authorization", "Bearer $it") }
+            }
+        }
+        if (response.status.value !in 200..299) {
+            val body = response.bodyAsText()
+            val detail = if (body.contains("rate limit", ignoreCase = true)) " - rate limit exceeded" else ""
+            throw UpdateSourceException("GitHub releases request failed (HTTP ${response.status.value})$detail")
+        }
+        return response.body()
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/source/SupabaseUpdateSource.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/source/SupabaseUpdateSource.kt
@@ -1,0 +1,106 @@
+package ai.rever.bossterm.compose.update.source
+
+import ai.rever.bossterm.compose.update.GitHubAsset
+import ai.rever.bossterm.compose.update.GitHubRelease
+import ai.rever.bossterm.compose.update.UpdateSourceConfig
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Primary [UpdateSource] backed by the Supabase `app_releases` table (queried over
+ * PostgREST). Binaries live in Supabase Storage; the row's asset URLs point at them.
+ * Plain Ktor REST keeps this independent of any shared Supabase client lifecycle.
+ */
+class SupabaseUpdateSource(
+    private val appId: String = UpdateSourceConfig.appId,
+    private val restBaseUrl: String = UpdateSourceConfig.restBaseUrl,
+    private val anonKey: String = UpdateSourceConfig.anonKey,
+    private val apiClient: HttpClient = defaultApiClient()
+) : UpdateSource {
+
+    override val name: String = "supabase"
+
+    companion object {
+        private const val MAX_RELEASES = 50
+
+        private fun defaultApiClient(): HttpClient = HttpClient(CIO) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    isLenient = true
+                })
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 30_000
+                connectTimeoutMillis = 15_000
+                socketTimeoutMillis = 15_000
+            }
+        }
+    }
+
+    override suspend fun listReleases(): List<GitHubRelease> {
+        if (anonKey.isBlank()) {
+            throw UpdateSourceException("Supabase anon key not configured")
+        }
+        val url = "$restBaseUrl/app_releases?app=eq.$appId&order=published_at.desc&limit=$MAX_RELEASES&select=*"
+        val response = apiClient.get(url) {
+            headers {
+                append("apikey", anonKey)
+                append(HttpHeaders.Authorization, "Bearer $anonKey")
+                append(HttpHeaders.Accept, "application/json")
+            }
+        }
+        if (response.status.value !in 200..299) {
+            throw UpdateSourceException("Supabase app_releases request failed (HTTP ${response.status.value})")
+        }
+        val rows: List<AppReleaseRow> = response.body()
+        return rows.map { it.toGitHubRelease() }
+    }
+}
+
+/** One row of the `app_releases` table. Field names match the PostgREST JSON. */
+@Serializable
+internal data class AppReleaseRow(
+    val app: String,
+    val version: String,
+    val channel: String = "stable",
+    val prerelease: Boolean = false,
+    @SerialName("release_notes") val releaseNotes: String = "",
+    val assets: List<AppReleaseAsset> = emptyList(),
+    @SerialName("published_at") val publishedAt: String = ""
+) {
+    fun toGitHubRelease(): GitHubRelease = GitHubRelease(
+        tag_name = "v$version",
+        name = version,
+        body = releaseNotes,
+        draft = false,
+        prerelease = prerelease,
+        published_at = publishedAt,
+        assets = assets.map { asset ->
+            GitHubAsset(
+                name = asset.name,
+                browser_download_url = asset.url,
+                size = asset.size,
+                content_type = "",
+                sha256 = asset.sha256
+            )
+        }
+    )
+}
+
+@Serializable
+internal data class AppReleaseAsset(
+    val name: String,
+    val url: String,
+    val size: Long = 0,
+    val sha256: String? = null
+)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/source/SupabaseUpdateSource.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/source/SupabaseUpdateSource.kt
@@ -51,7 +51,9 @@ class SupabaseUpdateSource(
         if (anonKey.isBlank()) {
             throw UpdateSourceException("Supabase anon key not configured")
         }
-        val url = "$restBaseUrl/app_releases?app=eq.$appId&order=published_at.desc&limit=$MAX_RELEASES&select=*"
+        // URL-encode the app id so an odd value can't corrupt the PostgREST query.
+        val url = "$restBaseUrl/app_releases?app=eq.${appId.encodeURLParameter()}" +
+            "&order=published_at.desc&limit=$MAX_RELEASES&select=*"
         val response = apiClient.get(url) {
             headers {
                 append("apikey", anonKey)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/source/UpdateSource.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/source/UpdateSource.kt
@@ -1,0 +1,22 @@
+package ai.rever.bossterm.compose.update.source
+
+import ai.rever.bossterm.compose.update.GitHubRelease
+
+/**
+ * Abstraction over "where release metadata comes from", normalizing each backend
+ * into the existing [GitHubRelease] shape so the update service's version-selection
+ * and platform-asset-matching logic is source-agnostic.
+ *
+ * Contract: transport/availability failures throw (so [FallbackUpdateSource] can try
+ * the backup); a successful-but-empty result is an empty list.
+ */
+interface UpdateSource {
+    /** Short identifier for logging, e.g. "supabase" / "github". */
+    val name: String
+
+    /** All known releases (unfiltered; callers apply prerelease/version filtering). */
+    suspend fun listReleases(): List<GitHubRelease>
+}
+
+/** Thrown by an [UpdateSource] when its backend is unreachable or returns an error. */
+class UpdateSourceException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/update/source/UpdateSourceTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/update/source/UpdateSourceTest.kt
@@ -1,0 +1,102 @@
+package ai.rever.bossterm.compose.update.source
+
+import ai.rever.bossterm.compose.update.GitHubRelease
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for BossTerm's update-source seam: Supabase `app_releases` row mapping and
+ * the Supabase-primary / GitHub-backup fallback behavior.
+ */
+class UpdateSourceTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    @Test
+    fun `app_releases row maps to GitHubRelease with assets and sha256`() {
+        val raw = """
+            {
+              "id": "11111111-1111-1111-1111-111111111111",
+              "app": "bossterm",
+              "version": "1.3.0",
+              "channel": "stable",
+              "prerelease": false,
+              "release_notes": "Faster rendering",
+              "assets": [
+                {"name": "BossTerm-1.3.0.dmg", "url": "https://cdn/bossterm/1.3.0/BossTerm-1.3.0.dmg", "size": 123456, "sha256": "cafebabe"}
+              ],
+              "published_at": "2026-07-01T00:00:00Z"
+            }
+        """.trimIndent()
+
+        val release = json.decodeFromString<AppReleaseRow>(raw).toGitHubRelease()
+
+        assertEquals("v1.3.0", release.tag_name)
+        assertEquals("Faster rendering", release.body)
+        assertFalse(release.prerelease)
+        assertEquals(1, release.assets.size)
+        val asset = release.assets.first()
+        assertEquals("BossTerm-1.3.0.dmg", asset.name)
+        assertEquals("https://cdn/bossterm/1.3.0/BossTerm-1.3.0.dmg", asset.browser_download_url)
+        assertEquals(123456L, asset.size)
+        assertEquals("cafebabe", asset.sha256)
+    }
+
+    private fun release(tag: String) = GitHubRelease(
+        tag_name = tag, name = tag, body = "", published_at = "2026-01-01T00:00:00Z"
+    )
+
+    private class FakeSource(
+        override val name: String,
+        private val releases: () -> List<GitHubRelease>
+    ) : UpdateSource {
+        var listCalls = 0
+        override suspend fun listReleases(): List<GitHubRelease> { listCalls++; return releases() }
+    }
+
+    @Test
+    fun `uses primary when it returns releases and does not call backup`() = runTest {
+        val primary = FakeSource("supabase") { listOf(release("v2.0.0")) }
+        val backup = FakeSource("github") { error("backup must not be called") }
+
+        val result = FallbackUpdateSource(primary, backup).listReleases()
+
+        assertEquals(listOf("v2.0.0"), result.map { it.tag_name })
+        assertEquals(0, backup.listCalls)
+    }
+
+    @Test
+    fun `falls back to backup when primary throws`() = runTest {
+        val primary = FakeSource("supabase") { throw UpdateSourceException("down") }
+        val backup = FakeSource("github") { listOf(release("v1.0.0")) }
+
+        val result = FallbackUpdateSource(primary, backup).listReleases()
+
+        assertEquals(listOf("v1.0.0"), result.map { it.tag_name })
+        assertEquals(1, backup.listCalls)
+    }
+
+    @Test
+    fun `falls back to backup when primary returns empty`() = runTest {
+        val primary = FakeSource("supabase") { emptyList() }
+        val backup = FakeSource("github") { listOf(release("v1.0.0")) }
+
+        val result = FallbackUpdateSource(primary, backup).listReleases()
+
+        assertEquals(listOf("v1.0.0"), result.map { it.tag_name })
+    }
+
+    @Test
+    fun `returns empty when both sources fail`() = runTest {
+        val primary = FakeSource("supabase") { throw UpdateSourceException("down") }
+        val backup = FakeSource("github") { throw UpdateSourceException("also down") }
+
+        val result = FallbackUpdateSource(primary, backup).listReleases()
+
+        assertTrue(result.isEmpty())
+    }
+}

--- a/scripts/publish-supabase-release.sh
+++ b/scripts/publish-supabase-release.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# publish-supabase-release.sh
+#
+# Publishes a desktop-app release to Supabase so clients can update via the
+# Supabase-primary path (with GitHub as the automatic backup):
+#   1. uploads each platform binary to Supabase Storage
+#         <bucket>/<app>/<version>/<asset>
+#   2. upserts a row into the `app_releases` table (which fires Supabase Realtime,
+#      pushing the new release to every running client).
+#
+# Usage:
+#   publish-supabase-release.sh <app> <version> <channel> <asset_dir> <bucket>
+#
+# Example:
+#   publish-supabase-release.sh boss 9.2.17 stable release-assets app-releases
+#
+# Required environment:
+#   SUPABASE_URL                e.g. https://api.risaboss.com
+#   SUPABASE_SERVICE_ROLE_KEY   service-role key (CI secret; bypasses RLS). Never ship in the client.
+#
+# Only files with known installer extensions (.dmg .msi .deb .rpm .jar) in
+# <asset_dir> are uploaded. Re-running for the same (app, version) upserts.
+
+set -euo pipefail
+
+APP="${1:?usage: publish-supabase-release.sh <app> <version> <channel> <asset_dir> <bucket>}"
+VERSION="${2:?missing version}"
+CHANNEL="${3:?missing channel}"
+ASSET_DIR="${4:?missing asset_dir}"
+BUCKET="${5:?missing bucket}"
+
+: "${SUPABASE_URL:?SUPABASE_URL must be set}"
+: "${SUPABASE_SERVICE_ROLE_KEY:?SUPABASE_SERVICE_ROLE_KEY must be set}"
+
+SUPABASE_URL="${SUPABASE_URL%/}"  # strip trailing slash
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 1; }
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+content_type_of() {
+  case "$1" in
+    *.dmg) echo "application/x-apple-diskimage" ;;
+    *.msi) echo "application/x-msi" ;;
+    *.deb) echo "application/vnd.debian.binary-package" ;;
+    *.rpm) echo "application/x-rpm" ;;
+    *.jar) echo "application/java-archive" ;;
+    *)     echo "application/octet-stream" ;;
+  esac
+}
+
+# prerelease = anything not on the stable channel, or a version with a pre-release suffix.
+PRERELEASE="false"
+if [[ "$CHANNEL" != "stable" || "$VERSION" == *-* ]]; then
+  PRERELEASE="true"
+fi
+
+echo "Publishing $APP $VERSION (channel=$CHANNEL, prerelease=$PRERELEASE) to Supabase bucket '$BUCKET'"
+
+assets_json="[]"
+uploaded=0
+
+shopt -s nullglob
+for file in "$ASSET_DIR"/*.dmg "$ASSET_DIR"/*.msi "$ASSET_DIR"/*.deb "$ASSET_DIR"/*.rpm "$ASSET_DIR"/*.jar; do
+  [[ -f "$file" ]] || continue
+  name="$(basename "$file")"
+  size="$(wc -c < "$file" | tr -d '[:space:]')"
+  sha="$(sha256_of "$file")"
+  ctype="$(content_type_of "$name")"
+  object_path="$APP/$VERSION/$name"
+
+  echo "  -> uploading $name ($size bytes, sha256=${sha:0:12}…)"
+  # x-upsert lets re-runs overwrite an existing object.
+  http_code="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST "$SUPABASE_URL/storage/v1/object/$BUCKET/$object_path" \
+    -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+    -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+    -H "Content-Type: $ctype" \
+    -H "x-upsert: true" \
+    --data-binary "@$file")"
+  if [[ "$http_code" != "200" ]]; then
+    echo "ERROR: storage upload failed for $name (HTTP $http_code)" >&2
+    exit 1
+  fi
+
+  public_url="$SUPABASE_URL/storage/v1/object/public/$BUCKET/$object_path"
+  assets_json="$(jq -c \
+    --arg name "$name" --arg url "$public_url" --argjson size "$size" --arg sha "$sha" \
+    '. + [{name: $name, url: $url, size: $size, sha256: $sha}]' <<<"$assets_json")"
+  uploaded=$((uploaded + 1))
+done
+
+if [[ "$uploaded" -eq 0 ]]; then
+  echo "ERROR: no installer assets (.dmg/.msi/.deb/.rpm/.jar) found in '$ASSET_DIR'" >&2
+  exit 1
+fi
+
+# Optional release notes from a file if present (sync-release.yml writes release-body.txt).
+notes=""
+if [[ -f "$ASSET_DIR/release-body.txt" ]]; then
+  notes="$(cat "$ASSET_DIR/release-body.txt")"
+fi
+
+row="$(jq -nc \
+  --arg app "$APP" --arg version "$VERSION" --arg channel "$CHANNEL" \
+  --argjson prerelease "$PRERELEASE" --arg notes "$notes" --argjson assets "$assets_json" \
+  '{app: $app, version: $version, channel: $channel, prerelease: $prerelease, release_notes: $notes, assets: $assets}')"
+
+echo "Upserting app_releases row for $APP $VERSION ($uploaded asset(s))"
+http_code="$(curl -sS -o /tmp/app_releases_resp.txt -w '%{http_code}' \
+  -X POST "$SUPABASE_URL/rest/v1/app_releases" \
+  -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+  -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: resolution=merge-duplicates,return=minimal" \
+  --data "$row")"
+if [[ "$http_code" != "200" && "$http_code" != "201" && "$http_code" != "204" ]]; then
+  echo "ERROR: app_releases upsert failed (HTTP $http_code): $(cat /tmp/app_releases_resp.txt)" >&2
+  exit 1
+fi
+
+echo "Published $APP $VERSION to Supabase (Realtime will notify connected clients)."

--- a/scripts/publish-supabase-release.sh
+++ b/scripts/publish-supabase-release.sh
@@ -101,7 +101,7 @@ if [[ "$uploaded" -eq 0 ]]; then
   exit 1
 fi
 
-# Optional release notes from a file if present (sync-release.yml writes release-body.txt).
+# Optional release notes from a file if present (the release workflow writes release-body.txt).
 notes=""
 if [[ -f "$ASSET_DIR/release-body.txt" ]]; then
   notes="$(cat "$ASSET_DIR/release-body.txt")"


### PR DESCRIPTION
## What

Make **Supabase** the primary source for the standalone app's self-update, with the **GitHub Releases API as an automatic backup**, delivered via **Realtime push** instead of polling. Mirrors the BossConsole change (risa-labs-inc/BossConsole#810) against the same shared `app_releases` table.

## Changes

- **`compose-ui/.../update/source/`** — `UpdateSource` seam reusing the existing `GitHubRelease` model:
  - `GitHubUpdateSource` (relocated GitHub API logic), `SupabaseUpdateSource` (PostgREST query on `app_releases`, `app=bossterm`), `FallbackUpdateSource` (Supabase → GitHub).
- **`AppUpdateRealtimeService`** — subscribes to `app_releases` `postgres_changes` (exponential-backoff reconnect), triggers a check on each new release and on every (re)connect. Wired via `UpdateManager.startRealtimePush()` from the app's startup `LaunchedEffect`. The existing one-shot startup check stays as the catch-up.
- **SHA-256 verification** of downloads when the Supabase row supplies a hash (`downloadUpdate` + `downloadRelease`).
- **`scripts/publish-supabase-release.sh`** + a step in **`release.yml`** — upload binaries to Storage and upsert the `app_releases` row. **No-op until `SUPABASE_SERVICE_ROLE_KEY` is set.**

## Build / dependency

- Bumps **Kotlin 2.1.21 → 2.2.20** (jvm + compose-compiler + serialization plugins) so the module can consume `supabase-kt:realtime-kt:3.6.0` (its Kotlin-2.3 metadata is readable by a 2.2 compiler). **Compose Multiplatform stays at 1.9.3** — only the Kotlin/Compose-compiler version moves, so the Compose runtime API surface is unchanged (build is clean; remaining warnings are pre-existing deprecations).
- `realtime-kt` is the only new dependency (Realtime only; the catalog is fetched via plain Ktor REST).

## Depends on / follow-up

- The `app_releases` table + `supabase_realtime` publication are created by the **BossConsole** migration (single shared Supabase project, `app` discriminator column).
- For the Supabase path to be active in BossTerm: provide **`SUPABASE_ANON_KEY`** (CI + release env; not embedded since this repo is public), set **`SUPABASE_SERVICE_ROLE_KEY`** secret and **`BOSSTERM_UPDATE_BUCKET`** var. Without them, update checks fall back to GitHub.

## Testing

- `./gradlew :compose-ui:compileKotlinDesktop :bossterm-app:compileKotlinDesktop` ✅
- `./gradlew :compose-ui:desktopTest --tests "ai.rever.bossterm.compose.update.source.UpdateSourceTest"` ✅ (5 tests: manifest→GitHubRelease mapping + fallback behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
