### PR TITLE
Daemon-backed split panes + single-pane border fix

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1010,6 +1010,21 @@ fun TabbedTerminal(
     fun splitActiveTab(orientation: SplitOrientation) {
         val activeTab = tabController.activeTab ?: return
         val splitState = getOrCreateSplitState(activeTab)
+        // Daemon-mirrored pane: route the split through the daemon instead of spawning a local
+        // PTY. Fire-and-forget — no optimistic local splice, the real pane arrives via the next
+        // GroupList (mirrors today's async requestNewTab contract). A plain local pane is
+        // completely unaffected and keeps today's behavior below.
+        val focusedSession = splitState.getFocusedSession()
+        if (daemonMode && ai.rever.bossterm.compose.daemon.DaemonBridgeCoordinator.isAttached && focusedSession?.isRemote == true) {
+            val parentId = (focusedSession as? TerminalTab)?.remotePaneId ?: return
+            val cwd = if (settings.splitInheritWorkingDirectory) focusedSession.workingDirectory.value else null
+            ai.rever.bossterm.compose.daemon.DaemonBridgeCoordinator.splitPane(
+                parentId,
+                if (orientation == SplitOrientation.HORIZONTAL) "h" else "v",
+                cwd,
+            )
+            return
+        }
         val workingDir = if (settings.splitInheritWorkingDirectory) {
             val s = splitState.getFocusedSession()
             s?.workingDirectory?.value ?: s?.processHandle?.value?.getWorkingDirectory()
@@ -1471,8 +1486,25 @@ fun TabbedTerminal(
                 }
             }
 
+            // Daemon-mirrored pane: route split/close through the daemon instead of touching the
+            // local PTY/tree directly — same rule as splitActiveTab() above. Returns the daemon
+            // session id of the focused pane, or null if this pane isn't (or can't be) daemon-routed.
+            fun focusedDaemonPaneId(): String? {
+                if (!daemonMode || !ai.rever.bossterm.compose.daemon.DaemonBridgeCoordinator.isAttached) return null
+                val session = splitState.getFocusedSession()
+                if (session?.isRemote != true) return null
+                return (session as? TerminalTab)?.remotePaneId
+            }
+
             // Split operation handlers
             val onSplitHorizontal: () -> Unit = {
+                val daemonParentId = focusedDaemonPaneId()
+                if (daemonParentId != null) {
+                    // Fire-and-forget — no optimistic local splice, the real pane arrives via the
+                    // next GroupList (mirrors today's async requestNewTab contract).
+                    val cwd = if (settings.splitInheritWorkingDirectory) splitState.getFocusedSession()?.workingDirectory?.value else null
+                    ai.rever.bossterm.compose.daemon.DaemonBridgeCoordinator.splitPane(daemonParentId, "h", cwd)
+                } else {
                 // Only inherit working directory if setting is enabled
                 val workingDir = if (settings.splitInheritWorkingDirectory) {
                     val session = splitState.getFocusedSession()
@@ -1503,9 +1535,15 @@ fun TabbedTerminal(
                 )
                 newSessionRef = newSession
                 splitState.splitFocusedPane(SplitOrientation.HORIZONTAL, newSession, settings.splitDefaultRatio)
+                }
             }
 
             val onSplitVertical: () -> Unit = {
+                val daemonParentId = focusedDaemonPaneId()
+                if (daemonParentId != null) {
+                    val cwd = if (settings.splitInheritWorkingDirectory) splitState.getFocusedSession()?.workingDirectory?.value else null
+                    ai.rever.bossterm.compose.daemon.DaemonBridgeCoordinator.splitPane(daemonParentId, "v", cwd)
+                } else {
                 // Only inherit working directory if setting is enabled
                 val workingDir = if (settings.splitInheritWorkingDirectory) {
                     val session = splitState.getFocusedSession()
@@ -1536,11 +1574,20 @@ fun TabbedTerminal(
                 )
                 newSessionRef = newSession
                 splitState.splitFocusedPane(SplitOrientation.VERTICAL, newSession, settings.splitDefaultRatio)
+                }
             }
 
             val onClosePane: () -> Unit = {
-                if (splitState.isSinglePane) {
-                    // Last pane - close the tab
+                val daemonPaneId = focusedDaemonPaneId()
+                if (daemonPaneId != null && !splitState.isSinglePane) {
+                    // Optimistic local removal — matches today's instant local pane-close UX; the
+                    // next GroupList self-heals any divergence (e.g. resurrects the pane if the
+                    // daemon-side close silently failed).
+                    ai.rever.bossterm.compose.daemon.DaemonBridgeCoordinator.closePane(daemonPaneId)
+                    splitState.closeFocusedPane()
+                } else if (splitState.isSinglePane) {
+                    // Last pane - close the tab (a daemon-backed single pane's session teardown
+                    // follows asynchronously, same as closing any other daemon tab today).
                     tabController.closeTab(tabController.activeTabIndex)
                 } else {
                     // Close just this pane
@@ -1591,6 +1638,14 @@ fun TabbedTerminal(
                     tabController.closeTab(currentIndex)
                 },
                 onCloseTab = {
+                    // Closing a daemon-backed tab's chip: tell the daemon to close every leaf
+                    // (1-pane or a whole split group) so its session(s) don't linger server-side.
+                    // Local removal proceeds immediately either way — same "local now, daemon
+                    // catches up async" pattern an ordinary daemon tab close already uses.
+                    splitState.getAllSessions().filterIsInstance<TerminalTab>()
+                        .filter { it.isRemote }
+                        .mapNotNull { it.remotePaneId }
+                        .forEach { ai.rever.bossterm.compose.daemon.DaemonBridgeCoordinator.closePane(it) }
                     tabController.closeTab(tabController.activeTabIndex)
                 },
                 onNextTab = {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachProtocol.kt
@@ -7,12 +7,15 @@ import kotlinx.serialization.json.Json
 /**
  * Wire protocol for the GUI ↔ daemon **attach** WebSocket — how the thin-client GUI renders and
  * steers daemon-hosted sessions. Loopback + secret-gated (the daemon's control secret), so it skips
- * the E2E/approval handshake the public share protocol needs. Purpose-built (not the full
- * window/tab/split [ai.rever.bossterm.compose.share.ShareProtocol]) because a daemon session is a
- * flat PTY: the GUI mirrors each one as a tab via `TabController.createRemoteSession`.
+ * the E2E/approval handshake the public share protocol needs. Each daemon session is still a flat
+ * PTY (a [SessionMeta] entry), but sessions can additionally belong to a group — a split tree of
+ * session ids ([GroupList]/[GroupView]/[GroupTreeDto]) the GUI renders as one tab's split layout via
+ * `SplitViewState`, so a daemon-hosted split persists/restores the same way a daemon-hosted tab
+ * already does. A single-pane group is an ordinary daemon tab.
  *
- * Server→client: [SessionList] (full set on connect/change), [Snapshot] (initial styled paint),
- * [Output] (live bytes), [Resized], [Closed]. Client→server: [Input], [Open], [Close], [Resize].
+ * Server→client: [SessionList] (full set on connect/change), [GroupList] (split-tree structure
+ * overlay), [Snapshot] (initial styled paint), [Output] (live bytes), [Resized], [Closed].
+ * Client→server: [Input], [Open], [Close], [Resize], [SplitPane], [ClosePane], [UpdateSplitRatio].
  *
  * Phase 2 (session sharing in the daemon) adds a share-management lane on this same socket: the GUI
  * starts/stops/approves daemon-hosted public shares ([Client.StartShare]/[Client.StopShare]/
@@ -27,7 +30,11 @@ object DaemonAttachProtocol {
      * refuses a mismatch — so GUI/daemon skew is detected instead of silently mis-rendering (the
      * relaxed [Json.ignoreUnknownKeys] alone can't catch a renamed/re-semantic'd field).
      */
-    const val PROTOCOL_VERSION = 1
+    // v2 adds GroupList/SplitPane/ClosePane/UpdateSplitRatio (daemon-backed split panes) — a new
+    // Server sealed-class variant an old client can't deserialize (ignoreUnknownKeys only covers
+    // unknown *fields*, not unknown sealed-discriminator values), so the version bump turns that
+    // into a clean connect-time reject via the existing ?v= handshake instead of a decode crash.
+    const val PROTOCOL_VERSION = 2
 
     /** Header carrying the daemon control secret on the attach WS handshake (not a ?query= param, so
      *  it doesn't leak into request-line logs / proxies). Shared by the GUI client and the daemon. */
@@ -86,6 +93,14 @@ object DaemonAttachProtocol {
         /** The full set of daemon sessions; sent on connect and whenever it changes. */
         @Serializable @SerialName("sessions")
         data class SessionList(val sessions: List<SessionMeta>) : Server()
+
+        /** The full set of daemon GROUPS (multi-pane windows) + their trees. Sent on connect and on
+         *  any group-tree change (split/close/ratio), same full-resend discipline as SessionList.
+         *  A plain ungrouped session (none today; every GUI-attach session is grouped) would only
+         *  ever arrive via SessionList. Every sessionId in every group's tree also appears in the
+         *  latest SessionList. */
+        @Serializable @SerialName("groups")
+        data class GroupList(val groups: List<GroupView>) : Server()
 
         /** One-time styled initial paint for a session (scrollback + screen as escapes). */
         @Serializable @SerialName("snapshot")
@@ -184,5 +199,53 @@ object DaemonAttachProtocol {
          */
         @Serializable @SerialName("setMcpEnabled")
         data class SetMcpEnabled(val enabled: Boolean) : Client()
+
+        /** Split the pane currently hosting [sessionId] (must belong to some group). [orientation]
+         *  is "v" | "h"; [cwd] null inherits the split pane's cwd. The daemon creates the new
+         *  session and grafts it into that group's tree, then broadcasts updated SessionList +
+         *  GroupList. Fire-and-forget, same state-resync-confirms pattern as [Open]/[Close]. */
+        @Serializable @SerialName("splitPane")
+        data class SplitPane(
+            val sessionId: String,
+            val orientation: String, // "v" | "h"
+            val cwd: String? = null,
+            val ratio: Float = 0.5f,
+        ) : Client()
+
+        /** Close one pane's session, collapsing its group's tree if it has siblings (vs. closing
+         *  the whole group/session if it's the last pane). Supersedes [Close] for anything that
+         *  might be grouped — the daemon looks up group membership itself. */
+        @Serializable @SerialName("closePane")
+        data class ClosePane(val sessionId: String) : Client()
+
+        /** Divider-drag ratio update for a split within a group's tree (sent on drag commit, not
+         *  per-pixel, to keep the wire quiet during a live drag). */
+        @Serializable @SerialName("updateSplitRatio")
+        data class UpdateSplitRatio(val groupId: String, val splitId: String, val ratio: Float) : Client()
     }
+}
+
+/** One daemon group's split tree (a "window" the GUI renders as a tab with its own split layout;
+ *  a single-pane group is an ordinary daemon tab). Top-level (not nested in [DaemonAttachProtocol])
+ *  so [SessionHost] and [SessionGroup.kt]'s `toDto()` can reference it without qualification. */
+@Serializable
+data class GroupView(val groupId: String, val tree: GroupTreeDto)
+
+/** Wire-serializable split tree — the twin of the daemon-internal [GroupNode], with session ids as
+ *  leaves. Single `Split(dir)` shape (not separate Vertical/Horizontal classes) to match the
+ *  existing [ai.rever.bossterm.compose.share.ShareProtocol] `PaneTreeNode` convention already used
+ *  for browser-share. */
+@Serializable
+sealed class GroupTreeDto {
+    @Serializable @SerialName("pane")
+    data class Pane(val paneId: String, val sessionId: String) : GroupTreeDto()
+
+    @Serializable @SerialName("split")
+    data class Split(
+        val id: String,
+        val dir: String, // "v" | "h"
+        val ratio: Float,
+        val a: GroupTreeDto,
+        val b: GroupTreeDto,
+    ) : GroupTreeDto()
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
@@ -169,6 +169,9 @@ class DaemonAttachServer(
                 DaemonAttachProtocol.SessionMeta(info.id, info.title, info.cwd, sz?.columns ?: 80, sz?.rows ?: 24)
             })
 
+        fun groupList(): DaemonAttachProtocol.Server.GroupList =
+            DaemonAttachProtocol.Server.GroupList(host.listGroups().map { GroupView(it.groupId, it.tree) })
+
         // Attach output tap + size collector + send the initial snapshot. Caller holds [lock].
         fun beginLocked(core: TerminalSessionCore) {
             if (attachments.containsKey(core.id)) return
@@ -253,6 +256,7 @@ class DaemonAttachServer(
             synchronized(lock) {
                 if (closed) return // connection torn down — don't re-attach taps/jobs after endLocked
                 send(sessionList())
+                send(groupList())
                 val liveIds = host.list().map { it.id }.toSet()
                 (attachments.keys - liveIds).toList().forEach { id ->
                     endLocked(id)
@@ -294,8 +298,21 @@ class DaemonAttachServer(
                 when (msg) {
                     is DaemonAttachProtocol.Client.Input -> host.get(msg.id)?.writeInput(msg.data)
                     is DaemonAttachProtocol.Client.Resize -> host.get(msg.id)?.resize(msg.cols, msg.rows)
-                    is DaemonAttachProtocol.Client.Open -> host.openSession(cwd = msg.cwd, cols = msg.cols, rows = msg.rows)
+                    // openWindow() additionally registers a fresh single-pane group — every
+                    // GUI-attach session is grouped, even alone, so reconcile logic never needs a
+                    // grouped-vs-flat distinction. Return value (sessionId, groupId) was already
+                    // discarded for openSession() too; the GUI learns the result via SessionList/
+                    // GroupList, not a reply.
+                    is DaemonAttachProtocol.Client.Open -> host.openWindow(cwd = msg.cwd, cols = msg.cols, rows = msg.rows)
                     is DaemonAttachProtocol.Client.Close -> host.closeSession(msg.id)
+                    is DaemonAttachProtocol.Client.SplitPane -> host.splitPane(
+                        sessionId = msg.sessionId,
+                        orientation = if (msg.orientation == "h") SplitOrientation.HORIZONTAL else SplitOrientation.VERTICAL,
+                        cwd = msg.cwd,
+                        ratio = msg.ratio,
+                    )
+                    is DaemonAttachProtocol.Client.ClosePane -> host.closeGroupedSession(msg.sessionId)
+                    is DaemonAttachProtocol.Client.UpdateSplitRatio -> host.updateSplitRatio(msg.groupId, msg.splitId, msg.ratio)
                     // Phase 2 share management — delegate to the daemon's public-share server (no-op
                     // if sharing is disabled). startShare is non-blocking; results arrive via ShareState.
                     is DaemonAttachProtocol.Client.StartShare -> shareServer?.startShare(msg.scope, msg.sessionId, msg.remoteMode)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonBridgeCoordinator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonBridgeCoordinator.kt
@@ -98,7 +98,7 @@ object DaemonBridgeCoordinator {
                 val a = attach
                 if (ctrl != null && a != null) {
                     if (bridge == null) {
-                        bridge = DaemonSessionBridge(ctrl, a.port, a.secret, uiScope).also { it.start() }
+                        bridge = DaemonSessionBridge(ctrl, state.splitStates, a.port, a.secret, uiScope).also { it.start() }
                         log.info("Daemon session bridge attached (attachPort={})", a.port)
                     }
                     return@launch
@@ -135,6 +135,15 @@ object DaemonBridgeCoordinator {
      * the request silently.
      */
     fun openSession(cwd: String? = null): Boolean = bridge?.openSession(cwd) ?: false
+
+    /** Ask the daemon to split [sessionId] (a daemon-hosted pane) — the GUI's "split pane" when in
+     *  daemon mode. Fire-and-forget like [openSession]; the new pane arrives via the next
+     *  GroupList, no optimistic local splice. */
+    fun splitPane(sessionId: String, orientation: String, cwd: String? = null): Boolean =
+        bridge?.splitPane(sessionId, orientation, cwd) ?: false
+
+    /** Ask the daemon to close one pane (session) — does not affect siblings. Fire-and-forget. */
+    fun closePane(sessionId: String): Boolean = bridge?.closePane(sessionId) ?: false
 
     val isAttached: Boolean get() = bridge != null
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonSessionBridge.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonSessionBridge.kt
@@ -1,9 +1,12 @@
 package ai.rever.bossterm.compose.daemon
 
+import ai.rever.bossterm.compose.splits.SplitNode
+import ai.rever.bossterm.compose.splits.SplitViewState
 import ai.rever.bossterm.compose.tabs.TabController
 import ai.rever.bossterm.compose.tabs.TerminalTab
 import ai.rever.bossterm.core.util.TermSize
 import ai.rever.bossterm.terminal.RequestOrigin
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.websocket.WebSockets
@@ -37,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class DaemonSessionBridge(
     private val controller: TabController,
+    private val splitStates: SnapshotStateMap<String, SplitViewState>,
     private val attachPort: Int,
     private val secret: String,
     private val uiScope: CoroutineScope,
@@ -48,8 +52,19 @@ class DaemonSessionBridge(
     // (stale Input/Resize) against a fresh socket.
     @Volatile private var outbox: Channel<String>? = null
 
-    /** daemon sessionId → its GUI mirror tab. */
+    /** daemon sessionId → its GUI mirror tab. Every leaf of every group lives here too, keyed by
+     *  its own session id — the same cache the flat (1-pane-group) path uses. */
     private val tabs = ConcurrentHashMap<String, TerminalTab>()
+    /** daemon groupId -> local container tab. Only meaningful for >1-pane groups — a 1-pane
+     *  group's "container" is just its own flat tab (already in [tabs], no wrapper needed). */
+    private val groupTabs = ConcurrentHashMap<String, TerminalTab>()
+    /** groupId -> last-applied tree, to skip redundant [SplitViewState.setTree] calls on a
+     *  no-op GroupList resend. */
+    private val lastTree = ConcurrentHashMap<String, GroupTreeDto>()
+    /** Every session id that's a member of some group, as of the latest GroupList — lets
+     *  [reconcile] tell a genuinely ungrouped session (MCP/CLI-created; daemon never wraps those
+     *  in a group) apart from one whose tab/leaf is owned by [reconcileGroups]. */
+    @Volatile private var allGroupedSessionIds: Set<String> = emptySet()
     @Volatile private var running = false
     // Auto-open bookkeeping for the "empty daemon → open one session" path. issuedAutoOpen: this bridge
     // enqueued the auto-open. sawAnySession: the daemon ever reported a non-empty list. If we issued the
@@ -91,6 +106,17 @@ class DaemonSessionBridge(
      *  the request was actually enqueued (false → no live connection / outbox full). */
     fun openSession(cwd: String? = null): Boolean =
         send(DaemonAttachProtocol.Client.Open(cwd = cwd))
+
+    /** Ask the daemon to split [sessionId] (a daemon-hosted pane) in [orientation] ("v"|"h"),
+     *  inheriting [cwd] if known. Fire-and-forget like [openSession]; the new pane arrives via the
+     *  next GroupList — no optimistic local splice. */
+    fun splitPane(sessionId: String, orientation: String, cwd: String? = null): Boolean =
+        send(DaemonAttachProtocol.Client.SplitPane(sessionId, orientation, cwd))
+
+    /** Ask the daemon to close one pane (session) — collapses its group if it has siblings, or
+     *  closes the whole (1-pane) group if it doesn't. Fire-and-forget. */
+    fun closePane(sessionId: String): Boolean =
+        send(DaemonAttachProtocol.Client.ClosePane(sessionId))
 
     /** Turn the daemon's MCP server on/off (the GUI's MCP settings toggle in daemon mode). The daemon
      *  replies with [DaemonAttachProtocol.Server.McpState], which updates the status indicator. */
@@ -177,7 +203,10 @@ class DaemonSessionBridge(
 
     private suspend fun dispatch(msg: DaemonAttachProtocol.Server) {
         when (msg) {
+            // Process SessionList first (drives tabs[id] title/cwd + vanish detection) so any leaf
+            // GroupList references next already has fresh metadata.
             is DaemonAttachProtocol.Server.SessionList -> reconcile(msg.sessions)
+            is DaemonAttachProtocol.Server.GroupList -> reconcileGroups(msg.groups)
             // Reset the mirror buffer before painting a snapshot. The snapshot has no clear sequence of
             // its own, so on a reconnect (the tab persists, only the socket blipped) it would paint a
             // SECOND full scrollback+screen below the existing content. Clear scrollback+screen+home
@@ -253,6 +282,12 @@ class DaemonSessionBridge(
                 }
                 continue
             }
+            // A session not yet in `tabs` and already known to be grouped (per the latest
+            // GroupList) is owned by reconcileGroups — it'll be created there (1-pane groups too),
+            // so don't race it into a duplicate flat tab here. Only a genuinely ungrouped session
+            // (MCP/CLI-created; the daemon never wraps those in a group) falls through to today's
+            // flat-tab creation below.
+            if (meta.id in allGroupedSessionIds) continue
             // New session → create a mirror tab (on the UI thread — mutates the Compose tabs list).
             withContext(Dispatchers.Main) {
                 val tab = controller.createRemoteSession(
@@ -268,6 +303,98 @@ class DaemonSessionBridge(
         }
     }
 
+    /**
+     * Build/update local [SplitViewState] trees from the daemon's [groups]. Owns ALL tab/leaf
+     * creation for grouped sessions (including 1-pane groups — an ordinary daemon tab is just a
+     * 1-pane group), so a session whose SessionList frame raced ahead of its GroupList frame is
+     * never left to [reconcile]'s ungrouped fallback. Mirrors the existing
+     * `RemoteSessionManager.reconcile`/`buildTree` pattern (rebuild-by-id, not incremental patch).
+     */
+    private suspend fun reconcileGroups(groups: List<GroupView>) {
+        val liveGroupIds = groups.map { it.groupId }.toSet()
+        withContext(Dispatchers.Main) {
+            // Drop containers for groups that vanished entirely (closed/merged away daemon-side).
+            (groupTabs.keys - liveGroupIds).toList().forEach { gone ->
+                groupTabs.remove(gone)?.let { closeMirrorContainer(it) }
+                lastTree.remove(gone)
+            }
+            for (group in groups) {
+                if (lastTree[group.groupId] == group.tree) continue // no-op resend — nothing changed
+                val paneIds = collectPaneIds(group.tree)
+                if (paneIds.size == 1) {
+                    // 1-pane group == ordinary daemon tab. No SplitViewState wrapper — the lone
+                    // TerminalTab IS the tab, exactly like today's flat daemon tabs.
+                    val onlyId = paneIds.first()
+                    val tab = tabs.getOrPut(onlyId) { createLeafMirror(onlyId) }
+                    groupTabs[group.groupId] = tab
+                    lastTree[group.groupId] = group.tree
+                    if (controller.tabs.none { it.id == tab.id }) controller.createTabFromExistingSession(tab)
+                    continue
+                }
+                // Multi-pane group. Any of its panes that currently sit as a TOP-LEVEL tab — either
+                // because this group just grew 1->N (the original lone tab is paneIds.first()) or
+                // because this pane's SessionList frame raced ahead of this GroupList frame and
+                // `reconcile()` wrongly flat-created it — must be pulled out of the tab list (NOT
+                // disposed) before it's folded into the split tree, so it doesn't render twice.
+                paneIds.forEach { pid ->
+                    tabs[pid]?.let { t ->
+                        val idx = controller.tabs.indexOfFirst { it.id == t.id }
+                        if (idx >= 0) controller.tabs.removeAt(idx)
+                    }
+                }
+                val isNewGroup = !groupTabs.containsKey(group.groupId)
+                val container = groupTabs.getOrPut(group.groupId) {
+                    tabs[paneIds.first()] ?: controller.createRemoteSession(title = "Split", feedsStream = false)
+                }
+                val ss = splitStates.getOrPut(container.id) { SplitViewState(initialSession = container) }
+                ss.onRemoteDividerDrag = { splitId, ratio, committed ->
+                    if (committed) send(DaemonAttachProtocol.Client.UpdateSplitRatio(group.groupId, splitId, ratio))
+                }
+                ss.setTree(buildGroupTree(group.tree), ss.focusedPaneId)
+                lastTree[group.groupId] = group.tree
+                if (isNewGroup) controller.createTabFromExistingSession(container)
+            }
+            allGroupedSessionIds = groups.flatMap { collectPaneIds(it.tree) }.toSet()
+        }
+    }
+
+    /** Create (not reuse) a leaf mirror session for [sessionId] — same shape as the flat-tab path,
+     *  factored out so both the 1-pane and multi-pane branches of [reconcileGroups] share it. */
+    private fun createLeafMirror(sessionId: String): TerminalTab =
+        controller.createRemoteSession(
+            title = "",
+            remotePaneId = sessionId,
+            onUserInput = { data -> send(DaemonAttachProtocol.Client.Input(sessionId, data)) },
+        ).also { it.onRemoteFit = { cols, rows -> send(DaemonAttachProtocol.Client.Resize(sessionId, cols, rows)) } }
+
+    /** [GroupTreeDto] -> [SplitNode], reusing/creating leaf mirrors by session id via the same
+     *  `tabs` cache the flat path uses. */
+    private fun buildGroupTree(node: GroupTreeDto): SplitNode = when (node) {
+        is GroupTreeDto.Pane -> SplitNode.Pane(id = node.paneId, session = tabs.getOrPut(node.sessionId) { createLeafMirror(node.sessionId) })
+        is GroupTreeDto.Split -> if (node.dir == "h") {
+            SplitNode.HorizontalSplit(id = node.id, top = buildGroupTree(node.a), bottom = buildGroupTree(node.b), ratio = node.ratio)
+        } else {
+            SplitNode.VerticalSplit(id = node.id, left = buildGroupTree(node.a), right = buildGroupTree(node.b), ratio = node.ratio)
+        }
+    }
+
+    private fun collectPaneIds(node: GroupTreeDto): List<String> = when (node) {
+        is GroupTreeDto.Pane -> listOf(node.sessionId)
+        is GroupTreeDto.Split -> collectPaneIds(node.a) + collectPaneIds(node.b)
+    }
+
+    /** Tear down a multi-pane group's container: dispose every leaf, drop its split state, close
+     *  the container tab. Mirrors `RemoteSessionManager.removeMirrorTab`. Must run on Main. */
+    private fun closeMirrorContainer(container: TerminalTab) {
+        splitStates[container.id]?.getAllSessions()?.filterIsInstance<TerminalTab>()?.forEach { mirror ->
+            tabs.entries.removeIf { it.value === mirror }
+            runCatching { mirror.dispose() }
+        }
+        splitStates.remove(container.id)
+        val idx = controller.tabs.indexOfFirst { it.id == container.id }
+        if (idx >= 0) controller.closeTab(idx)
+    }
+
     private fun resizeMirror(id: String, cols: Int, rows: Int) {
         val tab = tabs[id] ?: return
         if (cols < 1 || rows < 1) return
@@ -277,8 +404,22 @@ class DaemonSessionBridge(
     private suspend fun closeMirror(id: String) {
         val tab = tabs.remove(id) ?: return
         withContext(Dispatchers.Main) {
-            val idx = controller.tabs.indexOfFirst { it.id == tab.id }
-            if (idx >= 0) controller.closeTab(idx)
+            // A leaf inside a multi-pane group's SplitViewState isn't in controller.tabs at all —
+            // only its container is — so the old "assume it's a top-level tab" lookup would miss
+            // it. Check every tracked container's split tree first; fall back to the flat-tab
+            // removal only if it isn't a grouped leaf.
+            val containerSplitState = groupTabs.values.firstNotNullOfOrNull { container ->
+                splitStates[container.id]?.takeIf { ss -> ss.getAllSessions().any { it === tab } }
+            }
+            val pane = containerSplitState?.getAllPanes()?.firstOrNull { it.session === tab }
+            if (containerSplitState != null && pane != null) {
+                // If this was the group's last pane, the group is gone too — the next GroupList
+                // drives closeMirrorContainer; nothing to collapse here.
+                if (!containerSplitState.isSinglePane) containerSplitState.closePane(pane.id)
+            } else {
+                val idx = controller.tabs.indexOfFirst { it.id == tab.id }
+                if (idx >= 0) controller.closeTab(idx)
+            }
         }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/SessionGroup.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/SessionGroup.kt
@@ -1,0 +1,152 @@
+package ai.rever.bossterm.compose.daemon
+
+import java.util.UUID
+
+/** Orientation of a daemon-side pane split. Kept separate from the GUI's
+ *  `ai.rever.bossterm.compose.splits.SplitOrientation` so this module has no GUI dependency. */
+enum class SplitOrientation { HORIZONTAL, VERTICAL }
+
+/**
+ * Daemon-side split tree: the headless analogue of the GUI's `SplitNode`, but leaves hold a
+ * session id (String) rather than a `TerminalSession`, so this module never depends on GUI-only
+ * session types. One [GroupNode] tree = one "window" the GUI renders as a tab with its own split
+ * layout; a single-pane tree is an ordinary daemon tab.
+ */
+sealed class GroupNode {
+    abstract val id: String
+
+    data class Pane(
+        override val id: String = UUID.randomUUID().toString(),
+        val sessionId: String,
+    ) : GroupNode()
+
+    data class VerticalSplit(
+        override val id: String = UUID.randomUUID().toString(),
+        val left: GroupNode,
+        val right: GroupNode,
+        val ratio: Float = 0.5f,
+    ) : GroupNode()
+
+    data class HorizontalSplit(
+        override val id: String = UUID.randomUUID().toString(),
+        val top: GroupNode,
+        val bottom: GroupNode,
+        val ratio: Float = 0.5f,
+    ) : GroupNode()
+}
+
+/** Find a pane by its node id. */
+fun GroupNode.findPane(targetId: String): GroupNode.Pane? = when (this) {
+    is GroupNode.Pane -> if (this.id == targetId) this else null
+    is GroupNode.VerticalSplit -> left.findPane(targetId) ?: right.findPane(targetId)
+    is GroupNode.HorizontalSplit -> top.findPane(targetId) ?: bottom.findPane(targetId)
+}
+
+/** Find a pane by the session id it hosts. */
+fun GroupNode.findPaneBySessionId(sessionId: String): GroupNode.Pane? = when (this) {
+    is GroupNode.Pane -> if (this.sessionId == sessionId) this else null
+    is GroupNode.VerticalSplit -> left.findPaneBySessionId(sessionId) ?: right.findPaneBySessionId(sessionId)
+    is GroupNode.HorizontalSplit -> top.findPaneBySessionId(sessionId) ?: bottom.findPaneBySessionId(sessionId)
+}
+
+/** All panes (leaf nodes) in the tree. */
+fun GroupNode.getAllPanes(): List<GroupNode.Pane> = when (this) {
+    is GroupNode.Pane -> listOf(this)
+    is GroupNode.VerticalSplit -> left.getAllPanes() + right.getAllPanes()
+    is GroupNode.HorizontalSplit -> top.getAllPanes() + bottom.getAllPanes()
+}
+
+/** All session ids in the tree. */
+fun GroupNode.getAllSessionIds(): List<String> = getAllPanes().map { it.sessionId }
+
+/** Replace a node in the tree with a new node. Returns the new tree root, or the original if
+ *  [targetId] isn't found. */
+fun GroupNode.replaceNode(targetId: String, transform: (GroupNode) -> GroupNode): GroupNode {
+    if (this.id == targetId) return transform(this)
+    return when (this) {
+        is GroupNode.Pane -> this
+        is GroupNode.VerticalSplit -> copy(
+            left = left.replaceNode(targetId, transform),
+            right = right.replaceNode(targetId, transform),
+        )
+        is GroupNode.HorizontalSplit -> copy(
+            top = top.replaceNode(targetId, transform),
+            bottom = bottom.replaceNode(targetId, transform),
+        )
+    }
+}
+
+/** Remove a pane from the tree, collapsing its parent split (the sibling takes the parent's
+ *  slot). Returns null if [targetId] is the root pane (can't remove the last pane). */
+fun GroupNode.removePane(targetId: String): GroupNode? {
+    if (this is GroupNode.Pane && this.id == targetId) return null
+    return when (this) {
+        is GroupNode.Pane -> this
+        is GroupNode.VerticalSplit -> when {
+            left.id == targetId -> right
+            right.id == targetId -> left
+            else -> {
+                val newLeft = left.removePane(targetId)
+                val newRight = right.removePane(targetId)
+                when {
+                    newLeft == null -> right
+                    newRight == null -> left
+                    newLeft != left || newRight != right -> copy(left = newLeft, right = newRight)
+                    else -> this
+                }
+            }
+        }
+        is GroupNode.HorizontalSplit -> when {
+            top.id == targetId -> bottom
+            bottom.id == targetId -> top
+            else -> {
+                val newTop = top.removePane(targetId)
+                val newBottom = bottom.removePane(targetId)
+                when {
+                    newTop == null -> bottom
+                    newBottom == null -> top
+                    newTop != top || newBottom != bottom -> copy(top = newTop, bottom = newBottom)
+                    else -> this
+                }
+            }
+        }
+    }
+}
+
+/** Update the ratio of a split node. */
+fun GroupNode.updateRatio(targetId: String, newRatio: Float, minRatio: Float = 0.1f): GroupNode {
+    val clampedRatio = newRatio.coerceIn(minRatio, 1f - minRatio)
+    return when (this) {
+        is GroupNode.Pane -> this
+        is GroupNode.VerticalSplit -> if (this.id == targetId) {
+            copy(ratio = clampedRatio)
+        } else {
+            copy(left = left.updateRatio(targetId, newRatio, minRatio), right = right.updateRatio(targetId, newRatio, minRatio))
+        }
+        is GroupNode.HorizontalSplit -> if (this.id == targetId) {
+            copy(ratio = clampedRatio)
+        } else {
+            copy(top = top.updateRatio(targetId, newRatio, minRatio), bottom = bottom.updateRatio(targetId, newRatio, minRatio))
+        }
+    }
+}
+
+/** The parent split's id for a given node, or null if [targetId] is the root or not found. */
+fun GroupNode.findParentId(targetId: String): String? = when (this) {
+    is GroupNode.Pane -> null
+    is GroupNode.VerticalSplit -> when {
+        left.id == targetId || right.id == targetId -> this.id
+        else -> left.findParentId(targetId) ?: right.findParentId(targetId)
+    }
+    is GroupNode.HorizontalSplit -> when {
+        top.id == targetId || bottom.id == targetId -> this.id
+        else -> top.findParentId(targetId) ?: bottom.findParentId(targetId)
+    }
+}
+
+/** Convert to the wire-serializable [GroupTreeDto]. */
+fun GroupNode.toDto(): GroupTreeDto = when (this) {
+    is GroupNode.Pane -> GroupTreeDto.Pane(paneId = id, sessionId = sessionId)
+    is GroupNode.VerticalSplit -> GroupTreeDto.Split(id, "v", ratio, left.toDto(), right.toDto())
+    is GroupNode.HorizontalSplit -> GroupTreeDto.Split(id, "h", ratio, top.toDto(), bottom.toDto())
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/SessionHost.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/SessionHost.kt
@@ -19,6 +19,20 @@ class SessionHost(
     private val log = LoggerFactory.getLogger(SessionHost::class.java)
     private val sessions = ConcurrentHashMap<String, TerminalSessionCore>()
 
+    // groupId -> split tree (session ids as leaves). A session id that never appears as a Pane
+    // leaf in any group is a flat/ungrouped session (today's only kind: MCP/CLI-created). Every
+    // GUI-attach-created session is grouped, even a lone single-pane "tab" (a 1-pane group).
+    private val groups = ConcurrentHashMap<String, GroupNode>()
+    // Reverse index, sessionId -> groupId, maintained alongside `groups` under `groupLock`. Lets
+    // callers that only know a session id (closeSession, the PTY-exit reaper) cheaply find its
+    // group without scanning every tree.
+    private val sessionToGroup = ConcurrentHashMap<String, String>()
+    // Single coarse lock serializing all group-tree mutations (open-in-group, split, close-in-group,
+    // ratio update). Distinct from `sessions` (a ConcurrentHashMap, already mutation-safe on its
+    // own) because group mutations are read-modify-write over an immutable tree and must not
+    // interleave. Never held across PTY spawn/kill — see [splitPane].
+    private val groupLock = Any()
+
     /** Listeners notified when the session set changes (open/close/exit) — drives attach Layout pushes. */
     private val changeListeners = java.util.concurrent.CopyOnWriteArrayList<() -> Unit>()
     fun addChangeListener(l: () -> Unit) { changeListeners.add(l) }
@@ -43,6 +57,10 @@ class SessionHost(
         val alive: Boolean,
     )
 
+    /** A daemon group's wire-ready tree, for GUI-attach broadcast. */
+    @Serializable
+    data class GroupInfo(val groupId: String, val tree: GroupTreeDto)
+
     /** Create, start, and register a session. Returns its id. */
     fun openSession(
         cwd: String? = null,
@@ -60,12 +78,129 @@ class SessionHost(
             initialRows = rows,
         )
         sessions[core.id] = core
-        // Reap on exit so a dead shell doesn't linger in the registry.
-        core.onExit = { sessions.remove(core.id); notifyChanged() }
+        // Reap on exit so a dead shell doesn't linger in the registry. Also collapses the session
+        // out of its group (if any) — covers a SPONTANEOUS exit (shell `exit`, crash), not just an
+        // explicit close, so a split's tree never keeps a dangling leaf for a session that died on
+        // its own.
+        core.onExit = { collapseFromGroup(core.id); sessions.remove(core.id); notifyChanged() }
         core.start()
         log.info("opened session {} (cwd={}, cmd={})", core.id, cwd, command ?: "<default shell>")
         notifyChanged()
         return core.id
+    }
+
+    /** Open a brand-new session AND register it as a fresh single-pane group — the GUI attach
+     *  path's "new window" (Client.Open). A single-pane group renders identically to a flat tab,
+     *  so every attach-created session being grouped (even alone) lets callers treat "tab" and
+     *  "group" uniformly. Returns (sessionId, groupId). */
+    fun openWindow(
+        cwd: String? = null,
+        command: String? = null,
+        arguments: List<String> = emptyList(),
+        cols: Int = 80,
+        rows: Int = 24,
+    ): Pair<String, String> {
+        val sessionId = openSession(cwd, command, arguments, cols, rows)
+        val groupId = java.util.UUID.randomUUID().toString()
+        synchronized(groupLock) {
+            groups[groupId] = GroupNode.Pane(sessionId = sessionId)
+            sessionToGroup[sessionId] = groupId
+        }
+        notifyChanged()
+        return sessionId to groupId
+    }
+
+    /**
+     * Split the pane holding [sessionId] (must already be a member of some group). Creates a new
+     * session and grafts it into that group's tree next to the target pane. Returns the new
+     * session id, or null if [sessionId] isn't currently part of any live group (already closed,
+     * raced, or ungrouped).
+     */
+    fun splitPane(
+        sessionId: String,
+        orientation: SplitOrientation,
+        cwd: String? = null,
+        ratio: Float = 0.5f,
+    ): String? {
+        val groupId = synchronized(groupLock) { sessionToGroup[sessionId] } ?: return null
+        if (sessions[sessionId] == null) {
+            // Target vanished between the lookup above and here (race with PTY exit's
+            // collapseFromGroup, which should have already cleaned this up — defensive only).
+            synchronized(groupLock) { sessionToGroup.remove(sessionId) }
+            return null
+        }
+        // null is a legitimate "no specific cwd" value (e.g. cwd not yet captured via OSC 7) —
+        // openSession() already treats a null cwd as "use the default," so don't bail here.
+        val inheritedCwd = cwd ?: sessions[sessionId]?.workingDirectory?.value
+
+        // Spawn the new PTY OUTSIDE groupLock — openSession() does real process work and must not
+        // run while holding the tree lock (would block every other group mutation/resync for the
+        // duration of the spawn).
+        val newSessionId = openSession(cwd = inheritedCwd)
+
+        // Graft into the tree under groupLock, re-validating the target pane is still there — it
+        // could have been closed by a concurrent splitPane/closePane/exit while we were spawning.
+        val grafted = synchronized(groupLock) {
+            val tree = groups[groupId]
+            val targetPane = tree?.findPaneBySessionId(sessionId)
+            if (tree == null || targetPane == null) {
+                false
+            } else {
+                val newPane = GroupNode.Pane(sessionId = newSessionId)
+                val newTree = tree.replaceNode(targetPane.id) { pane ->
+                    when (orientation) {
+                        SplitOrientation.HORIZONTAL -> GroupNode.HorizontalSplit(top = pane, bottom = newPane, ratio = ratio)
+                        SplitOrientation.VERTICAL -> GroupNode.VerticalSplit(left = pane, right = newPane, ratio = ratio)
+                    }
+                }
+                groups[groupId] = newTree
+                sessionToGroup[newSessionId] = groupId
+                true
+            }
+        }
+        if (!grafted) {
+            // Lost the race: the target pane is gone. Don't leak the new session as an orphan.
+            closeSession(newSessionId)
+            return null
+        }
+        notifyChanged()
+        return newSessionId
+    }
+
+    /** Remove [sessionId] from whatever group it's in (idempotent; no-op if ungrouped), collapsing
+     *  the parent split so the sibling takes its slot, or dropping the group entirely if it was
+     *  the last pane. Pure tree edit — no session side effects. Shared by [closeGroupedSession]
+     *  (user-initiated close) and the [openSession] exit reaper (spontaneous exit), so there is
+     *  exactly one place that knows how to remove a session from a group. */
+    private fun collapseFromGroup(sessionId: String) {
+        synchronized(groupLock) {
+            val groupId = sessionToGroup.remove(sessionId) ?: return
+            val tree = groups[groupId] ?: return
+            val pane = tree.findPaneBySessionId(sessionId) ?: return
+            val newTree = tree.removePane(pane.id)
+            if (newTree == null) groups.remove(groupId) else groups[groupId] = newTree
+        }
+    }
+
+    /** Close one pane's session. If it's the last pane of its group, this is exactly
+     *  [closeSession] (the group disappears too). If it has siblings, the session is killed AND
+     *  the tree collapses around it. Ungrouped sessions just close normally. */
+    fun closeGroupedSession(sessionId: String) {
+        collapseFromGroup(sessionId)
+        closeSession(sessionId)
+    }
+
+    /** Update one split's ratio within its group's tree (divider drag commit). Pure tree edit. */
+    fun updateSplitRatio(groupId: String, splitId: String, ratio: Float) {
+        synchronized(groupLock) {
+            groups[groupId]?.let { groups[groupId] = it.updateRatio(splitId, ratio) }
+        }
+        notifyChanged()
+    }
+
+    /** All current groups, as wire DTOs, for GroupList broadcast. */
+    fun listGroups(): List<GroupInfo> = synchronized(groupLock) {
+        groups.map { (groupId, tree) -> GroupInfo(groupId, tree.toDto()) }
     }
 
     fun get(id: String): TerminalSessionCore? = sessions[id]
@@ -95,6 +230,7 @@ class SessionHost(
         // before the shells are actually destroyed (which would orphan them).
         val killThreads = sessions.values.mapNotNull { runCatching { it.close() }.getOrNull() }
         sessions.clear()
+        synchronized(groupLock) { groups.clear(); sessionToGroup.clear() }
         // Tell attached GUIs the sessions are gone — otherwise a mass close the daemon survives leaves
         // them showing stale tabs. (The notifier is a daemon-thread executor, so it needn't be shut
         // down explicitly; it dies with the JVM on actual daemon exit.)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
@@ -299,9 +299,9 @@ private fun RenderPane(
     hyperlinkRegistry: HyperlinkRegistry = HyperlinkDetector.registry,
     modifier: Modifier = Modifier
 ) {
-    // Focus border for active pane (only show when there are multiple panes and enabled)
-    val borderModifier = if (!splitState.isSinglePane && splitFocusBorderEnabled) {
-        if (isFocusedPane) {
+    // Focus border for active pane; single-pane tabs always get the plain unfocused border
+    val borderModifier = if (splitFocusBorderEnabled) {
+        if (isFocusedPane && !splitState.isSinglePane) {
             Modifier.border(2.dp, splitFocusBorderColor)
         } else {
             Modifier.border(1.dp, Color(0xFF404040))


### PR DESCRIPTION
## Summary

- **Single-pane border fix**: a tab with no split now renders the same plain gray pane border that split panes already get, instead of no border at all (`SplitContainer.kt`).
- **Daemon-backed split panes**: splitting a pane while session daemon mode is on now routes through the daemon and persists/restores like daemon tabs already do, instead of always falling back to a plain local pane.

The daemon's session model was completely flat — every daemon session became its own independent mirror tab, with no way to express "this session is pane 2 of a split inside tab X." This adds a real split-tree model:

- `SessionHost` gains a group registry (`groupId -> split tree of session ids`) alongside the flat session map, with `openWindow`/`splitPane`/`closeGroupedSession`/`updateSplitRatio`. Every GUI-attach session is grouped now, even alone (a 1-pane group is an ordinary tab). Tree mutations spawn PTYs outside the lock and re-validate before grafting, so a split racing a pane close can't leak an orphan session.
- The attach protocol adds `GroupList`/`SplitPane`/`ClosePane`/`UpdateSplitRatio` (protocol version bumped so mismatched GUI/daemon builds reject cleanly instead of failing to deserialize), modeled on the existing share-protocol pane-tree shape.
- `DaemonSessionBridge` rebuilds local `SplitViewState` trees from the daemon's `GroupList` via the existing `setTree()`, reusing leaf mirror tabs by session id — the same rebuild-by-id approach `RemoteSessionManager` already uses for browser-share mirroring.
- `TabbedTerminal` routes a split/close to the daemon only when the focused pane is itself daemon-backed; a plain local pane keeps today's behavior unchanged.

## Test plan

- [x] `:compose-ui:compileKotlinDesktop` and `:bossterm-app:compileKotlinDesktop` build clean
- [x] `:compose-ui:desktopTest` daemon-package suite passes (61/61, 0 failures)
- [ ] Manual: open a tab, split it under daemon mode, confirm the new pane is daemon-backed
- [ ] Manual: nested split (tree depth > 1)
- [ ] Manual: close one of 3 panes in a group, confirm remaining panes collapse correctly
- [ ] Manual: kill/relaunch the GUI and confirm the daemon reconstructs the split layout
- [ ] Manual: split a plain local (non-daemon) pane, confirm unaffected
- [ ] Manual: single-pane tab shows the gray border on both local and daemon-backed tabs