### PR TITLE
fix(release): upload large assets via TUS resumable (fixes Supabase 413)

### DIFF
--- a/scripts/publish-supabase-release.sh
+++ b/scripts/publish-supabase-release.sh
@@ -70,6 +70,8 @@ content_type_of() {
 # endpoint in fixed 6 MiB chunks. Everything else uses the simpler single POST.
 CHUNK_SIZE=$((6 * 1024 * 1024))            # 6 MiB — the only chunk size Supabase's TUS server accepts.
 RESUMABLE_THRESHOLD=$((50 * 1024 * 1024))  # Anything above 50 MB goes resumable (well under the 100 MB cap).
+MAX_ATTEMPTS=4                             # Tries (1 + 3 retries) per create/PATCH, so a transient blip on any
+RETRY_BACKOFF=2                            # of the ~N requests doesn't abandon the whole upload. Backoff = N*attempt s.
 
 b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
 
@@ -94,29 +96,50 @@ upload_single() {
   fi
 }
 
-# upload_resumable <file> <object_path> <content_type> — chunked TUS upload for large files.
-upload_resumable() {
-  local file="$1" object_path="$2" ctype="$3"
-  local total; total="$(wc -c < "$file" | tr -d '[:space:]')"
-  local meta="bucketName $(b64 "$BUCKET"),objectName $(b64 "$object_path"),contentType $(b64 "$ctype"),cacheControl $(b64 '3600')"
-
-  # 1) Create the upload; capture its per-upload Location URL. x-upsert overwrites on re-runs.
-  local create_hdrs
-  create_hdrs="$(curl -sS -D - -o /dev/null \
-    -X POST "$SUPABASE_URL/storage/v1/upload/resumable" \
+# tus_head_offset <upload_url> — prints the server's current Upload-Offset, or fails.
+# Lets a retry resume from the true offset when a failed PATCH may have partially applied.
+tus_head_offset() {
+  local loc="$1" hdrs code
+  # -I (HEAD) avoids the `-X HEAD` body-wait footgun.
+  hdrs="$(curl -sS -I "$loc" \
     -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
     -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
-    -H "Tus-Resumable: 1.0.0" \
-    -H "Upload-Length: $total" \
-    -H "Upload-Metadata: $meta" \
-    -H "x-upsert: true")" || true
+    -H "Tus-Resumable: 1.0.0")" || return 1
+  code="$(printf '%s\n' "$hdrs" | http_status_of)"
+  [[ "$code" == "200" || "$code" == "204" ]] || return 1
+  printf '%s\n' "$hdrs" | header_value_of Upload-Offset
+}
 
-  local code; code="$(printf '%s\n' "$create_hdrs" | http_status_of)"
-  if [[ "$code" != "201" ]]; then
-    echo "ERROR: resumable create failed for $object_path (HTTP ${code:-none})" >&2
-    printf '%s\n' "$create_hdrs" >&2
-    return 1
-  fi
+# upload_resumable <file> <object_path> <content_type> <size> — chunked TUS upload for large files.
+# create and every chunk are retried with backoff; on retry the true server offset is re-read
+# (via HEAD) and the upload resumes from there, so no single blip abandons the whole transfer.
+upload_resumable() {
+  local file="$1" object_path="$2" ctype="$3" total="$4"
+  local meta="bucketName $(b64 "$BUCKET"),objectName $(b64 "$object_path"),contentType $(b64 "$ctype"),cacheControl $(b64 '3600')"
+  local body="$TMP_DIR/resp_body" chunk="$TMP_DIR/chunk.bin" attempt
+
+  # 1) Create the upload; capture its per-upload Location URL. x-upsert overwrites on re-runs.
+  local create_hdrs code=""
+  for (( attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ )); do
+    create_hdrs="$(curl -sS -D - -o "$body" \
+      -X POST "$SUPABASE_URL/storage/v1/upload/resumable" \
+      -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+      -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+      -H "Tus-Resumable: 1.0.0" \
+      -H "Upload-Length: $total" \
+      -H "Upload-Metadata: $meta" \
+      -H "x-upsert: true")" || true
+    code="$(printf '%s\n' "$create_hdrs" | http_status_of)"
+    [[ "$code" == "201" ]] && break
+    if (( attempt == MAX_ATTEMPTS )); then
+      echo "ERROR: resumable create failed for $object_path after $MAX_ATTEMPTS attempts (last HTTP ${code:-none})" >&2
+      printf '%s\n' "$create_hdrs" >&2
+      cat "$body" >&2 2>/dev/null || true   # echo error body (e.g. a file_size_limit 400) so limit failures are diagnosable
+      return 1
+    fi
+    echo "     resumable create failed (HTTP ${code:-none}); retry $attempt/$((MAX_ATTEMPTS - 1))…" >&2
+    sleep $(( RETRY_BACKOFF * attempt ))
+  done
 
   local location; location="$(printf '%s\n' "$create_hdrs" | header_value_of Location)"
   case "$location" in
@@ -129,7 +152,7 @@ upload_resumable() {
   # 2) PATCH successive 6 MiB chunks until the server-reported offset reaches EOF.
   # The server's Upload-Offset is the single source of truth for where to resume;
   # since every full chunk advances it by exactly CHUNK_SIZE it stays aligned.
-  local chunk="$TMP_DIR/chunk.bin" offset=0
+  local offset=0
   while [[ "$offset" -lt "$total" ]]; do
     if (( offset % CHUNK_SIZE != 0 )); then
       echo "ERROR: resumable upload for $object_path got misaligned offset $offset; aborting" >&2
@@ -137,28 +160,42 @@ upload_resumable() {
     fi
     dd if="$file" of="$chunk" bs="$CHUNK_SIZE" skip=$(( offset / CHUNK_SIZE )) count=1 2>/dev/null
 
-    local patch_hdrs
-    patch_hdrs="$(curl -sS -D - -o /dev/null \
-      -X PATCH "$location" \
-      -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
-      -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
-      -H "Tus-Resumable: 1.0.0" \
-      -H "Content-Type: application/offset+octet-stream" \
-      -H "Upload-Offset: $offset" \
-      --data-binary "@$chunk")" || true
-
-    local pcode; pcode="$(printf '%s\n' "$patch_hdrs" | http_status_of)"
-    if [[ "$pcode" != "204" ]]; then
-      echo "ERROR: resumable chunk upload failed for $object_path at offset $offset (HTTP ${pcode:-none})" >&2
-      printf '%s\n' "$patch_hdrs" >&2
-      return 1
-    fi
-
-    local newoff; newoff="$(printf '%s\n' "$patch_hdrs" | header_value_of Upload-Offset)"
-    if [[ -z "$newoff" || "$newoff" -le "$offset" ]]; then
-      echo "ERROR: resumable upload for $object_path stalled at offset $offset (server offset='${newoff:-none}')" >&2
-      return 1
-    fi
+    local newoff=""
+    for (( attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ )); do
+      local patch_hdrs pcode
+      patch_hdrs="$(curl -sS -D - -o "$body" \
+        -X PATCH "$location" \
+        -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+        -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+        -H "Tus-Resumable: 1.0.0" \
+        -H "Content-Type: application/offset+octet-stream" \
+        -H "Upload-Offset: $offset" \
+        --data-binary "@$chunk")" || true
+      pcode="$(printf '%s\n' "$patch_hdrs" | http_status_of)"
+      if [[ "$pcode" == "204" ]]; then
+        newoff="$(printf '%s\n' "$patch_hdrs" | header_value_of Upload-Offset)"
+        [[ -n "$newoff" && "$newoff" -gt "$offset" ]] && break
+      fi
+      if (( attempt == MAX_ATTEMPTS )); then
+        echo "ERROR: resumable chunk upload for $object_path failed at offset $offset after $MAX_ATTEMPTS attempts (last HTTP ${pcode:-none})" >&2
+        printf '%s\n' "$patch_hdrs" >&2
+        cat "$body" >&2 2>/dev/null || true
+        return 1
+      fi
+      echo "     chunk at offset $offset failed (HTTP ${pcode:-none}); retry $attempt/$((MAX_ATTEMPTS - 1)) after re-syncing offset…" >&2
+      sleep $(( RETRY_BACKOFF * attempt ))
+      # The failed PATCH may have partially applied — re-read the true offset and re-slice.
+      local synced; synced="$(tus_head_offset "$location")" || synced=""
+      if [[ -n "$synced" && "$synced" -ge "$offset" ]]; then
+        offset="$synced"
+        (( offset >= total )) && { newoff="$offset"; break; }
+        if (( offset % CHUNK_SIZE != 0 )); then
+          echo "ERROR: resumable upload for $object_path got misaligned offset $offset after resync; aborting" >&2
+          return 1
+        fi
+        dd if="$file" of="$chunk" bs="$CHUNK_SIZE" skip=$(( offset / CHUNK_SIZE )) count=1 2>/dev/null
+      fi
+    done
     offset="$newoff"
   done
 }
@@ -188,7 +225,7 @@ for file in "$ASSET_DIR"/*.dmg "$ASSET_DIR"/*.msi "$ASSET_DIR"/*.deb "$ASSET_DIR
   # limit, so upload them in chunks via the resumable (TUS) endpoint instead.
   if [[ "$size" -gt "$RESUMABLE_THRESHOLD" ]]; then
     echo "     ($((size / 1024 / 1024)) MB > $((RESUMABLE_THRESHOLD / 1024 / 1024)) MB threshold — using resumable upload)"
-    upload_resumable "$file" "$object_path" "$ctype" || exit 1
+    upload_resumable "$file" "$object_path" "$ctype" "$size" || exit 1
   else
     upload_single "$file" "$object_path" "$ctype" || exit 1
   fi
@@ -217,7 +254,7 @@ row="$(jq -nc \
   '{app: $app, version: $version, channel: $channel, prerelease: $prerelease, release_notes: $notes, assets: $assets}')"
 
 echo "Upserting app_releases row for $APP $VERSION ($uploaded asset(s))"
-http_code="$(curl -sS -o /tmp/app_releases_resp.txt -w '%{http_code}' \
+http_code="$(curl -sS -o "$TMP_DIR/app_releases_resp.txt" -w '%{http_code}' \
   -X POST "$SUPABASE_URL/rest/v1/app_releases" \
   -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
   -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
@@ -225,7 +262,7 @@ http_code="$(curl -sS -o /tmp/app_releases_resp.txt -w '%{http_code}' \
   -H "Prefer: resolution=merge-duplicates,return=minimal" \
   --data "$row")"
 if [[ "$http_code" != "200" && "$http_code" != "201" && "$http_code" != "204" ]]; then
-  echo "ERROR: app_releases upsert failed (HTTP $http_code): $(cat /tmp/app_releases_resp.txt)" >&2
+  echo "ERROR: app_releases upsert failed (HTTP $http_code): $(cat "$TMP_DIR/app_releases_resp.txt")" >&2
   exit 1
 fi
 

--- a/scripts/publish-supabase-release.sh
+++ b/scripts/publish-supabase-release.sh
@@ -9,6 +9,11 @@
 #   2. upserts a row into the `app_releases` table (which fires Supabase Realtime,
 #      pushing the new release to every running client).
 #
+# Large installers (the macOS .dmg is ~160 MB) exceed Cloudflare's ~100 MB
+# single-request body limit — Cloudflare fronts Supabase and rejects the upload
+# with HTTP 413 before it reaches Storage. Such assets are uploaded via the TUS
+# resumable protocol in 6 MiB chunks instead, so no single request is too large.
+#
 # Usage:
 #   publish-supabase-release.sh <app> <version> <channel> <asset_dir> <bucket>
 #
@@ -36,6 +41,10 @@ BUCKET="${5:?missing bucket}"
 SUPABASE_URL="${SUPABASE_URL%/}"  # strip trailing slash
 command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 1; }
 
+# Scratch space for resumable-upload chunks; cleaned up on exit.
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
@@ -53,6 +62,105 @@ content_type_of() {
     *.jar) echo "application/java-archive" ;;
     *)     echo "application/octet-stream" ;;
   esac
+}
+
+# --- Storage upload -----------------------------------------------------------
+# Cloudflare fronts Supabase and rejects any single request body over ~100 MB
+# with HTTP 413, so files above the threshold are streamed via the TUS resumable
+# endpoint in fixed 6 MiB chunks. Everything else uses the simpler single POST.
+CHUNK_SIZE=$((6 * 1024 * 1024))            # 6 MiB — the only chunk size Supabase's TUS server accepts.
+RESUMABLE_THRESHOLD=$((50 * 1024 * 1024))  # Anything above 50 MB goes resumable (well under the 100 MB cap).
+
+b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
+
+# Last HTTP status code from a curl `-D -` header dump (handles 100-continue etc.).
+http_status_of() { awk 'toupper($1) ~ /^HTTP/ {c=$2} END{print c}'; }
+# First value of a (case-insensitive) header from a curl `-D -` header dump.
+header_value_of() { tr -d '\r' | awk -v k="$(printf '%s' "$1" | tr 'A-Z' 'a-z'):" 'tolower($1)==k {print $2; exit}'; }
+
+# upload_single <file> <object_path> <content_type> — plain single-request upload.
+upload_single() {
+  local file="$1" object_path="$2" ctype="$3" code
+  code="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST "$SUPABASE_URL/storage/v1/object/$BUCKET/$object_path" \
+    -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+    -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+    -H "Content-Type: $ctype" \
+    -H "x-upsert: true" \
+    --data-binary "@$file")" || true
+  if [[ "$code" != "200" ]]; then
+    echo "ERROR: storage upload failed for $(basename "$object_path") (HTTP ${code:-none})" >&2
+    return 1
+  fi
+}
+
+# upload_resumable <file> <object_path> <content_type> — chunked TUS upload for large files.
+upload_resumable() {
+  local file="$1" object_path="$2" ctype="$3"
+  local total; total="$(wc -c < "$file" | tr -d '[:space:]')"
+  local meta="bucketName $(b64 "$BUCKET"),objectName $(b64 "$object_path"),contentType $(b64 "$ctype"),cacheControl $(b64 '3600')"
+
+  # 1) Create the upload; capture its per-upload Location URL. x-upsert overwrites on re-runs.
+  local create_hdrs
+  create_hdrs="$(curl -sS -D - -o /dev/null \
+    -X POST "$SUPABASE_URL/storage/v1/upload/resumable" \
+    -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+    -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+    -H "Tus-Resumable: 1.0.0" \
+    -H "Upload-Length: $total" \
+    -H "Upload-Metadata: $meta" \
+    -H "x-upsert: true")" || true
+
+  local code; code="$(printf '%s\n' "$create_hdrs" | http_status_of)"
+  if [[ "$code" != "201" ]]; then
+    echo "ERROR: resumable create failed for $object_path (HTTP ${code:-none})" >&2
+    printf '%s\n' "$create_hdrs" >&2
+    return 1
+  fi
+
+  local location; location="$(printf '%s\n' "$create_hdrs" | header_value_of Location)"
+  case "$location" in
+    http*) : ;;
+    /*)    location="$SUPABASE_URL$location" ;;
+    "")    echo "ERROR: resumable create for $object_path returned no Location header" >&2; return 1 ;;
+    *)     location="$SUPABASE_URL/storage/v1/upload/resumable/$location" ;;
+  esac
+
+  # 2) PATCH successive 6 MiB chunks until the server-reported offset reaches EOF.
+  # The server's Upload-Offset is the single source of truth for where to resume;
+  # since every full chunk advances it by exactly CHUNK_SIZE it stays aligned.
+  local chunk="$TMP_DIR/chunk.bin" offset=0
+  while [[ "$offset" -lt "$total" ]]; do
+    if (( offset % CHUNK_SIZE != 0 )); then
+      echo "ERROR: resumable upload for $object_path got misaligned offset $offset; aborting" >&2
+      return 1
+    fi
+    dd if="$file" of="$chunk" bs="$CHUNK_SIZE" skip=$(( offset / CHUNK_SIZE )) count=1 2>/dev/null
+
+    local patch_hdrs
+    patch_hdrs="$(curl -sS -D - -o /dev/null \
+      -X PATCH "$location" \
+      -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+      -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+      -H "Tus-Resumable: 1.0.0" \
+      -H "Content-Type: application/offset+octet-stream" \
+      -H "Upload-Offset: $offset" \
+      --data-binary "@$chunk")" || true
+
+    local pcode; pcode="$(printf '%s\n' "$patch_hdrs" | http_status_of)"
+    if [[ "$pcode" != "204" ]]; then
+      echo "ERROR: resumable chunk upload failed for $object_path at offset $offset (HTTP ${pcode:-none})" >&2
+      printf '%s\n' "$patch_hdrs" >&2
+      return 1
+    fi
+
+    local newoff; newoff="$(printf '%s\n' "$patch_hdrs" | header_value_of Upload-Offset)"
+    if [[ -z "$newoff" || "$newoff" -le "$offset" ]]; then
+      echo "ERROR: resumable upload for $object_path stalled at offset $offset (server offset='${newoff:-none}')" >&2
+      return 1
+    fi
+    offset="$newoff"
+  done
 }
 
 # prerelease = anything not on the stable channel, or a version with a pre-release suffix.
@@ -76,17 +184,13 @@ for file in "$ASSET_DIR"/*.dmg "$ASSET_DIR"/*.msi "$ASSET_DIR"/*.deb "$ASSET_DIR
   object_path="$APP/$VERSION/$name"
 
   echo "  -> uploading $name ($size bytes, sha256=${sha:0:12}…)"
-  # x-upsert lets re-runs overwrite an existing object.
-  http_code="$(curl -sS -o /dev/null -w '%{http_code}' \
-    -X POST "$SUPABASE_URL/storage/v1/object/$BUCKET/$object_path" \
-    -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
-    -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
-    -H "Content-Type: $ctype" \
-    -H "x-upsert: true" \
-    --data-binary "@$file")"
-  if [[ "$http_code" != "200" ]]; then
-    echo "ERROR: storage upload failed for $name (HTTP $http_code)" >&2
-    exit 1
+  # Files above the threshold would exceed Cloudflare's ~100 MB single-request
+  # limit, so upload them in chunks via the resumable (TUS) endpoint instead.
+  if [[ "$size" -gt "$RESUMABLE_THRESHOLD" ]]; then
+    echo "     ($((size / 1024 / 1024)) MB > $((RESUMABLE_THRESHOLD / 1024 / 1024)) MB threshold — using resumable upload)"
+    upload_resumable "$file" "$object_path" "$ctype" || exit 1
+  else
+    upload_single "$file" "$object_path" "$ctype" || exit 1
   fi
 
   public_url="$SUPABASE_URL/storage/v1/object/public/$BUCKET/$object_path"


### PR DESCRIPTION
## Problem

The `create-release` job's **Publish release to Supabase Storage** step ([run #28477399132](https://github.com/kshivang/BossTerm/actions/runs/28477399132/job/84407107948)) failed uploading `BossTerm-1.2.122.dmg`:

```
ERROR: storage upload failed for BossTerm-1.2.122.dmg (HTTP 413)
```

`scripts/publish-supabase-release.sh` uploaded each asset with a single `curl POST --data-binary`. `api.risaboss.com` is the Supabase project (`sb-project-ref: pcnwqamqdnsadranufjv`) **fronted by Cloudflare**, which enforces a hard **~100 MB request-body cap** on non-Enterprise plans. The DMG is **159 MiB (166,899,431 bytes)**, so Cloudflare returns **413 at the edge**, before Supabase sees the request. Raising the bucket size limit alone cannot fix a single 159 MB request.

## Fix

Route assets **> 50 MB** through Supabase's **TUS resumable endpoint** (`POST /storage/v1/upload/resumable` then `PATCH` in **6 MiB chunks** — the only chunk size Supabase's tus-node-server accepts), so no single request approaches Cloudflare's cap. Small assets keep the proven single-POST path.

- `curl` + `jq` + `dd` only — no new dependencies (`create-release` runs on `ubuntu-latest`).
- `x-upsert: true` preserves re-run overwrite behaviour.
- Loop is driven by the server's `Upload-Offset` with alignment + stall guards.

## Testing

- `bash -n` clean.
- Header-parsing helpers unit-tested against mock 201 / 204 / 413 responses.
- `dd` chunk-slicing verified to reassemble a 14 MiB file **byte-identically** (6 MiB + 6 MiB + remainder).
- Live upload path needs `SUPABASE_SERVICE_ROLE_KEY` (CI secret) so it takes effect on the next dispatched release.

## ⚠️ Also required (infra, not in this PR)

Supabase enforces the bucket + project-global Storage `file_size_limit` against the **total** object size even for resumable uploads. Bump the `app-releases` bucket **and** the project's global upload limit to something generous (e.g. 500 MB) or the resumable `create` will still 413/400.

> Note: re-running the *failed* job won't pick this up — Actions uses the script from the original triggering commit. It applies to the next release dispatched after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)