### PR TITLE
perf(daemon): binary attach frames, output coalescing, event-driven attach

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -620,8 +620,9 @@ fun TabbedTerminal(
                 // don't end up with a stray local tab alongside the daemon-hosted ones. Safety: if the
                 // bridge never attaches (daemon unreachable), fall back to a local tab after a grace
                 // period so the window isn't stuck empty. The grace window must exceed the bridge's own
-                // attach window (DaemonBridgeCoordinator.register polls ~15s) and short-circuits the
-                // moment the bridge attaches — otherwise an 8–15s attach leaves a stray local tab.
+                // attach window (DaemonBridgeCoordinator waits up to ~15s, event-driven) and
+                // short-circuits the moment the bridge attaches — otherwise an 8–15s attach leaves a
+                // stray local tab.
                 var waited = 0
                 while (waited < 16000 && tabController.tabs.isEmpty() &&
                     !ai.rever.bossterm.compose.daemon.DaemonBridgeCoordinator.isAttached &&

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachProtocol.kt
@@ -122,6 +122,10 @@ object DaemonAttachProtocol {
             }
         }
 
+        // The 1-byte id length is deliberate: session ids are 36-char UUIDs (TerminalSessionCore
+        // defaults them), so 255 bytes is ~7x headroom. The invariant is enforced here on the
+        // encode side only — decode masks the length byte and bounds-checks, so a hostile frame
+        // can't overread; only a producer minting a >255-byte id would ever trip this.
         private fun idBytes(sessionId: String): ByteArray =
             sessionId.toByteArray(Charsets.UTF_8).also {
                 require(it.size <= 255) { "session id too long for binary framing: ${it.size} bytes" }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachProtocol.kt
@@ -34,7 +34,9 @@ object DaemonAttachProtocol {
     // Server sealed-class variant an old client can't deserialize (ignoreUnknownKeys only covers
     // unknown *fields*, not unknown sealed-discriminator values), so the version bump turns that
     // into a clean connect-time reject via the existing ?v= handshake instead of a decode crash.
-    const val PROTOCOL_VERSION = 2
+    // v3 moves Output/Snapshot from JSON text frames to binary websocket frames ([BinaryFrame]) —
+    // a v2 client would ignore binary frames entirely and render nothing, so reject at connect.
+    const val PROTOCOL_VERSION = 3
 
     /** Header carrying the daemon control secret on the attach WS handshake (not a ?query= param, so
      *  it doesn't leak into request-line logs / proxies). Shared by the GUI client and the daemon. */
@@ -46,6 +48,85 @@ object DaemonAttachProtocol {
     fun decodeServer(s: String): Server = json.decodeFromString(Server.serializer(), s)
     fun encodeClient(m: Client): String = json.encodeToString(Client.serializer(), m)
     fun decodeClient(s: String): Client = json.decodeFromString(Client.serializer(), s)
+
+    /**
+     * Binary wire framing for the two high-volume server→client messages, [Server.Output] and
+     * [Server.Snapshot] (v3). As JSON text frames they paid a string escape of every control
+     * character (ESC → the six chars `\u001b`) plus a JSON encode+decode per PTY chunk — pure overhead
+     * on the hottest path in the protocol, and terminal output is escape-dense. Binary frames
+     * carry the payload as raw UTF-8 instead. Layout (lengths/ints big-endian):
+     *
+     *     [0]            frame type: [TYPE_OUTPUT] | [TYPE_SNAPSHOT]
+     *     [1]            session-id byte length n (session ids are 36-char UUIDs today)
+     *     [2 .. 2+n)     session id, UTF-8
+     *     Snapshot only: cols (u16), rows (u16)   — grid dims are clamped ≤2000 upstream
+     *     [rest]         payload, UTF-8 (always whole graphemes: both producers chunk grapheme-safely)
+     *
+     * [decode] returns the same [Server.Output]/[Server.Snapshot] types the JSON path used, so
+     * client dispatch stays transport-agnostic. Every other message remains a JSON text frame
+     * (low-rate, structure-rich — not worth a hand-rolled layout).
+     */
+    object BinaryFrame {
+        const val TYPE_OUTPUT: Byte = 1
+        const val TYPE_SNAPSHOT: Byte = 2
+
+        fun encodeOutput(sessionId: String, data: String): ByteArray {
+            val id = idBytes(sessionId)
+            val payload = data.toByteArray(Charsets.UTF_8)
+            val out = ByteArray(2 + id.size + payload.size)
+            out[0] = TYPE_OUTPUT
+            out[1] = id.size.toByte()
+            id.copyInto(out, 2)
+            payload.copyInto(out, 2 + id.size)
+            return out
+        }
+
+        fun encodeSnapshot(sessionId: String, cols: Int, rows: Int, data: String): ByteArray {
+            val id = idBytes(sessionId)
+            val payload = data.toByteArray(Charsets.UTF_8)
+            val out = ByteArray(2 + id.size + 4 + payload.size)
+            out[0] = TYPE_SNAPSHOT
+            out[1] = id.size.toByte()
+            id.copyInto(out, 2)
+            var p = 2 + id.size
+            out[p++] = (cols ushr 8).toByte(); out[p++] = cols.toByte()
+            out[p++] = (rows ushr 8).toByte(); out[p++] = rows.toByte()
+            payload.copyInto(out, p)
+            return out
+        }
+
+        /** Decode a binary frame to its [Server] message, or null if malformed / unknown type
+         *  (tolerated like an undecodable JSON frame — skipped, not fatal). */
+        fun decode(bytes: ByteArray): Server? {
+            if (bytes.size < 2) return null
+            val idLen = bytes[1].toInt() and 0xFF
+            val idEnd = 2 + idLen
+            return when (bytes[0]) {
+                TYPE_OUTPUT -> {
+                    if (bytes.size < idEnd) return null
+                    Server.Output(
+                        String(bytes, 2, idLen, Charsets.UTF_8),
+                        String(bytes, idEnd, bytes.size - idEnd, Charsets.UTF_8),
+                    )
+                }
+                TYPE_SNAPSHOT -> {
+                    if (bytes.size < idEnd + 4) return null
+                    Server.Snapshot(
+                        String(bytes, 2, idLen, Charsets.UTF_8),
+                        String(bytes, idEnd + 4, bytes.size - idEnd - 4, Charsets.UTF_8),
+                        cols = ((bytes[idEnd].toInt() and 0xFF) shl 8) or (bytes[idEnd + 1].toInt() and 0xFF),
+                        rows = ((bytes[idEnd + 2].toInt() and 0xFF) shl 8) or (bytes[idEnd + 3].toInt() and 0xFF),
+                    )
+                }
+                else -> null
+            }
+        }
+
+        private fun idBytes(sessionId: String): ByteArray =
+            sessionId.toByteArray(Charsets.UTF_8).also {
+                require(it.size <= 255) { "session id too long for binary framing: ${it.size} bytes" }
+            }
+    }
 
     @Serializable
     data class SessionMeta(val id: String, val title: String, val cwd: String? = null, val cols: Int = 80, val rows: Int = 24)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
@@ -283,6 +283,7 @@ class DaemonAttachServer(
         // (resync() no-ops for already-attached sessions). Re-snapshot the affected session (end +
         // begin) after a short quiet delay; one pending heal per session bounds a sustained flood
         // to a re-snapshot per delay window, and the last drop always schedules a final heal.
+        // Set BEFORE the initial resync() below, so even a drop during the first paint is reported.
         val resnapshotPending = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
         outbox.onOutputDropped = { sid ->
             if (resnapshotPending.add(sid)) {
@@ -292,6 +293,10 @@ class DaemonAttachServer(
                     synchronized(lock) {
                         if (!closed) {
                             endLocked(sid)
+                            // Tap is detached — purge the session's still-queued output so the fresh
+                            // snapshot (priority control lane) isn't followed by older chunks it
+                            // already contains, replaying as duplicates below the repaint.
+                            outbox.dropQueuedOutput(sid)
                             host.get(sid)?.let { beginLocked(it) }
                         }
                     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
@@ -157,15 +157,24 @@ class DaemonAttachServer(
         // fires forever capturing the dead connection's send) with no pairing endLocked.
         var closed = false
 
+        // First-line guard for binary framing's 1-byte id length: a session id that can't fit
+        // (impossible for today's 36-char UUIDs) is rejected HERE, loudly, instead of encode's
+        // require() throwing later inside the writer coroutine, where it reads as a bare
+        // connection drop. Cheap char-length check only — the exact UTF-8 count is encode's job.
+        fun idFitsBinaryFrame(id: String): Boolean =
+            (id.length <= 255).also { if (!it) log.error("session id too long for binary framing ({} chars); frame dropped", id.length) }
+
         fun send(m: DaemonAttachProtocol.Server) {
             when (m) {
                 // Only incremental Output rides the droppable lane; every other frame is guaranteed.
                 // Output + Snapshot travel as binary frames (v3): raw UTF-8 payload, no JSON
                 // string-escaping of an escape-dense stream on the hot path.
-                is DaemonAttachProtocol.Server.Output -> outbox.sendOutput(m.id, m.data)
-                is DaemonAttachProtocol.Server.Snapshot -> outbox.sendControl(FrameOutbox.Frame.Binary(
-                    DaemonAttachProtocol.BinaryFrame.encodeSnapshot(m.id, m.cols, m.rows, m.data),
-                ))
+                is DaemonAttachProtocol.Server.Output ->
+                    if (idFitsBinaryFrame(m.id)) outbox.sendOutput(m.id, m.data)
+                is DaemonAttachProtocol.Server.Snapshot ->
+                    if (idFitsBinaryFrame(m.id)) outbox.sendControl(FrameOutbox.Frame.Binary(
+                        DaemonAttachProtocol.BinaryFrame.encodeSnapshot(m.id, m.cols, m.rows, m.data),
+                    ))
                 else -> outbox.sendControl(FrameOutbox.Frame.Text(DaemonAttachProtocol.encodeServer(m)))
             }
         }
@@ -317,7 +326,11 @@ class DaemonAttachServer(
                         ))
                     }
                 }
-            } catch (_: Exception) {}
+            } catch (e: Exception) {
+                // Socket teardown lands here routinely (debug), but so would an encode failure —
+                // don't let a real bug read as a bare connection drop.
+                if (e !is kotlinx.coroutines.CancellationException) log.debug("attach writer ended: {}", e.toString())
+            }
             // drainTo returns when the outbox closes — including the control-lane-saturation hard close
             // for a read-wedged client. Closing the socket here unblocks the `for (frame in incoming)`
             // loop below so serve()'s finally runs the cleanup promptly, instead of the client + taps +

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
@@ -30,8 +30,10 @@ import java.security.MessageDigest
  *
  * Loopback + secret-gated (the daemon's control secret, presented as `?token=`), so no E2E/approval
  * is needed — that's only for untrusted remote viewers ([ai.rever.bossterm.compose.share.MirrorShare]).
- * Output is pushed via each session's raw-output tap; a per-connection bounded DROP_OLDEST outbox
- * means a stalled GUI never blocks the PTY (the next snapshot heals it).
+ * Output is pushed via each session's raw-output tap into a per-connection bounded drop-oldest
+ * outbox, so a stalled GUI never blocks the PTY; a drop schedules a healing re-snapshot of the
+ * affected session. Output/Snapshot travel as binary frames (raw UTF-8, no JSON escaping — see
+ * [DaemonAttachProtocol.BinaryFrame]); everything else is JSON text.
  */
 class DaemonAttachServer(
     private val host: SessionHost,
@@ -143,7 +145,7 @@ class DaemonAttachServer(
 
         // Per-connection outbox: taps + layout pushes enqueue; this coroutine drains to the socket.
         // Two lanes — control frames (snapshot/list/closed/resized/shareState) are guaranteed; only
-        // incremental Output is droppable under back-pressure (the next snapshot/resync heals it).
+        // incremental Output is droppable under back-pressure (healed by a re-snapshot, see below).
         val outbox = FrameOutbox()
         // sessionId → its output tap + size-collector job. Mutated from BOTH the incoming-frame
         // coroutine and the SessionHost change listener (arbitrary threads), so guarded by [lock].
@@ -156,9 +158,16 @@ class DaemonAttachServer(
         var closed = false
 
         fun send(m: DaemonAttachProtocol.Server) {
-            val text = DaemonAttachProtocol.encodeServer(m)
-            // Only incremental Output rides the droppable lane; every other frame is guaranteed.
-            if (m is DaemonAttachProtocol.Server.Output) outbox.sendOutput(text) else outbox.sendControl(text)
+            when (m) {
+                // Only incremental Output rides the droppable lane; every other frame is guaranteed.
+                // Output + Snapshot travel as binary frames (v3): raw UTF-8 payload, no JSON
+                // string-escaping of an escape-dense stream on the hot path.
+                is DaemonAttachProtocol.Server.Output -> outbox.sendOutput(m.id, m.data)
+                is DaemonAttachProtocol.Server.Snapshot -> outbox.sendControl(FrameOutbox.Frame.Binary(
+                    DaemonAttachProtocol.BinaryFrame.encodeSnapshot(m.id, m.cols, m.rows, m.data),
+                ))
+                else -> outbox.sendControl(FrameOutbox.Frame.Text(DaemonAttachProtocol.encodeServer(m)))
+            }
         }
         val client = Client(ws.call.request.queryParameters["pid"]?.toLongOrNull(), { send(it) })
         clients.add(client)
@@ -269,9 +278,40 @@ class DaemonAttachServer(
         val onChange: () -> Unit = { resync() }
         host.addChangeListener(onChange)
 
-        // Drain outbox to the socket (control frames first, then output).
+        // Heal a mirror whose incremental output was evicted under back-pressure: without this, a
+        // drop silently corrupts the client's render of that session until the socket reconnects
+        // (resync() no-ops for already-attached sessions). Re-snapshot the affected session (end +
+        // begin) after a short quiet delay; one pending heal per session bounds a sustained flood
+        // to a re-snapshot per delay window, and the last drop always schedules a final heal.
+        val resnapshotPending = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
+        outbox.onOutputDropped = { sid ->
+            if (resnapshotPending.add(sid)) {
+                ws.launch {
+                    kotlinx.coroutines.delay(RESNAPSHOT_DELAY_MS)
+                    resnapshotPending.remove(sid) // before healing: drops during the heal re-arm it
+                    synchronized(lock) {
+                        if (!closed) {
+                            endLocked(sid)
+                            host.get(sid)?.let { beginLocked(it) }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Drain outbox to the socket (control frames first, then coalesced output).
         val writer = ws.launch {
-            try { outbox.drainTo { text -> ws.send(Frame.Text(text)) } } catch (_: Exception) {}
+            try {
+                outbox.drainTo { f ->
+                    when (f) {
+                        is FrameOutbox.Frame.Text -> ws.send(Frame.Text(f.text))
+                        is FrameOutbox.Frame.Binary -> ws.send(Frame.Binary(true, f.bytes))
+                        is FrameOutbox.Frame.Output -> ws.send(Frame.Binary(
+                            true, DaemonAttachProtocol.BinaryFrame.encodeOutput(f.sessionId, f.data),
+                        ))
+                    }
+                }
+            } catch (_: Exception) {}
             // drainTo returns when the outbox closes — including the control-lane-saturation hard close
             // for a read-wedged client. Closing the socket here unblocks the `for (frame in incoming)`
             // loop below so serve()'s finally runs the cleanup promptly, instead of the client + taps +
@@ -360,5 +400,8 @@ class DaemonAttachServer(
         const val MAX_PRELUDE_CHARS = 1_000_000
         /** Quiet window for coalescing title/cwd-driven session-list refreshes (ms). */
         const val META_DEBOUNCE_MS = 200L
+        /** Delay before re-snapshotting a session whose output was dropped under back-pressure —
+         *  long enough to coalesce a burst of drops into one heal, short enough to feel instant. */
+        const val RESNAPSHOT_DELAY_MS = 500L
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
@@ -275,15 +275,13 @@ class DaemonAttachServer(
             }
         }
 
-        val onChange: () -> Unit = { resync() }
-        host.addChangeListener(onChange)
-
         // Heal a mirror whose incremental output was evicted under back-pressure: without this, a
         // drop silently corrupts the client's render of that session until the socket reconnects
         // (resync() no-ops for already-attached sessions). Re-snapshot the affected session (end +
         // begin) after a short quiet delay; one pending heal per session bounds a sustained flood
         // to a re-snapshot per delay window, and the last drop always schedules a final heal.
-        // Set BEFORE the initial resync() below, so even a drop during the first paint is reported.
+        // Wired BEFORE the change listener below and the initial resync(), so no tap can produce a
+        // drop that goes unreported.
         val resnapshotPending = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
         outbox.onOutputDropped = { sid ->
             if (resnapshotPending.add(sid)) {
@@ -303,6 +301,9 @@ class DaemonAttachServer(
                 }
             }
         }
+
+        val onChange: () -> Unit = { resync() }
+        host.addChangeListener(onChange)
 
         // Drain outbox to the socket (control frames first, then coalesced output).
         val writer = ws.launch {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonBridgeCoordinator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonBridgeCoordinator.kt
@@ -4,6 +4,7 @@ import ai.rever.bossterm.compose.TabbedTerminalState
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -109,7 +110,7 @@ object DaemonBridgeCoordinator {
                     ?: return@withTimeoutOrNull null
                 if (activeState !== state) return@withTimeoutOrNull null
                 // The controller is Compose state set during composition — observe it, don't poll it.
-                ep to snapshotFlow { state.tabController }.first { it != null }
+                ep to snapshotFlow { state.tabController }.filterNotNull().first()
             }
             if (ready == null) {
                 if (bridge == null && activeState === state) {
@@ -118,7 +119,7 @@ object DaemonBridgeCoordinator {
                 return@launch
             }
             val (endpoint, ctrl) = ready
-            if (activeState === state && bridge == null && ctrl != null) {
+            if (activeState === state && bridge == null) {
                 bridge = DaemonSessionBridge(ctrl, state.splitStates, endpoint.port, endpoint.secret, uiScope).also { it.start() }
                 log.info("Daemon session bridge attached (attachPort={})", endpoint.port)
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonBridgeCoordinator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonBridgeCoordinator.kt
@@ -1,10 +1,12 @@
 package ai.rever.bossterm.compose.daemon
 
 import ai.rever.bossterm.compose.TabbedTerminalState
+import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
 
 /**
@@ -13,29 +15,36 @@ import org.slf4j.LoggerFactory
  * a [DaemonSessionBridge], so daemon-hosted sessions render as tabs in that window.
  *
  * Process-wide singleton (one daemon per settings dir). v1 attaches ONE window at a time; its
- * controller readiness and the daemon connection can arrive in either order, so [register] polls
- * briefly for both before starting the bridge. When the attached window closes, the bridge fails
- * over to another still-open window (if any) so daemon sessions keep rendering. Entirely inert
- * unless `daemonEnabled`.
+ * controller readiness and the daemon connection can arrive in either order, so [promote] awaits
+ * both (event-driven — the endpoint via [attachState], the controller via [snapshotFlow]) before
+ * starting the bridge. When the attached window closes, the bridge fails over to another still-open
+ * window (if any) so daemon sessions keep rendering. Entirely inert unless `daemonEnabled`.
  */
 object DaemonBridgeCoordinator {
     private val log = LoggerFactory.getLogger(DaemonBridgeCoordinator::class.java)
 
-    private data class Attach(val port: Int, val secret: String)
+    /** The daemon's attach endpoint as this launch discovers it: unknown → ready | never-coming. */
+    private sealed interface AttachEndpoint {
+        /** Still discovering (daemon connect runs async at startup). */
+        object Pending : AttachEndpoint
+        data class Ready(val port: Int, val secret: String) : AttachEndpoint
+        /** The daemon won't serve an attach endpoint this launch — unreachable, or reachable but
+         *  its attach server failed to bind. Terminal state; windows fall back to local tabs. */
+        object Unavailable : AttachEndpoint
+    }
 
-    @Volatile private var attach: Attach? = null
+    // StateFlow (not a @Volatile var) so waiters wake the moment the endpoint resolves instead of
+    // discovering it on a poll tick — the old 250ms poll granularity showed up directly in
+    // time-to-first-tab on every warm start.
+    private val attachState = MutableStateFlow<AttachEndpoint>(AttachEndpoint.Pending)
     @Volatile private var activeState: TabbedTerminalState? = null
     @Volatile private var bridge: DaemonSessionBridge? = null
 
-    // Set once we know the daemon won't provide an attach endpoint this launch — unreachable, or
-    // reachable but its attach server failed to bind. Lets a starting window stop waiting for a bridge
-    // that will never come and fall back to a local tab immediately, instead of sitting empty for the
-    // full ~16s grace period.
-    @Volatile private var attachUnavailable = false
-    val isAttachUnavailable: Boolean get() = attachUnavailable
+    val isAttachUnavailable: Boolean get() = attachState.value is AttachEndpoint.Unavailable
 
-    /** Mark the daemon as not serving an attach endpoint this launch (GUI falls back to local tabs). */
-    fun markAttachUnavailable() { attachUnavailable = true }
+    /** Mark the daemon as not serving an attach endpoint this launch (GUI falls back to local tabs).
+     *  Only Pending → Unavailable: a late failure signal must not clobber a discovered endpoint. */
+    fun markAttachUnavailable() { attachState.compareAndSet(AttachEndpoint.Pending, AttachEndpoint.Unavailable) }
 
     // Every open window that has registered, in registration order — so when the attached window
     // closes we can fail the bridge over to a survivor instead of stranding it tab-less. Guarded by
@@ -70,7 +79,7 @@ object DaemonBridgeCoordinator {
         status.mcpPort?.let { ai.rever.bossterm.compose.mcp.McpTerminalRegistry.setRunning(it) }
         val ap = status.attachPort
             ?: run { log.warn("daemon reported no attach port"); markAttachUnavailable(); return }
-        attach = Attach(ap, ep.secret)
+        attachState.value = AttachEndpoint.Ready(ap, ep.secret)
         log.info("Daemon attach endpoint: ws://127.0.0.1:{}/attach", ap)
     }
 
@@ -91,23 +100,27 @@ object DaemonBridgeCoordinator {
         activeState = state
         uiScope.launch {
             // Either ordering: the controller initializes during composition, the daemon connects
-            // async. Poll briefly for both, then start the bridge.
-            var tries = 0
-            while (isActive && activeState === state && tries < 60) {
-                val ctrl = state.tabController
-                val a = attach
-                if (ctrl != null && a != null) {
-                    if (bridge == null) {
-                        bridge = DaemonSessionBridge(ctrl, state.splitStates, a.port, a.secret, uiScope).also { it.start() }
-                        log.info("Daemon session bridge attached (attachPort={})", a.port)
-                    }
-                    return@launch
-                }
-                delay(250)
-                tries++
+            // async. Await both event-driven (no poll granularity) under ONE deadline — it must
+            // stay below the window's ~16s local-tab fallback grace (TabbedTerminal), which the
+            // old 60×250ms poll also respected. The endpoint wait ends early on Unavailable — no
+            // point sitting out the timeout for a daemon that will never serve one.
+            val ready = withTimeoutOrNull(ATTACH_WAIT_MS) {
+                val ep = attachState.first { it !is AttachEndpoint.Pending } as? AttachEndpoint.Ready
+                    ?: return@withTimeoutOrNull null
+                if (activeState !== state) return@withTimeoutOrNull null
+                // The controller is Compose state set during composition — observe it, don't poll it.
+                ep to snapshotFlow { state.tabController }.first { it != null }
             }
-            if (bridge == null && activeState === state) {
-                log.warn("Daemon bridge not started (controller/endpoint not ready in time)")
+            if (ready == null) {
+                if (bridge == null && activeState === state) {
+                    log.warn("Daemon bridge not started (controller/endpoint not ready in time)")
+                }
+                return@launch
+            }
+            val (endpoint, ctrl) = ready
+            if (activeState === state && bridge == null && ctrl != null) {
+                bridge = DaemonSessionBridge(ctrl, state.splitStates, endpoint.port, endpoint.secret, uiScope).also { it.start() }
+                log.info("Daemon session bridge attached (attachPort={})", endpoint.port)
             }
         }
     }
@@ -146,4 +159,9 @@ object DaemonBridgeCoordinator {
     fun closePane(sessionId: String): Boolean = bridge?.closePane(sessionId) ?: false
 
     val isAttached: Boolean get() = bridge != null
+
+    /** Single deadline for endpoint + controller readiness (matches the old 60×250ms poll window;
+     *  cold daemon spawn + handshake fits well inside it, and it stays under the window's ~16s
+     *  local-tab fallback grace). */
+    private const val ATTACH_WAIT_MS = 15_000L
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonClient.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonClient.kt
@@ -159,7 +159,10 @@ class DaemonClient {
             } catch (e: InterruptedException) {
                 Thread.currentThread().interrupt(); return null
             }
-            sleep = (sleep * 2).coerceAtMost(400)
+            // Cap the poll interval low: a daemon spawn takes seconds, and each probe is one cheap
+            // loopback HELLO — a 400ms cap added up to ~400ms of pure poll granularity to every
+            // cold start after the daemon was actually ready.
+            sleep = (sleep * 2).coerceAtMost(150)
         }
         log.error("Daemon did not become reachable within {}ms", timeoutMs)
         return null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonSessionBridge.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonSessionBridge.kt
@@ -93,11 +93,14 @@ class DaemonSessionBridge(
     private val resizeSamplers = ConcurrentHashMap<String, ResizeSampler>()
 
     /**
-     * Send a Resize for [id], sampled: the first request goes out immediately; while requests keep
-     * arriving faster than [RESIZE_MIN_INTERVAL_MS] the StateFlow conflates them and the collector
-     * forwards only the latest per interval — ending, once the burst stops, with the final grid
-     * (a StateFlow always retains the last value). Equal grids dedup for free (StateFlow skips
-     * value-equal updates).
+     * Send a Resize for [id], sampled: the first request is forwarded as soon as the sampler's
+     * collector starts (one dispatch hop onto [io] — the StateFlow retains the value, so nothing
+     * is lost, just not strictly synchronous); while requests keep arriving faster than
+     * [RESIZE_MIN_INTERVAL_MS] the StateFlow conflates them and the collector forwards only the
+     * latest per interval — ending, once the burst stops, with the final grid (a StateFlow always
+     * retains the last value). Equal grids dedup for free (StateFlow skips value-equal updates).
+     * Sampler creation (layout callbacks) and removal ([closeMirror]/[closeMirrorContainer]) are
+     * both Main-confined, so they can't interleave.
      */
     private fun sendResizeSampled(id: String, cols: Int, rows: Int) {
         val sampler = resizeSamplers.computeIfAbsent(id) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonSessionBridge.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonSessionBridge.kt
@@ -136,7 +136,8 @@ class DaemonSessionBridge(
     fun stop() {
         running = false
         outbox?.close()
-        io.cancel()
+        io.cancel() // reaps the resize-sampler collectors too
+        resizeSamplers.clear()
         runCatching { client.close() }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonSessionBridge.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonSessionBridge.kt
@@ -16,15 +16,12 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.readText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import ai.rever.bossterm.compose.settings.SettingsManager
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -88,37 +85,19 @@ class DaemonSessionBridge(
         const val SNAPSHOT_RESET = "\u001b[H\u001b[2J\u001b[3J"
     }
 
-    /** sessionId → its pending grid + sampler job (see [sendResizeSampled]). */
-    private class ResizeSampler(val grid: MutableStateFlow<Pair<Int, Int>?>, val job: Job)
-    private val resizeSamplers = ConcurrentHashMap<String, ResizeSampler>()
-
     /**
-     * Send a Resize for [id], sampled: the first request is forwarded as soon as the sampler's
-     * collector starts (one dispatch hop onto [io] — the StateFlow retains the value, so nothing
-     * is lost, just not strictly synchronous); while requests keep arriving faster than
-     * [RESIZE_MIN_INTERVAL_MS] the StateFlow conflates them and the collector forwards only the
-     * latest per interval — ending, once the burst stops, with the final grid (a StateFlow always
-     * retains the last value). Equal grids dedup for free (StateFlow skips value-equal updates).
-     * Sampler creation (layout callbacks) and removal ([closeMirror]/[closeMirrorContainer]) are
-     * both Main-confined, so they can't interleave.
+     * Per-session conflated Resize forwarding (see [ResizeSampler] for the invariants: first send
+     * near-immediate, at most one per interval during a burst, final grid always delivered).
+     * Creation (layout callbacks) and removal ([closeMirror]/[closeMirrorContainer]) are both
+     * Main-confined, so they can't interleave.
      */
-    private fun sendResizeSampled(id: String, cols: Int, rows: Int) {
-        val sampler = resizeSamplers.computeIfAbsent(id) {
-            val grid = MutableStateFlow<Pair<Int, Int>?>(null)
-            val job = io.launch {
-                grid.filterNotNull().collect { (c, r) ->
-                    send(DaemonAttachProtocol.Client.Resize(id, c, r))
-                    delay(RESIZE_MIN_INTERVAL_MS) // conflation window: intermediate grids are skipped
-                }
-            }
-            ResizeSampler(grid, job)
-        }
-        sampler.grid.value = cols to rows
+    private val resizeSamplers = ResizeSampler(io, RESIZE_MIN_INTERVAL_MS) { id, c, r ->
+        send(DaemonAttachProtocol.Client.Resize(id, c, r))
     }
 
-    private fun dropResizeSampler(id: String) {
-        resizeSamplers.remove(id)?.job?.cancel()
-    }
+    private fun sendResizeSampled(id: String, cols: Int, rows: Int) = resizeSamplers.request(id, cols, rows)
+
+    private fun dropResizeSampler(id: String) = resizeSamplers.drop(id)
 
     fun start() {
         if (running) return

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonSessionBridge.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonSessionBridge.kt
@@ -16,12 +16,15 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.readText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import ai.rever.bossterm.compose.settings.SettingsManager
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -74,9 +77,44 @@ class DaemonSessionBridge(
     @Volatile private var sawAnySession = false
 
     private companion object {
+        /** Min spacing between daemon-bound Resize sends per session. Auto-fit fires per layout
+         *  tick during a live window drag, and every Resize reflows the daemon's full scrollback
+         *  (then the Resized echo reflows the mirror's) — throttle to one grid per interval,
+         *  first send immediate, final value always delivered. */
+        const val RESIZE_MIN_INTERVAL_MS = 50L
+
         /** Home + clear screen + clear scrollback — prepended to a snapshot so a reattach repaint
          *  replaces (not appends below) the mirror tab's existing content. */
         const val SNAPSHOT_RESET = "\u001b[H\u001b[2J\u001b[3J"
+    }
+
+    /** sessionId → its pending grid + sampler job (see [sendResizeSampled]). */
+    private class ResizeSampler(val grid: MutableStateFlow<Pair<Int, Int>?>, val job: Job)
+    private val resizeSamplers = ConcurrentHashMap<String, ResizeSampler>()
+
+    /**
+     * Send a Resize for [id], sampled: the first request goes out immediately; while requests keep
+     * arriving faster than [RESIZE_MIN_INTERVAL_MS] the StateFlow conflates them and the collector
+     * forwards only the latest per interval — ending, once the burst stops, with the final grid
+     * (a StateFlow always retains the last value). Equal grids dedup for free (StateFlow skips
+     * value-equal updates).
+     */
+    private fun sendResizeSampled(id: String, cols: Int, rows: Int) {
+        val sampler = resizeSamplers.computeIfAbsent(id) {
+            val grid = MutableStateFlow<Pair<Int, Int>?>(null)
+            val job = io.launch {
+                grid.filterNotNull().collect { (c, r) ->
+                    send(DaemonAttachProtocol.Client.Resize(id, c, r))
+                    delay(RESIZE_MIN_INTERVAL_MS) // conflation window: intermediate grids are skipped
+                }
+            }
+            ResizeSampler(grid, job)
+        }
+        sampler.grid.value = cols to rows
+    }
+
+    private fun dropResizeSampler(id: String) {
+        resizeSamplers.remove(id)?.job?.cancel()
     }
 
     fun start() {
@@ -175,8 +213,13 @@ class DaemonSessionBridge(
                 }
                 try {
                     for (frame in incoming) {
-                        if (frame !is Frame.Text) continue
-                        val msg = runCatching { DaemonAttachProtocol.decodeServer(frame.readText()) }.getOrNull() ?: continue
+                        // v3: Output/Snapshot arrive as binary frames (raw UTF-8 payload, no JSON
+                        // escaping on the hot path); everything else stays JSON text.
+                        val msg = when (frame) {
+                            is Frame.Text -> runCatching { DaemonAttachProtocol.decodeServer(frame.readText()) }.getOrNull()
+                            is Frame.Binary -> DaemonAttachProtocol.BinaryFrame.decode(frame.data)
+                            else -> null
+                        } ?: continue
                         dispatch(msg)
                     }
                 } finally {
@@ -295,7 +338,7 @@ class DaemonSessionBridge(
                     remotePaneId = meta.id,
                     onUserInput = { data -> send(DaemonAttachProtocol.Client.Input(meta.id, data)) },
                 )
-                tab.onRemoteFit = { cols, rows -> send(DaemonAttachProtocol.Client.Resize(meta.id, cols, rows)) }
+                tab.onRemoteFit = { cols, rows -> sendResizeSampled(meta.id, cols, rows) }
                 tab.workingDirectory.value = meta.cwd
                 tabs[meta.id] = tab
                 controller.createTabFromExistingSession(tab)
@@ -365,7 +408,7 @@ class DaemonSessionBridge(
             title = "",
             remotePaneId = sessionId,
             onUserInput = { data -> send(DaemonAttachProtocol.Client.Input(sessionId, data)) },
-        ).also { it.onRemoteFit = { cols, rows -> send(DaemonAttachProtocol.Client.Resize(sessionId, cols, rows)) } }
+        ).also { it.onRemoteFit = { cols, rows -> sendResizeSampled(sessionId, cols, rows) } }
 
     /** [GroupTreeDto] -> [SplitNode], reusing/creating leaf mirrors by session id via the same
      *  `tabs` cache the flat path uses. */
@@ -387,6 +430,7 @@ class DaemonSessionBridge(
      *  the container tab. Mirrors `RemoteSessionManager.removeMirrorTab`. Must run on Main. */
     private fun closeMirrorContainer(container: TerminalTab) {
         splitStates[container.id]?.getAllSessions()?.filterIsInstance<TerminalTab>()?.forEach { mirror ->
+            tabs.entries.filter { it.value === mirror }.forEach { dropResizeSampler(it.key) }
             tabs.entries.removeIf { it.value === mirror }
             runCatching { mirror.dispose() }
         }
@@ -402,6 +446,7 @@ class DaemonSessionBridge(
     }
 
     private suspend fun closeMirror(id: String) {
+        dropResizeSampler(id)
         val tab = tabs.remove(id) ?: return
         withContext(Dispatchers.Main) {
             // A leaf inside a multi-pane group's SplitViewState isn't in controller.tabs at all —

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareConnection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareConnection.kt
@@ -4,13 +4,15 @@ import kotlinx.coroutines.CompletableDeferred
 
 /**
  * A connected browser viewer of a daemon-hosted share. The headless counterpart to
- * [ai.rever.bossterm.compose.share.ViewerConnection]: the share server pushes pre-encoded JSON
- * frames into [outbox] and the per-connection Ktor coroutine drains them (encrypting each when a
- * cipher was negotiated). The outbox has two lanes (see [FrameOutbox]): control frames (snapshot /
- * layout / presence / ...) are guaranteed, while incremental PaneOutput is bounded + DROP_OLDEST so
- * a slow viewer never back-pressures the PTY taps — it just misses intermediate output, and the next
- * [ai.rever.bossterm.compose.share.ServerMessage.PaneSnapshot] heals it. [canControl] is mutable
- * because an approved mid-session control upgrade flips a live view-only connection without a reconnect.
+ * [ai.rever.bossterm.compose.share.ViewerConnection]: the share server pushes control frames
+ * (pre-encoded JSON) and raw pane-output chunks into [outbox] and the per-connection Ktor coroutine
+ * drains them (encoding output to PaneOutput at drain time, encrypting each frame when a cipher was
+ * negotiated). The outbox has two lanes (see [FrameOutbox]): control frames (snapshot / layout /
+ * presence / ...) are guaranteed, while incremental pane output is char-bounded drop-oldest so a
+ * slow viewer never back-pressures the PTY taps — each drop schedules a healing
+ * [ai.rever.bossterm.compose.share.ServerMessage.PaneSnapshot] for the affected pane. [canControl]
+ * is mutable because an approved mid-session control upgrade flips a live view-only connection
+ * without a reconnect.
  */
 internal class DaemonShareConnection(
     val id: Int,
@@ -18,7 +20,9 @@ internal class DaemonShareConnection(
     /** Device label from the viewer's Hello — shown to attached GUIs in the approval list. */
     val name: String,
 ) {
-    val outbox = FrameOutbox(outputCapacity = 2048)
+    // Tighter budget than the attach outbox: browser viewers ride real (possibly remote) links, and
+    // a healing re-snapshot replaces a big stale backlog more cheaply than delivering it.
+    val outbox = FrameOutbox(outputCapacityChars = 2 * 1024 * 1024)
 }
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -744,6 +744,9 @@ class DaemonShareServer(
                     synchronized(attachLock) {
                         if (!viewerClosed) {
                             endLocked(pid)
+                            // Tap is detached — purge the pane's still-queued output so the fresh
+                            // snapshot isn't followed by older chunks it already contains.
+                            vc.outbox.dropQueuedOutput(pid)
                             inScopeCores(def).firstOrNull { it.id == pid }?.let { beginLocked(it) }
                         }
                     }
@@ -787,7 +790,12 @@ class DaemonShareServer(
                         is FrameOutbox.Frame.Text -> f.text
                         // Coalesced pane bytes → one PaneOutput, encoded here at drain time.
                         is FrameOutbox.Frame.Output -> ShareProtocol.encodeServer(ServerMessage.PaneOutput(f.sessionId, f.data))
-                        is FrameOutbox.Frame.Binary -> return@drainTo // not used on the share path
+                        is FrameOutbox.Frame.Binary -> {
+                            // Never enqueued on the share path — loud skip so a future mis-wiring
+                            // surfaces instead of silently dropping a frame.
+                            log.warn("share viewer {}: dropping unexpected binary control frame", vc.id)
+                            return@drainTo
+                        }
                     }
                     sc?.let { ws.send(Frame.Binary(true, it.encrypt(text))) } ?: ws.send(Frame.Text(text))
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -139,6 +139,9 @@ class DaemonShareServer(
         const val GRANT_MAX_LIFETIME_MS = 7L * 24 * 60 * 60 * 1000
         /** Cap on the per-viewer prelude buffer (output racing a snapshot encode) — bounds heap. */
         const val MAX_PRELUDE_CHARS = 1_000_000
+        /** Delay before re-snapshotting a pane whose output was dropped under back-pressure —
+         *  long enough to coalesce a burst of drops into one heal, short enough to feel instant. */
+        const val RESNAPSHOT_DELAY_MS = 500L
     }
 
     /** A granted device key: which share, its role, the client it was issued to, and its windows. */
@@ -201,7 +204,7 @@ class DaemonShareServer(
         val viewerCount: Int get() = viewers.size
 
         fun broadcast(msg: ServerMessage) {
-            val text = ShareProtocol.encodeServer(msg)
+            val text = FrameOutbox.Frame.Text(ShareProtocol.encodeServer(msg))
             // Broadcasts (Layout / Presence / Theme / ...) are all control-lane (guaranteed) frames.
             for (v in viewers) v.outbox.sendControl(text)
         }
@@ -680,23 +683,26 @@ class DaemonShareServer(
                         else -> { p.add(d); preludeChars += d.length; true }
                     }
                 }
-                if (!held) vc.outbox.sendOutput(ShareProtocol.encodeServer(ServerMessage.PaneOutput(core.id, d)))
+                // Raw chunk, not a pre-encoded PaneOutput: the writer encodes at drain time, so the
+                // outbox can coalesce queued same-pane chunks into ONE PaneOutput (concatenated pane
+                // bytes are protocol-equivalent, and a backlog collapses into few frames).
+                if (!held) vc.outbox.sendOutput(core.id, d)
             }
             core.addRawOutputListener(tap)
             // One-time styled initial paint (identical encoder to the attach server / MirrorShare).
-            vc.outbox.sendControl(ShareProtocol.encodeServer(ServerMessage.PaneSnapshot(
+            vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(ServerMessage.PaneSnapshot(
                 core.id,
                 TerminalSnapshotEncoder.encode(core.textBuffer.createSnapshot(), core.terminal.cursorX, core.terminal.cursorY),
                 sz.columns, sz.rows,
-            )))
+            ))))
             synchronized(preludeLock) {
-                prelude?.forEach { vc.outbox.sendOutput(ShareProtocol.encodeServer(ServerMessage.PaneOutput(core.id, it))) }
+                prelude?.forEach { vc.outbox.sendOutput(core.id, it) }
                 prelude = null
             }
             // Push PaneResize whenever the grid changes (a TUI resizing it), so the viewer's xterm.js follows.
             val sizeJob = ws.launch {
                 core.display.termSizeFlow.collect {
-                    vc.outbox.sendControl(ShareProtocol.encodeServer(ServerMessage.PaneResize(core.id, it.columns, it.rows)))
+                    vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(ServerMessage.PaneResize(core.id, it.columns, it.rows))))
                 }
             }
             attachments[core.id] = Attachment(core, tap, sizeJob)
@@ -709,18 +715,41 @@ class DaemonShareServer(
             }
         }
 
+        // Set under [attachLock] in the finally — a resync/heal already dispatched on another thread
+        // must not re-register taps after teardown (they'd fire forever on a dead connection).
+        var viewerClosed = false
+
         // Re-sync taps + resend Layout when the host's session set (or this scope's session) changes.
         fun resync() {
             synchronized(attachLock) {
+                if (viewerClosed) return
                 val live = inScopeCores(def).associateBy { it.id }
                 (attachments.keys - live.keys).toList().forEach { endLocked(it) }
                 live.values.forEach { beginLocked(it) }
             }
-            vc.outbox.sendControl(ShareProtocol.encodeServer(layoutFor(def)))
+            vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(layoutFor(def))))
         }
 
         val onChange: () -> Unit = { resync() }
         host.addChangeListener(onChange)
+
+        // Heal a viewer whose incremental output was evicted under back-pressure (slow remote link):
+        // re-snapshot the affected pane after a quiet delay — same pattern as the attach server.
+        val resnapshotPending = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
+        vc.outbox.onOutputDropped = { pid ->
+            if (resnapshotPending.add(pid)) {
+                ws.launch {
+                    delay(RESNAPSHOT_DELAY_MS)
+                    resnapshotPending.remove(pid) // before healing: drops during the heal re-arm it
+                    synchronized(attachLock) {
+                        if (!viewerClosed) {
+                            endLocked(pid)
+                            inScopeCores(def).firstOrNull { it.id == pid }?.let { beginLocked(it) }
+                        }
+                    }
+                }
+            }
+        }
 
         // Register the viewer UNDER [mutex] and verify the share is still live + under the viewer cap.
         // stopShare clears def.viewers under the lock, so adding outside it could orphan a viewer that
@@ -753,7 +782,13 @@ class DaemonShareServer(
         val sc = serverCipher
         val writer = ws.launch {
             try {
-                vc.outbox.drainTo { text ->
+                vc.outbox.drainTo { f ->
+                    val text = when (f) {
+                        is FrameOutbox.Frame.Text -> f.text
+                        // Coalesced pane bytes → one PaneOutput, encoded here at drain time.
+                        is FrameOutbox.Frame.Output -> ShareProtocol.encodeServer(ServerMessage.PaneOutput(f.sessionId, f.data))
+                        is FrameOutbox.Frame.Binary -> return@drainTo // not used on the share path
+                    }
                     sc?.let { ws.send(Frame.Binary(true, it.encrypt(text))) } ?: ws.send(Frame.Text(text))
                 }
             } catch (_: Throwable) { /* socket gone */ }
@@ -769,7 +804,10 @@ class DaemonShareServer(
             // client gone
         } finally {
             host.removeChangeListener(onChange)
-            synchronized(attachLock) { attachments.keys.toList().forEach { endLocked(it) } }
+            synchronized(attachLock) {
+                viewerClosed = true
+                attachments.keys.toList().forEach { endLocked(it) }
+            }
             writer.cancel()
             if (def.viewers.remove(vc)) {
                 runCatching { vc.outbox.close() }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -799,7 +799,11 @@ class DaemonShareServer(
                     }
                     sc?.let { ws.send(Frame.Binary(true, it.encrypt(text))) } ?: ws.send(Frame.Text(text))
                 }
-            } catch (_: Throwable) { /* socket gone */ }
+            } catch (e: Throwable) {
+                // Usually just the socket going away — but log it so an encode/encrypt failure
+                // doesn't read as a bare viewer drop.
+                if (e !is kotlinx.coroutines.CancellationException) log.debug("share writer {} ended: {}", vc.id, e.toString())
+            }
         }
 
         try {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
@@ -181,7 +181,10 @@ internal class FrameOutbox(
                 // A wake signal (or wake-close) just re-runs the loop, which sweeps both lanes.
                 wake.onReceiveCatching { false }
             }
-            if (ended) return
+            // Close observed while suspended: CONTINUE (not return) so the next pass does one
+            // final sweep of both lanes — an output chunk that raced close() past its wake signal
+            // is still flushed, and step 4 then terminates. Returning here would strand it.
+            if (ended) continue
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
@@ -76,6 +76,12 @@ internal class FrameOutbox(
          *  client, and dropped output is healed by [onOutputDropped]'s re-snapshot. */
         const val DEFAULT_OUTPUT_CAPACITY_CHARS = 4 * 1024 * 1024
 
+        /** Secondary bound on queued output FRAMES: the char budget bounds payload heap, but each
+         *  queued chunk also costs an object + deque slot, so a pathological stream of tiny chunks
+         *  could hold millions of objects while staying under the char budget. Evicts oldest-first
+         *  past either bound. */
+        const val MAX_OUTPUT_FRAMES = 8192
+
         /** Cap on one coalesced output emission, so a huge backlog still yields to control frames. */
         const val MAX_COALESCED_CHARS = 256 * 1024
     }
@@ -93,9 +99,10 @@ internal class FrameOutbox(
         synchronized(outputLock) {
             outputQueue.addLast(Frame.Output(sessionId, data))
             outputChars += data.length
-            // Evict oldest-first past the budget, but always keep the newest chunk — a single
-            // over-budget chunk must still go out (it's bounded upstream by the PTY reader anyway).
-            while (outputChars > outputCapacity && outputQueue.size > 1) {
+            // Evict oldest-first past either bound (chars for payload heap, frames for object
+            // count), but always keep the newest chunk — a single over-budget chunk must still go
+            // out (it's bounded upstream by the PTY reader anyway).
+            while ((outputChars > outputCapacity || outputQueue.size > MAX_OUTPUT_FRAMES) && outputQueue.size > 1) {
                 val evicted = outputQueue.removeFirst()
                 outputChars -= evicted.data.length
                 (dropped ?: mutableSetOf<String>().also { dropped = it }).add(evicted.sessionId)
@@ -103,6 +110,23 @@ internal class FrameOutbox(
         }
         wake.trySend(Unit)
         dropped?.forEach { sid -> onOutputDropped?.invoke(sid) }
+    }
+
+    /**
+     * Purge every queued output chunk for [sessionId]. The drop-heal calls this right before it
+     * enqueues the fresh snapshot: control frames outrank output in [drainTo], so without the purge
+     * a snapshot would be emitted AHEAD of that session's older queued output — output whose effect
+     * the snapshot already contains — and the stale chunks would then replay below the repaint as
+     * duplicated content. Not reported via [onOutputDropped] (this IS the heal). The caller must
+     * have detached the session's tap first, so nothing re-enqueues pre-snapshot chunks after the
+     * purge; the fresh tap's prelude flush lands after the snapshot, unaffected.
+     */
+    fun dropQueuedOutput(sessionId: String) {
+        synchronized(outputLock) {
+            var removed = 0
+            outputQueue.removeAll { c -> (c.sessionId == sessionId).also { if (it) removed += c.data.length } }
+            outputChars -= removed
+        }
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
@@ -1,102 +1,169 @@
 package ai.rever.bossterm.compose.daemon
 
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.selects.select
 
 /**
  * A per-connection send queue with TWO lanes, drained by ONE writer coroutine:
  *
- *  - [sendControl] — **guaranteed delivery** (unbounded). Full-paint snapshots, session/layout lists,
- *    lifecycle (closed), and resizes go here: dropping one corrupts the mirror until the next resync,
- *    so they must never be evicted.
- *  - [sendOutput] — **best-effort** (bounded, DROP_OLDEST). Incremental PTY output goes here: a stalled
- *    client must never back-pressure the PTY, so the oldest output is dropped under load and the next
- *    snapshot/resync heals it.
+ *  - [sendControl] — **guaranteed delivery** (bounded channel). Full-paint snapshots, session/layout
+ *    lists, lifecycle (closed), and resizes go here: dropping one corrupts the mirror until the next
+ *    resync, so they must never be evicted.
+ *  - [sendOutput] — **best-effort** (char-bounded deque, drop-oldest). Incremental PTY output goes
+ *    here: a stalled client must never back-pressure the PTY, so the oldest output is dropped under
+ *    load. Each drop reports the affected session via [onOutputDropped], so the connection can
+ *    re-snapshot it (the drop would otherwise silently corrupt the mirror until reconnect).
  *
- * [drainTo] fully flushes the control lane before each output frame, so a snapshot always reaches the
- * client before the output it anchors — without relying on a single channel's FIFO (where a burst of
- * output could otherwise evict the snapshot). Both lanes are non-blocking ([Channel.trySend]) so
- * producers on PTY / emulator threads never suspend.
+ * [drainTo] fully flushes the control lane before each output emission, so a snapshot always reaches
+ * the client before the output it anchors. On drain, consecutive queued chunks for the SAME session
+ * are **coalesced** into one [Frame.Output] (bounded by [MAX_COALESCED_CHARS]) — only what is already
+ * queued is merged, never awaited, so coalescing adds zero latency while collapsing a backlog of
+ * small PTY chunks into few large frames (fewer websocket frames + syscalls under bulk output).
+ * Both lanes are non-blocking on the producer side, so PTY / emulator threads never suspend.
  *
- * Replaces the previous single `Channel(4096, DROP_OLDEST)` that funneled *every* frame — including
- * snapshots — through the droppable path (issue: a burst could evict a snapshot, blanking the mirror).
+ * The output lane is bounded in CHARS (not frames): frame counts made the real memory bound depend
+ * on chunk size (4096 frames × 64KB-max chunks), while a char budget is what the heap actually holds.
  */
-internal class FrameOutbox(outputCapacity: Int = 4096, controlCapacity: Int = 1024) {
+internal class FrameOutbox(
+    outputCapacityChars: Int = DEFAULT_OUTPUT_CAPACITY_CHARS,
+    controlCapacity: Int = 1024,
+) {
+    /** What [drainTo] hands the socket writer. */
+    sealed interface Frame {
+        /** A JSON control frame (session/group lists, lifecycle, share state, …). */
+        data class Text(val text: String) : Frame
+
+        /** A pre-encoded binary control frame (snapshot). */
+        class Binary(val bytes: ByteArray) : Frame
+
+        /** Coalesced incremental output for one session; encoded to a binary frame at send time. */
+        data class Output(val sessionId: String, val data: String) : Frame
+    }
+
     // Control frames must not be DROPPED, but the lane is still BOUNDED: a wedged client (socket
     // reader stalled) plus repeated resync() — each pushing a full-scrollback Snapshot — would
     // otherwise grow the heap without limit. A client that can't even keep up with control frames is
     // unrecoverable, so on overflow we close the outbox: the writer ends, the connection drops, and
-    // the GUI reconnects to a fresh snapshot. (Was Channel.UNLIMITED, which defeated the backpressure
-    // guarantee the outbox exists to provide.)
-    //
-    // This is NOT an unbounded "reconnect storm": the reconnect is paced by DaemonSessionBridge's
-    // exponential backoff (250ms→4s), and a fresh attach replays only ONE current snapshot per session
-    // (resync's beginLocked snapshots a session once, on first attach) — never the dropped backlog. So
-    // a persistently-wedged client settles into slow backoff retries, not a tight loop. Hard-closing a
-    // truly-stuck connection is preferred over coalescing here: coalescing redundant control frames
-    // would require the outbox to parse frame semantics it deliberately treats as opaque bytes.
-    private val control = Channel<String>(capacity = controlCapacity)
-    private val output = Channel<String>(capacity = outputCapacity, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    // the GUI reconnects to a fresh snapshot. (Reconnects are paced by DaemonSessionBridge's
+    // exponential backoff, so a persistently-wedged client settles into slow retries.)
+    private val control = Channel<Frame>(capacity = controlCapacity)
+
+    // Output lane: a plain deque under a lock (not a Channel) so eviction can report WHICH session
+    // lost data ([onOutputDropped]) and so [takeCoalesced] can peek/merge same-session runs.
+    private val outputLock = Any()
+    private val outputQueue = ArrayDeque<Frame.Output>()
+    private var outputChars = 0
+    private val outputCapacity = outputCapacityChars.coerceAtLeast(1)
+
+    // Wakes an idle drainer when output arrives (CONFLATED: one pending signal is enough — the
+    // drainer sweeps the whole deque per pass).
+    private val wake = Channel<Unit>(capacity = Channel.CONFLATED)
+
     @Volatile private var closed = false
 
+    /**
+     * Invoked (outside the queue lock, on the producing thread) with the session id of each evicted
+     * output chunk. The attach connection uses it to schedule a healing re-snapshot — without it a
+     * drop silently corrupts the mirror until the socket reconnects.
+     */
+    @Volatile var onOutputDropped: ((sessionId: String) -> Unit)? = null
+
     internal companion object {
-        /** Max control frames drained before yielding to one output frame (fairness; see [drainTo]). */
+        /** Max control frames drained before yielding to one output emission (fairness; see [drainTo]). */
         const val CONTROL_BURST = 64
+
+        /** Output-lane budget. ~8MB of UTF-16 heap; a backlog beyond this means a badly stalled
+         *  client, and dropped output is healed by [onOutputDropped]'s re-snapshot. */
+        const val DEFAULT_OUTPUT_CAPACITY_CHARS = 4 * 1024 * 1024
+
+        /** Cap on one coalesced output emission, so a huge backlog still yields to control frames. */
+        const val MAX_COALESCED_CHARS = 256 * 1024
     }
 
     /** Enqueue a frame that must not be dropped (snapshot / list / lifecycle / resize). */
-    fun sendControl(text: String) {
+    fun sendControl(frame: Frame) {
         if (closed) return
-        if (control.trySend(text).isFailure) close() // saturated → unrecoverable client; drop it
+        if (control.trySend(frame).isFailure) close() // saturated → unrecoverable client; drop it
     }
 
     /** Enqueue incremental output that may be dropped under back-pressure. */
-    fun sendOutput(text: String) {
-        if (!closed) output.trySend(text)
+    fun sendOutput(sessionId: String, data: String) {
+        if (closed || data.isEmpty()) return
+        var dropped: MutableSet<String>? = null
+        synchronized(outputLock) {
+            outputQueue.addLast(Frame.Output(sessionId, data))
+            outputChars += data.length
+            // Evict oldest-first past the budget, but always keep the newest chunk — a single
+            // over-budget chunk must still go out (it's bounded upstream by the PTY reader anyway).
+            while (outputChars > outputCapacity && outputQueue.size > 1) {
+                val evicted = outputQueue.removeFirst()
+                outputChars -= evicted.data.length
+                (dropped ?: mutableSetOf<String>().also { dropped = it }).add(evicted.sessionId)
+            }
+        }
+        wake.trySend(Unit)
+        dropped?.forEach { sid -> onOutputDropped?.invoke(sid) }
     }
 
     /**
-     * Drain both lanes until either is closed, handing each frame to [emit] (which writes it to the
-     * socket). Drains all pending control frames before each single output frame; suspends on both
-     * when idle. Returns when a lane is closed.
+     * Take the head output chunk plus every immediately-queued successor for the SAME session,
+     * merged into one [Frame.Output]. Never waits for more data. Null if the lane is empty.
      */
-    suspend fun drainTo(emit: suspend (String) -> Unit) {
+    private fun takeCoalesced(): Frame.Output? = synchronized(outputLock) {
+        val first = outputQueue.removeFirstOrNull() ?: return null
+        outputChars -= first.data.length
+        if (outputQueue.firstOrNull()?.sessionId != first.sessionId) return first
+        val sb = StringBuilder(first.data)
+        while (sb.length < MAX_COALESCED_CHARS) {
+            val next = outputQueue.firstOrNull() ?: break
+            if (next.sessionId != first.sessionId) break
+            outputQueue.removeFirst()
+            outputChars -= next.data.length
+            sb.append(next.data)
+        }
+        Frame.Output(first.sessionId, sb.toString())
+    }
+
+    /**
+     * Drain both lanes, handing each frame to [emit] (which writes it to the socket). Drains all
+     * pending control frames (up to [CONTROL_BURST] per pass, so control churn can't starve output)
+     * before each single coalesced output emission; suspends when idle. Returns once the outbox is
+     * closed and everything buffered has been flushed.
+     */
+    suspend fun drainTo(emit: suspend (Frame) -> Unit) {
         while (true) {
-            // 1) Flush pending control frames first (priority) — but at most CONTROL_BURST per pass, so a
-            // lane that's continuously fed control frames (e.g. rapid title/cwd churn rebuilding the
-            // session list) can't starve terminal output forever. Control is never DROPPED here, only
-            // interleaved: the remaining control frames are drained on the next pass.
+            // 1) Flush pending control frames first (priority), capped per pass for fairness.
             var drainedControl = false
+            var controlClosed = false
             var burst = 0
             while (burst < CONTROL_BURST) {
                 val r = control.tryReceive()
                 when {
                     r.isSuccess -> { emit(r.getOrThrow()); drainedControl = true; burst++ }
-                    r.isClosed -> return
+                    r.isClosed -> { controlClosed = true; break }
                     else -> break // control lane empty
                 }
             }
-            // 2) Then a single output frame (re-checking control on the next loop).
-            val o = output.tryReceive()
-            when {
-                o.isSuccess -> { emit(o.getOrThrow()); continue }
-                o.isClosed -> return
-            }
+            // 2) Then a single coalesced output emission (re-checking control on the next loop).
+            val merged = takeCoalesced()
+            if (merged != null) { emit(merged); continue }
             // 3) If control had frames this pass, loop to re-check before suspending.
             if (drainedControl) continue
-            // 4) Both lanes idle — suspend until either delivers (or closes).
-            val closed = select<Boolean> {
+            // 4) Both lanes idle. If the outbox is closed, everything is flushed — done.
+            if (controlClosed || closed) return
+            // 5) Suspend until a control frame or an output wake (or close).
+            val ended = select<Boolean> {
                 control.onReceiveCatching { r -> if (r.isClosed) true else { emit(r.getOrThrow()); false } }
-                output.onReceiveCatching { r -> if (r.isClosed) true else { emit(r.getOrThrow()); false } }
+                // A wake signal (or wake-close) just re-runs the loop, which sweeps both lanes.
+                wake.onReceiveCatching { false }
             }
-            if (closed) return
+            if (ended) return
         }
     }
 
     fun close() {
         closed = true
         runCatching { control.close() }
-        runCatching { output.close() }
+        runCatching { wake.close() }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/ResizeSampler.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/ResizeSampler.kt
@@ -1,0 +1,59 @@
+package ai.rever.bossterm.compose.daemon
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Per-key conflated grid sampler for daemon-bound Resize sends. Auto-fit fires per layout tick
+ * during a live window drag, and every forwarded resize reflows the daemon's full scrollback (then
+ * the Resized echo reflows the mirror's) — so [request] conflates: the first request for a key is
+ * forwarded as soon as its collector starts (one dispatch hop onto [scope]; the StateFlow retains
+ * the value, so nothing is lost, just not strictly synchronous); during a burst the collector
+ * forwards at most one grid per [minIntervalMs]; and once the burst stops the FINAL grid is always
+ * delivered (a StateFlow always retains the last value, and the collector re-reads it after each
+ * interval). Equal grids dedup for free (StateFlow skips value-equal updates).
+ *
+ * Extracted from [DaemonSessionBridge] so these invariants are unit-testable ([request]/[drop] are
+ * Main-confined there, but this class is thread-safe regardless: per-key state is a StateFlow in a
+ * ConcurrentHashMap).
+ */
+internal class ResizeSampler(
+    private val scope: CoroutineScope,
+    private val minIntervalMs: Long,
+    private val send: (key: String, cols: Int, rows: Int) -> Unit,
+) {
+    private class Entry(val grid: MutableStateFlow<Pair<Int, Int>?>, val job: Job)
+
+    private val entries = ConcurrentHashMap<String, Entry>()
+
+    /** Record the latest requested grid for [key]; the key's collector forwards it (conflated). */
+    fun request(key: String, cols: Int, rows: Int) {
+        val entry = entries.computeIfAbsent(key) {
+            val grid = MutableStateFlow<Pair<Int, Int>?>(null)
+            val job = scope.launch {
+                grid.filterNotNull().collect { (c, r) ->
+                    send(key, c, r)
+                    delay(minIntervalMs) // conflation window: intermediate grids are skipped
+                }
+            }
+            Entry(grid, job)
+        }
+        entry.grid.value = cols to rows
+    }
+
+    /** Stop and forget [key]'s sampler (its session/mirror closed). */
+    fun drop(key: String) {
+        entries.remove(key)?.job?.cancel()
+    }
+
+    /** Stop everything (bridge teardown). The owner usually also cancels [scope]. */
+    fun clear() {
+        entries.values.forEach { it.job.cancel() }
+        entries.clear()
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
@@ -270,12 +270,17 @@ class TerminalSessionCore(
     private val pendingWriteUnits = java.util.concurrent.atomic.AtomicLong(0)
 
     private fun enqueueWrite(op: WriteOp, units: Int) {
-        if (pendingWriteUnits.get() >= MAX_PENDING_WRITE_UNITS) {
+        // Add first, then check-and-rollback: a check-then-add gate is racy with several producers
+        // (WS reader, MCP, emulator replies) — each could pass the gate before any increments and
+        // overshoot the ceiling together. Reserving up front bounds steady-state at the ceiling;
+        // the transient overshoot is at most one in-flight op per concurrent producer.
+        val pending = pendingWriteUnits.addAndGet(units.toLong())
+        if (pending > MAX_PENDING_WRITE_UNITS) {
+            pendingWriteUnits.addAndGet(-units.toLong())
             log.warn("session {}: write queue saturated ({} units pending, PTY not draining); dropping {} units",
-                id, pendingWriteUnits.get(), units)
+                id, pending - units, units)
             return
         }
-        pendingWriteUnits.addAndGet(units.toLong())
         if (writeChannel.trySend(op).isFailure) pendingWriteUnits.addAndGet(-units.toLong()) // closed
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
@@ -245,12 +245,20 @@ class TerminalSessionCore(
         }
     }
 
+    // trySend first: it succeeds unless 256 writes are already queued, keeping the keystroke path
+    // free of a per-call coroutine launch + dispatch hop (and strictly FIFO for a single producer).
+    // Only the rare full-queue case falls back to a suspending enqueue.
     fun writeInput(text: String) {
-        scope.launch { runCatching { writeChannel.send(WriteOp.Text(text)) } }
+        enqueueWrite(WriteOp.Text(text))
     }
 
     fun writeBytes(bytes: ByteArray) {
-        scope.launch { runCatching { writeChannel.send(WriteOp.Raw(bytes)) } }
+        enqueueWrite(WriteOp.Raw(bytes))
+    }
+
+    private fun enqueueWrite(op: WriteOp) {
+        if (writeChannel.trySend(op).isSuccess) return
+        scope.launch { runCatching { writeChannel.send(op) } }
     }
 
     // Last requested grid size, so a resize that arrives before the PTY is spawned (handle still null)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
@@ -114,6 +114,10 @@ class TerminalSessionCore(
     private companion object {
         /** Upper clamp for a requested grid dimension — generous; just guards against absurd values. */
         const val MAX_GRID_DIM = 2000
+
+        /** Safety ceiling on un-drained write units (see [pendingWriteUnits]) — far above any real
+         *  paste, only reachable when the PTY has stopped draining. */
+        const val MAX_PENDING_WRITE_UNITS = 32L * 1024 * 1024
     }
 
     init {
@@ -250,11 +254,29 @@ class TerminalSessionCore(
     // (see [writeChannel]). After close() the channel is closed and the write is dropped — the
     // PTY is gone anyway.
     fun writeInput(text: String) {
-        writeChannel.trySend(WriteOp.Text(text))
+        enqueueWrite(WriteOp.Text(text), text.length)
     }
 
     fun writeBytes(bytes: ByteArray) {
-        writeChannel.trySend(WriteOp.Raw(bytes))
+        enqueueWrite(WriteOp.Raw(bytes), bytes.size)
+    }
+
+    // Depth gauge for the write pipe: units (chars for Text, bytes for Raw — close enough for a
+    // ceiling) enqueued but not yet written to the PTY. The channel itself is unbounded so
+    // ordering stays structural; this counter is the safety ceiling a wedged PTY needs — its
+    // write() blocks forever, and a runaway programmatic producer (MCP send_input loop, giant
+    // paste) would otherwise grow a weeks-lived daemon's heap without bound. At the ceiling we
+    // log-and-drop: those bytes were never going to reach a wedged PTY anyway.
+    private val pendingWriteUnits = java.util.concurrent.atomic.AtomicLong(0)
+
+    private fun enqueueWrite(op: WriteOp, units: Int) {
+        if (pendingWriteUnits.get() >= MAX_PENDING_WRITE_UNITS) {
+            log.warn("session {}: write queue saturated ({} units pending, PTY not draining); dropping {} units",
+                id, pendingWriteUnits.get(), units)
+            return
+        }
+        pendingWriteUnits.addAndGet(units.toLong())
+        if (writeChannel.trySend(op).isFailure) pendingWriteUnits.addAndGet(-units.toLong()) // closed
     }
 
     // Last requested grid size, so a resize that arrives before the PTY is spawned (handle still null)
@@ -314,6 +336,11 @@ class TerminalSessionCore(
         class Raw(val data: ByteArray) : WriteOp()
     }
 
+    private fun opUnits(op: WriteOp): Long = when (op) {
+        is WriteOp.Text -> op.data.length.toLong()
+        is WriteOp.Raw -> op.data.size.toLong()
+    }
+
     // A single UNBOUNDED FIFO pipe for everything written to the PTY — user input, pastes, and
     // emulator replies. Unbounded so every producer is one non-suspending trySend: a bounded
     // channel needs a suspending fallback under backpressure, and any two-path enqueue can reorder
@@ -343,6 +370,9 @@ class TerminalSessionCore(
                 } catch (e: java.io.IOException) {
                     log.debug("PTY write failed (likely closed): {}", e.message)
                 }
+                // Drain the depth gauge whether the write succeeded or not — a failed write is
+                // gone either way, and a stuck counter would wedge enqueueWrite's ceiling.
+                pendingWriteUnits.addAndGet(-opUnits(op))
             }
         }
     }
@@ -356,10 +386,10 @@ class TerminalSessionCore(
      */
     private inner class PtyTerminalOutput : TerminalOutputStream {
         override fun sendBytes(response: ByteArray, userInput: Boolean) {
-            writeChannel.trySend(WriteOp.Raw(response))
+            enqueueWrite(WriteOp.Raw(response), response.size)
         }
         override fun sendString(string: String, userInput: Boolean) {
-            writeChannel.trySend(WriteOp.Text(string))
+            enqueueWrite(WriteOp.Text(string), string.length)
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
@@ -245,20 +245,16 @@ class TerminalSessionCore(
         }
     }
 
-    // trySend first: it succeeds unless 256 writes are already queued, keeping the keystroke path
-    // free of a per-call coroutine launch + dispatch hop (and strictly FIFO for a single producer).
-    // Only the rare full-queue case falls back to a suspending enqueue.
+    // One non-suspending trySend per write: on the unbounded channel it cannot fail while the
+    // session is open, so the keystroke path has no coroutine launch and ordering is structural
+    // (see [writeChannel]). After close() the channel is closed and the write is dropped — the
+    // PTY is gone anyway.
     fun writeInput(text: String) {
-        enqueueWrite(WriteOp.Text(text))
+        writeChannel.trySend(WriteOp.Text(text))
     }
 
     fun writeBytes(bytes: ByteArray) {
-        enqueueWrite(WriteOp.Raw(bytes))
-    }
-
-    private fun enqueueWrite(op: WriteOp) {
-        if (writeChannel.trySend(op).isSuccess) return
-        scope.launch { runCatching { writeChannel.send(op) } }
+        writeChannel.trySend(WriteOp.Raw(bytes))
     }
 
     // Last requested grid size, so a resize that arrives before the PTY is spawned (handle still null)
@@ -318,7 +314,14 @@ class TerminalSessionCore(
         class Raw(val data: ByteArray) : WriteOp()
     }
 
-    private val writeChannel = Channel<WriteOp>(capacity = 256)
+    // A single UNBOUNDED FIFO pipe for everything written to the PTY — user input, pastes, and
+    // emulator replies. Unbounded so every producer is one non-suspending trySend: a bounded
+    // channel needs a suspending fallback under backpressure, and any two-path enqueue can reorder
+    // a write past one that arrived earlier once a slot frees (silent corruption of a byte
+    // stream). Not a new memory risk: the bounded version parked each overflowing write in its own
+    // suspended coroutine, holding the same bytes with more overhead — a wedged PTY grew the heap
+    // either way, and input volume is human/MCP-scale.
+    private val writeChannel = Channel<WriteOp>(capacity = Channel.UNLIMITED)
     @Volatile private var writeConsumer: Job? = null
 
     /**
@@ -347,9 +350,9 @@ class TerminalSessionCore(
     /**
      * Routes emulator-generated replies (DA, cursor reports, …) back to the PTY. Enqueued onto the
      * SAME [writeChannel] as user input, so a reply can't interleave its bytes mid-sequence with a
-     * keystroke — a single [writeConsumer] owns the PTY's outputStream. trySend (non-suspending) keeps
-     * the emulator thread unblocked; a reply is dropped only if 256 writes are already queued (never in
-     * practice). Ordered with input, as the queue guarantees.
+     * keystroke — a single [writeConsumer] owns the PTY's outputStream. trySend (non-suspending)
+     * keeps the emulator thread unblocked and, on the unbounded channel, never drops while the
+     * session is open. Ordered with input, as the queue guarantees.
      */
     private inner class PtyTerminalOutput : TerminalOutputStream {
         override fun sendBytes(response: ByteArray, userInput: Boolean) {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachBinaryFrameTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachBinaryFrameTest.kt
@@ -1,0 +1,55 @@
+package ai.rever.bossterm.compose.daemon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Roundtrip + malformed-input coverage for [DaemonAttachProtocol.BinaryFrame] — the v3 binary
+ * transport for Output/Snapshot. Payload fidelity matters most for escape-dense terminal bytes
+ * (the whole point of leaving JSON) and multi-byte UTF-8.
+ */
+class DaemonAttachBinaryFrameTest {
+
+    private val sessionId = "550e8400-e29b-41d4-a716-446655440000" // 36-char UUID, like real ids
+
+    @Test
+    fun `output frame roundtrips escape-dense and multi-byte payloads`() {
+        val payloads = listOf(
+            "plain text",
+            "\u001b[31mred\u001b[0m\r\n\u001b]0;title\u0007", // SGR + OSC + control chars
+            "emoji 👩‍💻 and combining éü", // multi-byte UTF-8 + ZWJ sequence
+            "", // empty payload is legal on the wire (producers filter it, decoder must not care)
+        )
+        for (p in payloads) {
+            val decoded = DaemonAttachProtocol.BinaryFrame.decode(
+                DaemonAttachProtocol.BinaryFrame.encodeOutput(sessionId, p),
+            )
+            assertEquals(DaemonAttachProtocol.Server.Output(sessionId, p), decoded, "payload: ${p.take(20)}")
+        }
+    }
+
+    @Test
+    fun `snapshot frame roundtrips id, grid and payload`() {
+        val data = "\u001b[0mhello\r\nworld\u001b[5;10H"
+        val decoded = DaemonAttachProtocol.BinaryFrame.decode(
+            DaemonAttachProtocol.BinaryFrame.encodeSnapshot(sessionId, cols = 1999, rows = 3, data = data),
+        )
+        assertEquals(DaemonAttachProtocol.Server.Snapshot(sessionId, data, cols = 1999, rows = 3), decoded)
+    }
+
+    @Test
+    fun `malformed or unknown frames decode to null, not an exception`() {
+        assertNull(DaemonAttachProtocol.BinaryFrame.decode(ByteArray(0)), "empty")
+        assertNull(DaemonAttachProtocol.BinaryFrame.decode(byteArrayOf(1)), "type only")
+        assertNull(DaemonAttachProtocol.BinaryFrame.decode(byteArrayOf(99, 4, 1, 2, 3, 4)), "unknown type")
+        // Output frame whose declared id length exceeds the frame.
+        assertNull(DaemonAttachProtocol.BinaryFrame.decode(byteArrayOf(1, 50, 65, 66)), "truncated id")
+        // Snapshot frame with a valid id but missing the 4 grid bytes.
+        val id = "ab".toByteArray()
+        assertNull(
+            DaemonAttachProtocol.BinaryFrame.decode(byteArrayOf(2, 2) + id + byteArrayOf(0, 80)),
+            "truncated snapshot grid",
+        )
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServerTest.kt
@@ -25,6 +25,13 @@ import kotlin.test.assertTrue
  */
 class DaemonAttachServerTest {
 
+    /** v3 transport: Output/Snapshot arrive as binary frames, everything else as JSON text. */
+    private fun decodeAny(frame: Frame): DaemonAttachProtocol.Server? = when (frame) {
+        is Frame.Text -> runCatching { DaemonAttachProtocol.decodeServer(frame.readText()) }.getOrNull()
+        is Frame.Binary -> DaemonAttachProtocol.BinaryFrame.decode(frame.data)
+        else -> null
+    }
+
     @Test
     fun `attach streams snapshot + output and accepts input`() {
         if (ShellCustomizationUtils.isWindows()) return
@@ -39,6 +46,7 @@ class DaemonAttachServerTest {
 
             val client = HttpClient(CIO) { install(WebSockets) }
             try {
+                var markerCameAsBinary = false
                 val sawSession = runBlocking {
                     var ok = false
                     runCatching {
@@ -47,8 +55,7 @@ class DaemonAttachServerTest {
                                 // wait until the session is alive, then send input to cat
                                 var sentInput = false
                                 for (frame in incoming) {
-                                    if (frame !is Frame.Text) continue
-                                    val msg = DaemonAttachProtocol.decodeServer(frame.readText())
+                                    val msg = decodeAny(frame) ?: continue
                                     if (msg is DaemonAttachProtocol.Server.SessionList && msg.sessions.any { it.id == id }) {
                                         ok = true
                                         if (!sentInput) {
@@ -63,7 +70,10 @@ class DaemonAttachServerTest {
                                         is DaemonAttachProtocol.Server.Output -> msg.data
                                         else -> ""
                                     }
-                                    if (text.contains(marker)) return@webSocket // echoed back → done
+                                    if (text.contains(marker)) { // echoed back → done
+                                        markerCameAsBinary = frame is Frame.Binary
+                                        return@webSocket
+                                    }
                                 }
                             }
                         }
@@ -71,6 +81,7 @@ class DaemonAttachServerTest {
                     ok
                 }
                 assertTrue(sawSession, "client should receive a SessionList naming the session (and the input echo)")
+                assertTrue(markerCameAsBinary, "session bytes (Output/Snapshot) must ride binary frames in v3")
             } finally {
                 client.close()
             }
@@ -176,8 +187,7 @@ class DaemonAttachServerTest {
                             client.webSocket("ws://127.0.0.1:$port/attach", request = { header(DaemonAttachProtocol.TOKEN_HEADER, "mal") }) {
                                 var poked = false
                                 for (frame in incoming) {
-                                    if (frame !is Frame.Text) continue
-                                    val msg = DaemonAttachProtocol.decodeServer(frame.readText())
+                                    val msg = decodeAny(frame) ?: continue
                                     if (!poked && msg is DaemonAttachProtocol.Server.SessionList && msg.sessions.any { it.id == id }) {
                                         poked = true
                                         // Garbage + unknown discriminator must be skipped, not crash the loop…

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
@@ -13,20 +13,32 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * The two-lane send queue behind every attach/share connection: control frames (snapshots, lists,
- * lifecycle, resizes) are GUARANTEED, incremental output is best-effort DROP_OLDEST, control always
- * drains before output, and a control-lane overflow hard-closes an unrecoverable connection.
+ * The two-lane send queue behind every attach connection: control frames (snapshots, lists,
+ * lifecycle, resizes) are GUARANTEED, incremental output is best-effort char-bounded drop-oldest
+ * (reporting each dropped session via [FrameOutbox.onOutputDropped] so the connection can heal it
+ * with a re-snapshot), control always drains before output, queued same-session output coalesces
+ * into one frame, and a control-lane overflow hard-closes an unrecoverable connection.
  */
 class FrameOutboxTest {
 
+    private fun ctrl(s: String) = FrameOutbox.Frame.Text(s)
+
+    /** Flush everything buffered in [outbox] (which must already be closed) and return it. */
+    private fun drainAll(outbox: FrameOutbox): List<FrameOutbox.Frame> = runBlocking {
+        val got = mutableListOf<FrameOutbox.Frame>()
+        withTimeout(5_000) { outbox.drainTo { got.add(it) } }
+        got
+    }
+
     @Test
     fun `control frames are never dropped and keep FIFO order`() = runBlocking {
-        // Small output lane, generous control lane — we push more control frames than the output cap.
-        val outbox = FrameOutbox(outputCapacity = 8, controlCapacity = 4096)
+        val outbox = FrameOutbox(controlCapacity = 4096)
         val got = ConcurrentLinkedQueue<String>()
-        val drainer = launch(Dispatchers.IO) { outbox.drainTo { got.add(it) } }
+        val drainer = launch(Dispatchers.IO) {
+            outbox.drainTo { got.add((it as FrameOutbox.Frame.Text).text) }
+        }
         val n = 2000
-        repeat(n) { outbox.sendControl("c$it") }
+        repeat(n) { outbox.sendControl(ctrl("c$it")) }
         withTimeout(5_000) { while (got.size < n) delay(2) }
         outbox.close()
         drainer.join()
@@ -35,50 +47,74 @@ class FrameOutboxTest {
     }
 
     @Test
-    fun `output is dropped oldest-first under back-pressure while control survives`() = runBlocking {
-        val cap = 4
-        val outbox = FrameOutbox(outputCapacity = cap, controlCapacity = 1024)
-        // Overfill the output lane with NO drainer running, so DROP_OLDEST evicts the oldest.
-        repeat(20) { outbox.sendOutput("o$it") }
-        outbox.sendControl("CTRL")
-        val got = ConcurrentLinkedQueue<String>()
-        val drainer = launch(Dispatchers.IO) { outbox.drainTo { got.add(it) } }
-        withTimeout(5_000) { while (!got.contains("CTRL")) delay(2) }
+    fun `output is dropped oldest-first under back-pressure and each drop reports its session`() {
+        // 10-char chunks, budget for 4 — with NO drainer running, drop-oldest evicts the first 16.
+        val outbox = FrameOutbox(outputCapacityChars = 40, controlCapacity = 1024)
+        val droppedSessions = ConcurrentLinkedQueue<String>()
+        outbox.onOutputDropped = { droppedSessions.add(it) }
+        // Distinct session per chunk so nothing coalesces and eviction order is observable.
+        repeat(20) { outbox.sendOutput("s$it", "x".repeat(10)) }
+        outbox.sendControl(ctrl("CTRL"))
         outbox.close()
-        drainer.join()
-        val list = got.toList()
-        assertTrue(list.contains("CTRL"), "the control frame must survive the output flood")
-        // Only the last `cap` outputs survive, in order (DROP_OLDEST keeps the most recent).
-        assertEquals((16 until 20).map { "o$it" }, list.filter { it.startsWith("o") })
+        val got = drainAll(outbox)
+        assertEquals(ctrl("CTRL"), got.first(), "the control frame must survive the output flood")
+        assertEquals(
+            (16 until 20).map { "s$it" },
+            got.filterIsInstance<FrameOutbox.Frame.Output>().map { it.sessionId },
+            "only the newest chunks within the char budget survive, in order",
+        )
+        assertEquals(
+            (0 until 16).map { "s$it" },
+            droppedSessions.toList(),
+            "every evicted chunk must report its session for a healing re-snapshot",
+        )
     }
 
     @Test
-    fun `control always drains before queued output`() = runBlocking {
-        val outbox = FrameOutbox(outputCapacity = 1024, controlCapacity = 1024)
-        // Queue output first, then control, with no drainer; the drainer must still emit control first.
-        outbox.sendOutput("out")
-        outbox.sendControl("ctrl")
-        val got = ConcurrentLinkedQueue<String>()
-        val drainer = launch(Dispatchers.IO) { outbox.drainTo { got.add(it) } }
-        withTimeout(5_000) { while (got.size < 2) delay(2) }
+    fun `control always drains before queued output`() {
+        val outbox = FrameOutbox()
+        // Queue output first, then control, with no drainer; control must still be emitted first.
+        outbox.sendOutput("sess", "out")
+        outbox.sendControl(ctrl("ctrl"))
         outbox.close()
-        drainer.join()
-        assertEquals(listOf("ctrl", "out"), got.toList(), "control frame must precede the output frame")
+        assertEquals(
+            listOf(ctrl("ctrl"), FrameOutbox.Frame.Output("sess", "out")),
+            drainAll(outbox),
+            "control frame must precede the output frame",
+        )
     }
 
     @Test
-    fun `a control backlog does not starve output (fairness cap)`() = runBlocking {
-        val outbox = FrameOutbox(outputCapacity = 1024, controlCapacity = 4096)
+    fun `queued same-session output coalesces into one frame without crossing sessions`() {
+        val outbox = FrameOutbox()
+        outbox.sendOutput("a", "1")
+        outbox.sendOutput("a", "2")
+        outbox.sendOutput("b", "3")
+        outbox.sendOutput("a", "4")
+        outbox.close()
+        assertEquals(
+            listOf(
+                FrameOutbox.Frame.Output("a", "12"),
+                FrameOutbox.Frame.Output("b", "3"),
+                FrameOutbox.Frame.Output("a", "4"),
+            ),
+            drainAll(outbox),
+            "adjacent same-session chunks merge; ordering across sessions is preserved",
+        )
+    }
+
+    @Test
+    fun `a control backlog does not starve output (fairness cap)`() {
+        val outbox = FrameOutbox(controlCapacity = 4096)
         val controlCount = FrameOutbox.CONTROL_BURST * 3
-        // Enqueue everything BEFORE the drainer starts, so it faces a full control lane + pending output.
-        repeat(controlCount) { outbox.sendControl("c$it") }
-        repeat(5) { outbox.sendOutput("o$it") }
-        val got = ConcurrentLinkedQueue<String>()
-        val drainer = launch(Dispatchers.IO) { outbox.drainTo { got.add(it) } }
-        withTimeout(5_000) { while (got.size < controlCount + 5) delay(2) }
+        // Enqueue everything BEFORE draining, so the drainer faces a full control lane + pending
+        // output. Distinct sessions keep the outputs as separate frames.
+        repeat(controlCount) { outbox.sendControl(ctrl("c$it")) }
+        repeat(5) { outbox.sendOutput("s$it", "o$it") }
         outbox.close()
-        drainer.join()
-        val firstOutputIdx = got.toList().indexOfFirst { it.startsWith("o") }
+        val got = drainAll(outbox)
+        assertEquals(controlCount + 5, got.size)
+        val firstOutputIdx = got.indexOfFirst { it is FrameOutbox.Frame.Output }
         assertTrue(
             firstOutputIdx in 0..FrameOutbox.CONTROL_BURST,
             "an output frame must appear within the first CONTROL_BURST (${FrameOutbox.CONTROL_BURST}) frames, was at $firstOutputIdx",
@@ -97,18 +133,32 @@ class FrameOutboxTest {
     }
 
     @Test
-    fun `control-lane overflow closes the outbox`() = runBlocking {
+    fun `output arriving while the drainer is idle wakes it`() = runBlocking {
+        val outbox = FrameOutbox()
+        val got = ConcurrentLinkedQueue<FrameOutbox.Frame>()
+        val drainer = launch(Dispatchers.IO) { outbox.drainTo { got.add(it) } }
+        delay(150) // let the drainer suspend on both empty lanes
+        outbox.sendOutput("sess", "wake-up")
+        withTimeout(5_000) { while (got.isEmpty()) delay(2) }
+        outbox.close()
+        drainer.join()
+        assertEquals(listOf<FrameOutbox.Frame>(FrameOutbox.Frame.Output("sess", "wake-up")), got.toList())
+    }
+
+    @Test
+    fun `control-lane overflow closes the outbox`() {
         val cap = 4
-        val outbox = FrameOutbox(outputCapacity = 8, controlCapacity = cap)
+        val outbox = FrameOutbox(controlCapacity = cap)
         // No drainer: fill the control lane to capacity, then one more overflows → close().
-        repeat(cap) { outbox.sendControl("c$it") }
-        outbox.sendControl("overflow") // trySend fails → close()
+        repeat(cap) { outbox.sendControl(ctrl("c$it")) }
+        outbox.sendControl(ctrl("overflow")) // trySend fails → close()
         // Post-close sends are no-ops and a drainer flushes only the buffered frames, then returns.
-        val got = ConcurrentLinkedQueue<String>()
-        outbox.sendControl("after-close")
-        outbox.sendOutput("after-close-out")
-        withTimeout(2_000) { outbox.drainTo { got.add(it) } }
-        val list = got.toList()
-        assertEquals((0 until cap).map { "c$it" }, list, "only the pre-overflow buffered frames survive")
+        outbox.sendControl(ctrl("after-close"))
+        outbox.sendOutput("sess", "after-close-out")
+        assertEquals(
+            (0 until cap).map { ctrl("c$it") },
+            drainAll(outbox),
+            "only the pre-overflow buffered frames survive",
+        )
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
@@ -146,6 +146,47 @@ class FrameOutboxTest {
     }
 
     @Test
+    fun `heal purge - a snapshot enqueued after dropQueuedOutput is never followed by pre-snapshot output`() {
+        val outbox = FrameOutbox()
+        // Backlog for two sessions queued behind a slow drainer.
+        outbox.sendOutput("healing", "stale-1")
+        outbox.sendOutput("other", "keep-me")
+        outbox.sendOutput("healing", "stale-2")
+        // The heal (tap already detached): purge the session's queued output, THEN enqueue the
+        // fresh snapshot on the control lane and the post-snapshot prelude on the output lane.
+        outbox.dropQueuedOutput("healing")
+        outbox.sendControl(ctrl("SNAPSHOT:healing"))
+        outbox.sendOutput("healing", "post-snapshot")
+        outbox.close()
+        val got = drainAll(outbox)
+        assertEquals(
+            listOf(
+                ctrl("SNAPSHOT:healing"), // control priority — but no stale chunk left to outrank
+                FrameOutbox.Frame.Output("other", "keep-me"),
+                FrameOutbox.Frame.Output("healing", "post-snapshot"),
+            ),
+            got,
+            "pre-snapshot output for the healed session must not replay below the repaint; other sessions untouched",
+        )
+    }
+
+    @Test
+    fun `a flood of tiny chunks is bounded by the frame-count cap`() {
+        // Alternating sessions defeat coalescing; 1-char payloads stay far under the char budget,
+        // so only MAX_OUTPUT_FRAMES bounds the queue's object count.
+        val outbox = FrameOutbox()
+        val dropped = ConcurrentLinkedQueue<String>()
+        outbox.onOutputDropped = { dropped.add(it) }
+        val extra = 10
+        repeat(FrameOutbox.MAX_OUTPUT_FRAMES + extra) { outbox.sendOutput("s${it % 2}", "x") }
+        outbox.close()
+        val emitted = drainAll(outbox).filterIsInstance<FrameOutbox.Frame.Output>()
+            .sumOf { it.data.length } // coalescing merges alternating pairs, so count chars not frames
+        assertEquals(FrameOutbox.MAX_OUTPUT_FRAMES, emitted, "queue must be capped at MAX_OUTPUT_FRAMES chunks")
+        assertEquals(extra, dropped.size, "each over-cap chunk must evict (and report) the oldest")
+    }
+
+    @Test
     fun `control-lane overflow closes the outbox`() {
         val cap = 4
         val outbox = FrameOutbox(controlCapacity = cap)

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
@@ -133,6 +133,25 @@ class FrameOutboxTest {
     }
 
     @Test
+    fun `output enqueued while the drainer is idle survives an immediate close`() = runBlocking {
+        // Regression for the close-race window: with the drainer suspended in select, a sendOutput
+        // whose wake signal races close() used to be stranded when select picked the closed-control
+        // branch and returned. The close path now does a final sweep of both lanes.
+        val outbox = FrameOutbox()
+        val got = ConcurrentLinkedQueue<FrameOutbox.Frame>()
+        val drainer = launch(Dispatchers.IO) { outbox.drainTo { got.add(it) } }
+        delay(150) // let the drainer suspend on both empty lanes
+        outbox.sendOutput("sess", "last-words")
+        outbox.close() // immediately — no window for the wake signal to be consumed first
+        drainer.join()
+        assertEquals(
+            listOf<FrameOutbox.Frame>(FrameOutbox.Frame.Output("sess", "last-words")),
+            got.toList(),
+            "a chunk enqueued before close() must be flushed by the final sweep",
+        )
+    }
+
+    @Test
     fun `output arriving while the drainer is idle wakes it`() = runBlocking {
         val outbox = FrameOutbox()
         val got = ConcurrentLinkedQueue<FrameOutbox.Frame>()

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
@@ -171,6 +171,24 @@ class FrameOutboxTest {
     }
 
     @Test
+    fun `one coalesced emission is capped at MAX_COALESCED_CHARS`() {
+        // 5 × 100k-char chunks for one session: the merger stops appending once the merged length
+        // reaches the cap (it may overshoot by at most one chunk), so control frames still get a
+        // turn between emissions even against a huge same-session backlog.
+        val outbox = FrameOutbox()
+        val chunk = "x".repeat(100_000)
+        repeat(5) { outbox.sendOutput("big", chunk) }
+        outbox.close()
+        val sizes = drainAll(outbox).filterIsInstance<FrameOutbox.Frame.Output>().map { it.data.length }
+        assertEquals(500_000, sizes.sum(), "no bytes lost to the cap")
+        assertTrue(sizes.size > 1, "a 500k backlog must not merge into a single emission")
+        assertTrue(
+            sizes.all { it <= FrameOutbox.MAX_COALESCED_CHARS + chunk.length },
+            "each emission stays within the cap plus at most one chunk of overshoot, was $sizes",
+        )
+    }
+
+    @Test
     fun `a flood of tiny chunks is bounded by the frame-count cap`() {
         // Alternating sessions defeat coalescing; 1-char payloads stay far under the char budget,
         // so only MAX_OUTPUT_FRAMES bounds the queue's object count.

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/ResizeSamplerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/ResizeSamplerTest.kt
@@ -1,0 +1,85 @@
+package ai.rever.bossterm.compose.daemon
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The conflated per-session Resize sampler behind [DaemonSessionBridge]: first request forwarded
+ * promptly, a burst conflated to at most one send per interval, the FINAL grid always delivered,
+ * value-equal requests deduped, and dropped keys silenced.
+ */
+class ResizeSamplerTest {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    @AfterTest
+    fun tearDown() = scope.cancel()
+
+    private class Sent(val key: String, val cols: Int, val rows: Int)
+
+    @Test
+    fun `a burst conflates but always ends with the final grid`() = runBlocking {
+        val sent = ConcurrentLinkedQueue<Sent>()
+        val sampler = ResizeSampler(scope, minIntervalMs = 100) { k, c, r -> sent.add(Sent(k, c, r)) }
+        val n = 60
+        repeat(n) { sampler.request("s", cols = 80 + it, rows = 24) } // rapid drag-like burst
+        // Wait for the burst to settle: the final grid must arrive despite heavy conflation.
+        withTimeout(5_000) {
+            while (sent.none { it.cols == 80 + n - 1 }) delay(10)
+        }
+        delay(250) // a couple more intervals: no further sends should trickle out
+        val cols = sent.map { it.cols }
+        assertEquals(80 + n - 1, cols.last(), "the final grid of the burst must always be delivered")
+        assertTrue(cols.size < n / 2, "a rapid burst must be conflated, not forwarded 1:1 (sent ${cols.size}/$n)")
+        assertEquals(cols, cols.sorted(), "forwarded grids must be monotonically the latest (never an older one)")
+    }
+
+    @Test
+    fun `first request is forwarded without waiting an interval`() = runBlocking {
+        val sent = ConcurrentLinkedQueue<Sent>()
+        // A huge interval: if the first send waited for it, the timeout below would trip.
+        val sampler = ResizeSampler(scope, minIntervalMs = 60_000) { k, c, r -> sent.add(Sent(k, c, r)) }
+        sampler.request("s", 120, 40)
+        withTimeout(2_000) { while (sent.isEmpty()) delay(5) }
+        assertEquals(120 to 40, sent.first().let { it.cols to it.rows })
+    }
+
+    @Test
+    fun `value-equal requests do not resend`() = runBlocking {
+        val sent = ConcurrentLinkedQueue<Sent>()
+        val sampler = ResizeSampler(scope, minIntervalMs = 20) { k, c, r -> sent.add(Sent(k, c, r)) }
+        sampler.request("s", 100, 30)
+        withTimeout(2_000) { while (sent.isEmpty()) delay(5) }
+        repeat(5) { sampler.request("s", 100, 30) } // same grid again
+        delay(200) // several intervals — nothing new should be forwarded
+        assertEquals(1, sent.size, "a repeated identical grid must be deduped by the StateFlow")
+    }
+
+    @Test
+    fun `keys are independent and drop cancels a pending conflated send`() = runBlocking {
+        val sent = ConcurrentLinkedQueue<Sent>()
+        // Large interval: after the first (immediate) send the collector parks in its conflation
+        // delay, so a follow-up grid is pending — drop() must cancel it before the interval ends.
+        val sampler = ResizeSampler(scope, minIntervalMs = 60_000) { k, c, r -> sent.add(Sent(k, c, r)) }
+        sampler.request("a", 80, 24)
+        sampler.request("b", 100, 40)
+        withTimeout(2_000) { while (sent.map { it.key }.toSet() != setOf("a", "b")) delay(5) }
+        sampler.request("a", 999, 99) // parked behind the conflation window
+        sampler.drop("a")             // cancels the collector while the 999x99 grid is pending
+        delay(150)
+        assertEquals(listOf(80 to 24), sent.filter { it.key == "a" }.map { it.cols to it.rows },
+            "a dropped key's pending grid must never be forwarded")
+        assertEquals(listOf(100 to 40), sent.filter { it.key == "b" }.map { it.cols to it.rows },
+            "other keys are unaffected by a drop")
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCoreTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCoreTest.kt
@@ -6,6 +6,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
@@ -80,6 +81,44 @@ class TerminalSessionCoreTest {
             assertTrue(seen.await(10, TimeUnit.SECONDS), "cat should echo the written input back over the PTY")
         } finally {
             core.close()
+        }
+    }
+
+    @Test
+    fun `a rapid writeInput burst preserves order end-to-end`() {
+        if (ShellCustomizationUtils.isWindows()) return
+
+        // Regression for input reordering under backpressure: a bounded write channel with a
+        // suspending fallback could enqueue a later write ahead of an earlier one once a slot
+        // freed. 400 writes also crosses the old 256-slot boundary while the write consumer is
+        // still parked on connected.await() (writes sent immediately after start()).
+        //
+        // Oracle: `cat > file` — the file receives exactly the bytes cat read from the PTY, in
+        // order. (Asserting on the raw PTY output stream instead is flaky: tty echo and cat's
+        // copies interleave at byte granularity, and an echo copy split mid-marker makes a
+        // first-occurrence scan misreport order even when the input was perfectly ordered.)
+        val n = 400
+        val markers = (0 until n).map { "ORD_%04d".format(it) }
+        val sink = java.io.File.createTempFile("bossterm-order", ".txt")
+
+        val core = TerminalSessionCore(
+            settings = TerminalSettings.DEFAULT,
+            workingDir = System.getProperty("java.io.tmpdir"),
+            command = "/bin/sh",
+            arguments = listOf("-c", "exec cat > '${sink.absolutePath}'"),
+        )
+        core.start()
+        try {
+            markers.forEach { core.writeInput("$it\n") } // burst, no pacing
+            val expected = markers.joinToString("\n", postfix = "\n")
+            assertTrue(
+                awaitTrue(15_000) { sink.length() >= expected.length.toLong() },
+                "cat should drain the whole burst to the file (got ${sink.length()}/${expected.length} bytes)",
+            )
+            assertEquals(expected, sink.readText(), "input must reach the shell intact and in write order")
+        } finally {
+            core.close()
+            sink.delete()
         }
     }
 


### PR DESCRIPTION
Performance pass over daemon mode's hot paths — wire format, backlog handling, attach latency — plus a correctness fix the new backlog handling unlocks.

## What changed

### Attach protocol v3: binary frames for session bytes
`Output`/`Snapshot` now travel as **binary websocket frames** (`[type][idLen][id][cols/rows for Snapshot][raw UTF-8 payload]`, see `DaemonAttachProtocol.BinaryFrame`) instead of JSON text. Terminal output is escape-dense (SGR colors, TUI redraws), and JSON paid a 6-chars-per-ESC unicode escape of every control character plus an encode+decode **per PTY chunk** on both ends — pure overhead on the hottest path in the protocol. All low-rate, structure-rich messages stay JSON.

`PROTOCOL_VERSION` 2 → 3: the existing `?v=` handshake turns GUI/daemon skew into a clean connect-time reject (same precedent as the v1→v2 bump; the control-channel version stays at 1).

### Output coalescing with zero added latency
`FrameOutbox`'s output lane is now a **char-bounded deque** (bounds actual heap instead of a frame count whose memory depended on chunk size). On drain, consecutive already-queued chunks for the same session merge into one frame (≤256KB) — it never waits for data, so interactive latency is untouched, while a `cat bigfile`-style backlog collapses from thousands of tiny frames into a few large ones (fewer websocket frames, syscalls, and GUI-side append/redraw cycles).

The daemon **share server** gets the same win: pane bytes now enqueue raw and encode to `PaneOutput` at drain time (concatenated pane bytes are protocol-equivalent for xterm.js viewers).

### Drop-heal (correctness)
Previously, output evicted under back-pressure silently corrupted the mirror until the socket reconnected — `resync()` no-ops for already-attached sessions, so nothing healed it. Eviction now reports the affected session (`FrameOutbox.onOutputDropped`), and both the attach and share servers schedule a debounced (500ms) **re-snapshot of just that session**. The share path also gains a `viewerClosed` guard so a late heal/resync can't re-register output taps after teardown.

### Event-driven attach (time-to-first-tab)
- `DaemonBridgeCoordinator` awaited the endpoint + controller with a 250ms poll; that granularity showed up directly in time-to-first-tab on every warm start. It now awaits both event-driven (endpoint via `StateFlow`, controller via `snapshotFlow`) under one 15s deadline, preserving the invariant that the window's ~16s local-tab fallback grace exceeds the attach window.
- `DaemonClient.awaitLiveDaemon` cold-spawn poll cap: 400ms → 150ms.

### Resize sampling
Auto-fit fires per layout tick during a live window drag, and each daemon-bound `Resize` reflowed the daemon's full scrollback, SIGWINCHed the TUI, and echoed a `Resized` that reflowed the mirror again. `DaemonSessionBridge` now samples per session: first send immediate, then at most one per 50ms, final grid always delivered.

### Input-path micro
`TerminalSessionCore.writeInput`/`writeBytes` use a `trySend` fast path instead of launching a coroutine per keystroke (suspending fallback only if 256 writes are already queued).

## Compatibility

A daemon left running from a pre-v3 build will refuse v3 GUI attaches (by design — skew reject instead of a blank mirror). The GUI falls back to local tabs after its grace period; **quitting the old daemon** (menu-bar icon → Quit, or `SHUTDOWN` via the control channel) lets the next GUI launch spawn a current one. Sessions in the old daemon survive until it's retired.

## Testing

- Full `compose-ui` desktopTest suite: **338 tests, 0 failures**.
- `FrameOutboxTest` rewritten for the typed API: coalescing, per-session drop reporting, control-before-output ordering, fairness cap, idle wake, overflow hard-close.
- New `DaemonAttachBinaryFrameTest`: roundtrips (escape-dense, multi-byte/ZWJ emoji, empty payloads) + malformed-frame tolerance.
- `DaemonAttachServerTest` runs the real WS attach flow and now asserts session bytes arrive as **binary** frames end-to-end; share-server tests exercise drain-time `PaneOutput` encoding.

## Deferred (follow-ups from the same review)

- Lazy scrollback backfill on attach (send screen + tail first) — meaningful protocol addition; binary snapshots already cut the big cost.
- AppCDS archive for cold daemon spawn — packaging/release-pipeline change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
