### PR TITLE
feat(tabs): collapsible + window-size-aware left tab bar

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1,10 +1,15 @@
 package ai.rever.bossterm.compose
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -24,6 +29,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -1100,9 +1106,12 @@ fun TabbedTerminal(
     // Computed once so the MCP overlay below can offset itself clear of the
     // tab bar (which occupies the same top-right corner as the "+" button).
     val tabBarVisible = tabController.tabs.size > 1 || settings.alwaysShowTabBar
-    Box(modifier = modifier.fillMaxSize()) {
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
         val tabBarOnLeft = settings.tabBarPosition == "left"
-        val tabBarComposable: @Composable () -> Unit = {
+        // collapsed renders the left bar as the slim icon rail; onToggleCollapse backs the
+        // chevron. onDrawerDismiss is non-null only for the narrow-window overlay drawer
+        // instance — selecting a pane then also closes the drawer (share-viewer behavior).
+        val tabBarComposable: @Composable (collapsed: Boolean, onToggleCollapse: () -> Unit, onDrawerDismiss: (() -> Unit)?) -> Unit = { collapsed, onToggleCollapse, onDrawerDismiss ->
             // Tab bar (show when multiple tabs or alwaysShowTabBar is set).
             if (tabBarVisible) {
             val summaryMode = settings.tabBarSummaryMode
@@ -1367,6 +1376,7 @@ fun TabbedTerminal(
                 activeTabIndex = tabController.activeTabIndex,
                 focusedPaneId = focusedPaneId,
                 onPaneSelected = { tabIndex, paneId ->
+                    onDrawerDismiss?.invoke()
                     tabController.switchToTab(tabIndex)
                     tabController.tabs.getOrNull(tabIndex)?.let { t -> splitStates[t.id]?.setFocusedPane(paneId) }
                 },
@@ -1463,7 +1473,9 @@ fun TabbedTerminal(
                 onAddRemote = { showAddRemote = true },
                 orientation = if (tabBarOnLeft) ai.rever.bossterm.compose.tabs.TabBarOrientation.LEFT
                               else ai.rever.bossterm.compose.tabs.TabBarOrientation.TOP,
-                verticalWidth = settings.tabBarVerticalWidth.dp
+                verticalWidth = settings.tabBarVerticalWidth.dp,
+                collapsed = collapsed,
+                onToggleCollapse = if (tabBarOnLeft) onToggleCollapse else null
             )
             }
         }
@@ -1940,13 +1952,43 @@ fun TabbedTerminal(
         }
 
         if (tabBarOnLeft) {
+            // Window-size-aware sidebar (mirrors the share-viewer's 700px breakpoint): in a
+            // narrow window the bar is forced down to the icon rail and the expand chevron
+            // opens the full bar as an overlay drawer instead of pushing the terminal; in a
+            // wide window the chevron toggles a persisted in-flow collapse.
+            val narrow = maxWidth < ai.rever.bossterm.compose.tabs.TabBarAutoCollapseWidth
+            var drawerOpen by remember { mutableStateOf(false) }
+            LaunchedEffect(narrow) { if (!narrow) drawerOpen = false }
             Row(modifier = Modifier.fillMaxSize()) {
-                tabBarComposable()
+                tabBarComposable(
+                    narrow || settings.tabBarCollapsed,
+                    {
+                        if (narrow) drawerOpen = true
+                        else settingsManager.updateSetting { copy(tabBarCollapsed = !tabBarCollapsed) }
+                    },
+                    null
+                )
                 Box(modifier = Modifier.weight(1f).fillMaxHeight()) { mainContent() }
+            }
+            if (narrow && drawerOpen) {
+                // Click-catcher over the terminal: any press outside the drawer closes it.
+                Box(Modifier.fillMaxSize().pointerInput(Unit) {
+                    detectTapGestures(onPress = { drawerOpen = false })
+                })
+            }
+            if (narrow) {
+                AnimatedVisibility(
+                    visible = drawerOpen,
+                    modifier = Modifier.align(Alignment.CenterStart).fillMaxHeight(),
+                    enter = slideInHorizontally(initialOffsetX = { -it }),
+                    exit = slideOutHorizontally(targetOffsetX = { -it })
+                ) {
+                    tabBarComposable(false, { drawerOpen = false }, { drawerOpen = false })
+                }
             }
         } else {
             Column(modifier = Modifier.fillMaxSize()) {
-                tabBarComposable()
+                tabBarComposable(false, {}, null)
                 mainContent()
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -460,6 +460,13 @@ data class TerminalSettings(
     val tabBarVerticalWidth: Float = 180f,
 
     /**
+     * Vertical (left) tab bar collapsed to a slim icon rail. Toggled by the bar's
+     * chevron. Ignored when position is "top" and while the window is narrow enough
+     * to force the rail (auto-collapse).
+     */
+    val tabBarCollapsed: Boolean = false,
+
+    /**
      * Summary mode (Warp's VerticalTabsSummaryMode): show one chip per tab
      * (the active pane, labeled with the tab's title) instead of one chip per
      * split pane. Off = per-pane chips (default).

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -4,6 +4,7 @@ import ai.rever.bossterm.compose.features.ContextMenuController
 import ai.rever.bossterm.compose.settings.theme.Theme
 import ai.rever.bossterm.compose.settings.theme.ThemeManager
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -13,9 +14,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.HorizontalSplit
@@ -56,6 +60,15 @@ val TabBarHeight: Dp = 48.dp
 
 /** Default width of the [TabBar] surface when rendered vertically (left position). */
 val TabBarVerticalWidth: Dp = 180.dp
+
+/** Width of the vertical bar when collapsed to the slim icon rail. */
+val TabBarRailWidth: Dp = 44.dp
+
+/**
+ * Window width below which the vertical bar auto-collapses to the rail and the full
+ * bar becomes an overlay drawer — mirrors the share-viewer's 700px phone breakpoint.
+ */
+val TabBarAutoCollapseWidth: Dp = 700.dp
 
 /** Orientation of the tab bar: across the top (default) or down the left side. */
 enum class TabBarOrientation { TOP, LEFT }
@@ -228,7 +241,7 @@ private val REMOTE_AI_ASSISTANTS = listOf(
  *
  * Styling matches the Material 3 design of the search bar for visual consistency.
  */
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun TabBar(
     groups: List<TabBarGroup>,
@@ -259,6 +272,10 @@ fun TabBar(
     remoteGroups: List<RemoteTabGroup> = emptyList(),
     orientation: TabBarOrientation = TabBarOrientation.TOP,
     verticalWidth: Dp = TabBarVerticalWidth,
+    /** Vertical bar only: render as a slim icon rail ([TabBarRailWidth]) instead of the full panel. */
+    collapsed: Boolean = false,
+    /** Vertical bar only: collapse/expand chevron next to "Add remote" (and atop the rail). Null hides it. */
+    onToggleCollapse: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     // Context menu controller for chip right-click menu
@@ -472,13 +489,69 @@ fun TabBar(
 
     Surface(
         modifier = modifier.then(
-            if (vertical) Modifier.fillMaxHeight().width(verticalWidth)
+            if (vertical) Modifier.fillMaxHeight().width(if (collapsed) TabBarRailWidth else verticalWidth)
             else Modifier.fillMaxWidth().height(TabBarHeight)
         ),
         color = barBg,
         shadowElevation = 2.dp
     ) {
-        if (vertical) {
+        if (vertical && collapsed) {
+            // Slim icon rail: expand chevron on top, one accent dot per pane (click to
+            // focus, tooltip for the title), "Add remote" pinned at the bottom.
+            Column(
+                modifier = Modifier.fillMaxSize().padding(vertical = 6.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                onToggleCollapse?.let { toggle ->
+                    barButton(Icons.Default.ChevronRight, "Expand sidebar", toggle)
+                    Spacer(Modifier.height(6.dp))
+                    Box(Modifier.fillMaxWidth(0.7f).height(1.dp).background(barDivider))
+                    Spacer(Modifier.height(8.dp))
+                }
+                Column(
+                    modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(TabGroupGap / 2),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    // Same flattened ordering as the top bar: local tabs, then remote mirrors.
+                    (groups + remoteGroups.flatMap { it.groups + it.nested.flatMap { n -> n.groups } }).forEach { group ->
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(TabChipGap),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            group.panes.forEach { pane ->
+                                val active = group.tabIndex == activeTabIndex && pane.paneId == focusedPaneId
+                                val accent = parseTabColor(pane.colorHex) ?: barMuted
+                                TooltipArea(tooltip = {
+                                    Surface(color = barBg, shadowElevation = 4.dp, shape = RoundedCornerShape(4.dp)) {
+                                        Text(
+                                            pane.title, color = barFg, fontSize = 11.sp,
+                                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                                        )
+                                    }
+                                }) {
+                                    Box(
+                                        modifier = Modifier.size(24.dp).clip(RoundedCornerShape(6.dp))
+                                            .clickable { onPaneSelected(group.tabIndex, pane.paneId) },
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        if (active) Box(Modifier.size(16.dp).border(1.5.dp, barFg, CircleShape))
+                                        Box(
+                                            Modifier.size(10.dp).clip(CircleShape)
+                                                .background(if (active) accent else accent.copy(alpha = 0.55f))
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Spacer(Modifier.height(6.dp))
+                Box(Modifier.fillMaxWidth(0.7f).height(1.dp).background(barDivider))
+                Spacer(Modifier.height(4.dp))
+                barButton(Icons.Default.Cloud, "Add remote session", onAddRemote)
+            }
+        } else if (vertical) {
             Column(modifier = Modifier.fillMaxSize().padding(6.dp)) {
                 // Action toolbar pinned at the top, then a divider…
                 actionBar()
@@ -737,23 +810,40 @@ fun TabBar(
                         } // end tether unit (host box + its upstream boxes)
                     }
                 }
-                // Bottom bar — connect to another BossTerm's shared session.
+                // Bottom bar — connect to another BossTerm's shared session, plus the
+                // collapse chevron that shrinks the panel to the icon rail.
                 Spacer(Modifier.height(8.dp))
                 Box(Modifier.fillMaxWidth().height(1.dp).background(barDivider))
                 Spacer(Modifier.height(6.dp))
                 Row(
-                    modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp))
-                        .clickable(onClick = onAddRemote).padding(vertical = 6.dp, horizontal = 8.dp),
+                    modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Cloud,
-                        contentDescription = "Add remote session",
-                        tint = Color(0xFFB0B0B0),
-                        modifier = Modifier.size(16.dp)
-                    )
-                    Text("Add remote", color = Color(0xFFB0B0B0), fontSize = 12.sp)
+                    Row(
+                        modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp))
+                            .clickable(onClick = onAddRemote).padding(vertical = 6.dp, horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Cloud,
+                            contentDescription = "Add remote session",
+                            tint = Color(0xFFB0B0B0),
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Text("Add remote", color = Color(0xFFB0B0B0), fontSize = 12.sp)
+                    }
+                    onToggleCollapse?.let { toggle ->
+                        IconButton(onClick = toggle, modifier = Modifier.size(28.dp)) {
+                            Icon(
+                                imageVector = Icons.Default.ChevronLeft,
+                                contentDescription = "Collapse sidebar",
+                                tint = barMuted,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
## What

Makes the left (vertical) tab bar responsive, replicating the share-viewer's sidebar pattern natively:

- **Manual collapse** — a `‹` chevron next to "Add remote" collapses the panel to a slim 44dp icon rail; persisted as `tabBarCollapsed` in `settings.json`.
- **Icon rail** — one accent-colored dot per pane (click to focus, hover tooltip shows the title, active pane ringed), expand chevron on top, Add-remote cloud pinned at the bottom. Remote sessions' mirrored panes appear as dots too, in the same order as the top bar.
- **Window-size aware** — below `TabBarAutoCollapseWidth` (700dp, mirroring the share-viewer's 700px phone breakpoint) the bar force-collapses to the rail, and the expand chevron opens the full bar as a slide-in **overlay drawer** over the terminal instead of pushing it. The drawer dismisses on any terminal press, pane select, or its own chevron — same behavior as the share-viewer's `☰` drawer.

## How

- `TerminalSettings.tabBarCollapsed` — new persisted boolean (defaulted, so existing settings.json files load unchanged).
- `TabBar` — new `collapsed` + `onToggleCollapse` params (defaulted; TOP orientation unaffected) and the rail branch; new `TabBarRailWidth` / `TabBarAutoCollapseWidth` constants.
- `TabbedTerminal` — layout root is now `BoxWithConstraints`; narrow-mode drawer via `AnimatedVisibility` + `slideInHorizontally` with a press-catcher scrim.

## Testing

- `:compose-ui:compileKotlinDesktop` clean.
- Ran `:bossterm-app:run` locally: collapse/expand chevron, rail dots + tooltips, persistence across restart, auto-collapse + drawer below 700dp all verified by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)