### PR TITLE
feat(theme): dialogs, settings, and context menus follow the active theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ cd BossTerm
 
 ## Design
 
-BossTerm's default look is the **Operator** theme — part of the shared BOSS **"Operator's Console"** visual language: an amber **signal** (`#F2A93B`) for the live/now moment on a calm **ink** floor (`#0E1217`), with cyan **data** accents and a MesloLGS mono voice. The tab bar and terminal surface both follow the active theme, and you can switch themes/palettes in Settings.
+BossTerm's default look is the **Operator** theme — part of the shared BOSS **"Operator's Console"** visual language: an amber **signal** (`#F2A93B`) for the live/now moment on a calm **ink** floor (`#0E1217`), with cyan **data** accents and a MesloLGS mono voice. The whole chrome follows the active theme — tab bar, terminal surface, settings, dialogs, and context menus — and you can switch themes/palettes in Settings.
 
 🎨 **[Visual styleguide](docs/design-system.html)** — a self-contained HTML reference for the whole design system's colors / type / components (open it in a browser).
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantInstallDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantInstallDialog.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.compose.ai
 
 import ai.rever.bossterm.compose.EmbeddableTerminal
+import ai.rever.bossterm.compose.settings.SettingsTheme
 import ai.rever.bossterm.compose.settings.TerminalSettingsOverride
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -14,7 +15,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -86,7 +86,7 @@ fun AIAssistantInstallDialog(
                 .width(700.dp)
                 .height(450.dp)
                 .clip(RoundedCornerShape(12.dp)),
-            color = Color(0xFF1E1E1E),
+            color = SettingsTheme.BackgroundColor,
             elevation = 8.dp
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
@@ -94,14 +94,14 @@ fun AIAssistantInstallDialog(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(Color(0xFF2D2D2D))
+                        .background(SettingsTheme.SurfaceColor)
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
                         text = "Installing ${assistant.displayName}",
-                        color = Color.White,
+                        color = SettingsTheme.TextPrimary,
                         fontSize = 14.sp,
                         fontWeight = FontWeight.Medium
                     )
@@ -117,7 +117,7 @@ fun AIAssistantInstallDialog(
                         Icon(
                             imageVector = Icons.Default.Close,
                             contentDescription = "Close",
-                            tint = Color.White.copy(alpha = 0.7f),
+                            tint = SettingsTheme.TextPrimary.copy(alpha = 0.7f),
                             modifier = Modifier.size(18.dp)
                         )
                     }
@@ -140,13 +140,13 @@ fun AIAssistantInstallDialog(
                         ) {
                             Text(
                                 text = "✓",
-                                color = Color(0xFF4CAF50),
+                                color = SettingsTheme.Success,
                                 fontSize = 48.sp
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
                                 text = "Installation complete!",
-                                color = Color(0xFF4CAF50),
+                                color = SettingsTheme.Success,
                                 fontSize = 16.sp,
                                 fontWeight = FontWeight.Medium
                             )
@@ -154,10 +154,10 @@ fun AIAssistantInstallDialog(
                             Button(
                                 onClick = onDismiss,
                                 colors = ButtonDefaults.buttonColors(
-                                    backgroundColor = Color(0xFF4CAF50)
+                                    backgroundColor = SettingsTheme.Success
                                 )
                             ) {
-                                Text("Close", color = Color.White)
+                                Text("Close", color = SettingsTheme.TextOnAccent)
                             }
                         }
                     } else {
@@ -191,7 +191,7 @@ fun AIAssistantInstallDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(Color(0xFF5C2020))
+                            .background(SettingsTheme.Danger.copy(alpha = 0.15f))
                             .padding(horizontal = 16.dp, vertical = 10.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
@@ -203,7 +203,7 @@ fun AIAssistantInstallDialog(
                             Icon(
                                 imageVector = Icons.Default.Error,
                                 contentDescription = null,
-                                tint = Color(0xFFE57373),
+                                tint = SettingsTheme.Danger,
                                 modifier = Modifier.size(18.dp)
                             )
                             Spacer(modifier = Modifier.width(8.dp))
@@ -212,7 +212,7 @@ fun AIAssistantInstallDialog(
                                     "Script installation failed (exit code: ${errorState.exitCode})"
                                 else
                                     "npm installation failed (exit code: ${errorState.exitCode})",
-                                color = Color(0xFFE57373),
+                                color = SettingsTheme.Danger,
                                 fontSize = 13.sp
                             )
                         }
@@ -227,23 +227,23 @@ fun AIAssistantInstallDialog(
                                         terminalKey++ // Force new terminal
                                     },
                                     colors = ButtonDefaults.buttonColors(
-                                        backgroundColor = Color(0xFF1976D2)
+                                        backgroundColor = SettingsTheme.AccentColor
                                     ),
                                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
                                     modifier = Modifier.height(32.dp)
                                 ) {
-                                    Text("Try npm", color = Color.White, fontSize = 13.sp)
+                                    Text("Try npm", color = SettingsTheme.TextOnAccent, fontSize = 13.sp)
                                 }
                             }
                             Button(
                                 onClick = onDismiss,
                                 colors = ButtonDefaults.buttonColors(
-                                    backgroundColor = Color(0xFF3C3C3C)
+                                    backgroundColor = SettingsTheme.BorderColor
                                 ),
                                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
                                 modifier = Modifier.height(32.dp)
                             ) {
-                                Text("Dismiss", color = Color.White, fontSize = 13.sp)
+                                Text("Dismiss", color = SettingsTheme.TextPrimary, fontSize = 13.sp)
                             }
                         }
                     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/SignInWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/auth/SignInWindow.kt
@@ -2,7 +2,9 @@ package ai.rever.bossterm.compose.auth
 
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 import ai.rever.bossterm.compose.settings.components.SettingsSection
@@ -31,7 +33,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -39,8 +40,6 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.rememberWindowState
 import kotlinx.coroutines.delay
-
-private val Danger = Color(0xFFE57373)
 
 /**
  * Account sign-in window — opened from the Share menus' 4th item. Magic-link flow
@@ -125,7 +124,7 @@ fun SignInWindow(
                                     Button(
                                         onClick = { send(s.email) },
                                         enabled = cooldownLeft <= 0,
-                                        colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                                        colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
                                     ) {
                                         Text(if (cooldownLeft > 0) "Resend (${cooldownLeft}s)" else "Resend link", fontSize = 13.sp)
                                     }
@@ -166,7 +165,7 @@ fun SignInWindow(
                             Button(
                                 onClick = { send(email) },
                                 enabled = email.isNotBlank() && cooldownLeft <= 0,
-                                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
                             ) {
                                 Text(if (cooldownLeft > 0) "Send sign-in link (${cooldownLeft}s)" else "Send sign-in link", fontSize = 13.sp)
                             }
@@ -187,7 +186,7 @@ fun SignInWindow(
                 ) {
                     Button(
                         onClick = onDismiss,
-                        colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                        colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
                     ) { Text("Close", fontSize = 13.sp) }
                 }
             }
@@ -227,7 +226,7 @@ private fun PasteLinkSection(
         Button(
             onClick = onVerify,
             enabled = value.isNotBlank(),
-            colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White),
+            colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent),
         ) { Text("Verify link", fontSize = 13.sp) }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/cli/CLIInstallDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/cli/CLIInstallDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.cli
 
+import ai.rever.bossterm.compose.settings.SettingsTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,7 +11,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -46,7 +46,7 @@ fun CLIInstallDialog(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color(0xFF1E1E1E))
+                .background(SettingsTheme.BackgroundColor)
                 .padding(24.dp),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
@@ -54,7 +54,7 @@ fun CLIInstallDialog(
             Column {
                 Text(
                     text = if (isFirstRun) "Welcome to BossTerm!" else "Command Line Tool",
-                    color = Color.White,
+                    color = SettingsTheme.TextPrimary,
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold
                 )
@@ -67,7 +67,7 @@ fun CLIInstallDialog(
                     } else {
                         "Install the 'bossterm' command to open BossTerm from your terminal."
                     },
-                    color = Color(0xFFB0B0B0),
+                    color = SettingsTheme.TextSecondary,
                     fontSize = 13.sp,
                     lineHeight = 20.sp
                 )
@@ -76,7 +76,7 @@ fun CLIInstallDialog(
 
                 Text(
                     text = "Usage examples:",
-                    color = Color(0xFF808080),
+                    color = SettingsTheme.TextMuted,
                     fontSize = 12.sp
                 )
 
@@ -84,12 +84,12 @@ fun CLIInstallDialog(
 
                 Column(
                     modifier = Modifier
-                        .background(Color(0xFF2B2B2B), RoundedCornerShape(4.dp))
+                        .background(SettingsTheme.SurfaceColor, RoundedCornerShape(4.dp))
                         .padding(8.dp)
                 ) {
-                    Text("bossterm", color = Color(0xFF6A9955), fontSize = 12.sp)
-                    Text("bossterm ~/Projects", color = Color(0xFF6A9955), fontSize = 12.sp)
-                    Text("bossterm -d /path/to/dir", color = Color(0xFF6A9955), fontSize = 12.sp)
+                    Text("bossterm", color = SettingsTheme.Success, fontSize = 12.sp)
+                    Text("bossterm ~/Projects", color = SettingsTheme.Success, fontSize = 12.sp)
+                    Text("bossterm -d /path/to/dir", color = SettingsTheme.Success, fontSize = 12.sp)
                 }
             }
 
@@ -97,7 +97,7 @@ fun CLIInstallDialog(
             if (statusMessage != null) {
                 Text(
                     text = statusMessage!!,
-                    color = if (statusMessage!!.startsWith("Error")) Color(0xFFE57373) else Color(0xFF81C784),
+                    color = if (statusMessage!!.startsWith("Error")) SettingsTheme.Danger else SettingsTheme.Success,
                     fontSize = 12.sp,
                     modifier = Modifier.padding(vertical = 8.dp)
                 )
@@ -112,7 +112,7 @@ fun CLIInstallDialog(
                 if (isLoading) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(20.dp),
-                        color = Color(0xFF4A90E2),
+                        color = SettingsTheme.AccentColor,
                         strokeWidth = 2.dp
                     )
                     Spacer(modifier = Modifier.width(16.dp))
@@ -149,8 +149,8 @@ fun CLIInstallDialog(
                         },
                         enabled = !isLoading,
                         colors = ButtonDefaults.buttonColors(
-                            backgroundColor = Color(0xFF424242),
-                            contentColor = Color.White
+                            backgroundColor = SettingsTheme.BorderColor,
+                            contentColor = SettingsTheme.TextPrimary
                         ),
                         modifier = Modifier.height(40.dp)
                     ) {
@@ -191,8 +191,8 @@ fun CLIInstallDialog(
                         },
                         enabled = !isLoading,
                         colors = ButtonDefaults.buttonColors(
-                            backgroundColor = Color(0xFF4A90E2),
-                            contentColor = Color.White
+                            backgroundColor = SettingsTheme.AccentColor,
+                            contentColor = SettingsTheme.TextOnAccent
                         ),
                         modifier = Modifier.height(40.dp)
                     ) {
@@ -210,8 +210,8 @@ fun CLIInstallDialog(
                     onClick = onDismiss,
                     enabled = !isLoading,
                     colors = ButtonDefaults.buttonColors(
-                        backgroundColor = Color(0xFF424242),
-                        contentColor = Color.White
+                        backgroundColor = SettingsTheme.BorderColor,
+                        contentColor = SettingsTheme.TextPrimary
                     ),
                     modifier = Modifier.height(40.dp)
                 ) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareWindow.kt
@@ -3,12 +3,16 @@ package ai.rever.bossterm.compose.daemon
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
+import ai.rever.bossterm.compose.settings.SettingsTheme.Success
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 import ai.rever.bossterm.compose.settings.components.SettingsSection
 import ai.rever.bossterm.compose.settings.components.SettingsTextField
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -61,9 +65,7 @@ import com.google.zxing.EncodeHintType
 import com.google.zxing.qrcode.QRCodeWriter
 import java.awt.image.BufferedImage
 
-private val Track = Color(0xFF252526)
-private val Danger = Color(0xFFE57373)
-private val Success = Color(0xFF4CAF50)
+private val Track get() = BossUiTheme.current.ink
 
 /**
  * Daemon-hosted session-sharing window (Phase 2). The thin-client analogue of
@@ -160,7 +162,7 @@ fun DaemonShareWindow(
                 }
                 Button(
                     onClick = onDismiss,
-                    colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                    colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
                 ) { Text("Close") }
             }
           }
@@ -213,7 +215,7 @@ private fun StartSection(scope: String, focusedSessionId: String?) {
                 val sessionId = if (scope == DaemonAttachProtocol.ShareScopeKind.SESSION) focusedSessionId else null
                 DaemonShareClient.startShare(scope, sessionId, null)
             },
-            colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+            colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
         ) { Text("Start sharing") }
     }
 }
@@ -422,7 +424,7 @@ private fun Seg(label: String, selected: Boolean, onClick: () -> Unit) {
             .clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 5.dp),
         contentAlignment = Alignment.Center
     ) {
-        Text(label, color = if (selected) Color.White else TextMuted, fontSize = 12.sp)
+        Text(label, color = if (selected) TextOnAccent else TextMuted, fontSize = 12.sp)
     }
 }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/features/ContextMenuController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/features/ContextMenuController.kt
@@ -3,7 +3,6 @@ package ai.rever.bossterm.compose.features
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
-import java.awt.Color
 import java.awt.Font
 import java.awt.KeyboardFocusManager
 import java.awt.MouseInfo
@@ -17,6 +16,8 @@ import javax.swing.JPopupMenu
 import javax.swing.JSeparator
 import javax.swing.UIManager
 import javax.swing.plaf.ColorUIResource
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
+import ai.rever.bossterm.compose.settings.theme.toAwtColor
 import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 
 /**
@@ -26,6 +27,13 @@ import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 class ContextMenuController {
     // Track current popup to ensure proper dismissal before showing new one
     private var currentPopup: JPopupMenu? = null
+
+    // Theme-derived AWT colors. Getters (not vals) so each menu build reads the
+    // tokens for the currently active theme — the menu is rebuilt per right-click.
+    private val menuBg get() = BossUiTheme.current.raised.toAwtColor()
+    private val menuBorder get() = BossUiTheme.current.line.toAwtColor()
+    private val menuText get() = BossUiTheme.current.chalk.toAwtColor()
+    private val menuMuted get() = BossUiTheme.current.muted.toAwtColor()
 
     /**
      * Sealed class for menu elements (items, separators, submenus)
@@ -110,9 +118,9 @@ class ContextMenuController {
         }
 
         val popup = JPopupMenu().apply {
-            // Dark theme colors
-            background = Color(0x2B, 0x2B, 0x2B)
-            border = BorderFactory.createLineBorder(Color(0x3C, 0x3F, 0x41), 1)
+            // Theme colors
+            background = menuBg
+            border = BorderFactory.createLineBorder(menuBorder, 1)
         }
 
         // Add elements to popup
@@ -182,15 +190,15 @@ class ContextMenuController {
                 is MenuItem -> {
                     if (element.id.startsWith("separator")) {
                         val separator = JSeparator().apply {
-                            background = Color(0x2B, 0x2B, 0x2B)
-                            foreground = Color(0x3C, 0x3F, 0x41)
+                            background = menuBg
+                            foreground = menuBorder
                         }
                         addToMenu(menu, separator)
                     } else {
                         val menuItem = JMenuItem(element.label).apply {
                             isEnabled = element.enabled
-                            background = Color(0x2B, 0x2B, 0x2B)
-                            foreground = if (element.enabled) Color.WHITE else Color.GRAY
+                            background = menuBg
+                            foreground = if (element.enabled) menuText else menuMuted
                             font = Font(".AppleSystemUIFont", Font.PLAIN, 13)
                             border = BorderFactory.createEmptyBorder(4, 12, 4, 12)
                             isOpaque = true
@@ -210,12 +218,12 @@ class ContextMenuController {
                     if (element.label != null) {
                         // Section with label
                         val separator = JSeparator().apply {
-                            background = Color(0x2B, 0x2B, 0x2B)
-                            foreground = Color(0x3C, 0x3F, 0x41)
+                            background = menuBg
+                            foreground = menuBorder
                         }
                         addToMenu(menu, separator)
                         val label = JLabel(element.label).apply {
-                            foreground = Color.GRAY
+                            foreground = menuMuted
                             font = Font(".AppleSystemUIFont", Font.PLAIN, 11)
                             border = BorderFactory.createEmptyBorder(2, 12, 2, 12)
                         }
@@ -223,21 +231,21 @@ class ContextMenuController {
                     } else {
                         // Plain separator
                         val separator = JSeparator().apply {
-                            background = Color(0x2B, 0x2B, 0x2B)
-                            foreground = Color(0x3C, 0x3F, 0x41)
+                            background = menuBg
+                            foreground = menuBorder
                         }
                         addToMenu(menu, separator)
                     }
                 }
                 is MenuSubmenu -> {
                     val submenu = JMenu(element.label).apply {
-                        background = Color(0x2B, 0x2B, 0x2B)
-                        foreground = Color.WHITE
+                        background = menuBg
+                        foreground = menuText
                         font = Font(".AppleSystemUIFont", Font.PLAIN, 13)
                         border = BorderFactory.createEmptyBorder(4, 12, 4, 12)
                         isOpaque = true
-                        popupMenu.background = Color(0x2B, 0x2B, 0x2B)
-                        popupMenu.border = BorderFactory.createLineBorder(Color(0x3C, 0x3F, 0x41), 1)
+                        popupMenu.background = menuBg
+                        popupMenu.border = BorderFactory.createLineBorder(menuBorder, 1)
                     }
                     addElementsToMenu(submenu, element.items)
                     addToMenu(menu, submenu)
@@ -286,7 +294,7 @@ private val AccountGlyphIcon = object : javax.swing.Icon {
                 java.awt.RenderingHints.KEY_ANTIALIASING,
                 java.awt.RenderingHints.VALUE_ANTIALIAS_ON
             )
-            g2.color = Color(0xCC, 0xCC, 0xCC)
+            g2.color = BossUiTheme.current.mist.toAwtColor()
             // Head: a circle in the upper-middle.
             g2.fill(java.awt.geom.Ellipse2D.Float(x + 4f, y + 1.5f, 6f, 6f))
             // Shoulders: a half-disc clipped to the lower band so it reads as a torso, not a full circle.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingSteps.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingSteps.kt
@@ -46,6 +46,12 @@ import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
+import ai.rever.bossterm.compose.settings.SettingsTheme.Success
+import ai.rever.bossterm.compose.settings.SettingsTheme.Warning
+import ai.rever.bossterm.compose.settings.SettingsTheme.Info
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 
 /**
  * Step indicator showing progress through the wizard.
@@ -80,7 +86,7 @@ fun StepIndicator(
             ) {
                 Text(
                     text = if (isComplete) "✓" else "${index + 1}",
-                    color = if (isActive || isComplete) Color.White else TextMuted,
+                    color = if (isActive || isComplete) TextOnAccent else TextMuted,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold
                 )
@@ -431,9 +437,9 @@ chmod +x /tmp/bossterm_brew_install.sh && /tmp/bossterm_brew_install.sh
         Card(
             modifier = Modifier.fillMaxWidth(),
             backgroundColor = if (hasPackageManager) {
-                Color(0xFF1E3A1E)  // Dark green
+                Success.copy(alpha = 0.15f)
             } else {
-                Color(0xFF3A3A1E)  // Dark yellow/warning
+                Warning.copy(alpha = 0.15f)
             }
         ) {
             Row(
@@ -444,9 +450,9 @@ chmod +x /tmp/bossterm_brew_install.sh && /tmp/bossterm_brew_install.sh
                     text = if (hasPackageManager) "✓" else "⚠",
                     fontSize = 20.sp,
                     color = if (hasPackageManager) {
-                        Color(0xFF4CAF50)
+                        Success
                     } else {
-                        Color(0xFFFFC107)
+                        Warning
                     }
                 )
                 Spacer(modifier = Modifier.width(12.dp))
@@ -576,7 +582,7 @@ chmod +x /tmp/bossterm_brew_install.sh && /tmp/bossterm_brew_install.sh
                 Text(
                     text = "Installation failed. Please try again or skip this step.",
                     fontSize = 14.sp,
-                    color = Color(0xFFFF6B6B)
+                    color = Danger
                 )
             }
         }
@@ -621,10 +627,10 @@ private fun PackageManagerCard(
                         Spacer(modifier = Modifier.width(8.dp))
                         Box(
                             modifier = Modifier
-                                .background(Color(0xFF4CAF50), RoundedCornerShape(4.dp))
+                                .background(Success, RoundedCornerShape(4.dp))
                                 .padding(horizontal = 6.dp, vertical = 2.dp)
                         ) {
-                            Text("Installed", fontSize = 10.sp, color = Color.White)
+                            Text("Installed", fontSize = 10.sp, color = BossUiTheme.current.ink)
                         }
                     }
                     if (isRecommended && !isInstalled) {
@@ -634,7 +640,7 @@ private fun PackageManagerCard(
                                 .background(AccentColor, RoundedCornerShape(4.dp))
                                 .padding(horizontal = 6.dp, vertical = 2.dp)
                         ) {
-                            Text("Recommended", fontSize = 10.sp, color = Color.White)
+                            Text("Recommended", fontSize = 10.sp, color = TextOnAccent)
                         }
                     }
                 }
@@ -652,7 +658,7 @@ private fun PackageManagerCard(
                     onClick = onInstallClick,
                     colors = ButtonDefaults.buttonColors(
                         backgroundColor = AccentColor,
-                        contentColor = Color.White
+                        contentColor = TextOnAccent
                     ),
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
                 ) {
@@ -1114,7 +1120,7 @@ private fun ReviewItem(
                         .background(AccentColor, RoundedCornerShape(4.dp))
                         .padding(horizontal = 6.dp, vertical = 2.dp)
                 ) {
-                    Text("Install", fontSize = 10.sp, color = Color.White)
+                    Text("Install", fontSize = 10.sp, color = TextOnAccent)
                 }
             }
         }
@@ -1185,7 +1191,7 @@ fun InstallingStep(
             Text(
                 text = "Installation failed. Please check the output above for errors.",
                 fontSize = 14.sp,
-                color = Color(0xFFFF6B6B)
+                color = Danger
             )
         }
     }
@@ -1250,15 +1256,15 @@ fun GhAuthStep(
         ) {
             // Step 1: Code Appears
             Card(
-                backgroundColor = Color(0xFF2D4F2D),
-                border = BorderStroke(1.dp, Color(0xFF4CAF50)),
+                backgroundColor = Success.copy(alpha = 0.15f),
+                border = BorderStroke(1.dp, Success),
                 modifier = Modifier.weight(1f)
             ) {
                 Column(
                     modifier = Modifier.padding(8.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Text("1. CODE APPEARS", fontWeight = FontWeight.Bold, fontSize = 11.sp, color = Color(0xFF4CAF50))
+                    Text("1. CODE APPEARS", fontWeight = FontWeight.Bold, fontSize = 11.sp, color = Success)
                     Text("XXXX-XXXX", fontSize = 10.sp, color = TextMuted)
                 }
             }
@@ -1268,15 +1274,15 @@ fun GhAuthStep(
 
             // Step 2: Copy Code (highlighted)
             Card(
-                backgroundColor = Color(0xFF4F4F2D),
-                border = BorderStroke(2.dp, Color(0xFFFFD700)),
+                backgroundColor = Warning.copy(alpha = 0.15f),
+                border = BorderStroke(2.dp, Warning),
                 modifier = Modifier.weight(1f)
             ) {
                 Column(
                     modifier = Modifier.padding(8.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Text("2. COPY CODE", fontWeight = FontWeight.Bold, fontSize = 11.sp, color = Color(0xFFFFD700))
+                    Text("2. COPY CODE", fontWeight = FontWeight.Bold, fontSize = 11.sp, color = Warning)
                     Text("Select & Copy", fontSize = 10.sp, color = TextMuted)
                 }
             }
@@ -1286,15 +1292,15 @@ fun GhAuthStep(
 
             // Step 3: Paste in Browser
             Card(
-                backgroundColor = Color(0xFF2D3D4F),
-                border = BorderStroke(1.dp, Color(0xFF2196F3)),
+                backgroundColor = Info.copy(alpha = 0.15f),
+                border = BorderStroke(1.dp, Info),
                 modifier = Modifier.weight(1f)
             ) {
                 Column(
                     modifier = Modifier.padding(8.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Text("3. PASTE", fontWeight = FontWeight.Bold, fontSize = 11.sp, color = Color(0xFF2196F3))
+                    Text("3. PASTE", fontWeight = FontWeight.Bold, fontSize = 11.sp, color = Info)
                     Text("In Browser", fontSize = 10.sp, color = TextMuted)
                 }
             }
@@ -1312,7 +1318,7 @@ fun GhAuthStep(
                 text = "IMPORTANT: Copy the one-time code when it appears below!",
                 fontWeight = FontWeight.Bold,
                 fontSize = 13.sp,
-                color = Color(0xFFFFD700),
+                color = Warning,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.fillMaxWidth()
             )
@@ -1325,8 +1331,8 @@ fun GhAuthStep(
             exit = fadeOut()
         ) {
             Card(
-                backgroundColor = Color(0xFF2D4F2D),
-                border = BorderStroke(2.dp, Color(0xFF4CAF50)),
+                backgroundColor = Success.copy(alpha = 0.15f),
+                border = BorderStroke(2.dp, Success),
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Row(
@@ -1338,7 +1344,7 @@ fun GhAuthStep(
                         text = "Code: ${detectedOtp ?: ""}",
                         fontWeight = FontWeight.Bold,
                         fontSize = 16.sp,
-                        color = Color(0xFF4CAF50)
+                        color = Success
                     )
                     Spacer(Modifier.width(16.dp))
                     Button(
@@ -1348,8 +1354,8 @@ fun GhAuthStep(
                             }
                         },
                         colors = ButtonDefaults.buttonColors(
-                            backgroundColor = Color(0xFF4CAF50),
-                            contentColor = Color.White
+                            backgroundColor = Success,
+                            contentColor = BossUiTheme.current.ink
                         )
                     ) {
                         Text("Copy Code")
@@ -1410,7 +1416,7 @@ fun GhAuthStep(
                     onClick = onComplete,
                     colors = ButtonDefaults.buttonColors(
                         backgroundColor = AccentColor,
-                        contentColor = Color.White
+                        contentColor = TextOnAccent
                     )
                 ) {
                     Text("Continue")
@@ -1464,7 +1470,7 @@ fun CompleteStep(
                 onClick = onRelaunch,
                 colors = ButtonDefaults.buttonColors(
                     backgroundColor = AccentColor,
-                    contentColor = Color.White
+                    contentColor = TextOnAccent
                 )
             ) {
                 Text("Relaunch Terminal")
@@ -1529,7 +1535,7 @@ fun SelectionCard(
                                 .background(AccentColor, RoundedCornerShape(4.dp))
                                 .padding(horizontal = 6.dp, vertical = 2.dp)
                         ) {
-                            Text("Recommended", fontSize = 10.sp, color = Color.White)
+                            Text("Recommended", fontSize = 10.sp, color = TextOnAccent)
                         }
                     }
                     if (badge != null) {
@@ -1591,7 +1597,7 @@ fun CheckboxCard(
                 colors = CheckboxDefaults.colors(
                     checkedColor = AccentColor,
                     uncheckedColor = TextMuted,
-                    checkmarkColor = Color.White
+                    checkmarkColor = TextOnAccent
                 )
             )
             Spacer(modifier = Modifier.width(12.dp))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingWizard.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/onboarding/OnboardingWizard.kt
@@ -21,6 +21,7 @@ import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 import ai.rever.bossterm.compose.ai.AIAssistantIds
@@ -444,7 +445,7 @@ fun OnboardingWizard(
                                     },
                                     colors = ButtonDefaults.buttonColors(
                                         backgroundColor = AccentColor,
-                                        contentColor = Color.White
+                                        contentColor = TextOnAccent
                                     ),
                                     modifier = Modifier
                                         .focusRequester(primaryButtonFocusRequester)
@@ -489,7 +490,7 @@ fun OnboardingWizard(
                                     onClick = { doInstallOrFinish() },
                                     colors = ButtonDefaults.buttonColors(
                                         backgroundColor = AccentColor,
-                                        contentColor = Color.White
+                                        contentColor = TextOnAccent
                                     ),
                                     modifier = Modifier
                                         .focusRequester(primaryButtonFocusRequester)
@@ -529,9 +530,9 @@ fun OnboardingWizard(
                                     enabled = canProceedFromPrereqs,
                                     colors = ButtonDefaults.buttonColors(
                                         backgroundColor = AccentColor,
-                                        contentColor = Color.White,
+                                        contentColor = TextOnAccent,
                                         disabledBackgroundColor = AccentColor.copy(alpha = 0.5f),
-                                        disabledContentColor = Color.White.copy(alpha = 0.5f)
+                                        disabledContentColor = TextOnAccent.copy(alpha = 0.5f)
                                     ),
                                     modifier = Modifier
                                         .focusRequester(primaryButtonFocusRequester)
@@ -565,9 +566,9 @@ fun OnboardingWizard(
                                     enabled = canProceed,
                                     colors = ButtonDefaults.buttonColors(
                                         backgroundColor = AccentColor,
-                                        contentColor = Color.White,
+                                        contentColor = TextOnAccent,
                                         disabledBackgroundColor = AccentColor.copy(alpha = 0.5f),
-                                        disabledContentColor = Color.White.copy(alpha = 0.5f)
+                                        disabledContentColor = TextOnAccent.copy(alpha = 0.5f)
                                     ),
                                     modifier = Modifier
                                         .focusRequester(primaryButtonFocusRequester)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/AddRemoteDialog.kt
@@ -1,10 +1,12 @@
 package ai.rever.bossterm.compose.remote
 
+import ai.rever.bossterm.compose.settings.SettingsTheme
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 import ai.rever.bossterm.compose.settings.components.SettingsSection
@@ -46,9 +48,9 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.rememberWindowState
 
-private val Green = Color(0xFF4CAF50)
-private val Amber = Color(0xFFE0A030)
-private val Danger = Color(0xFFE57373)
+private val Green get() = SettingsTheme.Success
+private val Amber get() = SettingsTheme.Warning
+private val Danger get() = SettingsTheme.Danger
 
 /**
  * "Remote sessions" window — a top-level OS window styled like
@@ -135,7 +137,7 @@ fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
                         Button(
                             onClick = { connect() },
                             enabled = link.isNotBlank(),
-                            colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                            colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
                         ) { Text("Connect") }
                     }
                 }
@@ -157,7 +159,7 @@ fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
                 horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Button(onClick = onDismiss, colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)) {
+                Button(onClick = onDismiss, colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)) {
                     Text("Close")
                 }
             }
@@ -175,7 +177,7 @@ fun AddRemoteDialog(manager: RemoteSessionManager, onDismiss: () -> Unit) {
 fun RequestControlPrompt(onConfirm: () -> Unit, onDismiss: () -> Unit) {
     androidx.compose.material3.AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = BackgroundColor,
+        containerColor = SurfaceColor,
         title = { Text("View-only session", color = TextPrimary, fontWeight = FontWeight.SemiBold) },
         text = {
             Text(
@@ -188,7 +190,7 @@ fun RequestControlPrompt(onConfirm: () -> Unit, onDismiss: () -> Unit) {
         confirmButton = {
             Button(
                 onClick = onConfirm,
-                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
             ) { Text("Request Control") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel", color = TextSecondary) } },
@@ -211,7 +213,7 @@ fun RemoteFitPrompt(
 ) {
     androidx.compose.material3.AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = BackgroundColor,
+        containerColor = SurfaceColor,
         title = { Text("Match window sizes?", color = TextPrimary, fontWeight = FontWeight.SemiBold) },
         text = {
             // Both directions as stacked full-width buttons (a side-by-side row overflows
@@ -226,12 +228,12 @@ fun RemoteFitPrompt(
                 Button(
                     onClick = onFitMyWindow,
                     modifier = androidx.compose.ui.Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                    colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
                 ) { Text("Fit my window to host") }
                 Button(
                     onClick = onFitHost,
                     modifier = androidx.compose.ui.Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF3A3A3A), contentColor = TextPrimary)
+                    colors = ButtonDefaults.buttonColors(containerColor = BorderColor, contentColor = TextPrimary)
                 ) { Text("Fit host to my window") }
             }
         },
@@ -255,7 +257,7 @@ fun RemoteDisconnectedDialog(
 ) {
     androidx.compose.material3.AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = BackgroundColor,
+        containerColor = SurfaceColor,
         title = { Text("Remote disconnected", color = TextPrimary, fontWeight = FontWeight.SemiBold) },
         text = {
             Text(
@@ -268,7 +270,7 @@ fun RemoteDisconnectedDialog(
         confirmButton = {
             Button(
                 onClick = onReconnect,
-                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
             ) { Text("Reconnect") }
         },
         dismissButton = {
@@ -315,7 +317,7 @@ private fun statusColor(s: RemoteStatus): Color = when (s) {
     is RemoteStatus.Connected -> Green
     RemoteStatus.Pending, RemoteStatus.Connecting -> Amber
     is RemoteStatus.Denied, is RemoteStatus.Failed -> Danger
-    RemoteStatus.Closed -> Color(0xFF888888)
+    RemoteStatus.Closed -> TextMuted
 }
 
 private fun hostOf(link: String): String = runCatching {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsPanel.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.sp
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
@@ -167,7 +168,7 @@ fun SettingsPanel(
                         showResetConfirmation = false
                     },
                     colors = ButtonDefaults.buttonColors(
-                        backgroundColor = Color(0xFFE04040)
+                        backgroundColor = Danger
                     )
                 ) {
                     Text("Reset", color = TextPrimary)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsTheme.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsTheme.kt
@@ -1,16 +1,29 @@
 package ai.rever.bossterm.compose.settings
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.ui.graphics.Color
 
 /**
- * Shared UI constants for settings panel - aligned with TabBar.kt theme.
+ * Shared UI chrome for the settings panel and dialogs.
+ *
+ * Every value follows the active terminal theme via [BossUiTheme]; reads are
+ * snapshot-backed, so composables restyle live when the theme changes.
  */
 object SettingsTheme {
-    val SurfaceColor = Color(0xFF2B2B2B)
-    val BackgroundColor = Color(0xFF1E1E1E)
-    val AccentColor = Color(0xFF4A90E2)
-    val BorderColor = Color(0xFF404040)
-    val TextPrimary = Color.White
-    val TextSecondary = Color(0xFFB0B0B0)
-    val TextMuted = Color(0xFF707070)
+    val SurfaceColor: Color get() = BossUiTheme.current.raised
+    val BackgroundColor: Color get() = BossUiTheme.current.panel
+    val AccentColor: Color get() = BossUiTheme.current.signal
+    val BorderColor: Color get() = BossUiTheme.current.line
+    val TextPrimary: Color get() = BossUiTheme.current.chalk
+    val TextSecondary: Color get() = BossUiTheme.current.mist
+    val TextMuted: Color get() = BossUiTheme.current.muted
+
+    /** Content color for accent-filled controls (buttons, badges). */
+    val TextOnAccent: Color get() = BossUiTheme.current.onSignal
+
+    // Semantic status colors
+    val Danger: Color get() = BossUiTheme.current.alert
+    val Success: Color get() = BossUiTheme.current.ok
+    val Warning: Color get() = BossUiTheme.current.warn
+    val Info: Color get() = BossUiTheme.current.data
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/components/ColorPickerDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/components/ColorPickerDialog.kt
@@ -37,6 +37,7 @@ import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 
@@ -391,7 +392,7 @@ private fun AlphaSlider(
                 for (col in 0 until (size.width / checkerSize).toInt() + 1) {
                     val isLight = (row + col) % 2 == 0
                     drawRect(
-                        color = if (isLight) Color(0xFFCCCCCC) else Color(0xFF999999),
+                        color = if (isLight) TextSecondary else TextMuted,
                         topLeft = Offset(col * checkerSize, row * checkerSize),
                         size = Size(checkerSize, checkerSize)
                     )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/components/SettingsComponents.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/components/SettingsComponents.kt
@@ -24,6 +24,7 @@ import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 
@@ -756,7 +757,7 @@ fun SettingsFilePicker(
                 enabled = enabled,
                 colors = ButtonDefaults.buttonColors(
                     backgroundColor = AccentColor,
-                    contentColor = Color.White
+                    contentColor = TextOnAccent
                 ),
                 modifier = Modifier.height(36.dp)
             ) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/AIAssistantSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/AIAssistantSettingsSection.kt
@@ -10,11 +10,16 @@ import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
+import ai.rever.bossterm.compose.settings.SettingsTheme.Success
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
+import ai.rever.bossterm.compose.settings.SettingsTheme.Warning
 import ai.rever.bossterm.compose.settings.components.*
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -264,8 +269,8 @@ private fun AIAssistantConfigCard(
     var expanded by remember { mutableStateOf(false) }
     var copied by remember { mutableStateOf(false) }
 
-    val borderColor = if (config.enabled && isInstalled) Color(0xFF4CAF50).copy(alpha = 0.5f) else Color(0xFF3C3C3C)
-    val backgroundColor = if (config.enabled && isInstalled) Color(0xFF4CAF50).copy(alpha = 0.05f) else Color.Transparent
+    val borderColor = if (config.enabled && isInstalled) Success.copy(alpha = 0.5f) else BorderColor
+    val backgroundColor = if (config.enabled && isInstalled) Success.copy(alpha = 0.05f) else Color.Transparent
 
     Column(
         modifier = Modifier
@@ -314,7 +319,7 @@ private fun AIAssistantConfigCard(
                 }
                 if (onDelete != null) {
                     IconButton(onClick = onDelete, modifier = Modifier.size(32.dp)) {
-                        Icon(Icons.Default.Delete, "Delete", tint = Color(0xFFE57373), modifier = Modifier.size(16.dp))
+                        Icon(Icons.Default.Delete, "Delete", tint = Danger, modifier = Modifier.size(16.dp))
                     }
                 }
                 Switch(
@@ -330,7 +335,7 @@ private fun AIAssistantConfigCard(
 
         if (config.enabled) {
             Spacer(modifier = Modifier.height(12.dp))
-            Divider(color = Color(0xFF3C3C3C))
+            Divider(color = BorderColor)
             Spacer(modifier = Modifier.height(12.dp))
 
             // Auto Mode toggle
@@ -416,7 +421,7 @@ private fun AIAssistantConfigCard(
         // Install command for uninstalled built-in assistants
         if (!isInstalled && assistant.isBuiltIn && installCommand.isNotBlank()) {
             Spacer(modifier = Modifier.height(12.dp))
-            Divider(color = Color(0xFF3C3C3C))
+            Divider(color = BorderColor)
             Spacer(modifier = Modifier.height(12.dp))
 
             Text("Install Command", color = TextSecondary, fontSize = 11.sp, fontWeight = FontWeight.Medium)
@@ -426,13 +431,13 @@ private fun AIAssistantConfigCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(4.dp))
-                    .background(Color(0xFF1A1A1A))
+                    .background(BossUiTheme.current.ink)
                     .padding(10.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
                     text = installCommand.take(60) + if (installCommand.length > 60) "..." else "",
-                    color = Color(0xFFCE9178),
+                    color = Warning,
                     fontSize = 11.sp,
                     modifier = Modifier.weight(1f)
                 )
@@ -447,7 +452,7 @@ private fun AIAssistantConfigCard(
                     Icon(
                         imageVector = if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
                         contentDescription = "Copy",
-                        tint = if (copied) Color(0xFF4CAF50) else AccentColor,
+                        tint = if (copied) Success else AccentColor,
                         modifier = Modifier.size(14.dp)
                     )
                 }
@@ -591,7 +596,7 @@ private fun CustomAssistantDialog(
                     disabledBackgroundColor = AccentColor.copy(alpha = 0.3f)
                 )
             ) {
-                Text("Save", color = Color.White, fontSize = 13.sp)
+                Text("Save", color = TextOnAccent, fontSize = 13.sp)
             }
         },
         dismissButton = {
@@ -610,8 +615,8 @@ private fun StatusBadge(isInstalled: Boolean) {
         modifier = Modifier
             .clip(RoundedCornerShape(4.dp))
             .background(
-                if (isInstalled) Color(0xFF2E7D32).copy(alpha = 0.2f)
-                else Color(0xFFD32F2F).copy(alpha = 0.2f)
+                if (isInstalled) Success.copy(alpha = 0.2f)
+                else Danger.copy(alpha = 0.2f)
             )
             .padding(horizontal = 6.dp, vertical = 2.dp)
     ) {
@@ -619,7 +624,7 @@ private fun StatusBadge(isInstalled: Boolean) {
             Icon(
                 imageVector = if (isInstalled) Icons.Default.Check else Icons.Default.Close,
                 contentDescription = null,
-                tint = if (isInstalled) Color(0xFF4CAF50) else Color(0xFFE57373),
+                tint = if (isInstalled) Success else Danger,
                 modifier = Modifier.size(10.dp)
             )
             Spacer(modifier = Modifier.width(4.dp))
@@ -627,7 +632,7 @@ private fun StatusBadge(isInstalled: Boolean) {
                 text = if (isInstalled) "Installed" else "Not Found",
                 fontSize = 10.sp,
                 fontWeight = FontWeight.Medium,
-                color = if (isInstalled) Color(0xFF4CAF50) else Color(0xFFE57373)
+                color = if (isInstalled) Success else Danger
             )
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/DaemonSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/DaemonSettingsSection.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ai.rever.bossterm.compose.daemon.DaemonClient
@@ -24,7 +23,9 @@ import ai.rever.bossterm.compose.daemon.DaemonProtocol
 import ai.rever.bossterm.compose.daemon.LoginServiceManager
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.settings.components.SettingsSection
@@ -117,7 +118,7 @@ fun DaemonSettingsSection(
                         }
                     },
                     enabled = !busy,
-                    colors = ButtonDefaults.buttonColors(backgroundColor = AccentColor, contentColor = Color.White),
+                    colors = ButtonDefaults.buttonColors(backgroundColor = AccentColor, contentColor = TextOnAccent),
                 ) { Text("Refresh status", fontSize = 13.sp) }
 
                 Button(
@@ -133,7 +134,7 @@ fun DaemonSettingsSection(
                         }
                     },
                     enabled = !busy,
-                    colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFF6B2B2B), contentColor = Color.White),
+                    colors = ButtonDefaults.buttonColors(backgroundColor = Danger.copy(alpha = 0.25f), contentColor = TextPrimary),
                 ) { Text("Quit daemon", fontSize = 13.sp) }
             }
             if (status.isNotBlank()) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/GlobalHotkeySection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/GlobalHotkeySection.kt
@@ -1,9 +1,13 @@
 package ai.rever.bossterm.compose.settings.sections
 
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
+import ai.rever.bossterm.compose.settings.SettingsTheme.Success
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
+import ai.rever.bossterm.compose.settings.SettingsTheme.Warning
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.settings.components.SettingsSection
 import ai.rever.bossterm.compose.settings.components.SettingsToggle
@@ -31,7 +35,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -76,7 +79,7 @@ fun GlobalHotkeySection(
                     Text(
                         text = "⚠︎ One modifier can clash with app shortcuts (the global hotkey " +
                             "wins system-wide). Add a second modifier for a conflict-free chord.",
-                        color = Color(0xFFE2B44A),
+                        color = Warning,
                         fontSize = 12.sp,
                         lineHeight = 16.sp,
                         modifier = Modifier.padding(top = 6.dp)
@@ -190,7 +193,7 @@ private fun CurrentHotkeyDisplay(
                 } else {
                     "Select at least one modifier"
                 },
-                color = if (hasModifiers) AccentColor else Color(0xFFE04040),
+                color = if (hasModifiers) AccentColor else Danger,
                 fontSize = 15.sp,
                 fontWeight = FontWeight.Medium,
                 modifier = Modifier.padding(top = 2.dp)
@@ -244,10 +247,10 @@ private fun HowItWorksSection(config: HotKeyConfig, isMacOS: Boolean) {
 @Composable
 private fun StatusIndicator(status: HotKeyRegistrationStatus) {
     val (color, text) = when (status) {
-        HotKeyRegistrationStatus.INACTIVE -> Color.Gray to "Inactive"
-        HotKeyRegistrationStatus.REGISTERED -> Color(0xFF28C941) to "Active"
-        HotKeyRegistrationStatus.FAILED -> Color(0xFFE04040) to "Conflict"
-        HotKeyRegistrationStatus.UNAVAILABLE -> Color.Gray to "N/A"
+        HotKeyRegistrationStatus.INACTIVE -> TextMuted to "Inactive"
+        HotKeyRegistrationStatus.REGISTERED -> Success to "Active"
+        HotKeyRegistrationStatus.FAILED -> Danger to "Conflict"
+        HotKeyRegistrationStatus.UNAVAILABLE -> TextMuted to "N/A"
     }
 
     Row(
@@ -277,7 +280,7 @@ private fun RestartNotice() {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(6.dp))
-            .background(Color(0xFF3A3A3A))
+            .background(BorderColor)
             .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -33,8 +32,12 @@ import ai.rever.bossterm.compose.mcp.McpAttachResult
 import ai.rever.bossterm.compose.mcp.McpAttachTarget
 import ai.rever.bossterm.compose.mcp.McpCliAttacher
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Success
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
+import ai.rever.bossterm.compose.settings.SettingsTheme.Warning
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.settings.components.SettingsDropdown
 import ai.rever.bossterm.compose.settings.components.SettingsNumberInput
@@ -381,9 +384,9 @@ private fun AttachToCliSection(
                     enabled = enabled && inFlight == null,
                     colors = ButtonDefaults.buttonColors(
                         backgroundColor = AccentColor,
-                        contentColor = Color.White,
-                        disabledBackgroundColor = Color(0xFF3A3A3A),
-                        disabledContentColor = Color(0xFF888888)
+                        contentColor = TextOnAccent,
+                        disabledBackgroundColor = BorderColor,
+                        disabledContentColor = TextMuted
                     )
                 ) {
                     val label = when {
@@ -408,7 +411,7 @@ private fun AttachToCliSection(
             if (isAttached) {
                 Text(
                     text = "✓ ${target.displayName} is currently attached",
-                    color = Color(0xFF4CAF50),
+                    color = Success,
                     fontSize = 12.sp,
                     modifier = Modifier.padding(top = 8.dp)
                 )
@@ -418,9 +421,9 @@ private fun AttachToCliSection(
                     is McpAttachResult.Success ->
                         "Last attempt: ✓ ${result.target.displayName} attached" +
                             (if (result.detail.isNotEmpty()) " — ${result.detail}" else "") to
-                            Color(0xFF4CAF50)
+                            Success
                     is McpAttachResult.CopiedToClipboard ->
-                        "Last attempt: ${result.target.displayName}: ${result.reason}" to Color(0xFFFFC107)
+                        "Last attempt: ${result.target.displayName}: ${result.reason}" to Warning
                 }
                 Text(
                     text = label,
@@ -453,7 +456,7 @@ private fun ConfigurationBanner() {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(6.dp))
-            .background(Color(0x33_FF_C1_07)) // soft amber tint
+            .background(Warning.copy(alpha = 0.2f)) // soft amber tint
             .padding(horizontal = 12.dp, vertical = 10.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/ThemeSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/ThemeSettingsSection.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.sp
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
@@ -107,7 +108,7 @@ fun ThemeSettingsSection(
                     Button(
                         onClick = { showDeleteConfirmation = currentTheme },
                         colors = ButtonDefaults.buttonColors(
-                            backgroundColor = Color(0xFFE04040)
+                            backgroundColor = Danger
                         ),
                         modifier = Modifier.height(36.dp)
                     ) {
@@ -215,7 +216,7 @@ fun ThemeSettingsSection(
                     Button(
                         onClick = { showDeletePaletteConfirmation = effectivePalette },
                         colors = ButtonDefaults.buttonColors(
-                            backgroundColor = Color(0xFFE04040)
+                            backgroundColor = Danger
                         ),
                         modifier = Modifier.height(36.dp)
                     ) {
@@ -674,7 +675,7 @@ private fun DeleteThemeDialog(
             Button(
                 onClick = onConfirm,
                 colors = ButtonDefaults.buttonColors(
-                    backgroundColor = Color(0xFFE04040)
+                    backgroundColor = Danger
                 )
             ) {
                 Text("Delete", color = TextPrimary)
@@ -1000,7 +1001,7 @@ private fun DeletePaletteDialog(
             Button(
                 onClick = onConfirm,
                 colors = ButtonDefaults.buttonColors(
-                    backgroundColor = Color(0xFFE04040)
+                    backgroundColor = Danger
                 )
             ) {
                 Text("Delete", color = TextPrimary)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/VisualSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/VisualSettingsSection.kt
@@ -14,12 +14,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ai.rever.bossterm.compose.settings.TerminalSettings
+import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 import ai.rever.bossterm.compose.settings.components.*
@@ -157,7 +159,7 @@ fun VisualSettingsSection(
             if (settings.useNativeTitleBar) {
                 Text(
                     text = "Transparency requires custom title bar. Disable 'Use Native Title Bar' above to enable transparency.",
-                    color = Color.Gray,
+                    color = TextMuted,
                     fontSize = 12.sp
                 )
             } else {
@@ -249,10 +251,10 @@ fun VisualSettingsSection(
                         onRestartApp?.invoke()
                     },
                     colors = ButtonDefaults.buttonColors(
-                        backgroundColor = Color(0xFF4A90E2)
+                        backgroundColor = AccentColor
                     )
                 ) {
-                    Text("Restart", color = TextPrimary)
+                    Text("Restart", color = TextOnAccent)
                 }
             },
             dismissButton = {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/ThemeManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/ThemeManager.kt
@@ -81,7 +81,7 @@ class ThemeManager private constructor(
      * Apply a theme (sets it as active).
      */
     fun applyTheme(theme: Theme) {
-        _currentTheme.value = theme
+        setCurrentTheme(theme)
 
         // Update settings with the new theme's colors
         settingsManager.updateSetting {
@@ -220,7 +220,12 @@ class ThemeManager private constructor(
         val theme = getThemeById(activeThemeId)
             ?: getThemeById(BuiltinThemes.DEFAULT_THEME_ID)
             ?: BuiltinThemes.DEFAULT
+        setCurrentTheme(theme)
+    }
+
+    private fun setCurrentTheme(theme: Theme) {
         _currentTheme.value = theme
+        BossUiTheme.update(theme)
     }
 
     companion object {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/UiTheme.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/UiTheme.kt
@@ -1,0 +1,156 @@
+package ai.rever.bossterm.compose.settings.theme
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+
+/**
+ * UI chrome tokens for everything around the terminal surface — dialogs,
+ * settings, wizards, menus. The Compose-side mirror of the CSS custom
+ * properties in docs/design-system.html.
+ *
+ * Tokens are derived from the active terminal [Theme] so the chrome follows
+ * whatever theme the user picks; the BOSS Operator theme maps to the exact
+ * design-system values.
+ */
+data class UiTheme(
+    // Surfaces
+    val ink: Color,        // base floor — the terminal background
+    val panel: Color,      // dialog / settings window surface
+    val raised: Color,     // cards, menus, popovers
+    val line: Color,       // hairline border / divider
+    val line2: Color,      // stronger border
+    // Text
+    val chalk: Color,      // primary text
+    val mist: Color,       // secondary text
+    val muted: Color,      // tertiary / disabled
+    // Signals
+    val signal: Color,     // live / active / primary action
+    val signalDim: Color,  // pressed / variant
+    val signalWash: Color, // signal at home on ink (selected rows, chips)
+    val onSignal: Color,   // content on signal-filled controls
+    val data: Color,       // links / info
+    val ok: Color,
+    val warn: Color,
+    val alert: Color,
+) {
+    val isDark: Boolean get() = ink.luminance() < 0.5f
+
+    companion object {
+        /** Exact tokens from docs/design-system.html `:root`. */
+        val BOSS_OPERATOR = UiTheme(
+            ink = Color(0xFF0E1217),
+            panel = Color(0xFF161D26),
+            raised = Color(0xFF1E2731),
+            line = Color(0xFF2A3744),
+            line2 = Color(0xFF3A4B5C),
+            chalk = Color(0xFFE9EEF3),
+            mist = Color(0xFF8593A3),
+            muted = Color(0xFF5C6977),
+            signal = Color(0xFFF2A93B),
+            signalDim = Color(0xFFC98A2E),
+            signalWash = Color(0xFF2A2113),
+            onSignal = Color(0xFF0E1217),
+            data = Color(0xFF56C7E0),
+            ok = Color(0xFF6FD08C),
+            warn = Color(0xFFF0B429),
+            alert = Color(0xFFF2685F),
+        )
+
+        /**
+         * Derive chrome tokens from a terminal theme.
+         *
+         * The surface ladder nudges the terminal floor toward the text color
+         * using the same ratios the BOSS Operator tokens sit at on ink, so any
+         * theme (dark or light) yields a coherent panel/raised/border stack.
+         */
+        fun fromTheme(theme: Theme): UiTheme {
+            if (theme.id == BuiltinThemes.DEFAULT_THEME_ID) return BOSS_OPERATOR
+
+            val bg = theme.backgroundColorValue
+            val fg = theme.foregroundColor
+            val signal = signalFor(theme, bg, fg)
+            // Content on a signal fill: whichever of the theme's own floor/text
+            // colors contrasts more with the fill.
+            val onSignal = if (contrastRatio(signal, bg) >= contrastRatio(signal, fg)) bg else fg
+            return UiTheme(
+                ink = bg,
+                panel = mix(bg, fg, 0.05f),
+                raised = mix(bg, fg, 0.09f),
+                line = mix(bg, fg, 0.16f),
+                line2 = mix(bg, fg, 0.26f),
+                chalk = fg,
+                mist = mix(bg, fg, 0.62f),
+                muted = mix(bg, fg, 0.40f),
+                signal = signal,
+                signalDim = mix(signal, Color.Black, 0.17f),
+                signalWash = mix(bg, signal, 0.12f),
+                onSignal = onSignal,
+                data = theme.hyperlinkColor,
+                ok = theme.getAnsiColor(2),
+                warn = theme.getAnsiColor(3),
+                alert = theme.getAnsiColor(1),
+            )
+        }
+
+        /**
+         * The signal is the cursor color — the theme's "live / now" color —
+         * unless the cursor just repeats the foreground or background (common
+         * in ports of classic themes), in which case ANSI yellow keeps the
+         * accent in the amber family the design system is built around.
+         */
+        private fun signalFor(theme: Theme, bg: Color, fg: Color): Color {
+            val cursor = theme.cursorColor
+            return if (distance(cursor, fg) < 0.15f || distance(cursor, bg) < 0.15f) {
+                theme.getAnsiColor(3)
+            } else {
+                cursor
+            }
+        }
+
+        /**
+         * Component-space (gamma sRGB) mix. The token ratios above are
+         * calibrated against the design-system hex values in this space;
+         * Compose's Oklab [androidx.compose.ui.graphics.lerp] collapses small
+         * steps off pure black (lerp(black, white, 0.05) rounds back to black).
+         */
+        private fun mix(a: Color, b: Color, t: Float): Color = Color(
+            red = a.red + (b.red - a.red) * t,
+            green = a.green + (b.green - a.green) * t,
+            blue = a.blue + (b.blue - a.blue) * t,
+        )
+
+        private fun contrastRatio(a: Color, b: Color): Float {
+            val la = a.luminance() + 0.05f
+            val lb = b.luminance() + 0.05f
+            return maxOf(la, lb) / minOf(la, lb)
+        }
+
+        private fun distance(a: Color, b: Color): Float {
+            val dr = a.red - b.red
+            val dg = a.green - b.green
+            val db = a.blue - b.blue
+            return kotlin.math.sqrt(dr * dr + dg * dg + db * db)
+        }
+    }
+}
+
+/**
+ * Snapshot-backed holder for the [UiTheme] derived from the active terminal
+ * theme. Reads inside composition subscribe automatically, so every dialog and
+ * settings surface restyles live when the theme changes — across all windows.
+ *
+ * [ThemeManager] pushes updates whenever the active theme changes.
+ */
+object BossUiTheme {
+    private val state = mutableStateOf(UiTheme.BOSS_OPERATOR)
+
+    val current: UiTheme get() = state.value
+
+    fun update(theme: Theme) {
+        state.value = UiTheme.fromTheme(theme)
+    }
+}
+
+/** For the AWT-rendered surfaces (right-click context menu). */
+fun Color.toAwtColor(): java.awt.Color = java.awt.Color(red, green, blue, alpha)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareApprovalUi.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareApprovalUi.kt
@@ -1,9 +1,12 @@
 package ai.rever.bossterm.compose.share
 
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
+import ai.rever.bossterm.compose.settings.SettingsTheme.Success
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -22,13 +25,12 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
-private val ApproveColor = Color(0xFF4CAF50)
-private val DenyColor = Color(0xFFE57373)
+private val ApproveColor get() = Success
+private val DenyColor get() = Danger
 
 private fun verb(wantsControl: Boolean) = if (wantsControl) "control" else "view"
 
@@ -44,7 +46,7 @@ fun ShareRequestToast(
     onDeny: () -> Unit,
 ) {
     Surface(
-        color = Color(0xFF2B2B2B),
+        color = SurfaceColor,
         shape = RoundedCornerShape(8.dp),
         border = BorderStroke(1.dp, BorderColor),
         shadowElevation = 6.dp,
@@ -54,7 +56,7 @@ fun ShareRequestToast(
             Spacer(Modifier.height(2.dp))
             Text(
                 "${request.deviceName} wants to ${verb(request.wantsControl)} this session",
-                color = Color.White, fontSize = 13.sp
+                color = TextPrimary, fontSize = 13.sp
             )
             Spacer(Modifier.height(8.dp))
             Row(
@@ -67,7 +69,7 @@ fun ShareRequestToast(
                 }
                 Button(
                     onClick = onApprove,
-                    colors = ButtonDefaults.buttonColors(containerColor = ApproveColor, contentColor = Color.White)
+                    colors = ButtonDefaults.buttonColors(containerColor = ApproveColor, contentColor = BossUiTheme.current.ink)
                 ) { Text("Approve") }
             }
         }
@@ -100,7 +102,7 @@ fun PendingRequestsList(
                 }
                 Button(
                     onClick = { onApprove(req.id) },
-                    colors = ButtonDefaults.buttonColors(containerColor = ApproveColor, contentColor = Color.White)
+                    colors = ButtonDefaults.buttonColors(containerColor = ApproveColor, contentColor = BossUiTheme.current.ink)
                 ) { Text("Approve") }
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -3,12 +3,16 @@ package ai.rever.bossterm.compose.share
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
+import ai.rever.bossterm.compose.settings.SettingsTheme.Success
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 import ai.rever.bossterm.compose.settings.components.SettingsSection
 import ai.rever.bossterm.compose.settings.components.SettingsTextField
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -72,8 +76,7 @@ import com.google.zxing.EncodeHintType
 import com.google.zxing.qrcode.QRCodeWriter
 import java.awt.image.BufferedImage
 
-private val Track = Color(0xFF252526)
-private val Danger = Color(0xFFE57373)
+private val Track get() = BossUiTheme.current.ink
 
 /**
  * Session-sharing window (issue #276) — a top-level OS window styled like
@@ -294,7 +297,7 @@ fun ShareWindow(
                 TextButton(onClick = onStop, colors = ButtonDefaults.textButtonColors(contentColor = Danger)) {
                     Text("Stop sharing")
                 }
-                Button(onClick = onDismiss, colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)) {
+                Button(onClick = onDismiss, colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)) {
                     Text("Close")
                 }
             }
@@ -357,7 +360,7 @@ private fun Seg(label: String, selected: Boolean, onClick: () -> Unit) {
             .clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 5.dp),
         contentAlignment = Alignment.Center
     ) {
-        Text(label, color = if (selected) Color.White else TextMuted, fontSize = 12.sp)
+        Text(label, color = if (selected) TextOnAccent else TextMuted, fontSize = 12.sp)
     }
 }
 
@@ -448,7 +451,7 @@ private fun RemoteAccessSetupSection(
             confirmButton = {
                 Button(
                     onClick = { onModeChange(target); SessionShareManager.applyRemoteMode(target); pendingMode = null },
-                    colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                    colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
                 ) { Text(if (target == "off") "Turn off" else "Switch") }
             },
             dismissButton = {
@@ -484,7 +487,7 @@ private fun RemoteAccessSetupSection(
                     SessionShareManager.RemoteStatus.FellBack -> "${remote.mode} · unreachable — using LAN link"
                 },
                 color = when (remote.status) {
-                    SessionShareManager.RemoteStatus.Active -> Color(0xFF4CAF50)
+                    SessionShareManager.RemoteStatus.Active -> Success
                     SessionShareManager.RemoteStatus.FellBack -> Danger
                     else -> TextMuted
                 },
@@ -613,7 +616,7 @@ private fun ProviderInstallRow(
                                 else "Not found — install manually."
                     },
                     color = when {
-                        installed == true -> Color(0xFF4CAF50)
+                        installed == true -> Success
                         installFailed -> Danger
                         else -> TextSecondary
                     },
@@ -633,7 +636,7 @@ private fun ProviderInstallRow(
                 Button(
                     onClick = onInstall,
                     enabled = !installing,
-                    colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = Color.White)
+                    colors = ButtonDefaults.buttonColors(containerColor = AccentColor, contentColor = TextOnAccent)
                 ) { Text(if (installing) "Installing…" else if (installFailed) "Retry" else "Install") }
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/VersionSelector.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/VersionSelector.kt
@@ -19,10 +19,13 @@ import androidx.compose.ui.unit.sp
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
+import ai.rever.bossterm.compose.settings.SettingsTheme.Warning
 import kotlinx.coroutines.launch
 import java.awt.Desktop
 import java.io.File
@@ -181,8 +184,8 @@ fun VersionManagementSection(
                 enabled = state.selectedRelease != null && !isSameVersion && !state.isLoading,
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(
-                    backgroundColor = if (isDowngrading) Color(0xFFB71C1C) else AccentColor,
-                    contentColor = Color.White,
+                    backgroundColor = if (isDowngrading) Danger else AccentColor,
+                    contentColor = TextOnAccent,
                     disabledBackgroundColor = SurfaceColor,
                     disabledContentColor = TextMuted
                 )
@@ -290,7 +293,7 @@ private fun VersionDropdown(
                     ) {
                         Text(
                             text = error,
-                            color = Color(0xFFE57373),
+                            color = Danger,
                             fontSize = 11.sp
                         )
                         Text(
@@ -373,7 +376,7 @@ private fun VersionDropdown(
                                         fontWeight = if (isCurrent) FontWeight.Bold else FontWeight.Normal
                                     )
                                     if (release.prerelease) {
-                                        VersionBadge("pre-release", Color(0xFFFFA726))
+                                        VersionBadge("pre-release", Warning)
                                     }
                                     if (isCurrent) {
                                         VersionBadge("current", AccentColor)
@@ -456,8 +459,8 @@ fun DowngradeWarningDialog(
             Button(
                 onClick = onConfirm,
                 colors = ButtonDefaults.buttonColors(
-                    backgroundColor = Color(0xFFB71C1C),
-                    contentColor = Color.White
+                    backgroundColor = Danger,
+                    contentColor = TextOnAccent
                 )
             ) {
                 Text("Downgrade Anyway")
@@ -468,7 +471,7 @@ fun DowngradeWarningDialog(
                 Text("Cancel", color = TextPrimary)
             }
         },
-        backgroundColor = Color(0xFF2D2D2D)
+        backgroundColor = SurfaceColor
     )
 }
 
@@ -535,7 +538,7 @@ fun InstallInstructionsDialog(
                 },
                 colors = ButtonDefaults.buttonColors(
                     backgroundColor = AccentColor,
-                    contentColor = Color.White
+                    contentColor = TextOnAccent
                 )
             ) {
                 Text("Open Folder")
@@ -546,7 +549,7 @@ fun InstallInstructionsDialog(
                 Text("Close", color = TextPrimary)
             }
         },
-        backgroundColor = Color(0xFF2D2D2D)
+        backgroundColor = SurfaceColor
     )
 }
 
@@ -568,7 +571,7 @@ private fun SelectableCommand(command: String) {
         fontSize = 12.sp,
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color(0xFF1E1E1E), RoundedCornerShape(4.dp))
+            .background(BackgroundColor, RoundedCornerShape(4.dp))
             .padding(8.dp)
     )
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/wizard/WizardComponents.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/wizard/WizardComponents.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -18,6 +17,7 @@ import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 
@@ -58,7 +58,7 @@ fun WizardStepIndicator(
             ) {
                 Text(
                     text = if (isComplete) "✓" else "${index + 1}",
-                    color = if (isActive || isComplete) Color.White else TextMuted,
+                    color = if (isActive || isComplete) TextOnAccent else TextMuted,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold
                 )
@@ -138,7 +138,7 @@ fun SelectionCard(
                                 .background(AccentColor, RoundedCornerShape(4.dp))
                                 .padding(horizontal = 6.dp, vertical = 2.dp)
                         ) {
-                            Text("Recommended", fontSize = 10.sp, color = Color.White)
+                            Text("Recommended", fontSize = 10.sp, color = TextOnAccent)
                         }
                     }
                     if (badge != null) {
@@ -200,7 +200,7 @@ fun CheckboxCard(
                 colors = CheckboxDefaults.colors(
                     checkedColor = AccentColor,
                     uncheckedColor = TextMuted,
-                    checkmarkColor = Color.White
+                    checkmarkColor = TextOnAccent
                 )
             )
             Spacer(modifier = Modifier.width(12.dp))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/wizard/WizardDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/wizard/WizardDialog.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.window.rememberDialogState
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
+import ai.rever.bossterm.compose.settings.SettingsTheme.TextOnAccent
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
 
@@ -94,7 +96,7 @@ fun <S> WizardDialog(
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
                         text = error,
-                        color = Color(0xFFFF6B6B),
+                        color = Danger,
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
@@ -194,9 +196,9 @@ private fun <S> WizardNavigationBar(
                     enabled = state.canGoNext,
                     colors = ButtonDefaults.buttonColors(
                         backgroundColor = AccentColor,
-                        contentColor = Color.White,
+                        contentColor = TextOnAccent,
                         disabledBackgroundColor = AccentColor.copy(alpha = 0.5f),
-                        disabledContentColor = Color.White.copy(alpha = 0.5f)
+                        disabledContentColor = TextOnAccent.copy(alpha = 0.5f)
                     ),
                     modifier = Modifier.focusRequester(primaryButtonFocusRequester)
                 ) {
@@ -283,7 +285,7 @@ fun <S> WizardDialogCompact(
                         enabled = state.canGoNext,
                         colors = ButtonDefaults.buttonColors(
                             backgroundColor = AccentColor,
-                            contentColor = Color.White
+                            contentColor = TextOnAccent
                         )
                     ) {
                         Text(currentStep?.let { primaryButtonText(it) } ?: "Next")

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/wizard/WizardStepBuilders.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/wizard/WizardStepBuilders.kt
@@ -35,10 +35,14 @@ import ai.rever.bossterm.compose.settings.TerminalSettingsOverride
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
+import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
+import ai.rever.bossterm.compose.settings.SettingsTheme.Success
 import ai.rever.bossterm.compose.settings.SettingsTheme.SurfaceColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextMuted
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextPrimary
 import ai.rever.bossterm.compose.settings.SettingsTheme.TextSecondary
+import ai.rever.bossterm.compose.settings.SettingsTheme.Warning
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import kotlinx.coroutines.delay
 
@@ -249,7 +253,7 @@ object WizardStepBuilders {
                     Text(
                         text = "Installation failed. Please check the output above.",
                         fontSize = 14.sp,
-                        color = Color(0xFFFF6B6B),
+                        color = Danger,
                         modifier = Modifier.weight(1f)
                     )
                     if (showNpmFallback && onTryNpm != null) {
@@ -304,8 +308,8 @@ object WizardStepBuilders {
                 exit = fadeOut()
             ) {
                 Card(
-                    backgroundColor = Color(0xFF2D4F2D),
-                    border = BorderStroke(2.dp, Color(0xFF4CAF50)),
+                    backgroundColor = Success.copy(alpha = 0.15f),
+                    border = BorderStroke(2.dp, Success),
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Row(
@@ -317,7 +321,7 @@ object WizardStepBuilders {
                             text = "Code: ${detectedOtp ?: ""}",
                             fontWeight = FontWeight.Bold,
                             fontSize = 16.sp,
-                            color = Color(0xFF4CAF50)
+                            color = Success
                         )
                         Spacer(Modifier.width(16.dp))
                         Button(
@@ -327,8 +331,8 @@ object WizardStepBuilders {
                                 }
                             },
                             colors = ButtonDefaults.buttonColors(
-                                backgroundColor = Color(0xFF4CAF50),
-                                contentColor = Color.White
+                                backgroundColor = Success,
+                                contentColor = BossUiTheme.current.ink
                             )
                         ) {
                             Text("Copy Code")
@@ -347,7 +351,7 @@ object WizardStepBuilders {
                     text = "Copy the one-time code when it appears below!",
                     fontWeight = FontWeight.Bold,
                     fontSize = 13.sp,
-                    color = Color(0xFFFFD700),
+                    color = Warning,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -455,7 +459,7 @@ object WizardStepBuilders {
                 Text(
                     text = "✓",
                     fontSize = 48.sp,
-                    color = Color(0xFF4CAF50)
+                    color = Success
                 )
                 Spacer(modifier = Modifier.height(16.dp))
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/workflows/WorkflowRunDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/workflows/WorkflowRunDialog.kt
@@ -1,5 +1,7 @@
 package ai.rever.bossterm.compose.workflows
 
+import ai.rever.bossterm.compose.settings.SettingsTheme
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -90,7 +92,7 @@ fun WorkflowRunDialog(
                         false
                     }
                 },
-            color = Color(0xFF2A2A2A),
+            color = SettingsTheme.SurfaceColor,
             shape = RoundedCornerShape(8.dp),
             shadowElevation = 8.dp,
         ) {
@@ -99,27 +101,27 @@ fun WorkflowRunDialog(
                     .padding(16.dp)
                     .verticalScroll(rememberScrollState())
             ) {
-                Text(workflow.name, color = Color.White, fontSize = 15.sp)
+                Text(workflow.name, color = SettingsTheme.TextPrimary, fontSize = 15.sp)
                 workflow.description?.takeIf { it.isNotBlank() }?.let {
-                    Text(it, color = Color(0xFFAAAAAA), fontSize = 12.sp)
+                    Text(it, color = SettingsTheme.TextSecondary, fontSize = 12.sp)
                 }
                 Spacer(Modifier.height(12.dp))
 
                 workflow.arguments.forEachIndexed { index, arg ->
-                    Text(arg.name, color = Color(0xFFCCCCCC), fontSize = 12.sp)
+                    Text(arg.name, color = SettingsTheme.TextSecondary, fontSize = 12.sp)
                     arg.description?.takeIf { it.isNotBlank() }?.let {
-                        Text(it, color = Color(0xFF808080), fontSize = 11.sp)
+                        Text(it, color = SettingsTheme.TextMuted, fontSize = 11.sp)
                     }
                     BasicTextField(
                         value = values[arg.name].orEmpty(),
                         onValueChange = { values[arg.name] = it },
                         singleLine = true,
-                        textStyle = TextStyle(color = Color.White, fontSize = 13.sp),
-                        cursorBrush = SolidColor(Color.White),
+                        textStyle = TextStyle(color = SettingsTheme.TextPrimary, fontSize = 13.sp),
+                        cursorBrush = SolidColor(SettingsTheme.TextPrimary),
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = 4.dp)
-                            .background(Color(0xFF1E1E1E))
+                            .background(SettingsTheme.BackgroundColor)
                             .padding(8.dp)
                             .then(if (index == 0) Modifier.focusRequester(firstFieldFocus) else Modifier)
                             .onPreviewKeyEvent { e ->
@@ -130,8 +132,8 @@ fun WorkflowRunDialog(
                 }
 
                 // Live preview of the command that will run.
-                Text("Preview", color = Color(0xFF808080), fontSize = 11.sp)
-                Text(workflow.render(values), color = Color(0xFF66D9EF), fontSize = 12.sp)
+                Text("Preview", color = SettingsTheme.TextMuted, fontSize = 11.sp)
+                Text(workflow.render(values), color = SettingsTheme.Info, fontSize = 12.sp)
                 Spacer(Modifier.height(12.dp))
 
                 Row(
@@ -156,12 +158,12 @@ private fun DialogButton(label: String, primary: Boolean = false, onClick: () ->
     Box(
         modifier = Modifier
             .background(
-                if (primary) Color(0xFF094771) else Color(0xFF3A3A3A),
+                if (primary) BossUiTheme.current.signalWash else SettingsTheme.BorderColor,
                 RoundedCornerShape(4.dp),
             )
             .clickable { onClick() }
             .padding(horizontal = 14.dp, vertical = 6.dp),
     ) {
-        Text(label, color = Color.White, fontSize = 13.sp)
+        Text(label, color = SettingsTheme.TextPrimary, fontSize = 13.sp)
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/UiThemeTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/UiThemeTest.kt
@@ -1,0 +1,86 @@
+package ai.rever.bossterm.compose.theme
+
+import ai.rever.bossterm.compose.settings.SettingsTheme
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
+import ai.rever.bossterm.compose.settings.theme.BuiltinThemes
+import ai.rever.bossterm.compose.settings.theme.UiTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Locks the terminal-theme → UI-chrome bridge:
+ *  1. The default theme maps to the exact design-system tokens
+ *     (docs/design-system.html `:root`), not a lerp approximation.
+ *  2. Derivation for arbitrary themes yields a readable surface ladder and a
+ *     signal distinct from the floor (including light themes).
+ *  3. SettingsTheme stays wired to BossUiTheme (a fresh state = BOSS Operator
+ *     tokens, amber accent — not the old static blue).
+ */
+class UiThemeTest {
+
+    @Test
+    fun `boss-operator theme maps to exact design-system tokens`() {
+        val ui = UiTheme.fromTheme(BuiltinThemes.BOSS_OPERATOR)
+        assertEquals(Color(0xFF0E1217), ui.ink)
+        assertEquals(Color(0xFF161D26), ui.panel)
+        assertEquals(Color(0xFF1E2731), ui.raised)
+        assertEquals(Color(0xFF2A3744), ui.line)
+        assertEquals(Color(0xFFE9EEF3), ui.chalk)
+        assertEquals(Color(0xFF8593A3), ui.mist)
+        assertEquals(Color(0xFFF2A93B), ui.signal)
+        assertEquals(Color(0xFF0E1217), ui.onSignal)
+        assertEquals(Color(0xFF56C7E0), ui.data)
+        assertEquals(Color(0xFFF2685F), ui.alert)
+        assertTrue(ui.isDark)
+    }
+
+    @Test
+    fun `derived themes keep a readable surface ladder`() {
+        for (theme in BuiltinThemes.ALL) {
+            val ui = UiTheme.fromTheme(theme)
+            val inkLum = ui.ink.luminance()
+            val panelLum = ui.panel.luminance()
+            val chalkLum = ui.chalk.luminance()
+            // Surfaces step from the floor toward the text color.
+            if (chalkLum > inkLum) {
+                assertTrue(panelLum > inkLum, "${theme.id}: panel should be lighter than ink")
+                assertTrue(ui.raised.luminance() > panelLum, "${theme.id}: raised should be lighter than panel")
+            } else {
+                assertTrue(panelLum < inkLum, "${theme.id}: panel should be darker than ink (light theme)")
+                assertTrue(ui.raised.luminance() < panelLum, "${theme.id}: raised should be darker than panel (light theme)")
+            }
+            // The signal must never dissolve into the floor or the text color.
+            assertNotEquals(ui.ink, ui.signal, "${theme.id}: signal must differ from ink")
+            assertNotEquals(ui.chalk, ui.signal, "${theme.id}: signal must differ from chalk")
+            // Content on signal-filled controls must contrast with the fill.
+            // 2.5 floor: the best of the theme's own floor/text colors; Solarized
+            // Light's dark-yellow signal caps out just under 3.0 against its paper.
+            val contrast = contrastRatio(ui.signal, ui.onSignal)
+            assertTrue(contrast >= 2.5f, "${theme.id}: onSignal contrast $contrast on signal is too low")
+        }
+    }
+
+    @Test
+    fun `settings chrome follows the boss ui theme`() {
+        BossUiTheme.update(BuiltinThemes.BOSS_OPERATOR)
+        assertEquals(Color(0xFFF2A93B), SettingsTheme.AccentColor, "accent should be the amber signal")
+        assertEquals(Color(0xFF161D26), SettingsTheme.BackgroundColor)
+        assertEquals(Color(0xFF1E2731), SettingsTheme.SurfaceColor)
+        assertEquals(Color(0xFF0E1217), SettingsTheme.TextOnAccent)
+
+        BossUiTheme.update(BuiltinThemes.SOLARIZED_LIGHT)
+        assertNotEquals(Color(0xFF161D26), SettingsTheme.BackgroundColor, "chrome must follow theme switches")
+
+        BossUiTheme.update(BuiltinThemes.BOSS_OPERATOR)
+    }
+
+    private fun contrastRatio(a: Color, b: Color): Float {
+        val la = a.luminance() + 0.05f
+        val lb = b.luminance() + 0.05f
+        return maxOf(la, lb) / minOf(la, lb)
+    }
+}


### PR DESCRIPTION
## Summary

Extends the BOSS Operator theming (#303) beyond the tab bar and terminal surface: the settings panel, every dialog/window, and the right-click context menu now follow the active terminal theme.

### The bridge
- **`UiTheme`** (new, `settings/theme/UiTheme.kt`) — Compose-side mirror of the [design-system](docs/design-system.html) tokens (`ink/panel/raised/line/line2`, `chalk/mist/muted`, `signal/signalDim/signalWash/onSignal`, `data/ok/warn/alert`). The default theme maps to the exact design-system values; any other theme derives a coherent surface ladder from its own bg/fg, with the cursor color as the accent (ANSI yellow fallback when the cursor repeats fg/bg keeps the accent in the amber family across Dracula, Nord, Gruvbox, …). Light themes work — `onSignal` picks the higher-contrast content color.
- **`BossUiTheme`** — snapshot-state holder pushed by `ThemeManager`, so every open window recomposes live on theme switch.
- **`SettingsTheme`** members became live getters onto the tokens (accent = amber signal, not the old static blue) and gained `TextOnAccent` / `Danger` / `Success` / `Warning` / `Info`.

### The sweep
- ~180 hardcoded color literals replaced with semantic tokens across the settings panel + sections, color picker chrome, wizards, onboarding, and the install / share / auth / update / workflow dialogs (greens→ok, reds→alert, ambers→warn).
- Accent-filled buttons switched from white content to `TextOnAccent` (dark ink on amber, per the styleguide).
- The AWT right-click menu themes via a new `Color.toAwtColor()` bridge, reading tokens per menu build.
- File-scope `val X = SettingsTheme.Y` captures converted to getters so nothing freezes at class-init.

### Intentionally not themed
QR code backings (optical), HSV picker gradients (functional), macOS traffic-light buttons, theme-preview swatches. Non-dialog overlays (search bar, command palette, history overlay, debug panel, update banner, toasts) are follow-up work.

## Test plan
- New `UiThemeTest`: default theme → exact design-system tokens; surface-ladder direction + signal distinctness + onSignal contrast across all builtin themes (caught that Compose's Oklab `lerp` collapses small steps off pure black — derivation uses gamma-sRGB mix); `SettingsTheme` follows theme switches.
- Full `:compose-ui:desktopTest` suite green; all app modules compile.
- Ran the app: settings, dialogs, and context menu retint live when switching themes (incl. Solarized Light).

🤖 Generated with [Claude Code](https://claude.com/claude-code)