### PR TITLE
fix(daemon): spawn via the app's native launcher in packaged builds

### DIFF
--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/DaemonMain.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/DaemonMain.kt
@@ -41,9 +41,18 @@ private val log = LoggerFactory.getLogger("ai.rever.bossterm.app.DaemonMain")
 private val startNanos = System.nanoTime()
 private fun uptimeMs(): Long = (System.nanoTime() - startNanos) / 1_000_000
 
-fun main(args: Array<String>) {
+fun main(args: Array<String>) = runDaemon(args)
+
+/**
+ * Daemon entry point proper. Reached two ways: `java -cp … DaemonMainKt` (dev spawn, [main] above)
+ * or the packaged app's native launcher relaunched with `--daemon` (no `bin/java` in jpackage
+ * runtimes), where the GUI facade ([ai.rever.bossterm.app.main] in Main.kt) dispatches here before
+ * any AWT/Compose init.
+ */
+fun runDaemon(args: Array<String>) {
     // NOT headless: the daemon shows a menu-bar/tray icon so a background process isn't invisible.
-    // On macOS DaemonLauncher passes -Dapple.awt.UIElement=true so it's an agent (no Dock icon).
+    // On macOS it runs as a UIElement agent (no Dock icon): -Dapple.awt.UIElement=true from
+    // DaemonLauncher on the java -cp path, or set programmatically by Main.kt's --daemon dispatch.
     val version = Version.CURRENT.toString()
     log.info("BossTerm daemon starting (v{} proto{}) settingsDir={}",
         version, DaemonControlChannel.PROTOCOL_VERSION, BossTermPaths.dir().absolutePath)

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -62,6 +62,18 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
  * This is the main entry point for the BossTerm application.
  */
 fun main(args: Array<String>) {
+    // Daemon dispatch — packaged bundles ship no `java` binary (jpackage runtimes have no bin/),
+    // so DaemonLauncher relaunches THIS native launcher with --daemon. Must be the very first
+    // thing in main: apple.awt.UIElement is only honored if set before AWT boots (menu-bar-only
+    // agent, no Dock icon), forwarded --prop: args must land before any settings/path resolution,
+    // and none of the GUI's GPU/deep-link/window setup below belongs in the daemon process.
+    if (args.firstOrNull() == ai.rever.bossterm.compose.daemon.DaemonLauncher.DAEMON_ARG) {
+        val rest = ai.rever.bossterm.compose.daemon.DaemonLauncher.applyPropArgs(args.copyOfRange(1, args.size))
+        if (ShellCustomizationUtils.isMacOS()) System.setProperty("apple.awt.UIElement", "true")
+        runDaemon(rest)
+        return
+    }
+
     // Configure GPU rendering (must be before any Skiko/Compose initialization)
     configureGpuRendering()
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonLauncher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonLauncher.kt
@@ -314,8 +314,13 @@ object DaemonLauncher {
     }
 
     /** `<Bundle>.app` containing [path] (e.g. a bundled java.home), or null when not inside a bundle. */
-    private fun macBundleFile(path: String): File? =
-        if (path.contains(".app/Contents/")) File(path.substringBefore(".app/Contents/") + ".app") else null
+    private fun macBundleFile(path: String): File? {
+        // Normalize separators so the derivation stays a pure function of its input: real macOS
+        // paths always use '/', but the cross-OS unit tests feed platform-native paths (Windows
+        // CI passes '\'). File() converts back to the native separator on construction.
+        val p = path.replace('\\', '/')
+        return if (p.contains(".app/Contents/")) File(p.substringBefore(".app/Contents/") + ".app") else null
+    }
 
     /** Launch the GUI in a normal (non-headless, non-agent) JVM via the same JRE + classpath. */
     private fun buildGuiCommand(): List<String>? {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonLauncher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonLauncher.kt
@@ -16,13 +16,22 @@ import java.io.File
  * compatibility is gated on [DaemonControlChannel.PROTOCOL_VERSION] instead — bump it on any
  * incompatible daemon change so [DaemonClient] refuses a stale daemon rather than attaching to it.
  *
- * Recipe (works identically under `gradlew run` and a packaged `.app`/`.deb`/`.exe`):
+ * Two launch recipes, tried in order:
+ *
+ * 1. `java -cp …` (dev / `gradlew run`, or any runtime that ships a launcher binary):
  *   - JRE: `<java.home>/bin/java` (mac/Linux), `<java.home>/bin/javaw.exe` (Windows, no console).
- *   - Classpath: `System.getProperty("java.class.path")` verbatim — jpackage sets it to the full
- *     app jar list, which already includes the daemon's main class and all of compose-ui.
- *   - Props propagated: headless + version + settings-dir + bundled-resources dir, so the daemon
+ *   - Classpath: `System.getProperty("java.class.path")` verbatim.
+ *   - Props propagated: UIElement + version + settings-dir + bundled-resources dir, so the daemon
  *     resolves the same files ([BossTermPaths]) and finds bundled binaries (cloudflared, CLI).
  *   - The daemon does NOT need the GUI's AWT `--add-opens` flags (it runs headless).
+ *
+ * 2. The app's own native launcher with [DAEMON_ARG] (packaged `.app`/`.exe`/`.deb`): jpackage
+ *    runtimes ship NO `bin/java` at all (the app boots through its native launcher + libjli), so
+ *    recipe 1 is impossible there. Instead we relaunch the native launcher itself; the GUI facade
+ *    (`MainKt`) sees `--daemon` as its first arg and dispatches straight to the daemon entry point
+ *    before any AWT/Compose init. Runtime-set props travel as [PROP_ARG_PREFIX] args (a native
+ *    launcher can't take `-D` flags), and the launcher's own cfg re-applies the packaged
+ *    java-options for free. `apple.awt.UIElement` is set programmatically by the dispatch.
  *
  * The child is detached (its stdout/stderr append to [BossTermPaths.daemonLogFile]); the JVM does
  * not kill child processes on exit, so the daemon outlives the GUI — exactly what we want.
@@ -39,6 +48,36 @@ object DaemonLauncher {
      */
     const val DEFAULT_DAEMON_MAIN_CLASS = "ai.rever.bossterm.app.DaemonMainKt"
 
+    /** First program arg that makes the GUI facade (`MainKt`) run the daemon instead of the app. */
+    const val DAEMON_ARG = "--daemon"
+
+    /** Prefix for `--prop:key=value` program args carrying system props into a native-launcher daemon. */
+    const val PROP_ARG_PREFIX = "--prop:"
+
+    /** Props the daemon must agree with the GUI on; forwarded by both launch recipes when set. */
+    private val PASSTHROUGH_PROPS = listOf(
+        BossTermPaths.SETTINGS_DIR_PROPERTY, "bossterm.version", "compose.application.resources.dir",
+    )
+
+    /**
+     * Apply every [PROP_ARG_PREFIX] arg as a system property and return the remaining args.
+     * Called by the GUI facade's `--daemon` dispatch BEFORE the daemon entry point runs, so path
+     * and version resolution ([BossTermPaths] et al.) see the forwarded values. Explicit forwards
+     * intentionally override same-named props the packaged launcher cfg already set at JVM boot
+     * (the runtime-set value — e.g. a custom settings-dir profile — is the authoritative one).
+     */
+    fun applyPropArgs(args: Array<String>): Array<String> {
+        val rest = ArrayList<String>(args.size)
+        for (arg in args) {
+            if (!arg.startsWith(PROP_ARG_PREFIX)) { rest.add(arg); continue }
+            val kv = arg.removePrefix(PROP_ARG_PREFIX)
+            val eq = kv.indexOf('=')
+            if (eq > 0) System.setProperty(kv.take(eq), kv.substring(eq + 1))
+            else log.warn("Ignoring malformed prop arg: {}", arg)
+        }
+        return rest.toTypedArray()
+    }
+
     /**
      * Launch the daemon. Returns the spawned [Process] (already running, detached), or null if
      * the JRE couldn't be located. Callers then poll [BossTermPaths.daemonPortFile] /
@@ -53,8 +92,18 @@ object DaemonLauncher {
         mainClass: String = DEFAULT_DAEMON_MAIN_CLASS,
         extraArgs: List<String> = emptyList(),
     ): List<String>? {
-        val javaBin = resolveJavaBinary() ?: run {
-            log.error("DaemonLauncher: could not locate a java binary under java.home={}", System.getProperty("java.home"))
+        val javaBin = resolveJavaBinary()
+        if (javaBin == null) {
+            // Packaged bundles ship no java binary — relaunch the app's native launcher as the
+            // daemon instead. Only valid for the real daemon entry (the facade dispatch is
+            // hardwired to it), so a custom mainClass (tests) still requires a java binary.
+            if (mainClass == DEFAULT_DAEMON_MAIN_CLASS) {
+                nativeLauncherCommand(extraArgs)?.let { return it }
+            }
+            log.error(
+                "DaemonLauncher: no java binary under java.home={} and no packaged launcher found",
+                System.getProperty("java.home"),
+            )
             return null
         }
         val classpath = System.getProperty("java.class.path")
@@ -71,13 +120,64 @@ object DaemonLauncher {
             if (ShellCustomizationUtils.isMacOS()) add("-Dapple.awt.UIElement=true")
             // Propagate the props that affect path/resource/version resolution so the daemon
             // and GUI agree on settings dir, bundled-resource location, and reported version.
-            passthroughProp(BossTermPaths.SETTINGS_DIR_PROPERTY)?.let { add(it) }
-            passthroughProp("bossterm.version")?.let { add(it) }
-            passthroughProp("compose.application.resources.dir")?.let { add(it) }
+            PASSTHROUGH_PROPS.forEach { key -> passthroughProp(key)?.let { add(it) } }
             add("-cp")
             add(classpath)
             add(mainClass)
             addAll(extraArgs)
+        }
+    }
+
+    /**
+     * `<native launcher> --daemon [--prop:key=value …]`, or null when not running from a packaged
+     * install. The GUI facade dispatches on [DAEMON_ARG] before any AWT init, and the launcher's
+     * cfg re-applies the packaged java-options; only runtime-resolved props need forwarding.
+     */
+    private fun nativeLauncherCommand(extraArgs: List<String>): List<String>? {
+        val launcher = packagedLauncherBinary() ?: return null
+        log.info("DaemonLauncher: no bundled java binary; using native launcher {}", launcher.absolutePath)
+        return buildList {
+            add(launcher.absolutePath)
+            add(DAEMON_ARG)
+            PASSTHROUGH_PROPS.forEach { key ->
+                System.getProperty(key)?.takeIf { it.isNotBlank() }?.let { add("$PROP_ARG_PREFIX$key=$it") }
+            }
+            addAll(extraArgs)
+        }
+    }
+
+    /**
+     * The packaged app's native launcher binary, derived from `java.home` per jpackage layout, or
+     * null in dev / unrecognized layouts. Visible for tests (which pass a synthetic [javaHome]).
+     *   - macOS:   `<Bundle>.app/Contents/runtime/Contents/Home` → `<Bundle>.app/Contents/MacOS/<Bundle>`
+     *   - Windows: `<install>\runtime` → `<install>\<App>.exe`
+     *   - Linux:   `<install>/lib/runtime` → `<install>/bin/<App>`
+     */
+    internal fun packagedLauncherBinary(
+        javaHome: String? = System.getProperty("java.home"),
+    ): File? {
+        val jh = javaHome?.takeIf { it.isNotBlank() } ?: return null
+        return when {
+            ShellCustomizationUtils.isMacOS() -> {
+                if (!jh.contains(".app/Contents/")) return null
+                val bundle = File(jh.substringBefore(".app/Contents/") + ".app")
+                val macOsDir = File(bundle, "Contents/MacOS")
+                // jpackage names the launcher after the bundle; fall back to the sole executable.
+                File(macOsDir, bundle.name.removeSuffix(".app")).takeIf { it.canExecute() }
+                    ?: macOsDir.listFiles()?.singleOrNull { it.isFile && it.canExecute() }
+            }
+            ShellCustomizationUtils.isWindows() -> {
+                val home = File(jh)
+                if (!home.name.equals("runtime", ignoreCase = true)) return null
+                home.parentFile?.listFiles()?.singleOrNull { it.isFile && it.extension.equals("exe", ignoreCase = true) }
+            }
+            ShellCustomizationUtils.isLinux() -> {
+                val home = File(jh)
+                if (home.name != "runtime" || home.parentFile?.name != "lib") return null
+                val binDir = File(home.parentFile.parentFile ?: return null, "bin")
+                binDir.listFiles()?.singleOrNull { it.isFile && it.canExecute() }
+            }
+            else -> null
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonLauncher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonLauncher.kt
@@ -148,37 +148,60 @@ object DaemonLauncher {
 
     /**
      * The packaged app's native launcher binary, derived from `java.home` per jpackage layout, or
-     * null in dev / unrecognized layouts. Visible for tests (which pass a synthetic [javaHome]).
-     *   - macOS:   `<Bundle>.app/Contents/runtime/Contents/Home` → `<Bundle>.app/Contents/MacOS/<Bundle>`
-     *   - Windows: `<install>\runtime` → `<install>\<App>.exe`
-     *   - Linux:   `<install>/lib/runtime` → `<install>/bin/<App>`
+     * null in dev / unrecognized layouts. The per-OS derivations are pure functions of [javaHome]
+     * (no current-OS checks inside) so ALL of them are unit-tested regardless of the CI platform.
      */
     internal fun packagedLauncherBinary(
         javaHome: String? = System.getProperty("java.home"),
     ): File? {
         val jh = javaHome?.takeIf { it.isNotBlank() } ?: return null
         return when {
-            ShellCustomizationUtils.isMacOS() -> {
-                if (!jh.contains(".app/Contents/")) return null
-                val bundle = File(jh.substringBefore(".app/Contents/") + ".app")
-                val macOsDir = File(bundle, "Contents/MacOS")
-                // jpackage names the launcher after the bundle; fall back to the sole executable.
-                File(macOsDir, bundle.name.removeSuffix(".app")).takeIf { it.canExecute() }
-                    ?: macOsDir.listFiles()?.singleOrNull { it.isFile && it.canExecute() }
-            }
-            ShellCustomizationUtils.isWindows() -> {
-                val home = File(jh)
-                if (!home.name.equals("runtime", ignoreCase = true)) return null
-                home.parentFile?.listFiles()?.singleOrNull { it.isFile && it.extension.equals("exe", ignoreCase = true) }
-            }
-            ShellCustomizationUtils.isLinux() -> {
-                val home = File(jh)
-                if (home.name != "runtime" || home.parentFile?.name != "lib") return null
-                val binDir = File(home.parentFile.parentFile ?: return null, "bin")
-                binDir.listFiles()?.singleOrNull { it.isFile && it.canExecute() }
-            }
+            ShellCustomizationUtils.isMacOS() -> macLauncher(jh)
+            ShellCustomizationUtils.isWindows() -> windowsLauncher(jh)
+            ShellCustomizationUtils.isLinux() -> linuxLauncher(jh)
             else -> null
         }
+    }
+
+    /** macOS: `<Bundle>.app/Contents/runtime/Contents/Home` → `<Bundle>.app/Contents/MacOS/<Bundle>`. */
+    internal fun macLauncher(javaHome: String): File? {
+        val bundle = macBundleFile(javaHome) ?: return null
+        return pickLauncher(File(bundle, "Contents/MacOS"), bundle.name.removeSuffix(".app")) { it.canExecute() }
+    }
+
+    /** Windows: `<install>\runtime` → `<install>\<App>.exe` (launcher named after the install dir). */
+    internal fun windowsLauncher(javaHome: String): File? {
+        val home = File(javaHome)
+        if (!home.name.equals("runtime", ignoreCase = true)) return null
+        val install = home.parentFile ?: return null
+        return pickLauncher(install, install.name) { it.extension.equals("exe", ignoreCase = true) }
+    }
+
+    /** Linux: `<install>/lib/runtime` → `<install>/bin/<App>` (deb/rpm install dirs are lowercased). */
+    internal fun linuxLauncher(javaHome: String): File? {
+        val home = File(javaHome)
+        if (home.name != "runtime" || home.parentFile?.name != "lib") return null
+        val install = home.parentFile.parentFile ?: return null
+        return pickLauncher(File(install, "bin"), install.name) { it.canExecute() }
+    }
+
+    /**
+     * Pick the launcher from [dir]: the [executable] named [preferredName] (case-insensitive,
+     * extension ignored — jpackage names the main launcher after the app/install dir), else the
+     * directory's SOLE executable. With several candidates and no name match, refuse loudly —
+     * exec'ing a guess (an add-launcher, an uninstaller) is worse than failing.
+     */
+    private fun pickLauncher(dir: File, preferredName: String, executable: (File) -> Boolean): File? {
+        val candidates = dir.listFiles()?.filter { it.isFile && executable(it) }.orEmpty()
+        candidates.firstOrNull { it.nameWithoutExtension.equals(preferredName, ignoreCase = true) }?.let { return it }
+        candidates.singleOrNull()?.let { return it }
+        if (candidates.size > 1) {
+            log.warn(
+                "DaemonLauncher: multiple launcher candidates in {} and none named '{}': {}",
+                dir, preferredName, candidates.joinToString { it.name },
+            )
+        }
+        return null
     }
 
     fun spawn(
@@ -287,19 +310,28 @@ object DaemonLauncher {
     private fun macAppBundlePath(): String? {
         if (!ShellCustomizationUtils.isMacOS()) return null
         val jh = System.getProperty("java.home")?.takeIf { it.isNotBlank() } ?: return null
-        return if (jh.contains(".app/Contents/")) jh.substringBefore(".app/Contents/") + ".app" else null
+        return macBundleFile(jh)?.path
     }
+
+    /** `<Bundle>.app` containing [path] (e.g. a bundled java.home), or null when not inside a bundle. */
+    private fun macBundleFile(path: String): File? =
+        if (path.contains(".app/Contents/")) File(path.substringBefore(".app/Contents/") + ".app") else null
 
     /** Launch the GUI in a normal (non-headless, non-agent) JVM via the same JRE + classpath. */
     private fun buildGuiCommand(): List<String>? {
-        val javaBin = resolveJavaBinary() ?: return null
+        val javaBin = resolveJavaBinary()
+        if (javaBin == null) {
+            // Packaged Windows/Linux: no bin/java (the same gap the daemon spawn has) — relaunch
+            // the native launcher as a plain GUI; its cfg re-applies the packaged java-options and
+            // --add-opens. Like the macOS `open <bundle>` path above, a runtime-set settings-dir
+            // profile is not forwarded (the GUI facade only parses --prop: args after --daemon).
+            return packagedLauncherBinary()?.let { listOf(it.absolutePath) }
+        }
         val classpath = System.getProperty("java.class.path")?.takeIf { it.isNotBlank() } ?: return null
         return buildList {
             add(javaBin.absolutePath)
             // GUI is a normal foreground app: do NOT pass headless or UIElement.
-            passthroughProp(BossTermPaths.SETTINGS_DIR_PROPERTY)?.let { add(it) }
-            passthroughProp("bossterm.version")?.let { add(it) }
-            passthroughProp("compose.application.resources.dir")?.let { add(it) }
+            PASSTHROUGH_PROPS.forEach { key -> passthroughProp(key)?.let { add(it) } }
             // Mirror the GUI launcher's AWT --add-opens (global hotkeys / window integration).
             add("--add-opens"); add("java.desktop/java.awt=ALL-UNNAMED")
             if (ShellCustomizationUtils.isMacOS()) { add("--add-opens"); add("java.desktop/sun.lwawt.macosx=ALL-UNNAMED") }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/DaemonSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/DaemonSettingsSection.kt
@@ -69,7 +69,15 @@ fun DaemonSettingsSection(
                         // debounce window the flags would never reach disk — next launch reads
                         // daemonEnabled=true and reinstalls, silently undoing a later disable.
                         SettingsManager.instance.updateSetting { copy(daemonEnabled = true, startDaemonAtLogin = true) }
-                        scope.launch(Dispatchers.IO) { runCatching { LoginServiceManager.install() } }
+                        // Surface an install failure instead of swallowing it — a silent failure
+                        // here reads as "enabled" while no daemon will ever start (e.g. the
+                        // packaged-app bug where no launch command could be built).
+                        scope.launch(Dispatchers.IO) {
+                            val r = LoginServiceManager.install()
+                            withContext(Dispatchers.Main) {
+                                r.onFailure { status = "Login service install failed: ${it.message}" }
+                            }
+                        }
                     } else {
                         // Disabling the daemon must also tear down the at-login service + clear its
                         // flag, otherwise a daemon keeps spawning at login that the GUI no longer

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonInfraTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonInfraTest.kt
@@ -50,6 +50,43 @@ class DaemonInfraTest {
         assertEquals("ai.rever.bossterm.app.DaemonMainKt", DaemonLauncher.DEFAULT_DAEMON_MAIN_CLASS)
     }
 
+    @Test
+    fun `applyPropArgs sets properties, strips prop args, keeps the rest`() {
+        val key = "bossterm.test.applyPropArgs"
+        try {
+            val rest = DaemonLauncher.applyPropArgs(arrayOf(
+                "${DaemonLauncher.PROP_ARG_PREFIX}$key=hello world",
+                "--other",
+                "${DaemonLauncher.PROP_ARG_PREFIX}malformed-no-equals",
+            ))
+            assertEquals("hello world", System.getProperty(key))
+            // Malformed prop args are dropped (logged), not passed through to the daemon.
+            assertEquals(listOf("--other"), rest.toList())
+        } finally {
+            System.clearProperty(key)
+        }
+    }
+
+    @Test
+    fun `packagedLauncherBinary resolves the macOS bundle launcher from java-home`() {
+        if (!ai.rever.bossterm.compose.shell.ShellCustomizationUtils.isMacOS()) return
+        val root = java.nio.file.Files.createTempDirectory("bossterm-bundle").toFile()
+        try {
+            // Synthetic jpackage layout: Foo.app/Contents/runtime/Contents/Home + Contents/MacOS/Foo.
+            val bundle = java.io.File(root, "Foo.app")
+            val javaHome = java.io.File(bundle, "Contents/runtime/Contents/Home").apply { mkdirs() }
+            val launcher = java.io.File(bundle, "Contents/MacOS/Foo").apply {
+                parentFile.mkdirs(); writeText(""); setExecutable(true)
+            }
+            assertEquals(launcher, DaemonLauncher.packagedLauncherBinary(javaHome.absolutePath))
+            // A non-bundle java.home (dev JDK) is not a packaged install.
+            assertNull(DaemonLauncher.packagedLauncherBinary(root.absolutePath))
+            assertNull(DaemonLauncher.packagedLauncherBinary(null))
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
     // ---- DaemonControlChannel ----
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonInfraTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonInfraTest.kt
@@ -68,20 +68,47 @@ class DaemonInfraTest {
     }
 
     @Test
-    fun `packagedLauncherBinary resolves the macOS bundle launcher from java-home`() {
-        if (!ai.rever.bossterm.compose.shell.ShellCustomizationUtils.isMacOS()) return
-        val root = java.nio.file.Files.createTempDirectory("bossterm-bundle").toFile()
+    fun `launcher derivation resolves every jpackage layout (pure, runs on any CI OS)`() {
+        val root = java.nio.file.Files.createTempDirectory("bossterm-launcher").toFile()
         try {
-            // Synthetic jpackage layout: Foo.app/Contents/runtime/Contents/Home + Contents/MacOS/Foo.
+            // macOS: Foo.app/Contents/runtime/Contents/Home → Contents/MacOS/Foo.
             val bundle = java.io.File(root, "Foo.app")
-            val javaHome = java.io.File(bundle, "Contents/runtime/Contents/Home").apply { mkdirs() }
-            val launcher = java.io.File(bundle, "Contents/MacOS/Foo").apply {
+            val macHome = java.io.File(bundle, "Contents/runtime/Contents/Home").apply { mkdirs() }
+            val macLauncher = java.io.File(bundle, "Contents/MacOS/Foo").apply {
                 parentFile.mkdirs(); writeText(""); setExecutable(true)
             }
-            assertEquals(launcher, DaemonLauncher.packagedLauncherBinary(javaHome.absolutePath))
-            // A non-bundle java.home (dev JDK) is not a packaged install.
-            assertNull(DaemonLauncher.packagedLauncherBinary(root.absolutePath))
+            assertEquals(macLauncher, DaemonLauncher.macLauncher(macHome.absolutePath))
+            assertNull(DaemonLauncher.macLauncher(root.absolutePath), "dev JDK is not a bundle")
+
+            // Windows: <install>\runtime → <install>\<App>.exe; the install-dir-named exe wins
+            // over a stray sibling executable (add-launcher/uninstaller).
+            val winInstall = java.io.File(root, "Bar").apply { mkdirs() }
+            val winHome = java.io.File(winInstall, "runtime").apply { mkdirs() }
+            val exe = java.io.File(winInstall, "Bar.exe").apply { writeText("") }
+            java.io.File(winInstall, "helper.exe").writeText("")
+            assertEquals(exe, DaemonLauncher.windowsLauncher(winHome.absolutePath))
+            assertNull(DaemonLauncher.windowsLauncher(root.absolutePath), "java.home must be <install>\\runtime")
+
+            // Linux: <install>/lib/runtime → <install>/bin/<App>; deb/rpm lowercases the install
+            // dir but not the launcher, so the name preference is case-insensitive.
+            val linuxInstall = java.io.File(root, "baz").apply { mkdirs() }
+            val linuxHome = java.io.File(linuxInstall, "lib/runtime").apply { mkdirs() }
+            val bin = java.io.File(linuxInstall, "bin/Baz").apply {
+                parentFile.mkdirs(); writeText(""); setExecutable(true)
+            }
+            assertEquals(bin, DaemonLauncher.linuxLauncher(linuxHome.absolutePath))
+            assertNull(DaemonLauncher.linuxLauncher(root.absolutePath), "java.home must be <install>/lib/runtime")
+
+            // Several candidates, none matching the expected name → refuse (don't exec a guess).
+            val ambiguous = java.io.File(root, "Qux").apply { mkdirs() }
+            java.io.File(ambiguous, "runtime").mkdirs()
+            java.io.File(ambiguous, "alpha.exe").writeText("")
+            java.io.File(ambiguous, "beta.exe").writeText("")
+            assertNull(DaemonLauncher.windowsLauncher(java.io.File(ambiguous, "runtime").absolutePath))
+
+            // packagedLauncherBinary itself: null/blank java.home is never a packaged install.
             assertNull(DaemonLauncher.packagedLauncherBinary(null))
+            assertNull(DaemonLauncher.packagedLauncherBinary(""))
         } finally {
             root.deleteRecursively()
         }


### PR DESCRIPTION
## Problem

In every packaged install (`.app`/`.exe`/`.deb`), the session daemon **never starts** — no background sessions, no daemon-hosted MCP, and no menu-bar terminal icon — even with the daemon enabled in Settings. All failures are silent: the GUI quietly falls back to in-process MCP and the Settings toggle reads as enabled.

Root cause: jpackage runtimes ship **no `bin/java` at all** (the app boots through its native launcher + libjli). `DaemonLauncher.resolveJavaBinary()` therefore returns null in packaged builds, so:

- `DaemonClient` → `DaemonLauncher.spawn()` fails → GUI falls back to in-process MCP with only a stderr line nobody sees.
- `LoginServiceManager.install()` errors inside `runCatching` → the login service is never (re)written; a stale dev plist (Homebrew JDK + `.gradleBuild` jars) can linger and break after `gradlew clean`.

The daemon only ever worked from dev (`gradlew run`), where a real JDK provides `bin/java`. Diagnosed live on macOS: `/Applications/BossTerm.app/Contents/runtime/Contents/Home` has no `bin/` directory.

## Fix

Relaunch the app's **own native launcher** as the daemon when no java binary exists:

- **`DaemonLauncher`**: `buildCommand()` keeps the `java -cp …` recipe when a java binary exists (dev), else falls back to `<native launcher> --daemon [--prop:key=value …]`. The launcher binary is derived from `java.home` per jpackage layout (macOS bundle / Windows `runtime` sibling / Linux `lib/runtime`). Runtime props (settings dir, version, resources dir) travel as `--prop:` program args — a native launcher can't take `-D` flags — while the launcher's cfg re-applies the packaged java-options for free.
- **`Main.kt`**: dispatches `--daemon` to the daemon entry as the very first statement — before any AWT/Skiko/Compose init — applying forwarded props and setting `apple.awt.UIElement=true` programmatically so the daemon runs as a menu-bar-only agent (no Dock icon).
- **`DaemonMain.kt`**: entry body exposed as `runDaemon()` so the GUI facade can call it (two file-level `main`s in one package can't reference each other unambiguously).
- **`LoginServiceManager`** inherits the fix via `buildCommand()`: packaged installs now bake the stable native-launcher path into the login service instead of failing (or baking dev jars).
- **`DaemonSettingsSection`**: login-service install failures now surface in the status area instead of being swallowed — the silent failure is what made this bug invisible.

## Testing

- All 77 tests in the `daemon` package pass, including 2 new ones: `--prop:` arg parsing (set/strip/malformed) and macOS bundle-launcher derivation from a synthetic jpackage layout.
- `bossterm-app` assembles; `MainKt` verified to have no top-level state that could initialize AWT before the dispatch; app bundle doesn't set `LSMultipleInstancesProhibited`, so direct-exec relaunch is safe.
- Not exercised live from a packaged build — needs a packaged smoke test: install the release build, enable the daemon, confirm the menu-bar icon appears and `~/.bossterm/daemon.log` shows the daemon starting.

## Notes

- A separate bug observed while diagnosing (not fixed here): two daemons raced past the single-instance guard and both installed tray icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)