### PR TITLE
ci: make Snap build opt-in by default; rerun-safe release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ on:
           - patch
           - minor
           - major
-      skip_snap:
-        description: 'Skip Snap build'
+      build_snap:
+        description: 'Build Snap package (off by default: Snap Store rejects our classic confinement pending Canonical approval, so the store publish always fails)'
         required: false
         default: false
         type: boolean
@@ -344,7 +344,10 @@ jobs:
 
   build-snap:
     needs: prepare-version
-    if: ${{ github.event.inputs.publish_only != 'true' && github.event.inputs.skip_snap != 'true' }}
+    # Opt-in (dispatch-only): the snap is unpublishable until Canonical approves the
+    # classic-confinement request, and create-release would otherwise wait ~10 min on
+    # this job for nothing. Tag pushes have no inputs, so they skip it too.
+    if: ${{ github.event.inputs.publish_only != 'true' && github.event.inputs.build_snap == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -443,8 +446,14 @@ jobs:
           VERSION="${{ needs.prepare-version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v$VERSION" -m "Release v$VERSION"
-          git push origin "v$VERSION"
+          # Idempotent so a rerun of a partially-failed release (tag pushed, later
+          # step failed) can proceed instead of dying on "tag already exists".
+          if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null; then
+            echo "Tag v$VERSION already exists on origin; keeping it (release rerun)."
+          else
+            git tag -a "v$VERSION" -m "Release v$VERSION"
+            git push origin "v$VERSION"
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -463,7 +472,6 @@ jobs:
             | **Ubuntu/Debian** | ARM64 | `bossterm_${{ needs.prepare-version.outputs.version }}_arm64.deb` |
             | **Fedora/RHEL** | AMD64 | `bossterm-${{ needs.prepare-version.outputs.version }}.x86_64.rpm` |
             | **Fedora/RHEL** | ARM64 | `bossterm-${{ needs.prepare-version.outputs.version }}.aarch64.rpm` |
-            | **Snap** | AMD64 | `bossterm_${{ needs.prepare-version.outputs.version }}_amd64.snap` |
             | **Any (JAR)** | Any | `bossterm-${{ needs.prepare-version.outputs.version }}.jar` |
 
             ### Installation
@@ -483,13 +491,6 @@ jobs:
             **Fedora/RHEL:**
             ```bash
             sudo dnf install bossterm-${{ needs.prepare-version.outputs.version }}.x86_64.rpm
-            ```
-
-            **Snap:**
-            ```bash
-            sudo snap install bossterm --classic
-            # Or from downloaded file:
-            sudo snap install bossterm_*.snap --classic --dangerous
             ```
 
             **JAR (requires Java 17+):**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,9 +384,14 @@ jobs:
 
       # Optional: Publish to Snap Store (requires SNAPCRAFT_STORE_CREDENTIALS secret)
       # To get credentials: snapcraft export-login --snaps=bossterm --acls package_access,package_push,package_update,package_release credentials.txt
+      #
+      # No continue-on-error here: it previously masked months of guaranteed failures
+      # (classic confinement pending Canonical approval) as green runs. The whole job is
+      # opt-in now, so anyone setting build_snap=true wants a real publish — a store
+      # rejection should fail loudly. create-release tolerates this job failing, so a
+      # red build-snap never blocks the release itself.
       - name: Publish to Snap Store
         if: env.SNAPCRAFT_STORE_CREDENTIALS != ''
-        continue-on-error: true  # Don't fail build if snap publish fails (e.g., review queue)
         uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
@@ -431,7 +436,12 @@ jobs:
           find ./artifacts -name "*.deb" -path "*arm64*" -exec cp {} ./release-assets/bossterm_${VERSION}_arm64.deb \; 2>/dev/null || true
           find ./artifacts -name "*.rpm" -path "*arm64*" -exec cp {} ./release-assets/bossterm-${VERSION}.aarch64.rpm \; 2>/dev/null || true
 
-          # Snap (if available)
+          # Snap (only present when dispatched with build_snap=true). Intentional
+          # asymmetry: the release-notes body below does NOT mention the snap — it is
+          # unpublishable to the Snap Store until Canonical approves classic confinement,
+          # so the notes stay snap-free rather than documenting an asset most releases
+          # won't have. If snap publishing resumes, make the notes conditional instead
+          # of re-adding an unconditional Snap row.
           find ./artifacts -name "*.snap" -exec cp {} ./release-assets/bossterm_${VERSION}_amd64.snap \; 2>/dev/null || true
 
           # Uber JAR


### PR DESCRIPTION
## Why

**The Snap Store has rejected every `bossterm` upload ever made.** The snap uses `confinement: classic`, which requires manual Canonical approval via a [classic-confinement forum request](https://forum.snapcraft.io/c/store-requests/classic-confinement/26) that was never filed/granted. Every `snapcraft upload` ends with:

> (NEEDS REVIEW) confinement 'classic' not allowed…

`continue-on-error: true` on the publish step masked this — the job shows green while snapcraft exits 1 on every single release. Meanwhile `create-release` `needs: build-snap`, so every release waits ~10 min on a package that can never ship.

## Changes

- Replace the `skip_snap` opt-out input with a `build_snap` **opt-in** (default off). Tag pushes carry no inputs, so they skip the snap too. `create-release` already tolerates a skipped `build-snap` (`always()` + it only requires macOS/amd64), as does `update-homebrew`.
- Drop the Snap row + install instructions from the generated release notes — `sudo snap install bossterm` has never worked (nothing was ever published), and by default no `.snap` asset is attached now.
- Make **Create Git Tag** idempotent. Rerunning a `create-release` job that failed *after* the tag push (exactly what happened with v1.2.123's Supabase 413) died on `tag already exists`, making a partial release impossible to complete via rerun.

To resume snap publishing later: file the classic-confinement request with Canonical, then dispatch releases with `build_snap: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)