### PR TITLE
feat(daemon): make the session daemon opt-in (off by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ cd BossTerm
 - **Session Sharing** - Watch or control a tab / window / all windows from any device — self-hosted, with a QR code and a mobile-friendly web viewer (LAN, Tailscale, or a zero-config Cloudflare tunnel)
 - **Remote Control** - End-to-end encrypted; viewers get typing access on approval, or connect from another BossTerm as a native remote client
 - **AI / MCP Server** - Built-in [Model Context Protocol](https://modelcontextprotocol.io) server exposes your terminals to Claude Code, Codex, Gemini CLI, and OpenCode
-- **Session Daemon** - tmux-style background process (on by default) keeps your sessions, MCP server, and shares alive after the GUI closes — reopen to reattach; starts at login
+- **Session Daemon** - opt-in tmux-style background process keeps your sessions, MCP server, and shares alive after the GUI closes — reopen to reattach; can start at login
 - **Embeddable** - Drop the terminal into your own Kotlin/Compose Desktop app as a library (`com.risaboss:bossterm-compose`)
 
 ## Design
@@ -610,8 +610,8 @@ every built-in tool's JSON schema, the `manage_tools` meta-tool, the
 ## Session Daemon
 
 A tmux-style background process that **owns your terminal sessions, MCP server, and shares** so they
-keep running after you close the GUI — reopen BossTerm and it reattaches to the live sessions. **On by
-default**; turn it off under Settings → Session Daemon to fall back to the pre-daemon behavior
+keep running after you close the GUI — reopen BossTerm and it reattaches to the live sessions. **Off by
+default**; turn it on under Settings → Session Daemon. When off, BossTerm uses the pre-daemon behavior
 (in-process MCP/sharing, sessions die with the window), a path that's preserved byte-for-byte.
 
 - **Survives the GUI**: sessions live in the daemon, not the window. Close the app (or all its

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -926,21 +926,23 @@ data class TerminalSettings(
     /**
      * Master switch for the BossTerm session daemon — a long-lived background process that owns
      * terminal sessions, the MCP server, and session sharing, so they survive the GUI closing.
-     * Defaults to true: the GUI spawns/connects the daemon and hosts MCP there, and sessions outlive
-     * the window. Set to false to fall back to the pre-daemon behavior (in-process MCP/sharing,
-     * sessions die with the window) — that path is preserved byte-for-byte. The daemon is started
-     * on-demand by the GUI; see also [startDaemonAtLogin] for an always-on at-login service.
+     * Defaults to false (opt-in): out of the box BossTerm uses the pre-daemon behavior (in-process
+     * MCP/sharing, sessions die with the window) — that path is preserved byte-for-byte. Set to
+     * true to have the GUI spawn/connect the daemon, host MCP there, and let sessions outlive the
+     * window. The daemon is started on-demand by the GUI; see also [startDaemonAtLogin] for an
+     * always-on at-login service.
      */
-    val daemonEnabled: Boolean = true,
+    val daemonEnabled: Boolean = false,
 
     /**
      * Install a per-OS login service (macOS LaunchAgent / Linux systemd user unit / Windows Run
      * key) so the daemon starts at login — always available, even before the GUI is first opened.
-     * Defaults on and is coupled to [daemonEnabled]: enabling the daemon also schedules it at login
-     * (the daemon is meant to be always-available); only meaningful while [daemonEnabled] is true.
-     * The toggle install/uninstalls the service via LoginServiceManager.
+     * Defaults off, matching [daemonEnabled], and stays coupled to it: enabling the daemon also
+     * schedules it at login (an enabled daemon is meant to be always-available); only meaningful
+     * while [daemonEnabled] is true. The toggle install/uninstalls the service via
+     * LoginServiceManager.
      */
-    val startDaemonAtLogin: Boolean = true,
+    val startDaemonAtLogin: Boolean = false,
 
     // ===== Session sharing / remote control (issue #276) =====
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/DaemonSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/DaemonSettingsSection.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
- * Session-daemon settings: toggle the tmux-style background daemon (on by default), install/remove
+ * Session-daemon settings: toggle the tmux-style background daemon (off by default), install/remove
  * its login service, and see/control its status. The daemon owns terminal sessions + MCP + sharing
  * so they survive the GUI closing. [TerminalSettings.daemonEnabled] is read at app startup, so
  * toggling it needs a restart — surfaced in the note.


### PR DESCRIPTION
## Summary
- Flip `daemonEnabled` default from `true` to `false` — fresh installs now get the pre-daemon behavior (in-process MCP/sharing, sessions die with the window) until the daemon is explicitly enabled under **Settings → Session Daemon**.
- Flip the coupled `startDaemonAtLogin` default to `false` to match; enabling the daemon still schedules it at login and installs the login service, exactly as before.
- Update the KDoc on both settings, the `DaemonSettingsSection` doc comment, and the two README statements that said the daemon is on by default.

## Impact on existing installs
None. `SettingsManager` writes settings with `encodeDefaults = true`, so every existing `settings.json` already contains an explicit `daemonEnabled` value — upgrading does not turn the daemon off for anyone who has it on. Only fresh installs (and settings files predating the daemon fields) pick up the new off default.

## Testing
- `./gradlew :compose-ui:compileKotlinDesktop` — clean
- `./gradlew :compose-ui:desktopTest --tests "*Settings*" --tests "*LoginService*" --tests "*DaemonInfra*"` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
