### PR TITLE
fix(daemon): single-instance lock — stop duplicate daemons (two menu-bar icons)

### DIFF
--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/DaemonMain.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/DaemonMain.kt
@@ -4,6 +4,7 @@ import ai.rever.bossterm.compose.daemon.BossTermPaths
 import ai.rever.bossterm.compose.daemon.DaemonAttachServer
 import ai.rever.bossterm.compose.daemon.DaemonControlChannel
 import ai.rever.bossterm.compose.daemon.DaemonControlHandler
+import ai.rever.bossterm.compose.daemon.DaemonInstanceLock
 import ai.rever.bossterm.compose.daemon.DaemonMcpServer
 import ai.rever.bossterm.compose.daemon.DaemonShareServer
 import ai.rever.bossterm.compose.daemon.DaemonTray
@@ -69,9 +70,17 @@ fun runDaemon(args: Array<String>) {
         })
     }.onFailure { log.debug("Could not install SIGHUP handler: {}", it.message) }
 
-    // Single-instance self-guard: if a compatible daemon is already live (it answers PING on the
-    // recorded port), don't start a second one that would overwrite daemon.port and orphan the
-    // first. Backstops the GUI's FileChannel.tryLock spawn guard under a cold-start race.
+    // Single-instance guard, two layers. (1) The OS instance lock is the atomic arbiter: a
+    // GUI-spawned daemon racing a service-manager start (launchd RunAtLoad / systemd enable --now,
+    // which bypass the GUI's spawn lock) used to have BOTH daemons pass the probe below before
+    // either had bound its port — two tray icons, and the loser's port file clobbered the winner's.
+    // (2) The PING probe stays as a backstop against a live daemon from a build that predates the
+    // instance lock. Both paths exit 0: launchd's KeepAlive(SuccessfulExit=false) respawns a
+    // non-zero exit straight back into the same contention.
+    if (!DaemonInstanceLock.tryAcquire()) {
+        log.info("Another BossTerm daemon holds the instance lock; exiting (single-instance)")
+        return
+    }
     if (liveCompatibleDaemonPresent()) {
         log.info("A compatible BossTerm daemon is already running; exiting (single-instance)")
         return

--- a/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
+++ b/bossterm-app/src/desktopMain/kotlin/ai/rever/bossterm/app/Main.kt
@@ -139,11 +139,12 @@ fun main(args: Array<String>) {
                     ai.rever.bossterm.compose.daemon.DaemonBridgeCoordinator.markAttachUnavailable()
                     ensureInProcessMcp()
                 }
-            }
-            // Refresh the at-login service so its baked java/classpath stay current after an app
-            // update (stale paths would silently fail to start the daemon at next login).
-            if (SettingsManager.instance.settings.value.startDaemonAtLogin) {
-                daemonScope.launch {
+                // Refresh the at-login service so its baked java/classpath stay current after an app
+                // update (stale paths would silently fail to start the daemon at next login). Strictly
+                // AFTER ensureConnected() has settled: install() can start a daemon immediately
+                // (launchd RunAtLoad / systemd enable --now), and running it concurrently with the
+                // spawn used to race two daemons into existence (two menu-bar icons).
+                if (SettingsManager.instance.settings.value.startDaemonAtLogin) {
                     runCatching { ai.rever.bossterm.compose.daemon.LoginServiceManager.install() }
                 }
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/BossTermPaths.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/BossTermPaths.kt
@@ -79,6 +79,9 @@ object BossTermPaths {
     /** Advisory lock guarding single daemon spawn per settings dir (`daemon.lock`). */
     fun daemonLockFile(): File = file("daemon.lock")
 
+    /** OS lock held by THE running daemon for its lifetime (`daemon.instance.lock`, see [DaemonInstanceLock]). */
+    fun daemonInstanceLockFile(): File = file("daemon.instance.lock")
+
     /** Running daemon's PID, for diagnostics (`daemon.pid`). */
     fun daemonPidFile(): File = file("daemon.pid")
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonInstanceLock.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonInstanceLock.kt
@@ -1,0 +1,57 @@
+package ai.rever.bossterm.compose.daemon
+
+import java.io.RandomAccessFile
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+
+/**
+ * Process-lifetime OS file lock (`daemon.instance.lock`) marking "a daemon owns this settings dir".
+ *
+ * The GUI's spawn guard ([DaemonClient] on `daemon.lock`) only serializes GUI-initiated spawns; a
+ * service-manager start (launchd `RunAtLoad`, systemd `enable --now`) bypasses it entirely. And the
+ * daemon's own self-guard (probe `daemon.port`, PING) is check-then-act: two daemons cold-starting
+ * in the same instant both see "no live daemon" before either has bound its control channel, so
+ * both keep running — two menu-bar icons, and the second overwrites `daemon.port`, orphaning the
+ * daemon the GUI attached to. This lock is the atomic arbiter across ALL spawn paths: the first
+ * daemon to [tryAcquire] wins and holds the lock until the OS releases it at process death (kill
+ * -9 included); every later daemon gets `false` and must exit.
+ *
+ * Deliberately a DIFFERENT file from `daemon.lock`: the GUI holds that one across spawn+await, so
+ * a daemon contending on the same file could never start while its own spawner waits for it.
+ */
+object DaemonInstanceLock {
+    // Held for the whole process lifetime. Keep hard refs: a GC'd channel releases the OS lock.
+    @Volatile private var held: FileLock? = null
+    private var channel: FileChannel? = null
+
+    /** Try to become THE daemon for this settings dir. Idempotent while held. */
+    @Synchronized
+    fun tryAcquire(): Boolean {
+        held?.takeIf { it.isValid }?.let { return true }
+        return runCatching {
+            val file = BossTermPaths.daemonInstanceLockFile()
+            // Owner-only pre-create, same rationale as daemon.lock: don't leave a window where
+            // another local user can open()+lock the file and wedge daemon startup.
+            BossTermPaths.createOwnerOnly(file)
+            val ch = RandomAccessFile(file, "rw").channel
+            val lock = ch.tryLock()
+            if (lock != null) {
+                channel = ch
+                held = lock
+                true
+            } else {
+                ch.close()
+                false
+            }
+        }.getOrDefault(false) // OverlappingFileLockException (same-JVM holder) lands here too
+    }
+
+    /** Release the lock (tests only — a real daemon holds it until process exit). */
+    @Synchronized
+    fun release() {
+        runCatching { held?.release() }
+        runCatching { channel?.close() }
+        held = null
+        channel = null
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/LoginServiceManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/LoginServiceManager.kt
@@ -65,13 +65,23 @@ object LoginServiceManager {
     private fun installMac(command: List<String>) {
         val file = macPlistFile()
         file.parentFile?.mkdirs()
-        file.writeText(macPlist(serviceId(), command, BossTermPaths.daemonLogFile().absolutePath))
-        // Prefer the modern `bootstrap`/`bootout` (load/unload are deprecated and unreliable on
-        // recent macOS); fall back to load/unload on older systems or if bootstrap fails. RunAtLoad
-        // makes it start next login regardless. Re-bootstrapping refreshes the baked command.
+        val content = macPlist(serviceId(), command, BossTermPaths.daemonLogFile().absolutePath)
         val uid = uid()
+        // Never bootout a service that's currently registered: bootout KILLS a running daemon (and
+        // every session it owns), and with RunAtLoad the follow-up bootstrap starts a fresh daemon
+        // immediately — the pair used to race the GUI's own spawn into two live daemons. When the
+        // service is registered, writing the plist file is enough: launchd re-reads it at next
+        // login, which is exactly when a refreshed baked command matters.
+        val registered = uid != null &&
+            runCapture("launchctl", "print", "gui/$uid/${serviceId()}").first == 0
+        if (registered && runCatching { file.readText() == content }.getOrDefault(false)) return
+        file.writeText(content)
+        if (registered) return
+        // Not registered — register and start it now. Prefer the modern `bootstrap` (load/unload are
+        // deprecated and unreliable on recent macOS); fall back to load on older systems or if
+        // bootstrap fails. RunAtLoad makes it start next login regardless.
         if (uid != null) {
-            run("launchctl", "bootout", "gui/$uid", file.absolutePath) // clear any prior reg (ok to fail)
+            run("launchctl", "bootout", "gui/$uid", file.absolutePath) // clear any half-dead reg (ok to fail)
             val (code, _) = runCapture("launchctl", "bootstrap", "gui/$uid", file.absolutePath)
             if (code == 0) return
         }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonInfraTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonInfraTest.kt
@@ -179,6 +179,28 @@ class DaemonInfraTest {
             BufferedReader(InputStreamReader(s.getInputStream(), StandardCharsets.UTF_8)).readLine()
         }
 
+    // ---- DaemonInstanceLock ----
+
+    @Test
+    fun `instance lock is exclusive while held and reacquirable after release`() = withSettingsDir {
+        try {
+            assertTrue(DaemonInstanceLock.tryAcquire())
+            assertTrue(DaemonInstanceLock.tryAcquire()) // idempotent while held
+            // A second locker must lose (same-JVM contender throws OverlappingFileLockException,
+            // a separate process would get null — either way it must not acquire).
+            val other = runCatching {
+                java.io.RandomAccessFile(BossTermPaths.daemonInstanceLockFile(), "rw")
+                    .channel.use { it.tryLock() }
+            }.getOrNull()
+            assertNull(other)
+        } finally {
+            DaemonInstanceLock.release()
+        }
+        // Released (old daemon exited) → the next daemon can take over.
+        assertTrue(DaemonInstanceLock.tryAcquire())
+        DaemonInstanceLock.release()
+    }
+
     private fun newTempDir(): String =
         java.nio.file.Files.createTempDirectory("bossterm-paths").toFile().absolutePath
 


### PR DESCRIPTION
## Problem

Launching the packaged app (1.2.124, first build where the packaged daemon can actually spawn, #315) can put **two BossTerm daemon icons in the macOS menu bar**.

At GUI startup two coroutines run concurrently:

1. `DaemonClient.ensureConnected()` — finds no daemon, takes the `daemon.lock` spawn guard, spawns a daemon as a child process.
2. `LoginServiceManager.install()` — "refreshes" the login service via `launchctl bootout` + `bootstrap`; with `RunAtLoad=true`, bootstrap starts a second daemon **immediately**.

Both daemons start in the same instant. The daemon's self-guard (read `daemon.port`, PING) is check-then-act, so both pass it before either has bound its control channel. Result: two daemons → two tray icons, and the loser overwrites `daemon.port`, orphaning the daemon the GUI attached to (observed live: GUI attached to port 51073 while `daemon.port` said 51076, plus a `BindException` on the MCP port from the losing daemon).

The `daemon.lock` guard only serializes GUI-initiated spawns — launchd/systemd starts bypass it entirely.

## Fix (three layers)

- **`DaemonInstanceLock`** (`daemon.instance.lock`): OS file lock acquired at daemon startup and held for the process lifetime — atomic arbiter across **all** spawn paths (GUI spawn, launchd, systemd, manual). Losers exit 0 so launchd's `KeepAlive(SuccessfulExit=false)` doesn't respawn them into the same contention. Deliberately a different file from `daemon.lock` (the GUI holds that one across spawn+await). The PING probe stays as a backstop against daemons from older builds.
- **`Main.kt`**: `LoginServiceManager.install()` now runs strictly *after* `ensureConnected()` settles, not concurrently.
- **`installMac()`**: never `bootout` a registered service — that kills a running daemon (and its sessions) on every app launch just to refresh the baked command. If registered, only rewrite the plist (launchd re-reads it at next login, when the refreshed command matters); bootstrap only when not registered.

## Testing

- `:compose-ui:desktopTest` DaemonInfraTest — 9/9 pass, including new `instance lock is exclusive while held and reacquirable after release`.
- `:bossterm-app:compileKotlinDesktop` compiles clean.
- Reproduced the duplicate live before the fix (pids 7710 GUI-spawned + 7718 launchd, both up at 18:47:02, two tray icons, clobbered `daemon.port`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)