### PR TITLE
fix(splits): divider drag reads live sizes — fixes sluggish/over-shooting drags

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitDivider.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitDivider.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
@@ -94,12 +92,17 @@ fun SplitDragHandle(
     /** Called when the drag ends (or is cancelled) — used to commit the final ratio to a host. */
     onDragEnd: () -> Unit = {}
 ) {
-    // Track the starting ratio when drag begins
-    var startRatio by remember { mutableFloatStateOf(currentRatio) }
-    var cumulativeDelta by remember { mutableFloatStateOf(0f) }
-
-    // Calculate max ratio based on min (ensures both panes respect minimum)
-    val maxRatio = 1f - minRatio
+    // The pointerInput block below never restarts (its key never changes for a live split),
+    // so parameters captured directly would stay frozen at their first-composition values:
+    // a stale availableSize scales every drag by oldSize/newSize (sluggish or overshooting
+    // dividers after the container resizes), and a stale currentRatio snaps the divider back
+    // to its original position when the next drag starts. Read live values via
+    // rememberUpdatedState instead.
+    val latestRatio by rememberUpdatedState(currentRatio)
+    val latestAvailableSize by rememberUpdatedState(availableSize)
+    val latestMinRatio by rememberUpdatedState(minRatio)
+    val latestOnRatioChange by rememberUpdatedState(onRatioChange)
+    val latestOnDragEnd by rememberUpdatedState(onDragEnd)
 
     // Apply resize cursor based on orientation using direct AWT manipulation
     val cursorModifier = when (orientation) {
@@ -118,19 +121,20 @@ fun SplitDragHandle(
             .alpha(0f) // Invisible
             .then(cursorModifier)
             .pointerInput(orientation) {
+                // Track the starting ratio when drag begins
+                var startRatio = 0f
+                var cumulativeDelta = 0f
                 detectDragGestures(
                     onDragStart = {
                         // Capture the ratio at drag start
-                        startRatio = currentRatio
+                        startRatio = latestRatio
                         cumulativeDelta = 0f
                     },
                     onDragEnd = {
-                        cumulativeDelta = 0f
-                        onDragEnd()
+                        latestOnDragEnd()
                     },
                     onDragCancel = {
-                        cumulativeDelta = 0f
-                        onDragEnd()
+                        latestOnDragEnd()
                     },
                     onDrag = { change, dragAmount ->
                         change.consume()
@@ -141,9 +145,10 @@ fun SplitDragHandle(
                         cumulativeDelta += delta
 
                         // Calculate new ratio from start ratio + cumulative delta
-                        val deltaRatio = cumulativeDelta / availableSize
-                        val newRatio = (startRatio + deltaRatio).coerceIn(minRatio, maxRatio)
-                        onRatioChange(newRatio)
+                        val deltaRatio = cumulativeDelta / latestAvailableSize
+                        val maxRatio = 1f - latestMinRatio
+                        val newRatio = (startRatio + deltaRatio).coerceIn(latestMinRatio, maxRatio)
+                        latestOnRatioChange(newRatio)
                     }
                 )
             }


### PR DESCRIPTION
## Problem

Split-divider drags felt sluggish, and sometimes moved further than the pointer ("gain"). Re-grabbing a divider could also snap it back toward its original position.

## Root cause

`SplitDragHandle`'s `pointerInput(orientation)` coroutine never restarts (the key never changes for a live split), so its gesture lambdas kept the **first composition's** captures:

- stale `availableSize` → every drag scaled by `oldSize/newSize` after the container resized (window resize, sidebar toggle, or an outer divider moving a nested split) — sluggish when the container shrank, over-shooting when it grew
- stale `currentRatio` → `onDragStart` reset the divider toward the ratio it had when the split was created

## Fix

Route `currentRatio`, `availableSize`, `minRatio`, `onRatioChange` and `onDragEnd` through `rememberUpdatedState` so the long-lived gesture always reads live values. `startRatio`/`cumulativeDelta` become plain locals inside the gesture block (they never needed to be composition state).

## Testing

- `:compose-ui:compileKotlinDesktop` clean
- Manually verified in `bossterm-app`: divider tracks the pointer 1:1, including after maximizing/resizing the window and when re-grabbing a previously moved divider

🤖 Generated with [Claude Code](https://claude.com/claude-code)