### PR TITLE
fix(mcp): self-heal stale CLI registrations + connection-time port resolution

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -931,6 +931,12 @@ private suspend fun initializeProcess(
             // (e.g. Claude Code) pick the matching `mcp__<name>__*` toolset. An
             // explicit override in `environment` still wins (applied last).
             put("BOSS_MCP_SERVER", McpTerminalRegistry.mcpServerName)
+            // Live port for Claude Code's ${VAR:-default} URL expansion — see
+            // McpTerminalRegistry.mcpPortEnvVar. Skipped while the server is
+            // down; the registered default takes over.
+            McpTerminalRegistry.runningPort.value?.let {
+                put(McpTerminalRegistry.mcpPortEnvVar, it.toString())
+            }
             // Set PWD to match actual working directory (required for Starship and other prompts)
             put("PWD", effectiveWorkingDir)
             environment?.let { putAll(it) }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -16,6 +16,7 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -158,6 +159,16 @@ class BossTermMcpManager(
         }
 
         watcherJob = parentScope.launch {
+            // Before the first bind (and thus the first auto-reattach), adopt
+            // registrations that already exist in the CLIs' own config files
+            // but are missing from our persisted set. The persisted set can
+            // lose entries (historically a single failed quiet reattach
+            // dropped the target for good), after which the CLI's registered
+            // endpoint froze on a stale port with no code path left to repair
+            // it. The CLI config is the canonical record — trust it. Runs
+            // inside this job so it is guaranteed to complete before the
+            // first reconcile/bind kicks off the reattach fan-out.
+            adoptExternallyRegisteredTargets()
             settingsManager.settings
                 .map { McpRuntimeConfig(enabled = it.mcpEnabled, port = it.mcpPort) }
                 .distinctUntilChanged()
@@ -509,11 +520,40 @@ class BossTermMcpManager(
     }
 
     /**
+     * Merge registrations found in the CLIs' own config files into the
+     * persisted attached-targets set. See [McpRegistrationScanner] for the
+     * why and the (conservative) matching rules. markAttached persists, so
+     * the adoption also survives to future launches.
+     */
+    private suspend fun adoptExternallyRegisteredTargets() {
+        val adopted = try {
+            withContext(Dispatchers.IO) {
+                McpRegistrationScanner.scan(config.serverName)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            log.warn("Registration scan failed: {}", t.message)
+            return
+        }
+        val missing = adopted - registry.attachedTargets.value
+        if (missing.isEmpty()) return
+        log.info(
+            "Adopting existing MCP registration(s) from CLI config: {}",
+            missing.joinToString { it.displayName }
+        )
+        missing.forEach { registry.markAttached(it) }
+    }
+
+    /**
      * Re-run `<cli> mcp add` (quiet mode) for every CLI in the persisted
      * attached-targets set. Lets a user's saved attachments survive port
-     * changes between launches — and fixes them silently. If a CLI's
-     * binary is missing now (uninstalled since last run), we drop it from
-     * the persisted set instead of polluting the clipboard.
+     * changes between launches — and fixes them silently. A failure keeps
+     * the target persisted: attach failures are usually transient (missing
+     * binary on a packaged app's bare PATH, a timeout), and dropping the
+     * target here is what used to freeze the CLI's registered endpoint on a
+     * stale port forever. A genuinely uninstalled CLI costs one quiet
+     * background retry per bind, which is harmless.
      */
     private fun launchAutoReattach(port: Int) {
         val targets = registry.attachedTargets.value
@@ -536,10 +576,9 @@ class BossTermMcpManager(
             outcomes.forEach { (target, result) ->
                 if (result is McpAttachResult.CopiedToClipboard) {
                     log.warn(
-                        "Auto-reattach failed for {}: {}; dropping from persisted set",
+                        "Auto-reattach failed for {}: {} — keeping it persisted; will retry on next bind",
                         target.displayName, result.reason
                     )
-                    registry.markDetached(target)
                 }
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -159,16 +159,13 @@ class BossTermMcpManager(
         }
 
         watcherJob = parentScope.launch {
-            // Before the first bind (and thus the first auto-reattach), adopt
-            // registrations that already exist in the CLIs' own config files
-            // but are missing from our persisted set. The persisted set can
-            // lose entries (historically a single failed quiet reattach
-            // dropped the target for good), after which the CLI's registered
-            // endpoint froze on a stale port with no code path left to repair
-            // it. The CLI config is the canonical record — trust it. Runs
-            // inside this job so it is guaranteed to complete before the
-            // first reconcile/bind kicks off the reattach fan-out.
-            adoptExternallyRegisteredTargets()
+            // Before the first bind (and thus the first auto-reattach),
+            // reconcile the persisted set against the CLIs' own config files
+            // (adopt entries we're missing, prune ones the user removed) —
+            // the CLI config is the canonical record. Runs inside this job so
+            // it is guaranteed to complete before the first reconcile/bind
+            // kicks off the reattach fan-out.
+            reconcileTargetsWithCliConfigs()
             settingsManager.settings
                 .map { McpRuntimeConfig(enabled = it.mcpEnabled, port = it.mcpPort) }
                 .distinctUntilChanged()
@@ -520,13 +517,19 @@ class BossTermMcpManager(
     }
 
     /**
-     * Merge registrations found in the CLIs' own config files into the
-     * persisted attached-targets set. See [McpRegistrationScanner] for the
-     * why and the (conservative) matching rules. markAttached persists, so
-     * the adoption also survives to future launches.
+     * Reconcile the persisted attached-targets set against the CLIs' own
+     * config files — the canonical record. Two directions:
+     *  - ADOPT targets whose config carries our loopback entry but that are
+     *    missing from the persisted set (heals the historical drop-on-failure
+     *    bug with zero clicks).
+     *  - PRUNE persisted targets whose config cleanly lacks the entry: the
+     *    user removed it (e.g. `claude mcp remove boss`) and auto-reattach
+     *    must not keep resurrecting it. UNKNOWN (unreadable config right now)
+     *    never prunes — see [McpRegistrationScanner.Presence].
+     * Both mark* calls persist, so the outcome survives to future launches.
      */
-    private suspend fun adoptExternallyRegisteredTargets() {
-        val adopted = try {
+    private suspend fun reconcileTargetsWithCliConfigs() {
+        val presence = try {
             withContext(Dispatchers.IO) {
                 McpRegistrationScanner.scan(config.serverName)
             }
@@ -536,13 +539,23 @@ class BossTermMcpManager(
             log.warn("Registration scan failed: {}", t.message)
             return
         }
-        val missing = adopted - registry.attachedTargets.value
-        if (missing.isEmpty()) return
-        log.info(
-            "Adopting existing MCP registration(s) from CLI config: {}",
-            missing.joinToString { it.displayName }
-        )
-        missing.forEach { registry.markAttached(it) }
+        val persisted = registry.attachedTargets.value
+        val adopt = presence.filterValues { it == McpRegistrationScanner.Presence.PRESENT }.keys - persisted
+        val prune = persisted.filter { presence[it] == McpRegistrationScanner.Presence.ABSENT }
+        if (adopt.isNotEmpty()) {
+            log.info(
+                "Adopting existing MCP registration(s) from CLI config: {}",
+                adopt.joinToString { it.displayName }
+            )
+            adopt.forEach { registry.markAttached(it) }
+        }
+        if (prune.isNotEmpty()) {
+            log.info(
+                "Pruning persisted MCP target(s) no longer registered in their CLI config: {}",
+                prune.joinToString { it.displayName }
+            )
+            prune.forEach { registry.markDetached(it) }
+        }
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolver.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolver.kt
@@ -1,9 +1,12 @@
 package ai.rever.bossterm.compose.mcp
 
+import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Resolves an AI-CLI binary name (`claude`, `codex`, `gemini`, `node`, …) to
@@ -51,27 +54,49 @@ internal object CliBinaryResolver {
      */
     private val missedAtNanos = ConcurrentHashMap<String, Long>()
 
+    /**
+     * In-flight resolutions by binary name: the first caller probes, and
+     * concurrent callers for the same name wait on its future instead of each
+     * spawning their own up-to-5s login-shell probe. A bind's auto-reattach
+     * fan-out hits the same binary from several coroutines at once (remove +
+     * add per target), which the TTL caches alone can't collapse — they're
+     * only written after the first probe finishes.
+     */
+    private val inFlight = ConcurrentHashMap<String, CompletableFuture<String>>()
+
     /** Resolve [binary] using the real process environment. Cached. */
     fun resolve(binary: String): String {
         if (binary.contains('/') || binary.contains('\\')) return binary
         cache[binary]?.let { return it }
         val now = System.nanoTime()
         if (isFreshMiss(binary, now)) return binary
-        val resolved = resolveUncached(
-            binary = binary,
-            pathValue = System.getenv("PATH").orEmpty(),
-            extraDirs = wellKnownDirs(System.getProperty("user.home").orEmpty()),
-            isWindows = System.getProperty("os.name").orEmpty().contains("windows", ignoreCase = true),
-            loginShellProbe = ::probeLoginShell
-        )
-        if (resolved != binary) {
-            missedAtNanos.remove(binary)
-            cache[binary] = resolved
-            log.info("Resolved CLI '{}' -> {}", binary, resolved)
-        } else {
-            missedAtNanos[binary] = now
+        val mine = CompletableFuture<String>()
+        inFlight.putIfAbsent(binary, mine)?.let { winner -> return winner.join() }
+        try {
+            val resolved = resolveUncached(
+                binary = binary,
+                pathValue = System.getenv("PATH").orEmpty(),
+                extraDirs = wellKnownDirs(System.getProperty("user.home").orEmpty()),
+                isWindows = ShellCustomizationUtils.isWindows(),
+                loginShellProbe = ::probeLoginShell
+            )
+            if (resolved != binary) {
+                missedAtNanos.remove(binary)
+                cache[binary] = resolved
+                log.info("Resolved CLI '{}' -> {}", binary, resolved)
+            } else {
+                missedAtNanos[binary] = now
+            }
+            mine.complete(resolved)
+            return resolved
+        } catch (t: Throwable) {
+            // Waiters degrade to the bare name (same as a miss); the thrower
+            // reports the real failure to its own caller.
+            mine.complete(binary)
+            throw t
+        } finally {
+            inFlight.remove(binary)
         }
-        return resolved
     }
 
     /** True while a recorded miss for [binary] is younger than the TTL. */
@@ -153,16 +178,34 @@ internal object CliBinaryResolver {
         val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() } ?: "/bin/sh"
         return try {
             val process = ProcessBuilder(shell, "-l", "-c", "command -v $binary")
-                .redirectErrorStream(false)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
                 .start()
             process.outputStream.close()
+            // Drain stdout on a daemon thread while we wait: a login profile
+            // that echoes an MOTD/banner larger than the OS pipe buffer would
+            // otherwise block the child on write until the timeout kills it,
+            // turning a resolvable binary into a spurious 5s miss. stderr is
+            // discarded at the OS level above for the same reason.
+            val output = AtomicReference("")
+            val drainer = Thread {
+                try {
+                    output.set(process.inputStream.bufferedReader().readText())
+                } catch (_: Throwable) {
+                    // ignore: output stays empty
+                }
+            }.apply {
+                isDaemon = true
+                name = "cli-resolver-probe-drain"
+                start()
+            }
             if (!process.waitFor(LOGIN_SHELL_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
                 log.warn("Login-shell probe for '{}' timed out", binary)
                 return null
             }
+            drainer.join(1_000)
             if (process.exitValue() != 0) return null
-            process.inputStream.bufferedReader().readText().lineSequence()
+            output.get().lineSequence()
                 .map { it.trim() }
                 .firstOrNull { it.startsWith("/") }
         } catch (t: Throwable) {
@@ -173,6 +216,10 @@ internal object CliBinaryResolver {
 
     private const val LOGIN_SHELL_TIMEOUT_SECONDS = 5L
 
-    /** 60s: long enough to collapse one bind's attach fan-out into a single probe. */
+    /**
+     * 60s: keeps sequential re-lookups cheap (a target's remove+add pair,
+     * back-to-back binds). Concurrent lookups within one fan-out are
+     * collapsed by [inFlight], not this TTL.
+     */
     private const val NEGATIVE_CACHE_TTL_NANOS = 60_000_000_000L
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolver.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolver.kt
@@ -38,12 +38,25 @@ internal object CliBinaryResolver {
 
     private val log = LoggerFactory.getLogger(CliBinaryResolver::class.java)
 
-    /** Positive results only — a CLI installed mid-session is found on the next call. */
+    /** Positive results, kept for the process lifetime. */
     private val cache = ConcurrentHashMap<String, String>()
+
+    /**
+     * Misses, remembered for [NEGATIVE_CACHE_TTL_NANOS]. A full miss costs a
+     * dir scan plus an up-to-5s login-shell probe, and a persisted target
+     * whose CLI is genuinely uninstalled retries on every bind (remove + add
+     * = two resolutions per attach) — without this, that's the probe cost ×2
+     * ×N targets on the IO dispatcher per bind. The TTL is short so a user
+     * who installs the CLI and clicks Attach isn't stuck behind a stale miss.
+     */
+    private val missedAtNanos = ConcurrentHashMap<String, Long>()
 
     /** Resolve [binary] using the real process environment. Cached. */
     fun resolve(binary: String): String {
+        if (binary.contains('/') || binary.contains('\\')) return binary
         cache[binary]?.let { return it }
+        val now = System.nanoTime()
+        if (isFreshMiss(binary, now)) return binary
         val resolved = resolveUncached(
             binary = binary,
             pathValue = System.getenv("PATH").orEmpty(),
@@ -52,10 +65,28 @@ internal object CliBinaryResolver {
             loginShellProbe = ::probeLoginShell
         )
         if (resolved != binary) {
+            missedAtNanos.remove(binary)
             cache[binary] = resolved
             log.info("Resolved CLI '{}' -> {}", binary, resolved)
+        } else {
+            missedAtNanos[binary] = now
         }
         return resolved
+    }
+
+    /** True while a recorded miss for [binary] is younger than the TTL. */
+    internal fun isFreshMiss(binary: String, nowNanos: Long): Boolean {
+        val missed = missedAtNanos[binary] ?: return false
+        return nowNanos - missed < NEGATIVE_CACHE_TTL_NANOS
+    }
+
+    internal fun noteMiss(binary: String, nowNanos: Long) {
+        missedAtNanos[binary] = nowNanos
+    }
+
+    internal fun clearForTest() {
+        cache.clear()
+        missedAtNanos.clear()
     }
 
     /**
@@ -137,4 +168,7 @@ internal object CliBinaryResolver {
     }
 
     private const val LOGIN_SHELL_TIMEOUT_SECONDS = 5L
+
+    /** 60s: long enough to collapse one bind's attach fan-out into a single probe. */
+    private const val NEGATIVE_CACHE_TTL_NANOS = 60_000_000_000L
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolver.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolver.kt
@@ -105,7 +105,11 @@ internal object CliBinaryResolver {
         if (binary.contains('/') || binary.contains('\\')) return binary
         if (isWindows) return binary
 
-        val pathDirs = pathValue.split(':').filter { it.isNotBlank() }.map(::File)
+        // The platform separator, not ':' — a literal ':' split would shred
+        // Windows entries at the drive colon (D:\foo). Production never gets
+        // here on Windows (early return above), but the host-correct split
+        // keeps the function honest for tests and future callers.
+        val pathDirs = pathValue.split(File.pathSeparatorChar).filter { it.isNotBlank() }.map(::File)
         for (dir in pathDirs + extraDirs) {
             val candidate = File(dir, binary)
             if (candidate.isFile && candidate.canExecute()) return candidate.absolutePath

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolver.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolver.kt
@@ -1,0 +1,140 @@
+package ai.rever.bossterm.compose.mcp
+
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+/**
+ * Resolves an AI-CLI binary name (`claude`, `codex`, `gemini`, `node`, …) to
+ * an absolute path that [ProcessBuilder] can spawn even when the JVM's
+ * inherited `PATH` is the bare launchd default.
+ *
+ * Why this exists: a packaged desktop app launched from Finder/the Dock
+ * inherits `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — none of the places these
+ * CLIs actually live (`~/.local/bin`, `/opt/homebrew/bin`, …). Every
+ * `claude mcp add` shell-out then dies with "CLI not found", the startup
+ * auto-reattach silently fails, and the CLI's registered endpoint is left
+ * pointing at a stale port until the user manually re-runs the attach from a
+ * real terminal. Resolving to an absolute path here makes attach work the
+ * same from a packaged app as from `gradlew run`.
+ *
+ * Resolution order (first executable match wins, result cached per name):
+ *  1. The inherited `PATH`, exactly what ProcessBuilder would search.
+ *  2. A short list of well-known install dirs (Homebrew, npm/bun/volta
+ *     globals, the Claude Code native installer's `~/.local/bin`, …).
+ *  3. A best-effort `$SHELL -l -c 'command -v <name>'` login-shell probe,
+ *     which picks up PATH exports from the user's shell profile (nvm, asdf,
+ *     custom prefixes). Bounded by a 5s timeout.
+ *
+ * If nothing is found the original name is returned unchanged so the caller
+ * hits the existing IOException → clipboard-fallback path.
+ *
+ * Windows note: GUI apps there inherit the full user PATH from the registry,
+ * and PATHEXT handling makes manual probing subtly wrong — so on Windows the
+ * name is returned as-is and ProcessBuilder's own lookup applies.
+ */
+internal object CliBinaryResolver {
+
+    private val log = LoggerFactory.getLogger(CliBinaryResolver::class.java)
+
+    /** Positive results only — a CLI installed mid-session is found on the next call. */
+    private val cache = ConcurrentHashMap<String, String>()
+
+    /** Resolve [binary] using the real process environment. Cached. */
+    fun resolve(binary: String): String {
+        cache[binary]?.let { return it }
+        val resolved = resolveUncached(
+            binary = binary,
+            pathValue = System.getenv("PATH").orEmpty(),
+            extraDirs = wellKnownDirs(System.getProperty("user.home").orEmpty()),
+            isWindows = System.getProperty("os.name").orEmpty().contains("windows", ignoreCase = true),
+            loginShellProbe = ::probeLoginShell
+        )
+        if (resolved != binary) {
+            cache[binary] = resolved
+            log.info("Resolved CLI '{}' -> {}", binary, resolved)
+        }
+        return resolved
+    }
+
+    /**
+     * Pure resolution core, parameterized for tests. Returns [binary]
+     * unchanged when no executable is found (or when resolution doesn't
+     * apply: absolute/relative paths, Windows).
+     */
+    internal fun resolveUncached(
+        binary: String,
+        pathValue: String,
+        extraDirs: List<File>,
+        isWindows: Boolean,
+        loginShellProbe: (String) -> String? = { null }
+    ): String {
+        // Embedders may already pass an explicit path — honor it untouched.
+        if (binary.contains('/') || binary.contains('\\')) return binary
+        if (isWindows) return binary
+
+        val pathDirs = pathValue.split(':').filter { it.isNotBlank() }.map(::File)
+        for (dir in pathDirs + extraDirs) {
+            val candidate = File(dir, binary)
+            if (candidate.isFile && candidate.canExecute()) return candidate.absolutePath
+        }
+
+        val fromShell = loginShellProbe(binary)
+        if (fromShell != null) {
+            val candidate = File(fromShell)
+            if (candidate.isFile && candidate.canExecute()) return candidate.absolutePath
+        }
+        return binary
+    }
+
+    internal fun wellKnownDirs(home: String): List<File> = listOf(
+        // Claude Code's native installer target; also a common pipx/user-local bin.
+        "$home/.local/bin",
+        // Homebrew (Apple Silicon, then Intel/Linuxbrew).
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/home/linuxbrew/.linuxbrew/bin",
+        // Claude Code's legacy local-install shim.
+        "$home/.claude/local",
+        // JS toolchain globals (node for the OpenCode config script, npm-installed CLIs).
+        "$home/.bun/bin",
+        "$home/.npm-global/bin",
+        "$home/.volta/bin",
+        "$home/.asdf/shims",
+        "$home/bin"
+    ).map(::File)
+
+    /**
+     * Ask the user's login shell where [binary] lives. Login (not interactive)
+     * mode: profile files carry the PATH exports we need without the prompt/rc
+     * machinery that can hang a headless spawn. Best-effort — any failure or
+     * timeout returns null.
+     */
+    private fun probeLoginShell(binary: String): String? {
+        // The names we probe come from the fixed McpAttachTarget command
+        // tables, but quote defensively anyway.
+        if (!binary.all { it.isLetterOrDigit() || it in "._-" }) return null
+        val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() } ?: "/bin/sh"
+        return try {
+            val process = ProcessBuilder(shell, "-l", "-c", "command -v $binary")
+                .redirectErrorStream(false)
+                .start()
+            process.outputStream.close()
+            if (!process.waitFor(LOGIN_SHELL_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                log.warn("Login-shell probe for '{}' timed out", binary)
+                return null
+            }
+            if (process.exitValue() != 0) return null
+            process.inputStream.bufferedReader().readText().lineSequence()
+                .map { it.trim() }
+                .firstOrNull { it.startsWith("/") }
+        } catch (t: Throwable) {
+            log.debug("Login-shell probe for '{}' failed: {}", binary, t.message)
+            null
+        }
+    }
+
+    private const val LOGIN_SHELL_TIMEOUT_SECONDS = 5L
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -338,9 +338,15 @@ object McpCliAttacher {
      * mid-wait (e.g. the user closed the window), the child process is
      * destroyForcibly'd before the InterruptedException is rethrown, so we
      * don't leave a `claude mcp add` zombie running after dispose.
+     *
+     * The command head is resolved to an absolute path via [CliBinaryResolver]
+     * — a packaged app launched from Finder/the Dock inherits the bare launchd
+     * `PATH`, where none of these CLIs are findable and every attach would
+     * otherwise die with "CLI not found".
      */
     private fun runProcess(cmd: List<String>): ProcessOutcome {
-        val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+        val resolved = listOf(CliBinaryResolver.resolve(cmd.first())) + cmd.drop(1)
+        val process = ProcessBuilder(resolved).redirectErrorStream(true).start()
         try {
             // Signal EOF to any CLI that might be waiting on stdin.
             try {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -46,8 +46,9 @@ private const val OPENCODE_REMOVE_SCRIPT = "" +
  *
  * The `{NAME}` placeholder in command/clipboard templates is filled with
  * the embedder's `BossTermMcpConfig.serverName` (or `"bossterm"` for the
- * default app), and `{URL}` with the resolved
- * `http://127.0.0.1:<port>` endpoint.
+ * default app), and `{URL}` with the target's [McpAttachTarget.registrationUrl]
+ * — plain `http://127.0.0.1:<port>` for most CLIs, the `${VAR:-port}`
+ * env-expanded form for Claude Code.
  *
  * Tested CLI shapes (last verified May 2026):
  *  - Claude Code: `claude mcp add --transport sse <name> <url>` (verified)
@@ -100,8 +101,21 @@ enum class McpAttachTarget(
             "--transport", "sse",
             "{NAME}", "{URL}"
         ),
-        clipboardFallback = "claude mcp add --scope user --transport sse {NAME} {URL}"
-    ),
+        // {URL} is the ${VAR:-port} form (see registrationUrl) — single-quoted
+        // so a shell the user pastes this into doesn't expand the variable
+        // right there and freeze the URL to a concrete port.
+        clipboardFallback = "claude mcp add --scope user --transport sse {NAME} '{URL}'"
+    ) {
+        // Claude Code expands ${VAR:-default} in registered URLs from the
+        // env of each `claude` process (verified against Claude Code 2.x,
+        // user scope). Our PTYs export the per-embedder port var, so a
+        // session inside one of our terminals dials THIS instance's actual
+        // bound port; sessions outside any of our terminals fall back to
+        // [port], which the manager's auto-reattach keeps current. The
+        // other CLIs have no documented expansion — they stay on plain URLs.
+        override fun registrationUrl(serverName: String, port: Int): String =
+            "http://127.0.0.1:\${${McpTerminalRegistry.portEnvVarName(serverName)}:-$port}"
+    },
     CODEX(
         displayName = "Codex",
         persistenceKey = "CODEX",
@@ -179,6 +193,14 @@ enum class McpAttachTarget(
         """.trimIndent()
     );
 
+    /**
+     * The URL string registered with this CLI for a server named [serverName]
+     * bound to [port]. Plain `http://127.0.0.1:<port>` by default; CLAUDE_CODE
+     * overrides with the `${VAR:-port}` env-expanded form (see its entry).
+     */
+    open fun registrationUrl(serverName: String, port: Int): String =
+        "http://127.0.0.1:$port"
+
     fun resolvedAddCommand(name: String, url: String): List<String>? =
         addCommand?.map { it.replace("{NAME}", name).replace("{URL}", url) }
 
@@ -247,7 +269,9 @@ object McpCliAttacher {
             // SDK 0.8.3 mounts SSE+POST at the application root; the path
             // overload is broken (see BossTermMcpManager kdoc). So the URL
             // we register with each CLI is loopback + port, no path suffix.
-            val url = "http://127.0.0.1:$port"
+            // Per-target form: Claude Code gets the ${VAR:-port} env-expanded
+            // variant so in-terminal sessions track this instance's live port.
+            val url = target.registrationUrl(serverName, port)
             try {
                 // First, best-effort remove. Many CLIs' `mcp add` is not
                 // idempotent — this turns "already exists" errors into a

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScanner.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScanner.kt
@@ -7,20 +7,22 @@ import org.slf4j.LoggerFactory
 import java.io.File
 
 /**
- * Detects which AI CLIs already carry a registration for this embedder's MCP
- * server by reading their config files directly (read-only).
+ * Reads the AI CLIs' own config files (read-only) to report whether each one
+ * currently carries a registration for this embedder's MCP server.
  *
  * Why: the persisted attached-targets set ([McpTerminalRegistry.attachedTargets])
- * can drift out of sync with reality — historically a single failed quiet
- * reattach dropped the target from settings, after which startup auto-reattach
- * never ran again and the CLI's registered endpoint froze on whatever port it
- * last saw. The CLI config file is the canonical record; scanning it lets the
- * manager re-adopt those registrations on startup so the port they point at is
- * rewritten to the actually-bound one with zero user interaction.
+ * can drift out of sync with reality in both directions — historically a
+ * single failed quiet reattach dropped the target from settings (freezing the
+ * CLI's registered endpoint on a stale port), and conversely a user who ran
+ * `claude mcp remove` by hand kept getting the entry resurrected by the next
+ * bind's auto-reattach. The CLI config file is the canonical record; the
+ * manager reconciles the persisted set against this scan on startup — adopting
+ * entries we're missing, pruning ones the user removed.
  *
- * Matching is deliberately conservative: an entry counts only when it has the
- * exact server name AND a loopback URL — a user's hand-written entry pointing
- * at a remote host is never adopted (we must not rewrite it to 127.0.0.1).
+ * Matching is deliberately conservative: an entry counts as PRESENT only when
+ * it has the exact server name AND a loopback URL. A same-named entry pointing
+ * at a remote host reports ABSENT — we neither adopt it nor keep auto-rewriting
+ * it to 127.0.0.1; it belongs to the user.
  */
 internal object McpRegistrationScanner {
 
@@ -28,15 +30,23 @@ internal object McpRegistrationScanner {
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    /** All targets whose config registers a loopback server named [serverName]. */
+    /**
+     * Per-CLI registration state. UNKNOWN (config unreadable/malformed right
+     * now) is distinct from ABSENT on purpose: the manager prunes persisted
+     * targets only on a clean ABSENT — pruning on a transient read failure
+     * would silently disable auto-reattach, the exact bug this file exists
+     * to prevent.
+     */
+    enum class Presence { PRESENT, ABSENT, UNKNOWN }
+
+    /** Registration state of a loopback server named [serverName], per CLI. */
     fun scan(
         serverName: String,
         home: File = File(System.getProperty("user.home"))
-    ): Set<McpAttachTarget> {
-        val found = mutableSetOf<McpAttachTarget>()
-        for (target in McpAttachTarget.entries) {
-            val registered = try {
-                when (target) {
+    ): Map<McpAttachTarget, Presence> =
+        McpAttachTarget.entries.associateWith { target ->
+            try {
+                val registered = when (target) {
                     McpAttachTarget.CLAUDE_CODE ->
                         jsonHasLoopbackEntry(File(home, ".claude.json"), "mcpServers", serverName)
                     McpAttachTarget.GEMINI ->
@@ -46,15 +56,12 @@ internal object McpRegistrationScanner {
                     McpAttachTarget.CODEX ->
                         codexTomlHasLoopbackEntry(File(home, ".codex/config.toml"), serverName)
                 }
+                if (registered) Presence.PRESENT else Presence.ABSENT
             } catch (t: Throwable) {
-                // A malformed config file must never break startup; just skip it.
                 log.warn("Could not scan {} config: {}", target.displayName, t.message)
-                false
+                Presence.UNKNOWN
             }
-            if (registered) found += target
         }
-        return found
-    }
 
     /**
      * True when [file] parses as JSON and `<containerKey>.<serverName>` exists

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScanner.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScanner.kt
@@ -87,8 +87,15 @@ internal object McpRegistrationScanner {
                     line == "[mcp_servers.\"$serverName\"]"
                 continue
             }
-            if (inSection && line.startsWith("url")) {
-                val url = line.substringAfter('=').trim().removeSurrounding("\"")
+            if (inSection && line.substringBefore('=').trim() == "url") {
+                val raw = line.substringAfter('=').trim()
+                // Quoted values end at the closing quote (tolerates trailing
+                // inline comments); unquoted ones are cut at any '#'.
+                val url = if (raw.startsWith("\"")) {
+                    raw.drop(1).substringBefore('"')
+                } else {
+                    raw.substringBefore('#').trim()
+                }
                 return isLoopbackUrl(url)
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScanner.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScanner.kt
@@ -1,0 +1,102 @@
+package ai.rever.bossterm.compose.mcp
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * Detects which AI CLIs already carry a registration for this embedder's MCP
+ * server by reading their config files directly (read-only).
+ *
+ * Why: the persisted attached-targets set ([McpTerminalRegistry.attachedTargets])
+ * can drift out of sync with reality — historically a single failed quiet
+ * reattach dropped the target from settings, after which startup auto-reattach
+ * never ran again and the CLI's registered endpoint froze on whatever port it
+ * last saw. The CLI config file is the canonical record; scanning it lets the
+ * manager re-adopt those registrations on startup so the port they point at is
+ * rewritten to the actually-bound one with zero user interaction.
+ *
+ * Matching is deliberately conservative: an entry counts only when it has the
+ * exact server name AND a loopback URL — a user's hand-written entry pointing
+ * at a remote host is never adopted (we must not rewrite it to 127.0.0.1).
+ */
+internal object McpRegistrationScanner {
+
+    private val log = LoggerFactory.getLogger(McpRegistrationScanner::class.java)
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** All targets whose config registers a loopback server named [serverName]. */
+    fun scan(
+        serverName: String,
+        home: File = File(System.getProperty("user.home"))
+    ): Set<McpAttachTarget> {
+        val found = mutableSetOf<McpAttachTarget>()
+        for (target in McpAttachTarget.entries) {
+            val registered = try {
+                when (target) {
+                    McpAttachTarget.CLAUDE_CODE ->
+                        jsonHasLoopbackEntry(File(home, ".claude.json"), "mcpServers", serverName)
+                    McpAttachTarget.GEMINI ->
+                        jsonHasLoopbackEntry(File(home, ".gemini/settings.json"), "mcpServers", serverName)
+                    McpAttachTarget.OPENCODE ->
+                        jsonHasLoopbackEntry(File(home, ".config/opencode/opencode.json"), "mcp", serverName)
+                    McpAttachTarget.CODEX ->
+                        codexTomlHasLoopbackEntry(File(home, ".codex/config.toml"), serverName)
+                }
+            } catch (t: Throwable) {
+                // A malformed config file must never break startup; just skip it.
+                log.warn("Could not scan {} config: {}", target.displayName, t.message)
+                false
+            }
+            if (registered) found += target
+        }
+        return found
+    }
+
+    /**
+     * True when [file] parses as JSON and `<containerKey>.<serverName>` exists
+     * with a loopback `url`/`httpUrl`. Gemini writes `httpUrl`, the others
+     * `url`; checking both keeps one code path for all three JSON configs.
+     */
+    internal fun jsonHasLoopbackEntry(file: File, containerKey: String, serverName: String): Boolean {
+        if (!file.isFile) return false
+        val text = file.readText()
+        if (text.isBlank()) return false
+        val root = json.parseToJsonElement(text).jsonObject
+        val entry = root[containerKey]?.jsonObject?.get(serverName)?.jsonObject ?: return false
+        val url = (entry["url"] ?: entry["httpUrl"])?.jsonPrimitive?.content ?: return false
+        return isLoopbackUrl(url)
+    }
+
+    /**
+     * Minimal TOML scan for `[mcp_servers.<serverName>]` followed by a
+     * loopback `url = "…"` before the next section header. Codex's config is
+     * machine-written with this exact shape; a full TOML parser isn't worth
+     * the dependency.
+     */
+    internal fun codexTomlHasLoopbackEntry(file: File, serverName: String): Boolean {
+        if (!file.isFile) return false
+        var inSection = false
+        for (rawLine in file.readLines()) {
+            val line = rawLine.trim()
+            if (line.startsWith("[")) {
+                inSection = line == "[mcp_servers.$serverName]" ||
+                    line == "[mcp_servers.\"$serverName\"]"
+                continue
+            }
+            if (inSection && line.startsWith("url")) {
+                val url = line.substringAfter('=').trim().removeSurrounding("\"")
+                return isLoopbackUrl(url)
+            }
+        }
+        return false
+    }
+
+    internal fun isLoopbackUrl(url: String): Boolean {
+        val host = url.substringAfter("://", "").substringBefore('/').substringBefore(':')
+        return host == "127.0.0.1" || host.equals("localhost", ignoreCase = true)
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -196,7 +196,9 @@ object McpTerminalRegistry {
         }
     }
 
-    /** @suppress Internal — recorded when an attach fails (auto-reattach) or user detaches. */
+    /** @suppress Internal — recorded when the startup reconcile finds the CLI's
+     *  config no longer carries our entry (the user removed it), so
+     *  auto-reattach stops resurrecting a registration the user deleted. */
     internal fun markDetached(target: McpAttachTarget) {
         val next = _attachedTargets.value - target
         if (next != _attachedTargets.value) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -129,6 +129,26 @@ object McpTerminalRegistry {
         mcpServerLabel = label
     }
 
+    /**
+     * Name of the env var carrying this embedder's actually-bound MCP port,
+     * injected into every PTY this app spawns. Claude Code registrations use
+     * it via `${VAR:-default}` URL expansion, so a session inside one of our
+     * terminals always dials THIS instance's port — even when the server
+     * fallback-walked off its configured one — while sessions elsewhere get
+     * the registered default.
+     *
+     * Derived from [mcpServerName] (`boss` → `BOSS_MCP_PORT`, `bossterm` →
+     * `BOSSTERM_MCP_PORT`) rather than shared: with one common var, a session
+     * inside a BossConsole terminal would also expand a standalone BossTerm
+     * registration to BossConsole's port and dial the wrong app's server.
+     */
+    val mcpPortEnvVar: String get() = portEnvVarName(mcpServerName)
+
+    /** See [mcpPortEnvVar]. Non-alphanumerics map to `_` for env-name validity. */
+    fun portEnvVarName(serverName: String): String =
+        serverName.uppercase().map { if (it.isLetterOrDigit()) it else '_' }
+            .joinToString("") + "_MCP_PORT"
+
     // -----------------------------------------------------------------
     // Attached-CLI tracking — written by McpCliAttacher's callers when an
     // attach succeeds; read by the Settings panel and the right-click menus

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -144,10 +144,17 @@ object McpTerminalRegistry {
      */
     val mcpPortEnvVar: String get() = portEnvVarName(mcpServerName)
 
-    /** See [mcpPortEnvVar]. Non-alphanumerics map to `_` for env-name validity. */
-    fun portEnvVarName(serverName: String): String =
-        serverName.uppercase().map { if (it.isLetterOrDigit()) it else '_' }
-            .joinToString("") + "_MCP_PORT"
+    /**
+     * See [mcpPortEnvVar]. Non-alphanumerics map to `_`, and a leading digit
+     * gets an `_` prefix — POSIX identifiers can't start with a digit.
+     */
+    fun portEnvVarName(serverName: String): String {
+        val sanitized = serverName.uppercase()
+            .map { if (it.isLetterOrDigit()) it else '_' }
+            .joinToString("")
+        val prefix = if (sanitized.firstOrNull()?.isDigit() == true) "_" else ""
+        return "$prefix${sanitized}_MCP_PORT"
+    }
 
     // -----------------------------------------------------------------
     // Attached-CLI tracking — written by McpCliAttacher's callers when an

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -1199,6 +1199,14 @@ class TabController(
                 // BossTermMcpConfig.serverName. An explicit override in
                 // config.environment still wins (it is applied last).
                 put("BOSS_MCP_SERVER", McpTerminalRegistry.mcpServerName)
+                // This instance's actually-bound MCP port, consumed by Claude
+                // Code's ${VAR:-default} URL expansion (see McpTerminalRegistry.
+                // mcpPortEnvVar) so in-terminal sessions dial the right instance
+                // even after a fallback-port walk. Omitted when the server isn't
+                // up yet — the registered default takes over.
+                McpTerminalRegistry.runningPort.value?.let {
+                    put(McpTerminalRegistry.mcpPortEnvVar, it.toString())
+                }
                 // Set PWD to match actual working directory (required for Starship and other prompts)
                 put("PWD", config.workingDir ?: System.getProperty("user.home"))
                 putAll(config.environment)
@@ -1374,6 +1382,11 @@ class TabController(
                     // toolset. (This pre-connect path takes no caller-supplied
                     // environment, so there is nothing to override here.)
                     put("BOSS_MCP_SERVER", McpTerminalRegistry.mcpServerName)
+                    // Live port for Claude Code's ${VAR:-default} URL expansion —
+                    // see McpTerminalRegistry.mcpPortEnvVar.
+                    McpTerminalRegistry.runningPort.value?.let {
+                        put(McpTerminalRegistry.mcpPortEnvVar, it.toString())
+                    }
                     // Set PWD to match actual working directory (required for Starship and other prompts)
                     put("PWD", workingDir ?: System.getProperty("user.home"))
                 }.toMutableMap()

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolverTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolverTest.kt
@@ -1,5 +1,7 @@
 package ai.rever.bossterm.compose.mcp
 
+import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
+import org.junit.Assume.assumeFalse
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -58,6 +60,9 @@ class CliBinaryResolverTest {
 
     @Test
     fun `non-executable file is skipped`() {
+        // Windows has no exec bit — canExecute() is true for any readable
+        // file, so "present but not executable" cannot be expressed there.
+        assumeFalse(ShellCustomizationUtils.isWindows())
         val dir = createTempDirectory("cli-resolver-test").toFile().apply { deleteOnExit() }
         File(dir, "claude").apply {
             writeText("not executable")
@@ -130,8 +135,10 @@ class CliBinaryResolverTest {
     @Test
     fun `well-known dirs include the usual install locations`() {
         val dirs = CliBinaryResolver.wellKnownDirs("/Users/someone").map { it.path }
-        assertTrue("/Users/someone/.local/bin" in dirs)
-        assertTrue("/opt/homebrew/bin" in dirs)
-        assertTrue("/usr/local/bin" in dirs)
+        // Expected values built through File so separator normalization
+        // matches on every host (Windows flips these to backslashes).
+        assertTrue(File("/Users/someone/.local/bin").path in dirs)
+        assertTrue(File("/opt/homebrew/bin").path in dirs)
+        assertTrue(File("/usr/local/bin").path in dirs)
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolverTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolverTest.kt
@@ -1,0 +1,119 @@
+package ai.rever.bossterm.compose.mcp
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.io.path.createTempDirectory
+
+class CliBinaryResolverTest {
+
+    private fun tempDirWithExecutable(name: String): Pair<File, File> {
+        val dir = createTempDirectory("cli-resolver-test").toFile().apply { deleteOnExit() }
+        val bin = File(dir, name).apply {
+            writeText("#!/bin/sh\nexit 0\n")
+            setExecutable(true)
+            deleteOnExit()
+        }
+        return dir to bin
+    }
+
+    @Test
+    fun `finds binary on PATH`() {
+        val (dir, bin) = tempDirWithExecutable("claude")
+        val resolved = CliBinaryResolver.resolveUncached(
+            binary = "claude",
+            pathValue = dir.absolutePath,
+            extraDirs = emptyList(),
+            isWindows = false
+        )
+        assertEquals(bin.absolutePath, resolved)
+    }
+
+    @Test
+    fun `falls back to well-known dir when PATH misses`() {
+        val (dir, bin) = tempDirWithExecutable("claude")
+        val resolved = CliBinaryResolver.resolveUncached(
+            binary = "claude",
+            pathValue = "/usr/bin:/bin",
+            extraDirs = listOf(File("/nonexistent-dir"), dir),
+            isWindows = false
+        )
+        assertEquals(bin.absolutePath, resolved)
+    }
+
+    @Test
+    fun `PATH wins over extra dirs`() {
+        val (pathDir, pathBin) = tempDirWithExecutable("claude")
+        val (extraDir, _) = tempDirWithExecutable("claude")
+        val resolved = CliBinaryResolver.resolveUncached(
+            binary = "claude",
+            pathValue = pathDir.absolutePath,
+            extraDirs = listOf(extraDir),
+            isWindows = false
+        )
+        assertEquals(pathBin.absolutePath, resolved)
+    }
+
+    @Test
+    fun `non-executable file is skipped`() {
+        val dir = createTempDirectory("cli-resolver-test").toFile().apply { deleteOnExit() }
+        File(dir, "claude").apply {
+            writeText("not executable")
+            setExecutable(false)
+            deleteOnExit()
+        }
+        val resolved = CliBinaryResolver.resolveUncached(
+            binary = "claude",
+            pathValue = "",
+            extraDirs = listOf(dir),
+            isWindows = false
+        )
+        assertEquals("claude", resolved)
+    }
+
+    @Test
+    fun `login shell probe used as last resort`() {
+        val (_, bin) = tempDirWithExecutable("claude")
+        val resolved = CliBinaryResolver.resolveUncached(
+            binary = "claude",
+            pathValue = "",
+            extraDirs = emptyList(),
+            isWindows = false,
+            loginShellProbe = { bin.absolutePath }
+        )
+        assertEquals(bin.absolutePath, resolved)
+    }
+
+    @Test
+    fun `unresolvable binary returned unchanged`() {
+        val resolved = CliBinaryResolver.resolveUncached(
+            binary = "definitely-not-a-real-cli",
+            pathValue = "/usr/bin:/bin",
+            extraDirs = emptyList(),
+            isWindows = false,
+            loginShellProbe = { null }
+        )
+        assertEquals("definitely-not-a-real-cli", resolved)
+    }
+
+    @Test
+    fun `explicit paths and windows are passed through`() {
+        assertEquals(
+            "/opt/custom/claude",
+            CliBinaryResolver.resolveUncached("/opt/custom/claude", "", emptyList(), isWindows = false)
+        )
+        assertEquals(
+            "claude",
+            CliBinaryResolver.resolveUncached("claude", "", emptyList(), isWindows = true)
+        )
+    }
+
+    @Test
+    fun `well-known dirs include the usual install locations`() {
+        val dirs = CliBinaryResolver.wellKnownDirs("/Users/someone").map { it.path }
+        assertTrue("/Users/someone/.local/bin" in dirs)
+        assertTrue("/opt/homebrew/bin" in dirs)
+        assertTrue("/usr/local/bin" in dirs)
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolverTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/CliBinaryResolverTest.kt
@@ -3,6 +3,7 @@ package ai.rever.bossterm.compose.mcp
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.io.path.createTempDirectory
 
@@ -107,6 +108,23 @@ class CliBinaryResolverTest {
             "claude",
             CliBinaryResolver.resolveUncached("claude", "", emptyList(), isWindows = true)
         )
+    }
+
+    @Test
+    fun `negative cache is honored within TTL and expires after it`() {
+        CliBinaryResolver.clearForTest()
+        try {
+            val t0 = 1_000_000_000L
+            CliBinaryResolver.noteMiss("missing-cli", t0)
+            assertTrue(CliBinaryResolver.isFreshMiss("missing-cli", t0 + 1))
+            assertTrue(CliBinaryResolver.isFreshMiss("missing-cli", t0 + 59_000_000_000L))
+            // Past the 60s TTL the miss is stale — a new probe is allowed.
+            assertFalse(CliBinaryResolver.isFreshMiss("missing-cli", t0 + 61_000_000_000L))
+            // Unknown binaries have no recorded miss.
+            assertFalse(CliBinaryResolver.isFreshMiss("never-seen", t0))
+        } finally {
+            CliBinaryResolver.clearForTest()
+        }
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScannerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScannerTest.kt
@@ -1,0 +1,117 @@
+package ai.rever.bossterm.compose.mcp
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.io.path.createTempDirectory
+
+class McpRegistrationScannerTest {
+
+    private fun tempHome(): File =
+        createTempDirectory("scanner-test-home").toFile().apply { deleteOnExit() }
+
+    private fun File.write(relative: String, content: String) {
+        val f = File(this, relative)
+        f.parentFile.mkdirs()
+        f.writeText(content)
+        f.deleteOnExit()
+    }
+
+    @Test
+    fun `detects claude code loopback registration`() {
+        val home = tempHome()
+        home.write(
+            ".claude.json",
+            """{"someOtherKey": 1, "mcpServers": {"boss": {"type": "sse", "url": "http://127.0.0.1:7679"}}}"""
+        )
+        assertEquals(setOf(McpAttachTarget.CLAUDE_CODE), McpRegistrationScanner.scan("boss", home))
+    }
+
+    @Test
+    fun `server name must match exactly`() {
+        val home = tempHome()
+        home.write(
+            ".claude.json",
+            """{"mcpServers": {"bossterm": {"type": "sse", "url": "http://127.0.0.1:7676"}}}"""
+        )
+        assertTrue(McpRegistrationScanner.scan("boss", home).isEmpty())
+    }
+
+    @Test
+    fun `remote urls are never adopted`() {
+        val home = tempHome()
+        home.write(
+            ".claude.json",
+            """{"mcpServers": {"boss": {"type": "sse", "url": "https://mcp.example.com/sse"}}}"""
+        )
+        assertTrue(McpRegistrationScanner.scan("boss", home).isEmpty())
+    }
+
+    @Test
+    fun `detects gemini httpUrl and opencode url`() {
+        val home = tempHome()
+        home.write(
+            ".gemini/settings.json",
+            """{"mcpServers": {"boss": {"httpUrl": "http://localhost:7677"}}}"""
+        )
+        home.write(
+            ".config/opencode/opencode.json",
+            """{"mcp": {"boss": {"type": "remote", "url": "http://127.0.0.1:7677", "enabled": true}}}"""
+        )
+        assertEquals(
+            setOf(McpAttachTarget.GEMINI, McpAttachTarget.OPENCODE),
+            McpRegistrationScanner.scan("boss", home)
+        )
+    }
+
+    @Test
+    fun `detects codex toml registration`() {
+        val home = tempHome()
+        home.write(
+            ".codex/config.toml",
+            """
+            model = "gpt-5"
+
+            [mcp_servers.boss]
+            url = "http://127.0.0.1:7677"
+
+            [other_section]
+            url = "https://remote.example.com"
+            """.trimIndent()
+        )
+        assertEquals(setOf(McpAttachTarget.CODEX), McpRegistrationScanner.scan("boss", home))
+    }
+
+    @Test
+    fun `codex url outside our section is ignored`() {
+        val home = tempHome()
+        home.write(
+            ".codex/config.toml",
+            """
+            [mcp_servers.other]
+            url = "http://127.0.0.1:9999"
+            """.trimIndent()
+        )
+        assertTrue(McpRegistrationScanner.scan("boss", home).isEmpty())
+    }
+
+    @Test
+    fun `missing empty or malformed files are safe`() {
+        val home = tempHome()
+        home.write(".claude.json", "")
+        home.write(".gemini/settings.json", "{not json!!")
+        assertTrue(McpRegistrationScanner.scan("boss", home).isEmpty())
+    }
+
+    @Test
+    fun `loopback check parses host correctly`() {
+        assertTrue(McpRegistrationScanner.isLoopbackUrl("http://127.0.0.1:7677"))
+        assertTrue(McpRegistrationScanner.isLoopbackUrl("http://localhost:7677/sse"))
+        assertTrue(McpRegistrationScanner.isLoopbackUrl("http://127.0.0.1"))
+        assertFalse(McpRegistrationScanner.isLoopbackUrl("http://127.0.0.1.evil.com:7677"))
+        assertFalse(McpRegistrationScanner.isLoopbackUrl("https://mcp.example.com"))
+        assertFalse(McpRegistrationScanner.isLoopbackUrl("not a url"))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScannerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScannerTest.kt
@@ -85,6 +85,30 @@ class McpRegistrationScannerTest {
     }
 
     @Test
+    fun `codex key must be exactly url and tolerates inline comments`() {
+        val home = tempHome()
+        home.write(
+            ".codex/config.toml",
+            """
+            [mcp_servers.boss]
+            url_extra = "http://127.0.0.1:1111"
+            url = "http://127.0.0.1:7677" # written by attach
+            """.trimIndent()
+        )
+        assertEquals(setOf(McpAttachTarget.CODEX), McpRegistrationScanner.scan("boss", home))
+
+        val home2 = tempHome()
+        home2.write(
+            ".codex/config.toml",
+            """
+            [mcp_servers.boss]
+            url_extra = "http://127.0.0.1:1111"
+            """.trimIndent()
+        )
+        assertTrue(McpRegistrationScanner.scan("boss", home2).isEmpty())
+    }
+
+    @Test
     fun `codex url outside our section is ignored`() {
         val home = tempHome()
         home.write(

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScannerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScannerTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.mcp
 
+import ai.rever.bossterm.compose.mcp.McpRegistrationScanner.Presence
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,6 +20,9 @@ class McpRegistrationScannerTest {
         f.deleteOnExit()
     }
 
+    private fun present(scan: Map<McpAttachTarget, Presence>): Set<McpAttachTarget> =
+        scan.filterValues { it == Presence.PRESENT }.keys
+
     @Test
     fun `detects claude code loopback registration`() {
         val home = tempHome()
@@ -26,7 +30,7 @@ class McpRegistrationScannerTest {
             ".claude.json",
             """{"someOtherKey": 1, "mcpServers": {"boss": {"type": "sse", "url": "http://127.0.0.1:7679"}}}"""
         )
-        assertEquals(setOf(McpAttachTarget.CLAUDE_CODE), McpRegistrationScanner.scan("boss", home))
+        assertEquals(setOf(McpAttachTarget.CLAUDE_CODE), present(McpRegistrationScanner.scan("boss", home)))
     }
 
     @Test
@@ -36,7 +40,7 @@ class McpRegistrationScannerTest {
             ".claude.json",
             """{"mcpServers": {"bossterm": {"type": "sse", "url": "http://127.0.0.1:7676"}}}"""
         )
-        assertTrue(McpRegistrationScanner.scan("boss", home).isEmpty())
+        assertTrue(present(McpRegistrationScanner.scan("boss", home)).isEmpty())
     }
 
     @Test
@@ -46,7 +50,12 @@ class McpRegistrationScannerTest {
             ".claude.json",
             """{"mcpServers": {"boss": {"type": "sse", "url": "https://mcp.example.com/sse"}}}"""
         )
-        assertTrue(McpRegistrationScanner.scan("boss", home).isEmpty())
+        // A cleanly parsed remote entry is ABSENT (not ours to manage), so the
+        // manager also prunes any persisted target that pointed at it.
+        assertEquals(
+            Presence.ABSENT,
+            McpRegistrationScanner.scan("boss", home)[McpAttachTarget.CLAUDE_CODE]
+        )
     }
 
     @Test
@@ -62,7 +71,7 @@ class McpRegistrationScannerTest {
         )
         assertEquals(
             setOf(McpAttachTarget.GEMINI, McpAttachTarget.OPENCODE),
-            McpRegistrationScanner.scan("boss", home)
+            present(McpRegistrationScanner.scan("boss", home))
         )
     }
 
@@ -81,7 +90,7 @@ class McpRegistrationScannerTest {
             url = "https://remote.example.com"
             """.trimIndent()
         )
-        assertEquals(setOf(McpAttachTarget.CODEX), McpRegistrationScanner.scan("boss", home))
+        assertEquals(setOf(McpAttachTarget.CODEX), present(McpRegistrationScanner.scan("boss", home)))
     }
 
     @Test
@@ -95,7 +104,7 @@ class McpRegistrationScannerTest {
             url = "http://127.0.0.1:7677" # written by attach
             """.trimIndent()
         )
-        assertEquals(setOf(McpAttachTarget.CODEX), McpRegistrationScanner.scan("boss", home))
+        assertEquals(setOf(McpAttachTarget.CODEX), present(McpRegistrationScanner.scan("boss", home)))
 
         val home2 = tempHome()
         home2.write(
@@ -105,7 +114,7 @@ class McpRegistrationScannerTest {
             url_extra = "http://127.0.0.1:1111"
             """.trimIndent()
         )
-        assertTrue(McpRegistrationScanner.scan("boss", home2).isEmpty())
+        assertTrue(present(McpRegistrationScanner.scan("boss", home2)).isEmpty())
     }
 
     @Test
@@ -118,15 +127,23 @@ class McpRegistrationScannerTest {
             url = "http://127.0.0.1:9999"
             """.trimIndent()
         )
-        assertTrue(McpRegistrationScanner.scan("boss", home).isEmpty())
+        assertTrue(present(McpRegistrationScanner.scan("boss", home)).isEmpty())
     }
 
     @Test
-    fun `missing empty or malformed files are safe`() {
+    fun `tri-state - missing and empty are ABSENT, malformed is UNKNOWN`() {
         val home = tempHome()
         home.write(".claude.json", "")
         home.write(".gemini/settings.json", "{not json!!")
-        assertTrue(McpRegistrationScanner.scan("boss", home).isEmpty())
+        val scan = McpRegistrationScanner.scan("boss", home)
+        // Empty file parses to "no entry" — a clean ABSENT the manager may prune on.
+        assertEquals(Presence.ABSENT, scan[McpAttachTarget.CLAUDE_CODE])
+        // Malformed JSON must be UNKNOWN — pruning on a transient read failure
+        // would silently disable auto-reattach.
+        assertEquals(Presence.UNKNOWN, scan[McpAttachTarget.GEMINI])
+        // Files that don't exist are a clean ABSENT.
+        assertEquals(Presence.ABSENT, scan[McpAttachTarget.CODEX])
+        assertEquals(Presence.ABSENT, scan[McpAttachTarget.OPENCODE])
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationUrlTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationUrlTest.kt
@@ -1,0 +1,51 @@
+package ai.rever.bossterm.compose.mcp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class McpRegistrationUrlTest {
+
+    @Test
+    fun `claude code registers the env-expanded url form`() {
+        assertEquals(
+            "http://127.0.0.1:\${BOSS_MCP_PORT:-7677}",
+            McpAttachTarget.CLAUDE_CODE.registrationUrl("boss", 7677)
+        )
+        assertEquals(
+            "http://127.0.0.1:\${BOSSTERM_MCP_PORT:-7676}",
+            McpAttachTarget.CLAUDE_CODE.registrationUrl("bossterm", 7676)
+        )
+    }
+
+    @Test
+    fun `other clis keep the plain url`() {
+        for (target in McpAttachTarget.entries - McpAttachTarget.CLAUDE_CODE) {
+            assertEquals("http://127.0.0.1:7677", target.registrationUrl("boss", 7677))
+        }
+    }
+
+    @Test
+    fun `port env var name is derived and sanitized from the server name`() {
+        assertEquals("BOSS_MCP_PORT", McpTerminalRegistry.portEnvVarName("boss"))
+        assertEquals("BOSSTERM_MCP_PORT", McpTerminalRegistry.portEnvVarName("bossterm"))
+        assertEquals(
+            "BOSSTERM_EMBEDDED_EXAMPLE_MCP_PORT",
+            McpTerminalRegistry.portEnvVarName("bossterm-embedded-example")
+        )
+    }
+
+    @Test
+    fun `scanner treats the env-expanded url as loopback so adoption keeps working`() {
+        assertTrue(McpRegistrationScanner.isLoopbackUrl("http://127.0.0.1:\${BOSS_MCP_PORT:-7677}"))
+    }
+
+    @Test
+    fun `claude clipboard fallback quotes the url against shell pre-expansion`() {
+        val snippet = McpAttachTarget.CLAUDE_CODE.resolvedClipboard(
+            "boss",
+            McpAttachTarget.CLAUDE_CODE.registrationUrl("boss", 7677)
+        )
+        assertTrue("'http://127.0.0.1:\${BOSS_MCP_PORT:-7677}'" in snippet)
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationUrlTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationUrlTest.kt
@@ -33,6 +33,8 @@ class McpRegistrationUrlTest {
             "BOSSTERM_EMBEDDED_EXAMPLE_MCP_PORT",
             McpTerminalRegistry.portEnvVarName("bossterm-embedded-example")
         )
+        // A leading digit would make the name an invalid POSIX identifier.
+        assertEquals("_7BOSS_MCP_PORT", McpTerminalRegistry.portEnvVarName("7boss"))
     }
 
     @Test


### PR DESCRIPTION
## Problem

The MCP endpoint registered with Claude Code (and other CLIs) freezes on a stale port. Observed in the field: the server listening on 7677 while `~/.claude.json` pointed at 7679 → every session fails with `SSE error: Unable to connect`.

Three links break in sequence:

1. **Packaged apps can't spawn the CLIs.** An app launched from Finder/the Dock inherits the bare launchd `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`), so every quiet startup `claude mcp add` dies with "CLI not found".
2. **One failure dropped the target forever.** Auto-reattach failure called `markDetached`, removing CLAUDE_CODE from the persisted `mcpAttachedTo` set — after which no code path ever rewrote the registration again.
3. **Registrations pin an absolute port** while the server fallback-walks (+1…+9) when its configured port is busy; any drift between the two is permanent once (1)+(2) disable the repair loop.

## Fix

**Commit 1 — self-heal the write-through sync:**
- `CliBinaryResolver`: resolve `claude`/`codex`/`gemini`/`node` to absolute paths — inherited `PATH`, then well-known install dirs (`~/.local/bin`, `/opt/homebrew/bin`, …), then a bounded (5s) login-shell `command -v` probe. Applied to every attach shell-out.
- `McpRegistrationScanner`: on manager start, adopt loopback registrations matching our server name that already exist in the CLIs' own config files but are missing from the persisted set (the CLI config is the canonical record). Conservative matching: exact name + loopback URL only — never adopts/rewrites a remote entry. Heals installs already broken in the field with zero clicks.
- Auto-reattach failures keep the target persisted and retry on the next bind instead of dropping it.

**Commit 2 — connection-time port resolution for Claude Code:**
- Claude Code registrations now use `http://127.0.0.1:${<NAME>_MCP_PORT:-<port>}`, and every PTY we spawn exports that var (e.g. `BOSS_MCP_PORT`) with the actually-bound port, next to the existing `BOSS_MCP_SERVER`.
- Claude Code expands `${VAR:-default}` in user-scope URLs from each `claude` process's own environment (verified empirically: unset → default connects; set → that port is dialed). So in-terminal sessions always reach *their* instance — even after a fallback-port walk, and even with dev + packaged instances running side by side — while outside sessions use the registered default, kept current by auto-reattach.
- Var name is derived per embedder (`boss` → `BOSS_MCP_PORT`, `bossterm` → `BOSSTERM_MCP_PORT`) so a BossConsole terminal can't expand a standalone BossTerm registration onto the wrong app's port.

## Tests

- 21 new tests (`CliBinaryResolverTest`, `McpRegistrationScannerTest`, `McpRegistrationUrlTest`); full `:compose-ui:desktopTest` suite passes.

## Notes

- BossConsole picks this up via the bundled `bossterm-compose` in the `terminal-tab` plugin (bump after release).
- Known residual: two simultaneous instances sharing one server name still overwrite each other's *default* — but in-terminal sessions are no longer affected, which was the practical pain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)