### PR TITLE
feat(mcp): polite multi-instance auto-reattach via /identity probe

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.compose.mcp
 
 import ai.rever.bossterm.compose.settings.SettingsManager
+import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCallPipeline
@@ -13,7 +14,10 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.request.host
 import io.ktor.server.request.httpMethod
 import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import io.ktor.server.sse.SSE
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import kotlinx.coroutines.CancellationException
@@ -457,6 +461,21 @@ class BossTermMcpManager(
                 // mount at root directly and advertise the URL as
                 // http://127.0.0.1:<port>/ — clients register that URL.
                 routing {
+                    // Identity for sibling instances: a starting instance's
+                    // polite auto-reattach probes this to learn whether the
+                    // port a CLI registration points at is owned by a LIVE
+                    // server of the same name (keep it) or is stale/foreign
+                    // (claim it). See McpInstanceProbe. Sits behind the
+                    // loopback bind + Host-header check like everything else.
+                    get(McpInstanceProbe.IDENTITY_PATH) {
+                        call.respondText(
+                            buildJsonObject {
+                                put("serverName", config.serverName)
+                                put("pid", ProcessHandle.current().pid())
+                            }.toString(),
+                            ContentType.Application.Json
+                        )
+                    }
                     mcp { mcpServer }
                 }
             }
@@ -567,18 +586,52 @@ class BossTermMcpManager(
      * target here is what used to freeze the CLI's registered endpoint on a
      * stale port forever. A genuinely uninstalled CLI costs one quiet
      * background retry per bind, which is harmless.
+     *
+     * Polite to siblings: before rewriting, each target's currently
+     * registered default port is probed ([McpInstanceProbe]) — when a LIVE
+     * server with the same name owns it (e.g. the packaged app, while this
+     * is a dev instance on a fallback port), the registration is left alone
+     * instead of last-writer-wins clobbered. Our own terminals reach this
+     * instance via the injected port env var regardless. Explicit attach
+     * (the Settings/Toolbox button) stays impolite on purpose: the user
+     * asked THIS instance to own the registration.
      */
     private fun launchAutoReattach(port: Int) {
         val targets = registry.attachedTargets.value
         if (targets.isEmpty()) return
         log.info("Auto-reattaching {} CLI(s) to new endpoint…", targets.size)
         parentScope.launch(Dispatchers.IO) {
+            // One identity probe per distinct registered port (several CLIs
+            // usually point at the same default), before the fan-out.
+            val registeredPorts = targets.associateWith { target ->
+                runCatching {
+                    McpRegistrationScanner.registeredDefaultPort(target, config.serverName)
+                }.getOrNull()
+            }
+            val liveOwnerByPort = registeredPorts.values.filterNotNull().distinct()
+                .filter { it != port }
+                .associateWith { McpInstanceProbe.liveServerName(it) }
+
             // Fan out: each CLI's mcp add/remove operates on its own config
             // file, so they're independent. Running sequentially used to add
             // up to ~5-10s for four targets; parallel keeps total time bound
             // by the slowest one (~1-2s).
             val outcomes = coroutineScope {
-                targets.map { target ->
+                targets.mapNotNull { target ->
+                    val registered = registeredPorts[target]
+                    val rewrite = McpInstanceProbe.shouldRewrite(
+                        registeredDefaultPort = registered,
+                        ourPort = port,
+                        ourServerName = config.serverName,
+                        liveOwnerName = registered?.let { liveOwnerByPort[it] }
+                    )
+                    if (!rewrite) {
+                        log.info(
+                            "Skipping reattach for {} — a live '{}' instance already owns registered port {}",
+                            target.displayName, config.serverName, registered
+                        )
+                        return@mapNotNull null
+                    }
                     async {
                         target to McpCliAttacher.attach(
                             target, config.serverName, port, quiet = true

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpInstanceProbe.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpInstanceProbe.kt
@@ -1,0 +1,86 @@
+package ai.rever.bossterm.compose.mcp
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.slf4j.LoggerFactory
+import java.net.HttpURLConnection
+import java.net.URI
+
+/**
+ * Asks a loopback port whether a live Boss/BossTerm MCP server owns it, and
+ * which one. Servers expose `GET /identity` (see BossTermMcpManager) returning
+ * `{"serverName": "...", "pid": ...}`.
+ *
+ * Used by the polite auto-reattach: before an instance rewrites a CLI's
+ * registered endpoint to its own port, it probes the port the registration
+ * currently points at — a live sibling with the same server name keeps
+ * ownership (first-owner-wins-while-alive) instead of the historical
+ * last-writer-wins clobbering between e.g. a packaged app and a dev instance.
+ *
+ * Best-effort by design: any failure (nothing listening, a non-Boss service,
+ * an older Boss build without /identity, timeout) returns null, which callers
+ * treat as "not a live sibling — safe to claim".
+ */
+internal object McpInstanceProbe {
+
+    private val log = LoggerFactory.getLogger(McpInstanceProbe::class.java)
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    internal const val IDENTITY_PATH = "/identity"
+
+    /** Server name of the live MCP instance on [port], or null. */
+    fun liveServerName(port: Int, timeoutMs: Int = PROBE_TIMEOUT_MS): String? {
+        return try {
+            val connection = URI("http://127.0.0.1:$port$IDENTITY_PATH").toURL()
+                .openConnection() as HttpURLConnection
+            try {
+                connection.connectTimeout = timeoutMs
+                connection.readTimeout = timeoutMs
+                connection.requestMethod = "GET"
+                if (connection.responseCode != 200) return null
+                // Identity payloads are tiny; cap the read so a misbehaving
+                // service on the port can't feed us an unbounded body.
+                val body = connection.inputStream.bufferedReader()
+                    .use { it.readText().take(MAX_IDENTITY_BYTES) }
+                json.parseToJsonElement(body).jsonObject["serverName"]
+                    ?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+            } finally {
+                connection.disconnect()
+            }
+        } catch (t: Throwable) {
+            log.debug("Identity probe of port {} failed: {}", port, t.message)
+            null
+        }
+    }
+
+    /**
+     * Whether an instance bound to [ourPort] should rewrite a CLI's registered
+     * entry, given the entry's current default port and the identity of
+     * whatever is live there. Pure — the manager supplies the probe result.
+     *
+     *  - No parseable registered port → rewrite (nothing to be polite to).
+     *  - Registered port is ours → rewrite (idempotent refresh).
+     *  - A live server with OUR name owns the registered port → skip: that
+     *    sibling instance keeps the default; our own terminals reach us via
+     *    the injected port env var regardless.
+     *  - Anything else (dead port, foreign service, older build without
+     *    /identity) → rewrite and claim the default.
+     */
+    fun shouldRewrite(
+        registeredDefaultPort: Int?,
+        ourPort: Int,
+        ourServerName: String,
+        liveOwnerName: String?
+    ): Boolean = when {
+        registeredDefaultPort == null -> true
+        registeredDefaultPort == ourPort -> true
+        liveOwnerName == ourServerName -> false
+        else -> true
+    }
+
+    private const val PROBE_TIMEOUT_MS = 750
+
+    private const val MAX_IDENTITY_BYTES = 4096
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpInstanceProbe.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpInstanceProbe.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.slf4j.LoggerFactory
 import java.net.HttpURLConnection
+import java.net.Proxy
 import java.net.URI
 
 /**
@@ -33,17 +34,30 @@ internal object McpInstanceProbe {
     /** Server name of the live MCP instance on [port], or null. */
     fun liveServerName(port: Int, timeoutMs: Int = PROBE_TIMEOUT_MS): String? {
         return try {
+            // NO_PROXY: a configured system/HTTP proxy must never sit between
+            // us and a loopback port — it would answer for (or hang on) an
+            // address only this machine can serve, skewing the probe result.
             val connection = URI("http://127.0.0.1:$port$IDENTITY_PATH").toURL()
-                .openConnection() as HttpURLConnection
+                .openConnection(Proxy.NO_PROXY) as HttpURLConnection
             try {
                 connection.connectTimeout = timeoutMs
                 connection.readTimeout = timeoutMs
                 connection.requestMethod = "GET"
                 if (connection.responseCode != 200) return null
-                // Identity payloads are tiny; cap the read so a misbehaving
-                // service on the port can't feed us an unbounded body.
-                val body = connection.inputStream.bufferedReader()
-                    .use { it.readText().take(MAX_IDENTITY_BYTES) }
+                // Identity payloads are tiny. Read at most MAX_IDENTITY_CHARS
+                // into a fixed buffer and stop — a misbehaving service on the
+                // port can stream gigabytes inside the read timeout, and a
+                // readText()-then-truncate would have materialized all of it.
+                val body = connection.inputStream.bufferedReader().use { reader ->
+                    val buf = CharArray(MAX_IDENTITY_CHARS)
+                    var filled = 0
+                    while (filled < buf.size) {
+                        val n = reader.read(buf, filled, buf.size - filled)
+                        if (n == -1) break
+                        filled += n
+                    }
+                    String(buf, 0, filled)
+                }
                 json.parseToJsonElement(body).jsonObject["serverName"]
                     ?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
             } finally {
@@ -82,5 +96,6 @@ internal object McpInstanceProbe {
 
     private const val PROBE_TIMEOUT_MS = 750
 
-    private const val MAX_IDENTITY_BYTES = 4096
+    /** Hard cap on how much of the response is ever read into memory. */
+    private const val MAX_IDENTITY_CHARS = 4096
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScanner.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScanner.kt
@@ -46,17 +46,8 @@ internal object McpRegistrationScanner {
     ): Map<McpAttachTarget, Presence> =
         McpAttachTarget.entries.associateWith { target ->
             try {
-                val registered = when (target) {
-                    McpAttachTarget.CLAUDE_CODE ->
-                        jsonHasLoopbackEntry(File(home, ".claude.json"), "mcpServers", serverName)
-                    McpAttachTarget.GEMINI ->
-                        jsonHasLoopbackEntry(File(home, ".gemini/settings.json"), "mcpServers", serverName)
-                    McpAttachTarget.OPENCODE ->
-                        jsonHasLoopbackEntry(File(home, ".config/opencode/opencode.json"), "mcp", serverName)
-                    McpAttachTarget.CODEX ->
-                        codexTomlHasLoopbackEntry(File(home, ".codex/config.toml"), serverName)
-                }
-                if (registered) Presence.PRESENT else Presence.ABSENT
+                if (registeredLoopbackUrl(target, serverName, home) != null) Presence.PRESENT
+                else Presence.ABSENT
             } catch (t: Throwable) {
                 log.warn("Could not scan {} config: {}", target.displayName, t.message)
                 Presence.UNKNOWN
@@ -64,18 +55,46 @@ internal object McpRegistrationScanner {
         }
 
     /**
-     * True when [file] parses as JSON and `<containerKey>.<serverName>` exists
-     * with a loopback `url`/`httpUrl`. Gemini writes `httpUrl`, the others
-     * `url`; checking both keeps one code path for all three JSON configs.
+     * The default port of [target]'s currently-registered entry for
+     * [serverName], or null when there is no (loopback) entry or the port is
+     * unparseable. For env-expanded URLs (`…:${VAR:-7677}`) this is the
+     * fallback port — i.e. what a session outside any of our terminals would
+     * dial. Used by the manager's polite auto-reattach to decide whether the
+     * registered endpoint is already owned by a live sibling instance.
      */
-    internal fun jsonHasLoopbackEntry(file: File, containerKey: String, serverName: String): Boolean {
-        if (!file.isFile) return false
+    fun registeredDefaultPort(
+        target: McpAttachTarget,
+        serverName: String,
+        home: File = File(System.getProperty("user.home"))
+    ): Int? = registeredLoopbackUrl(target, serverName, home)?.let(::defaultPortOf)
+
+    /** [target]'s registered loopback URL for [serverName], or null. Throws on unreadable config. */
+    internal fun registeredLoopbackUrl(target: McpAttachTarget, serverName: String, home: File): String? =
+        when (target) {
+            McpAttachTarget.CLAUDE_CODE ->
+                jsonLoopbackUrl(File(home, ".claude.json"), "mcpServers", serverName)
+            McpAttachTarget.GEMINI ->
+                jsonLoopbackUrl(File(home, ".gemini/settings.json"), "mcpServers", serverName)
+            McpAttachTarget.OPENCODE ->
+                jsonLoopbackUrl(File(home, ".config/opencode/opencode.json"), "mcp", serverName)
+            McpAttachTarget.CODEX ->
+                codexTomlLoopbackUrl(File(home, ".codex/config.toml"), serverName)
+        }
+
+    /**
+     * The loopback `url`/`httpUrl` of `<containerKey>.<serverName>` in [file],
+     * or null when the file/entry is absent or the URL isn't loopback. Gemini
+     * writes `httpUrl`, the others `url`; checking both keeps one code path
+     * for all three JSON configs.
+     */
+    internal fun jsonLoopbackUrl(file: File, containerKey: String, serverName: String): String? {
+        if (!file.isFile) return null
         val text = file.readText()
-        if (text.isBlank()) return false
+        if (text.isBlank()) return null
         val root = json.parseToJsonElement(text).jsonObject
-        val entry = root[containerKey]?.jsonObject?.get(serverName)?.jsonObject ?: return false
-        val url = (entry["url"] ?: entry["httpUrl"])?.jsonPrimitive?.content ?: return false
-        return isLoopbackUrl(url)
+        val entry = root[containerKey]?.jsonObject?.get(serverName)?.jsonObject ?: return null
+        val url = (entry["url"] ?: entry["httpUrl"])?.jsonPrimitive?.content ?: return null
+        return url.takeIf(::isLoopbackUrl)
     }
 
     /**
@@ -84,8 +103,8 @@ internal object McpRegistrationScanner {
      * machine-written with this exact shape; a full TOML parser isn't worth
      * the dependency.
      */
-    internal fun codexTomlHasLoopbackEntry(file: File, serverName: String): Boolean {
-        if (!file.isFile) return false
+    internal fun codexTomlLoopbackUrl(file: File, serverName: String): String? {
+        if (!file.isFile) return null
         var inSection = false
         for (rawLine in file.readLines()) {
             val line = rawLine.trim()
@@ -103,10 +122,21 @@ internal object McpRegistrationScanner {
                 } else {
                     raw.substringBefore('#').trim()
                 }
-                return isLoopbackUrl(url)
+                return url.takeIf(::isLoopbackUrl)
             }
         }
-        return false
+        return null
+    }
+
+    /**
+     * Default port a registered URL resolves to without any env override:
+     * the `:-<port>` fallback of an env-expanded URL, else the literal
+     * `:<port>`. Null when neither is present.
+     */
+    internal fun defaultPortOf(url: String): Int? {
+        Regex("""\$\{[A-Za-z_][A-Za-z0-9_]*:-(\d+)}""").find(url)
+            ?.let { return it.groupValues[1].toIntOrNull() }
+        return Regex(""":(\d+)(?:[/?#]|$)""").find(url)?.groupValues?.get(1)?.toIntOrNull()
     }
 
     internal fun isLoopbackUrl(url: String): Boolean {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpPoliteReattachTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpPoliteReattachTest.kt
@@ -21,6 +21,8 @@ class McpPoliteReattachTest {
         assertEquals(7677, McpRegistrationScanner.defaultPortOf("http://127.0.0.1:\${BOSS_MCP_PORT:-7677}"))
         assertEquals(7676, McpRegistrationScanner.defaultPortOf("http://127.0.0.1:7676"))
         assertEquals(7677, McpRegistrationScanner.defaultPortOf("http://localhost:7677/sse"))
+        assertEquals(7677, McpRegistrationScanner.defaultPortOf("http://127.0.0.1:7677?session=1"))
+        assertEquals(7677, McpRegistrationScanner.defaultPortOf("http://127.0.0.1:7677#frag"))
         assertNull(McpRegistrationScanner.defaultPortOf("http://127.0.0.1"))
     }
 
@@ -81,6 +83,54 @@ class McpPoliteReattachTest {
 
         // After stop, the same port is dead — probe must return null, fast.
         assertNull(McpInstanceProbe.liveServerName(server.address.port, timeoutMs = 500))
+    }
+
+    @Test
+    fun `a live foreign-named server results in a claim end-to-end`() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        try {
+            server.createContext(McpInstanceProbe.IDENTITY_PATH) { exchange ->
+                val body = """{"serverName":"bossterm","pid":99}""".toByteArray()
+                exchange.sendResponseHeaders(200, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+            val registeredPort = server.address.port
+
+            val owner = McpInstanceProbe.liveServerName(registeredPort)
+            assertEquals("bossterm", owner)
+            // A 'boss' instance probing a live 'bossterm' owner must still
+            // claim the entry — it is named after US, not the other app.
+            assertTrue(McpInstanceProbe.shouldRewrite(registeredPort, 7679, "boss", owner))
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `oversized identity bodies are read bounded and rejected`() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        try {
+            server.createContext(McpInstanceProbe.IDENTITY_PATH) { exchange ->
+                // Chunked (length 0): stream far more than the probe's cap.
+                // The probe must stop reading at its fixed buffer, not
+                // materialize the whole body. Broken pipe when the client
+                // bails early is expected — swallow it.
+                try {
+                    exchange.sendResponseHeaders(200, 0)
+                    val chunk = ByteArray(64 * 1024) { 'x'.code.toByte() }
+                    exchange.responseBody.use { out ->
+                        repeat(160) { out.write(chunk) } // ~10 MB offered
+                    }
+                } catch (_: Throwable) {
+                    // client disconnected after its bounded read — fine
+                }
+            }
+            server.start()
+            assertNull(McpInstanceProbe.liveServerName(server.address.port))
+        } finally {
+            server.stop(0)
+        }
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpPoliteReattachTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpPoliteReattachTest.kt
@@ -1,0 +1,101 @@
+package ai.rever.bossterm.compose.mcp
+
+import com.sun.net.httpserver.HttpServer
+import java.io.File
+import java.net.InetSocketAddress
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class McpPoliteReattachTest {
+
+    // ------------------------------------------------------------------
+    // Default-port parsing of registered URLs
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `defaultPortOf handles env-expanded plain and pathed urls`() {
+        assertEquals(7677, McpRegistrationScanner.defaultPortOf("http://127.0.0.1:\${BOSS_MCP_PORT:-7677}"))
+        assertEquals(7676, McpRegistrationScanner.defaultPortOf("http://127.0.0.1:7676"))
+        assertEquals(7677, McpRegistrationScanner.defaultPortOf("http://localhost:7677/sse"))
+        assertNull(McpRegistrationScanner.defaultPortOf("http://127.0.0.1"))
+    }
+
+    @Test
+    fun `registeredDefaultPort reads the claude entry from disk`() {
+        val home = createTempDirectory("polite-test-home").toFile().apply { deleteOnExit() }
+        val f = File(home, ".claude.json")
+        f.writeText("""{"mcpServers": {"boss": {"type": "sse", "url": "http://127.0.0.1:${'$'}{BOSS_MCP_PORT:-7679}"}}}""")
+        f.deleteOnExit()
+        assertEquals(7679, McpRegistrationScanner.registeredDefaultPort(McpAttachTarget.CLAUDE_CODE, "boss", home))
+        // No entry for a different name; no entry at all for other CLIs.
+        assertNull(McpRegistrationScanner.registeredDefaultPort(McpAttachTarget.CLAUDE_CODE, "bossterm", home))
+        assertNull(McpRegistrationScanner.registeredDefaultPort(McpAttachTarget.GEMINI, "boss", home))
+    }
+
+    // ------------------------------------------------------------------
+    // Rewrite decision
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `shouldRewrite truth table`() {
+        // No parseable registration — nothing to be polite to.
+        assertTrue(McpInstanceProbe.shouldRewrite(null, 7677, "boss", null))
+        // Registered port is ours — idempotent refresh.
+        assertTrue(McpInstanceProbe.shouldRewrite(7677, 7677, "boss", null))
+        // Live sibling with our name owns the registered port — keep it.
+        assertFalse(McpInstanceProbe.shouldRewrite(7677, 7679, "boss", "boss"))
+        // Dead port — claim.
+        assertTrue(McpInstanceProbe.shouldRewrite(7677, 7679, "boss", null))
+        // Foreign live server (different name) — claim; the entry is named
+        // after US, so pointing it at another app's server is a misconfig.
+        assertTrue(McpInstanceProbe.shouldRewrite(7676, 7679, "boss", "bossterm"))
+    }
+
+    // ------------------------------------------------------------------
+    // Live identity probe against a real loopback HTTP server
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `liveServerName reads identity and fails safe`() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        try {
+            server.createContext(McpInstanceProbe.IDENTITY_PATH) { exchange ->
+                val body = """{"serverName":"boss","pid":12345}""".toByteArray()
+                exchange.sendResponseHeaders(200, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.createContext("/other") { exchange ->
+                exchange.sendResponseHeaders(404, -1)
+            }
+            server.start()
+            val port = server.address.port
+
+            assertEquals("boss", McpInstanceProbe.liveServerName(port))
+        } finally {
+            server.stop(0)
+        }
+
+        // After stop, the same port is dead — probe must return null, fast.
+        assertNull(McpInstanceProbe.liveServerName(server.address.port, timeoutMs = 500))
+    }
+
+    @Test
+    fun `liveServerName rejects malformed and non-200 responses`() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        try {
+            server.createContext(McpInstanceProbe.IDENTITY_PATH) { exchange ->
+                val body = "not json at all".toByteArray()
+                exchange.sendResponseHeaders(200, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+            assertNull(McpInstanceProbe.liveServerName(server.address.port))
+        } finally {
+            server.stop(0)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Follow-up to #320's known gap: two live instances sharing one MCP server name (packaged BOSS.app + a dev instance, both `boss`) clobber each other's registered CLI endpoint last-writer-wins. Whichever binds last rewrites `~/.claude.json` (and the other CLIs' configs) to its own port; when it exits, the registration points at a dead port until the surviving instance happens to rebind.

## Fix

**`GET /identity`** on the MCP server (`{"serverName": ..., "pid": ...}`) — loopback-bound and behind the same Host-header rebinding defense as every other route.

**Polite auto-reattach**: before rewriting a CLI's registration, the manager parses the entry's current default port (`McpRegistrationScanner.registeredDefaultPort`, aware of both plain and `${VAR:-port}` env-expanded URLs) and probes it (`McpInstanceProbe`, 750ms timeout, one probe per distinct port per bind):

- **Live server with our name owns it → skip.** First-owner-wins-while-alive. Our own terminals reach this instance through the injected `<NAME>_MCP_PORT` env var regardless, so nothing is lost.
- **Dead port / foreign service / older build without `/identity` → claim it** (rewrite as before).
- **Explicit attach** (Settings/Toolbox button) stays impolite by design — the user asked this instance to own the registration.

## Tests

5 new tests in `McpPoliteReattachTest`: URL default-port parsing (env + plain + pathed), on-disk `registeredDefaultPort`, the `shouldRewrite` truth table, and live-probe behavior against a real loopback HTTP server (identity read, dead-port fast-null, malformed-response rejection). Full `:compose-ui:desktopTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)