### PR TITLE
docs: stable always-latest download links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![CI](https://github.com/kshivang/BossTerm/actions/workflows/test.yml/badge.svg)](https://github.com/kshivang/BossTerm/actions/workflows/test.yml)
 [![Release](https://github.com/kshivang/BossTerm/actions/workflows/release.yml/badge.svg)](https://github.com/kshivang/BossTerm/releases)
-[![Download DMG](https://img.shields.io/github/v/release/kshivang/BossTerm?label=Download%20DMG&logo=apple)](https://github.com/kshivang/BossTerm/releases/latest)
+[![Download DMG](https://img.shields.io/github/v/release/kshivang/BossTerm?label=Download%20DMG&logo=apple)](https://api.risaboss.com/functions/v1/latest-release?app=bossterm&download=dmg)
 [![Maven Central](https://img.shields.io/maven-central/v/com.risaboss/bossterm-core)](https://central.sonatype.com/namespace/com.risaboss)
 
 </div>
@@ -111,6 +111,28 @@ curl -fsSL https://raw.githubusercontent.com/kshivang/BossTerm/master/install.sh
 ### Alternative Installation Methods
 
 <details>
+<summary><strong>Direct download links (always latest)</strong></summary>
+
+Stable URLs that always redirect to the newest release (the downloaded file keeps its versioned name):
+
+| Package | Link |
+|---|---|
+| macOS DMG | https://api.risaboss.com/functions/v1/latest-release?app=bossterm&download=dmg |
+| Debian/Ubuntu (x86_64) | https://api.risaboss.com/functions/v1/latest-release?app=bossterm&download=deb&arch=amd64 |
+| Debian/Ubuntu (ARM64) | https://api.risaboss.com/functions/v1/latest-release?app=bossterm&download=deb&arch=arm64 |
+| Fedora/RHEL (x86_64) | https://api.risaboss.com/functions/v1/latest-release?app=bossterm&download=rpm&arch=amd64 |
+| Fedora/RHEL (ARM64) | https://api.risaboss.com/functions/v1/latest-release?app=bossterm&download=rpm&arch=arm64 |
+| JAR (cross-platform) | https://api.risaboss.com/functions/v1/latest-release?app=bossterm&download=jar |
+
+Drop the `download` parameter for release metadata as JSON (version, assets, sha256 checksums), e.g.:
+
+```bash
+curl -s "https://api.risaboss.com/functions/v1/latest-release?app=bossterm" | jq .version
+```
+
+</details>
+
+<details>
 <summary><strong>macOS (Homebrew)</strong></summary>
 
 ```bash
@@ -123,7 +145,7 @@ brew install --cask bossterm
 <details>
 <summary><strong>macOS (DMG)</strong></summary>
 
-Download the latest DMG from [GitHub Releases](https://github.com/kshivang/BossTerm/releases) and drag BossTerm to Applications.
+[Download the latest DMG](https://api.risaboss.com/functions/v1/latest-release?app=bossterm&download=dmg) (or grab it from [GitHub Releases](https://github.com/kshivang/BossTerm/releases)) and drag BossTerm to Applications.
 
 </details>
 


### PR DESCRIPTION
## Summary

Wires the README to the new stable **always-latest** download endpoint (`api.risaboss.com/functions/v1/latest-release`, added in risa-labs-inc/BossConsole#822). Each URL 302-redirects to the newest installer in the release catalog, so links never go stale — something GitHub's `releases/latest/download/<asset>` pattern can't do here because BossTerm's asset names embed the version.

## Changes

- **Download DMG badge** now downloads the latest DMG directly instead of landing on the releases page
- New **"Direct download links (always latest)"** section under Alternative Installation Methods: dmg, deb (amd64/arm64), rpm (x86_64/aarch64), jar, plus the JSON metadata query (`version`, `sha256` checksums)
- **macOS (DMG)** section offers the direct link alongside GitHub Releases

## Verification

All six links verified live — each 302s to the correct v1.2.126 asset, including the arch aliasing (`arch=amd64` → `x86_64.rpm`, `arch=arm64` → `aarch64.rpm`). Downloads keep their versioned filenames since the redirect targets the real storage object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)