### PR TITLE
fix(images): correct show_image sizing/crop across three layers (#323, #324, #325)

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -124,15 +124,17 @@ class BossTerminal(
     @Volatile
     private var myUiLayoutReady = false
 
-    // Last plausible grid, tracked on every resize. Transient layout artifacts can
-    // momentarily shrink the grid to a size no real pane has (rows clamped to 2);
+    // Last trusted grid. Normal-sized grids are trusted immediately on resize;
+    // genuinely tiny grids are trusted after the UI stability gate confirms them.
+    // Transient layout artifacts can momentarily shrink the grid to the terminal
+    // minimum before the pane reaches its real size;
     // if an inline image lands in exactly that window, sizing against the live grid
     // bakes a squashed footprint into the buffer permanently. These remember the
     // geometry the pane actually settles at so processInlineImage can fall back.
     @Volatile
-    private var myLastSaneWidth = 0
+    private var myLastTrustedWidth = 0
     @Volatile
-    private var myLastSaneHeight = 0
+    private var myLastTrustedHeight = 0
 
     override fun setModeEnabled(mode: TerminalMode?, enabled: Boolean) {
         mode?.let {
@@ -592,28 +594,27 @@ class BossTerminal(
         var bufferRow = myCursorY - 1  // 0-indexed screen row
         val anchorCol = myCursorX  // Save original column for placement
 
-        // Calculate image dimensions. If the live grid is degenerate (a transient
-        // layout artifact, e.g. rows clamped to 2 mid-settle), size against the
-        // last sane grid instead — the footprint below is a one-time snapshot
-        // baked into the buffer, so sizing against the blip is permanent while
-        // the blip itself lasts one frame.
-        val saneWidthCells =
-            if (myTerminalWidth >= MIN_SANE_GRID_COLS || myLastSaneWidth <= 0) myTerminalWidth
-            else myLastSaneWidth
-        val saneHeightCells =
-            if (myTerminalHeight >= MIN_SANE_GRID_ROWS || myLastSaneHeight <= 0) myTerminalHeight
-            else myLastSaneHeight
+        // Calculate image dimensions. Until a small live grid has remained stable,
+        // size against the last trusted grid instead — the footprint below is a
+        // one-time snapshot baked into the buffer, so sizing against a transient
+        // first layout pass would remain wrong after the pane settles.
+        val trustedWidthCells =
+            if (myTerminalWidth >= AUTO_TRUST_GRID_COLS || myLastTrustedWidth <= 0) myTerminalWidth
+            else myLastTrustedWidth
+        val trustedHeightCells =
+            if (myTerminalHeight >= AUTO_TRUST_GRID_ROWS || myLastTrustedHeight <= 0) myTerminalHeight
+            else myLastTrustedHeight
         val dimensions = ImageDimensionCalculator.calculate(
             image = image,
-            terminalWidthCells = saneWidthCells,
-            terminalHeightCells = saneHeightCells,
+            terminalWidthCells = trustedWidthCells,
+            terminalHeightCells = trustedHeightCells,
             cellWidthPx = myCellWidthPx,
             cellHeightPx = myCellHeightPx,
             pixelScale = myDisplayScale
         )
-        LOG.info(
+        LOG.debug(
             "processInlineImage: grid={}x{} sized-against={}x{} cellPx={}x{} scale={} intrinsic={}x{} -> px={}x{} cells={}x{} anchor=({},{})",
-            myTerminalWidth, myTerminalHeight, saneWidthCells, saneHeightCells,
+            myTerminalWidth, myTerminalHeight, trustedWidthCells, trustedHeightCells,
             myCellWidthPx, myCellHeightPx, myDisplayScale, image.intrinsicWidth, image.intrinsicHeight,
             dimensions.pixelWidth, dimensions.pixelHeight,
             dimensions.cellWidth, dimensions.cellHeight, anchorCol, bufferRow
@@ -714,6 +715,16 @@ class BossTerminal(
      */
     fun markUiLayoutReady() {
         myUiLayoutReady = true
+    }
+
+    /**
+     * Record the current grid after the UI has observed it remain unchanged across
+     * consecutive layout samples. This lets a legitimate tiny pane replace the
+     * normal-sized fallback without treating a one-frame resize blip as trusted.
+     */
+    fun markCurrentGridStable() {
+        myLastTrustedWidth = myTerminalWidth
+        myLastTrustedHeight = myTerminalHeight
     }
 
     /**
@@ -1729,9 +1740,9 @@ class BossTerminal(
                 resizeListener.onResize(oldTermSize, newTermSize)
             }
         })
-        if (newTermSize.columns >= MIN_SANE_GRID_COLS && newTermSize.rows >= MIN_SANE_GRID_ROWS) {
-            myLastSaneWidth = newTermSize.columns
-            myLastSaneHeight = newTermSize.rows
+        if (newTermSize.columns >= AUTO_TRUST_GRID_COLS && newTermSize.rows >= AUTO_TRUST_GRID_ROWS) {
+            myLastTrustedWidth = newTermSize.columns
+            myLastTrustedHeight = newTermSize.rows
         }
     }
 
@@ -1903,13 +1914,12 @@ class BossTerminal(
         private const val MIN_ROWS = 2
 
         /**
-         * Floor below which a grid is treated as a transient layout artifact
-         * rather than a real pane, for purposes of inline-image sizing (see
-         * myLastSaneWidth/Height). Distinct from MIN_COLUMNS/MIN_ROWS, which
-         * only clamp what a resize request may set.
+         * Normal-sized grids can be trusted immediately. Smaller grids may be
+         * legitimate, so the UI stability gate records those explicitly via
+         * [markCurrentGridStable] before geometry-dependent content is inserted.
          */
-        private const val MIN_SANE_GRID_COLS = 10
-        private const val MIN_SANE_GRID_ROWS = 3
+        private const val AUTO_TRUST_GRID_COLS = 10
+        private const val AUTO_TRUST_GRID_ROWS = 3
 
         fun ensureTermMinimumSize(termSize: TermSize): TermSize {
             return TermSize(max(MIN_COLUMNS, termSize.columns), max(MIN_ROWS, termSize.rows))

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -131,10 +131,10 @@ class BossTerminal(
     // if an inline image lands in exactly that window, sizing against the live grid
     // bakes a squashed footprint into the buffer permanently. These remember the
     // geometry the pane actually settles at so processInlineImage can fall back.
+    // Keep the pair in one volatile holder so readers cannot combine dimensions
+    // from two different resize events.
     @Volatile
-    private var myLastTrustedWidth = 0
-    @Volatile
-    private var myLastTrustedHeight = 0
+    private var myLastTrustedGrid: TerminalGrid? = null
 
     override fun setModeEnabled(mode: TerminalMode?, enabled: Boolean) {
         mode?.let {
@@ -598,23 +598,24 @@ class BossTerminal(
         // size against the last trusted grid instead — the footprint below is a
         // one-time snapshot baked into the buffer, so sizing against a transient
         // first layout pass would remain wrong after the pane settles.
-        val trustedWidthCells =
-            if (myTerminalWidth >= AUTO_TRUST_GRID_COLS || myLastTrustedWidth <= 0) myTerminalWidth
-            else myLastTrustedWidth
-        val trustedHeightCells =
-            if (myTerminalHeight >= AUTO_TRUST_GRID_ROWS || myLastTrustedHeight <= 0) myTerminalHeight
-            else myLastTrustedHeight
+        val currentGrid = TerminalGrid(myTerminalWidth, myTerminalHeight)
+        val sizingGrid =
+            if (currentGrid.columns >= AUTO_TRUST_GRID_COLS && currentGrid.rows >= AUTO_TRUST_GRID_ROWS) {
+                currentGrid
+            } else {
+                myLastTrustedGrid ?: currentGrid
+            }
         val dimensions = ImageDimensionCalculator.calculate(
             image = image,
-            terminalWidthCells = trustedWidthCells,
-            terminalHeightCells = trustedHeightCells,
+            terminalWidthCells = sizingGrid.columns,
+            terminalHeightCells = sizingGrid.rows,
             cellWidthPx = myCellWidthPx,
             cellHeightPx = myCellHeightPx,
             pixelScale = myDisplayScale
         )
         LOG.debug(
             "processInlineImage: grid={}x{} sized-against={}x{} cellPx={}x{} scale={} intrinsic={}x{} -> px={}x{} cells={}x{} anchor=({},{})",
-            myTerminalWidth, myTerminalHeight, trustedWidthCells, trustedHeightCells,
+            myTerminalWidth, myTerminalHeight, sizingGrid.columns, sizingGrid.rows,
             myCellWidthPx, myCellHeightPx, myDisplayScale, image.intrinsicWidth, image.intrinsicHeight,
             dimensions.pixelWidth, dimensions.pixelHeight,
             dimensions.cellWidth, dimensions.cellHeight, anchorCol, bufferRow
@@ -718,13 +719,13 @@ class BossTerminal(
     }
 
     /**
-     * Record the current grid after the UI has observed it remain unchanged across
-     * consecutive layout samples. This lets a legitimate tiny pane replace the
-     * normal-sized fallback without treating a one-frame resize blip as trusted.
+     * Record a grid after the UI has observed it remain unchanged across consecutive
+     * layout samples. The dimensions are supplied together so a concurrent resize
+     * cannot produce a mixed pair. This lets a legitimate tiny pane replace the
+     * normal-sized fallback without trusting a one-frame resize blip.
      */
-    fun markCurrentGridStable() {
-        myLastTrustedWidth = myTerminalWidth
-        myLastTrustedHeight = myTerminalHeight
+    fun markGridStable(columns: Int, rows: Int) {
+        myLastTrustedGrid = TerminalGrid(columns, rows)
     }
 
     /**
@@ -1741,8 +1742,7 @@ class BossTerminal(
             }
         })
         if (newTermSize.columns >= AUTO_TRUST_GRID_COLS && newTermSize.rows >= AUTO_TRUST_GRID_ROWS) {
-            myLastTrustedWidth = newTermSize.columns
-            myLastTrustedHeight = newTermSize.rows
+            myLastTrustedGrid = TerminalGrid(newTermSize.columns, newTermSize.rows)
         }
     }
 
@@ -1916,7 +1916,7 @@ class BossTerminal(
         /**
          * Normal-sized grids can be trusted immediately. Smaller grids may be
          * legitimate, so the UI stability gate records those explicitly via
-         * [markCurrentGridStable] before geometry-dependent content is inserted.
+         * [markGridStable] before geometry-dependent content is inserted.
          */
         private const val AUTO_TRUST_GRID_COLS = 10
         private const val AUTO_TRUST_GRID_ROWS = 3
@@ -1925,4 +1925,6 @@ class BossTerminal(
             return TermSize(max(MIN_COLUMNS, termSize.columns), max(MIN_ROWS, termSize.rows))
         }
     }
+
+    private data class TerminalGrid(val columns: Int, val rows: Int)
 }

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -110,6 +110,12 @@ class BossTerminal(
     @Volatile
     private var myCellHeightPx: Float = 20f // Default estimate until UI sets actual value
 
+    // Device pixels per logical pixel of the display this terminal renders on
+    // (2.0 on retina). Cell metrics above are DEVICE px; inline-image sizing
+    // needs this to interpret intrinsic/px-spec image dimensions (logical px).
+    @Volatile
+    private var myDisplayScale: Float = 1f
+
     // True once the UI has completed its first layout pass for this session: real cell
     // pixel metrics pushed AND the initial grid resize applied. Until then, sizing math
     // runs against the 80x24 @ 10x20px placeholders above. Shell-prompt readiness
@@ -602,7 +608,15 @@ class BossTerminal(
             terminalWidthCells = saneWidthCells,
             terminalHeightCells = saneHeightCells,
             cellWidthPx = myCellWidthPx,
-            cellHeightPx = myCellHeightPx
+            cellHeightPx = myCellHeightPx,
+            pixelScale = myDisplayScale
+        )
+        LOG.info(
+            "processInlineImage: grid={}x{} sized-against={}x{} cellPx={}x{} scale={} intrinsic={}x{} -> px={}x{} cells={}x{} anchor=({},{})",
+            myTerminalWidth, myTerminalHeight, saneWidthCells, saneHeightCells,
+            myCellWidthPx, myCellHeightPx, myDisplayScale, image.intrinsicWidth, image.intrinsicHeight,
+            dimensions.pixelWidth, dimensions.pixelHeight,
+            dimensions.cellWidth, dimensions.cellHeight, anchorCol, bufferRow
         )
 
         // Store image data in cache
@@ -676,6 +690,13 @@ class BossTerminal(
             myCellWidthPx = cellWidthPx
             myCellHeightPx = cellHeightPx
             LOG.debug("Cell dimensions updated: {}x{} px", cellWidthPx, cellHeightPx)
+        }
+    }
+
+    /** See [myDisplayScale]. Pushed by the UI alongside [setCellDimensions]. */
+    fun setDisplayScale(scale: Float) {
+        if (scale > 0f) {
+            myDisplayScale = scale
         }
     }
 

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -110,6 +110,14 @@ class BossTerminal(
     @Volatile
     private var myCellHeightPx: Float = 20f // Default estimate until UI sets actual value
 
+    // True once the UI has completed its first layout pass for this session: real cell
+    // pixel metrics pushed AND the initial grid resize applied. Until then, sizing math
+    // runs against the 80x24 @ 10x20px placeholders above. Shell-prompt readiness
+    // (OSC 133;A) gives NO ordering guarantee relative to this — callers that place
+    // geometry-dependent content (inline images) must gate on this flag too.
+    @Volatile
+    private var myUiLayoutReady = false
+
     override fun setModeEnabled(mode: TerminalMode?, enabled: Boolean) {
         mode?.let {
             if (enabled) {
@@ -654,6 +662,18 @@ class BossTerminal(
     /** Last cell pixel size the UI measured (physical px) — used for remote "fit-to-client" resizing. */
     val cellWidthPx: Float get() = myCellWidthPx
     val cellHeightPx: Float get() = myCellHeightPx
+
+    /** See [markUiLayoutReady]. */
+    val isUiLayoutReady: Boolean get() = myUiLayoutReady
+
+    /**
+     * Called by the UI once real cell metrics have been pushed via [setCellDimensions]
+     * and the initial grid resize for this session has been applied — i.e. sizing math
+     * no longer runs against placeholder defaults. One-way latch.
+     */
+    fun markUiLayoutReady() {
+        myUiLayoutReady = true
+    }
 
     /**
      * Notify image storage when buffer scrolls.

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -118,6 +118,16 @@ class BossTerminal(
     @Volatile
     private var myUiLayoutReady = false
 
+    // Last plausible grid, tracked on every resize. Transient layout artifacts can
+    // momentarily shrink the grid to a size no real pane has (rows clamped to 2);
+    // if an inline image lands in exactly that window, sizing against the live grid
+    // bakes a squashed footprint into the buffer permanently. These remember the
+    // geometry the pane actually settles at so processInlineImage can fall back.
+    @Volatile
+    private var myLastSaneWidth = 0
+    @Volatile
+    private var myLastSaneHeight = 0
+
     override fun setModeEnabled(mode: TerminalMode?, enabled: Boolean) {
         mode?.let {
             if (enabled) {
@@ -576,11 +586,21 @@ class BossTerminal(
         var bufferRow = myCursorY - 1  // 0-indexed screen row
         val anchorCol = myCursorX  // Save original column for placement
 
-        // Calculate image dimensions
+        // Calculate image dimensions. If the live grid is degenerate (a transient
+        // layout artifact, e.g. rows clamped to 2 mid-settle), size against the
+        // last sane grid instead — the footprint below is a one-time snapshot
+        // baked into the buffer, so sizing against the blip is permanent while
+        // the blip itself lasts one frame.
+        val saneWidthCells =
+            if (myTerminalWidth >= MIN_SANE_GRID_COLS || myLastSaneWidth <= 0) myTerminalWidth
+            else myLastSaneWidth
+        val saneHeightCells =
+            if (myTerminalHeight >= MIN_SANE_GRID_ROWS || myLastSaneHeight <= 0) myTerminalHeight
+            else myLastSaneHeight
         val dimensions = ImageDimensionCalculator.calculate(
             image = image,
-            terminalWidthCells = myTerminalWidth,
-            terminalHeightCells = myTerminalHeight,
+            terminalWidthCells = saneWidthCells,
+            terminalHeightCells = saneHeightCells,
             cellWidthPx = myCellWidthPx,
             cellHeightPx = myCellHeightPx
         )
@@ -1688,6 +1708,10 @@ class BossTerminal(
                 resizeListener.onResize(oldTermSize, newTermSize)
             }
         })
+        if (newTermSize.columns >= MIN_SANE_GRID_COLS && newTermSize.rows >= MIN_SANE_GRID_ROWS) {
+            myLastSaneWidth = newTermSize.columns
+            myLastSaneHeight = newTermSize.rows
+        }
     }
 
     override fun fillScreen(c: Char) {
@@ -1856,6 +1880,15 @@ class BossTerminal(
 
         private const val MIN_COLUMNS = 5
         private const val MIN_ROWS = 2
+
+        /**
+         * Floor below which a grid is treated as a transient layout artifact
+         * rather than a real pane, for purposes of inline-image sizing (see
+         * myLastSaneWidth/Height). Distinct from MIN_COLUMNS/MIN_ROWS, which
+         * only clamp what a resize request may set.
+         */
+        private const val MIN_SANE_GRID_COLS = 10
+        private const val MIN_SANE_GRID_ROWS = 3
 
         fun ensureTermMinimumSize(termSize: TermSize): TermSize {
             return TermSize(max(MIN_COLUMNS, termSize.columns), max(MIN_ROWS, termSize.rows))

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/ChangeWidthOperation.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/ChangeWidthOperation.kt
@@ -203,6 +203,22 @@ internal class ChangeWidthOperation(
             return
         }
 
+        // Image-bearing rows are ATOMIC: each ImageCell encodes its position in
+        // the image grid (cellX/cellY vs totalCellsX/Y), so reflowing the cells
+        // like text characters — wrapping a row onto multiple output lines and
+        // reassigning columns — permanently corrupts the rendered image (the
+        // renderer derives the image's anchor from `col - cellX`). Pass the row
+        // through unchanged instead: cells right of the new width simply don't
+        // draw, and TerminalCanvasRenderer's draw-time re-fit compresses the
+        // visible portion to the live pane; if the pane widens again the intact
+        // cells render at full size. Corruption is permanent — clipping is not.
+        if (line.hasImageCells()) {
+            myCurrentLine = null
+            myCurrentLineLength = 0
+            myAllLines.add(line.copy())
+            return
+        }
+
         // Get image cells sorted by column
         val imageCells = if (line.hasImageCells()) {
             line.getAllImageCells().toSortedMap()

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/ChangeWidthOperation.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/ChangeWidthOperation.kt
@@ -1,7 +1,6 @@
 package ai.rever.bossterm.terminal.model
 
 import ai.rever.bossterm.core.compatibility.Point
-import ai.rever.bossterm.terminal.model.image.ImageCell
 import ai.rever.bossterm.terminal.util.GraphemeBoundaryUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -219,35 +218,15 @@ internal class ChangeWidthOperation(
             return
         }
 
-        // Get image cells sorted by column
-        val imageCells = if (line.hasImageCells()) {
-            line.getAllImageCells().toSortedMap()
-        } else {
-            sortedMapOf()
-        }
-        val placedImageCols = mutableSetOf<Int>()
-
-        // Track current input column position
-        var inputCol = 0
         var addedContent = false
 
-        // Process text entries, interleaving image cells at their original positions
+        // Image-bearing lines returned above, so only text entries remain here.
         line.forEachEntry(Consumer { entry: TerminalLine.TextEntry? ->
             if (entry?.isNul != false) {
                 return@Consumer
             }
             var entryProcessedLength = 0
             while (entryProcessedLength < entry.length) {
-                // Place any image cells that come before current text position
-                val currentInputPos = inputCol + entryProcessedLength
-                for ((imgCol, imgCell) in imageCells) {
-                    if (imgCol !in placedImageCols && imgCol <= currentInputPos) {
-                        placeImageCell(imgCell)
-                        placedImageCols.add(imgCol)
-                        addedContent = true
-                    }
-                }
-
                 // Ensure we have a current line
                 ensureCurrentLine()
 
@@ -274,17 +253,7 @@ internal class ChangeWidthOperation(
                     myCurrentLineLength = 0
                 }
             }
-            inputCol += entry.length
         })
-
-        // Place any remaining image cells
-        for ((imgCol, imgCell) in imageCells) {
-            if (imgCol !in placedImageCols) {
-                placeImageCell(imgCell)
-                placedImageCols.add(imgCol)
-                addedContent = true
-            }
-        }
 
         // Handle empty lines that aren't truly null
         if (!addedContent && myCurrentLine == null) {
@@ -307,23 +276,6 @@ internal class ChangeWidthOperation(
             myCurrentLineLength = 0
             myAllLines.add(newLine)
         }
-    }
-
-    /**
-     * Place a single image cell at current position.
-     * Image cells are treated like text - one cell per column position, wrap when line full.
-     */
-    private fun placeImageCell(cell: ImageCell) {
-        // Wrap if line is full
-        if (myCurrentLine != null && myCurrentLineLength == myNewWidth) {
-            myCurrentLine?.isWrapped = true
-            myCurrentLine = null
-            myCurrentLineLength = 0
-        }
-        ensureCurrentLine()
-
-        myCurrentLine?.setImageCell(myCurrentLineLength, cell)
-        myCurrentLineLength++
     }
 
     class TrackingPoint(val x: Int, val y: Int, val forceVisible: Boolean) {

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/image/TerminalImagePlacement.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/image/TerminalImagePlacement.kt
@@ -73,6 +73,11 @@ object ImageDimensionCalculator {
      * @param terminalHeightCells Terminal height in cells
      * @param cellWidthPx Width of a single cell in pixels
      * @param cellHeightPx Height of a single cell in pixels
+     * @param pixelScale Device pixels per logical pixel (2.0 on retina). Cell
+     *   metrics arrive in DEVICE px, but [DimensionSpec.Pixels] values and the
+     *   image's intrinsic size are logical quantities — without this factor an
+     *   auto-sized image bakes at half its intended size on a 2x display.
+     *   Percent/Cells specs are unit-free and unaffected.
      * @return Pair of (pixelWidth, pixelHeight) and (cellWidth, cellHeight)
      */
     fun calculate(
@@ -80,25 +85,29 @@ object ImageDimensionCalculator {
         terminalWidthCells: Int,
         terminalHeightCells: Int,
         cellWidthPx: Float,
-        cellHeightPx: Float
+        cellHeightPx: Float,
+        pixelScale: Float = 1f
     ): ImageDimensions {
         val terminalWidthPx = terminalWidthCells * cellWidthPx
         val terminalHeightPx = terminalHeightCells * cellHeightPx
+        val scale = if (pixelScale > 0f) pixelScale else 1f
+        val intrinsicWidthPx = image.intrinsicWidth * scale
+        val intrinsicHeightPx = image.intrinsicHeight * scale
 
         // Calculate target width in pixels
         var targetWidthPx = when (val spec = image.widthSpec) {
             is DimensionSpec.Cells -> (spec.count * cellWidthPx).toInt()
-            is DimensionSpec.Pixels -> spec.count
+            is DimensionSpec.Pixels -> (spec.count * scale).toInt()
             is DimensionSpec.Percent -> (terminalWidthPx * spec.value / 100).toInt()
-            is DimensionSpec.Auto -> image.intrinsicWidth
+            is DimensionSpec.Auto -> intrinsicWidthPx.toInt()
         }
 
         // Calculate target height in pixels
         var targetHeightPx = when (val spec = image.heightSpec) {
             is DimensionSpec.Cells -> (spec.count * cellHeightPx).toInt()
-            is DimensionSpec.Pixels -> spec.count
+            is DimensionSpec.Pixels -> (spec.count * scale).toInt()
             is DimensionSpec.Percent -> (terminalHeightPx * spec.value / 100).toInt()
-            is DimensionSpec.Auto -> image.intrinsicHeight
+            is DimensionSpec.Auto -> intrinsicHeightPx.toInt()
         }
 
         // Preserve aspect ratio if requested
@@ -128,11 +137,11 @@ object ImageDimensionCalculator {
                 }
                 // Both specified - fit within bounds while preserving aspect ratio
                 else -> {
-                    val widthRatio = targetWidthPx.toFloat() / image.intrinsicWidth
-                    val heightRatio = targetHeightPx.toFloat() / image.intrinsicHeight
-                    val scale = minOf(widthRatio, heightRatio)
-                    targetWidthPx = (image.intrinsicWidth * scale).toInt()
-                    targetHeightPx = (image.intrinsicHeight * scale).toInt()
+                    val widthRatio = targetWidthPx / intrinsicWidthPx
+                    val heightRatio = targetHeightPx / intrinsicHeightPx
+                    val fitScale = minOf(widthRatio, heightRatio)
+                    targetWidthPx = (intrinsicWidthPx * fitScale).toInt()
+                    targetHeightPx = (intrinsicHeightPx * fitScale).toInt()
                 }
             }
         }

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/image/TerminalImagePlacement.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/image/TerminalImagePlacement.kt
@@ -106,12 +106,15 @@ object ImageDimensionCalculator {
             val aspectRatio = image.intrinsicWidth.toFloat() / image.intrinsicHeight.toFloat()
 
             when {
-                // Both auto - use intrinsic size but constrain to terminal width
+                // Both auto - use intrinsic size but constrain to terminal bounds.
+                // Either dimension can overflow (wide image in a narrow pane, tall
+                // image in a short split), so fit by the most-constrained axis.
                 image.widthSpec is DimensionSpec.Auto && image.heightSpec is DimensionSpec.Auto -> {
-                    // If wider than terminal, scale down to fit while preserving aspect ratio
-                    if (targetWidthPx > terminalWidthPx) {
-                        val scale = terminalWidthPx / targetWidthPx
-                        targetWidthPx = terminalWidthPx.toInt()
+                    val widthScale = if (targetWidthPx > terminalWidthPx) terminalWidthPx / targetWidthPx else 1f
+                    val heightScale = if (targetHeightPx > terminalHeightPx) terminalHeightPx / targetHeightPx else 1f
+                    val scale = minOf(widthScale, heightScale)
+                    if (scale < 1f) {
+                        targetWidthPx = (targetWidthPx * scale).toInt()
                         targetHeightPx = (targetHeightPx * scale).toInt()
                     }
                 }

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/BossTerminalImageSizingTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/BossTerminalImageSizingTest.kt
@@ -29,12 +29,24 @@ class BossTerminalImageSizingTest {
         val terminal = createTerminal()
         terminal.resize(TermSize(100, 20), RequestOrigin.User)
         terminal.resize(TermSize(5, 2), RequestOrigin.User)
-        terminal.markCurrentGridStable()
+        terminal.markGridStable(columns = 5, rows = 2)
 
         val placement = terminal.processInlineImage(autoImage())!!
 
         assertEquals(5, placement.cellWidth)
         assertEquals(2, placement.cellHeight)
+    }
+
+    @Test
+    fun transientDimensionFallsBackToOneTrustedGridPair() {
+        val terminal = createTerminal()
+        terminal.resize(TermSize(81, 24), RequestOrigin.User)
+        terminal.resize(TermSize(100, 2), RequestOrigin.User)
+
+        val placement = terminal.processInlineImage(autoImage(width = 900, height = 300))!!
+
+        assertEquals(81, placement.cellWidth)
+        assertEquals(14, placement.cellHeight)
     }
 
     private fun createTerminal(): BossTerminal {
@@ -45,10 +57,10 @@ class BossTerminalImageSizingTest {
         }
     }
 
-    private fun autoImage() = TerminalImage(
+    private fun autoImage(width: Int = 500, height: Int = 300) = TerminalImage(
         data = ByteArray(1),
-        intrinsicWidth = 500,
-        intrinsicHeight = 300
+        intrinsicWidth = width,
+        intrinsicHeight = height
     )
 
     private class NoopTerminalDisplay : TerminalDisplay {

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/BossTerminalImageSizingTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/BossTerminalImageSizingTest.kt
@@ -1,0 +1,69 @@
+package ai.rever.bossterm.terminal.model
+
+import ai.rever.bossterm.core.util.TermSize
+import ai.rever.bossterm.terminal.CursorShape
+import ai.rever.bossterm.terminal.RequestOrigin
+import ai.rever.bossterm.terminal.TerminalDisplay
+import ai.rever.bossterm.terminal.emulator.mouse.MouseFormat
+import ai.rever.bossterm.terminal.emulator.mouse.MouseMode
+import ai.rever.bossterm.terminal.model.image.TerminalImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BossTerminalImageSizingTest {
+
+    @Test
+    fun inlineImageUsesLastNormalGridDuringTransientTinyResize() {
+        val terminal = createTerminal()
+        terminal.resize(TermSize(100, 20), RequestOrigin.User)
+        terminal.resize(TermSize(5, 2), RequestOrigin.User)
+
+        val placement = terminal.processInlineImage(autoImage())!!
+
+        assertEquals(50, placement.cellWidth)
+        assertEquals(15, placement.cellHeight)
+    }
+
+    @Test
+    fun stableTinyGridReplacesNormalFallback() {
+        val terminal = createTerminal()
+        terminal.resize(TermSize(100, 20), RequestOrigin.User)
+        terminal.resize(TermSize(5, 2), RequestOrigin.User)
+        terminal.markCurrentGridStable()
+
+        val placement = terminal.processInlineImage(autoImage())!!
+
+        assertEquals(5, placement.cellWidth)
+        assertEquals(2, placement.cellHeight)
+    }
+
+    private fun createTerminal(): BossTerminal {
+        val styleState = StyleState()
+        val textBuffer = TerminalTextBuffer(width = 80, height = 24, styleState = styleState)
+        return BossTerminal(NoopTerminalDisplay(), textBuffer, styleState).apply {
+            setCellDimensions(cellWidthPx = 10f, cellHeightPx = 20f)
+        }
+    }
+
+    private fun autoImage() = TerminalImage(
+        data = ByteArray(1),
+        intrinsicWidth = 500,
+        intrinsicHeight = 300
+    )
+
+    private class NoopTerminalDisplay : TerminalDisplay {
+        override var windowTitle: String? = null
+        override var iconTitle: String? = null
+        override val selection: TerminalSelection? = null
+
+        override fun setCursor(x: Int, y: Int) = Unit
+        override fun setCursorShape(cursorShape: CursorShape?) = Unit
+        override fun beep() = Unit
+        override fun scrollArea(scrollRegionTop: Int, scrollRegionSize: Int, dy: Int) = Unit
+        override fun setCursorVisible(isCursorVisible: Boolean) = Unit
+        override fun useAlternateScreenBuffer(useAlternateScreenBuffer: Boolean) = Unit
+        override fun terminalMouseModeSet(mouseMode: MouseMode) = Unit
+        override fun setMouseFormat(mouseFormat: MouseFormat) = Unit
+        override fun ambiguousCharsAreDoubleWidth(): Boolean = false
+    }
+}

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/ChangeWidthOperationImageTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/ChangeWidthOperationImageTest.kt
@@ -1,0 +1,41 @@
+package ai.rever.bossterm.terminal.model
+
+import ai.rever.bossterm.terminal.model.image.ImageCell
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+
+class ChangeWidthOperationImageTest {
+
+    @Test
+    fun imageBearingRowPassesThroughNarrowerReflowAtomically() {
+        val styleState = StyleState()
+        val textBuffer = TerminalTextBuffer(width = 8, height = 4, styleState = styleState)
+        val imageLine = TerminalLine().apply {
+            repeat(6) { column ->
+                setImageCell(
+                    column,
+                    ImageCell(
+                        imageId = 42,
+                        cellX = column,
+                        cellY = 1,
+                        totalCellsX = 6,
+                        totalCellsY = 3
+                    )
+                )
+            }
+        }
+        textBuffer.screenLinesStorage.addToBottom(imageLine)
+
+        ChangeWidthOperation(textBuffer, myNewWidth = 4, myNewHeight = 4).run()
+
+        val outputLine = textBuffer.screenLinesStorage[0]
+        assertNotSame(imageLine, outputLine)
+        assertEquals((0 until 6).toSet(), outputLine.getAllImageCells().keys)
+        assertEquals(
+            (0 until 6).toList(),
+            outputLine.getAllImageCells().toSortedMap().values.map { it.cellX }
+        )
+        assertEquals(setOf(1), outputLine.getAllImageCells().values.map { it.cellY }.toSet())
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -796,7 +796,14 @@ fun TabbedTerminal(
             else active.id to active.display.termSize.value
         }.collect { sized ->
             val (activeId, size) = sized ?: return@collect
-            if (size.columns < 2 || size.rows < 2) return@collect
+            if (size.columns < 4 || size.rows < 3) return@collect
+            // A freshly created (now active) tab reports its unmeasured initial
+            // 80x24 grid until its first real layout pass; fanning that — or a
+            // transient degenerate measure — out to every background tab thrashes
+            // their grids (and anything sized against them mid-blip, e.g. MCP
+            // show_image, bakes wrong permanently). Wait for a real layout.
+            val activeTerminal = (tabController.activeTab)?.terminal ?: return@collect
+            if (!activeTerminal.isUiLayoutReady) return@collect
             tabController.tabs.forEach { t ->
                 if (t.id == activeId || t.isRemote) return@forEach
                 val ss = splitStates[t.id]

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -794,16 +794,22 @@ fun TabbedTerminal(
             val ss = splitStates[active.id]
             if (ss != null && ss.getAllPanes().size > 1) null
             else active.id to active.display.termSize.value
-        }.collect { sized ->
-            val (activeId, size) = sized ?: return@collect
-            if (size.columns < 4 || size.rows < 3) return@collect
+        }.collectLatest { sized ->
+            val (activeId, size) = sized ?: return@collectLatest
+            if (size.columns < 5 || size.rows < 2) return@collectLatest
             // A freshly created (now active) tab reports its unmeasured initial
             // 80x24 grid until its first real layout pass; fanning that — or a
-            // transient degenerate measure — out to every background tab thrashes
+            // transient first measure — out to every background tab thrashes
             // their grids (and anything sized against them mid-blip, e.g. MCP
-            // show_image, bakes wrong permanently). Wait for a real layout.
-            val activeTerminal = (tabController.activeTab)?.terminal ?: return@collect
-            if (!activeTerminal.isUiLayoutReady) return@collect
+            // show_image, bakes wrong permanently). Debounce size changes instead
+            // of rejecting valid tiny panes by dimension; collectLatest cancels
+            // this delay if another layout arrives.
+            kotlinx.coroutines.delay(180)
+            val settledActive = tabController.activeTab ?: return@collectLatest
+            if (settledActive.id != activeId || settledActive.display.termSize.value != size) {
+                return@collectLatest
+            }
+            if (!settledActive.terminal.isUiLayoutReady) return@collectLatest
             tabController.tabs.forEach { t ->
                 if (t.id == activeId || t.isRemote) return@forEach
                 val ss = splitStates[t.id]

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1284,7 +1284,7 @@ class BossTermMcpServer(
                     withTimeoutOrNull(timeoutMs) { signal.await() }
                 }
                 val layoutWait = async {
-                    val settled = withTimeoutOrNull(LAYOUT_SETTLE_TIMEOUT_MS) {
+                    val settledGrid = withTimeoutOrNull(LAYOUT_SETTLE_TIMEOUT_MS) {
                         while (!terminal.isUiLayoutReady) delay(25)
                         var stableSamples = 0
                         var lastWidth = -1
@@ -1305,10 +1305,10 @@ class BossTermMcpServer(
                             }
                             delay(GRID_STABLE_SAMPLE_MS)
                         }
-                        true
-                    } == true
-                    if (settled) {
-                        terminal.markCurrentGridStable()
+                        lastWidth to lastHeight
+                    }
+                    if (settledGrid != null) {
+                        terminal.markGridStable(settledGrid.first, settledGrid.second)
                     }
                 }
                 promptWait.await()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1252,11 +1252,18 @@ class BossTermMcpServer(
 
     /**
      * Suspend until [session] is ready to receive geometry-dependent content, or
-     * [timeoutMs] elapses. Readiness is TWO independent conditions (issue #324):
-     * the shell has signalled OSC 133;A (prompt ready), and the Compose UI has
-     * completed its first layout pass ([BossTerminal.isUiLayoutReady] — real cell
-     * metrics + initial grid resize). The prompt often wins that race, so waiting
-     * on it alone would size images against the placeholder 80x24 @ 10x20px grid.
+     * [timeoutMs] elapses. Readiness is THREE conditions (issue #324):
+     *
+     *  1. The shell has signalled OSC 133;A (prompt ready).
+     *  2. The Compose UI has completed a layout pass ([BossTerminal.isUiLayoutReady]
+     *     — real cell metrics + a grid resize). The prompt often wins that race,
+     *     so waiting on it alone would size images against the placeholder
+     *     80x24 @ 10x20px grid.
+     *  3. The grid has stopped changing. The FIRST layout pass of a fresh
+     *     tab/split can be degenerate (a transient 2-row grid mid-settle);
+     *     content injected at that moment is sized against the throwaway grid
+     *     and baked that way into the buffer, so we require the dimensions to
+     *     hold still across consecutive samples before trusting them.
      */
     private suspend fun awaitPaneReady(session: TerminalSession, timeoutMs: Long) {
         val terminal = session.terminal
@@ -1268,9 +1275,34 @@ class BossTermMcpServer(
         }
         terminal.addCommandStateListener(listener)
         try {
-            withTimeoutOrNull(timeoutMs) {
-                signal.await()
+            // Prompt readiness runs on the user-configured budget (missing
+            // shell integration should cost no more than it does today) ...
+            withTimeoutOrNull(timeoutMs) { signal.await() }
+            // ... while layout settle gets its own fixed budget: sharing one
+            // budget let a slow shell rc exhaust the wait and inject against a
+            // mid-settle grid. Normally completes in well under 500ms.
+            withTimeoutOrNull(LAYOUT_SETTLE_TIMEOUT_MS) {
                 while (!terminal.isUiLayoutReady) delay(25)
+                var stableSamples = 0
+                var lastWidth = -1
+                var lastHeight = -1
+                while (stableSamples < GRID_STABLE_SAMPLES) {
+                    val width = session.textBuffer.width
+                    val height = session.textBuffer.height
+                    // A fresh pane's first layout pass can measure a throwaway
+                    // near-zero canvas, producing rows == coerceAtLeast(2).
+                    // Such a grid is never a real pane — keep waiting for the
+                    // settled layout even if it is momentarily "stable".
+                    val sane = width >= MIN_SANE_GRID_COLS && height >= MIN_SANE_GRID_ROWS
+                    if (sane && width == lastWidth && height == lastHeight) {
+                        stableSamples++
+                    } else {
+                        stableSamples = 0
+                        lastWidth = width
+                        lastHeight = height
+                    }
+                    delay(GRID_STABLE_SAMPLE_MS)
+                }
             }
         } finally {
             terminal.removeCommandStateListener(listener)
@@ -2384,6 +2416,35 @@ class BossTermMcpServer(
          * it would invite agents to set it sky-high and lose TUI detection.
          */
         private const val TUI_POLL_INTERVAL_MS = 100L
+
+        /**
+         * Grid-stability gate for `awaitPaneReady`: the buffer's cols/rows must
+         * be unchanged across this many consecutive samples, taken this far
+         * apart, before a freshly-created pane is trusted with geometry-
+         * dependent content. 3 x 60ms ≈ one to two Compose layout/resize beats:
+         * long enough to outlive the transient first-pass grid (observed: a
+         * 2-row measure before a fresh tab settles), short enough to be
+         * imperceptible next to shell startup.
+         */
+        private const val GRID_STABLE_SAMPLES = 3
+        private const val GRID_STABLE_SAMPLE_MS = 60L
+
+        /**
+         * Floor below which a grid is treated as a transient layout artifact
+         * rather than a real pane (ProperTerminal clamps degenerate measures
+         * to 2 rows/cols, and no usable pane is 2 rows tall). A genuinely
+         * tiny pane falls back to the overall timeout instead of the gate.
+         */
+        private const val MIN_SANE_GRID_COLS = 10
+        private const val MIN_SANE_GRID_ROWS = 3
+
+        /**
+         * Dedicated budget for the UI-layout-ready + grid-stability wait in
+         * `awaitPaneReady`, independent of the shell-prompt budget so a slow
+         * shell rc can't starve it. Generous vs. the ~200-500ms it takes in
+         * practice; small vs. a user noticing a hung tool call.
+         */
+        private const val LAYOUT_SETTLE_TIMEOUT_MS = 3_000L
 
         /**
          * Valid values for `mcpRunCommandDefaultPanel`. Excludes "reuse"

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1212,13 +1212,15 @@ class BossTermMcpServer(
             // show_image calls on the same pane.
             registry.paneMutex(resolvedPaneId).withLock {
                 // Freshly created panes haven't drawn their first prompt (or been laid
-                // out, which sets real cell metrics). Wait for OSC 133;A so placement
-                // sizes against the real grid and lands below a clean prompt.
+                // out, which sets real cell metrics). Wait for OSC 133;A so the image
+                // lands below a clean prompt, AND for the UI layout latch so placement
+                // sizes against the real grid instead of the 80x24 placeholder — the
+                // two signals arrive on independent paths with no ordering guarantee.
                 if (freshlyCreated) {
                     val shellReadyTimeoutMs = settingsManager.settings.value
                         .mcpRunCommandShellReadyTimeoutMs
                         .coerceIn(0, MAX_SHELL_READY_TIMEOUT_MS).toLong()
-                    if (shellReadyTimeoutMs > 0) awaitPromptReady(tab, shellReadyTimeoutMs)
+                    if (shellReadyTimeoutMs > 0) awaitPaneReady(tab, shellReadyTimeoutMs)
                 }
 
                 val osc = buildOsc1337Image(
@@ -1249,11 +1251,14 @@ class BossTermMcpServer(
     }
 
     /**
-     * Suspend until [session]'s shell signals OSC 133;A (prompt ready) or
-     * [timeoutMs] elapses. Used to defer image injection on freshly created
-     * panes until the pane is laid out and the prompt is drawn.
+     * Suspend until [session] is ready to receive geometry-dependent content, or
+     * [timeoutMs] elapses. Readiness is TWO independent conditions (issue #324):
+     * the shell has signalled OSC 133;A (prompt ready), and the Compose UI has
+     * completed its first layout pass ([BossTerminal.isUiLayoutReady] — real cell
+     * metrics + initial grid resize). The prompt often wins that race, so waiting
+     * on it alone would size images against the placeholder 80x24 @ 10x20px grid.
      */
-    private suspend fun awaitPromptReady(session: TerminalSession, timeoutMs: Long) {
+    private suspend fun awaitPaneReady(session: TerminalSession, timeoutMs: Long) {
         val terminal = session.terminal
         val signal = CompletableDeferred<Unit>()
         val listener = object : CommandStateListener {
@@ -1263,7 +1268,10 @@ class BossTermMcpServer(
         }
         terminal.addCommandStateListener(listener)
         try {
-            withTimeoutOrNull(timeoutMs) { signal.await() }
+            withTimeoutOrNull(timeoutMs) {
+                signal.await()
+                while (!terminal.isUiLayoutReady) delay(25)
+            }
         } finally {
             terminal.removeCommandStateListener(listener)
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1210,7 +1210,10 @@ class BossTermMcpServer(
                 ?: return@addTool errorResult("Target pane does not support image output")
 
             // Per-pane mutex serializes with concurrent run_command / run_in_panel /
-            // show_image calls on the same pane.
+            // show_image calls on the same pane. Keep the readiness wait inside the
+            // lock intentionally: it can cost up to LAYOUT_SETTLE_TIMEOUT_MS on a
+            // slow layout, but releasing here would let later pane writes overtake
+            // this image and race its prompt/layout-dependent placement.
             registry.paneMutex(resolvedPaneId).withLock {
                 // Freshly created panes haven't drawn their first prompt (or been laid
                 // out, which sets real cell metrics). Wait for OSC 133;A so the image

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -19,6 +19,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -1275,34 +1276,43 @@ class BossTermMcpServer(
         }
         terminal.addCommandStateListener(listener)
         try {
-            // Prompt readiness runs on the user-configured budget (missing
-            // shell integration should cost no more than it does today) ...
-            withTimeoutOrNull(timeoutMs) { signal.await() }
-            // ... while layout settle gets its own fixed budget: sharing one
-            // budget let a slow shell rc exhaust the wait and inject against a
-            // mid-settle grid. Normally completes in well under 500ms.
-            withTimeoutOrNull(LAYOUT_SETTLE_TIMEOUT_MS) {
-                while (!terminal.isUiLayoutReady) delay(25)
-                var stableSamples = 0
-                var lastWidth = -1
-                var lastHeight = -1
-                while (stableSamples < GRID_STABLE_SAMPLES) {
-                    val width = session.textBuffer.width
-                    val height = session.textBuffer.height
-                    // A fresh pane's first layout pass can measure a throwaway
-                    // near-zero canvas, producing rows == coerceAtLeast(2).
-                    // Such a grid is never a real pane — keep waiting for the
-                    // settled layout even if it is momentarily "stable".
-                    val sane = width >= MIN_SANE_GRID_COLS && height >= MIN_SANE_GRID_ROWS
-                    if (sane && width == lastWidth && height == lastHeight) {
-                        stableSamples++
-                    } else {
-                        stableSamples = 0
-                        lastWidth = width
-                        lastHeight = height
-                    }
-                    delay(GRID_STABLE_SAMPLE_MS)
+            // Prompt and layout readiness arrive independently, so run their
+            // independent timeout budgets concurrently. Worst-case latency is
+            // max(prompt, layout), rather than their sum.
+            coroutineScope {
+                val promptWait = async {
+                    withTimeoutOrNull(timeoutMs) { signal.await() }
                 }
+                val layoutWait = async {
+                    val settled = withTimeoutOrNull(LAYOUT_SETTLE_TIMEOUT_MS) {
+                        while (!terminal.isUiLayoutReady) delay(25)
+                        var stableSamples = 0
+                        var lastWidth = -1
+                        var lastHeight = -1
+                        while (stableSamples < GRID_STABLE_SAMPLES) {
+                            val width = session.textBuffer.width
+                            val height = session.textBuffer.height
+                            // Do not reject a genuinely tiny pane. The terminal's
+                            // actual 5x2 minimum is valid; stability across samples
+                            // distinguishes it from a throwaway first layout pass.
+                            val valid = width >= MIN_TERMINAL_GRID_COLS && height >= MIN_TERMINAL_GRID_ROWS
+                            if (valid && width == lastWidth && height == lastHeight) {
+                                stableSamples++
+                            } else {
+                                stableSamples = 0
+                                lastWidth = width
+                                lastHeight = height
+                            }
+                            delay(GRID_STABLE_SAMPLE_MS)
+                        }
+                        true
+                    } == true
+                    if (settled) {
+                        terminal.markCurrentGridStable()
+                    }
+                }
+                promptWait.await()
+                layoutWait.await()
             }
         } finally {
             terminal.removeCommandStateListener(listener)
@@ -2430,13 +2440,12 @@ class BossTermMcpServer(
         private const val GRID_STABLE_SAMPLE_MS = 60L
 
         /**
-         * Floor below which a grid is treated as a transient layout artifact
-         * rather than a real pane (ProperTerminal clamps degenerate measures
-         * to 2 rows/cols, and no usable pane is 2 rows tall). A genuinely
-         * tiny pane falls back to the overall timeout instead of the gate.
+         * BossTerminal's actual grid minimum. A 5x2 pane is small but valid;
+         * the consecutive-sample gate above, rather than an arbitrary size
+         * floor, distinguishes stable layout from a transient first pass.
          */
-        private const val MIN_SANE_GRID_COLS = 10
-        private const val MIN_SANE_GRID_ROWS = 3
+        private const val MIN_TERMINAL_GRID_COLS = 5
+        private const val MIN_TERMINAL_GRID_ROWS = 2
 
         /**
          * Dedicated budget for the UI-layout-ready + grid-stability wait in

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -308,6 +308,10 @@ data class CachedMeasurement(
  */
 object TerminalCanvasRenderer {
 
+    // Dedupe set for the image-geometry anomaly log below — each distinct
+    // geometry logs once, not once per frame.
+    private val imageDiagSeen = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
+
     /**
      * LRU cache for text measurements (issue #147 - special character rendering optimization).
      * Caches TextMeasurer results to avoid expensive measure() calls for repeated characters.
@@ -790,6 +794,16 @@ object TerminalCanvasRenderer {
                             } else {
                                 effCellsX = imageCell.totalCellsX
                                 effCellsY = imageCell.totalCellsY
+                            }
+                            // Anomaly flight-recorder (#326): draw-time geometry disagreeing
+                            // with the baked footprint is exactly the state that produced
+                            // silent image corruption before; log it (deduped) so a field
+                            // report comes with numbers. Healthy frames log nothing.
+                            if (effCellsX != imageCell.totalCellsX || anchorCol < 0) {
+                                val sig = "img=${imageCell.imageId} lineIdx=$lineIndex col=$col cellXY=(${imageCell.cellX},${imageCell.cellY}) " +
+                                        "total=(${imageCell.totalCellsX},${imageCell.totalCellsY}) eff=($effCellsX,$effCellsY) " +
+                                        "anchorCol=$anchorCol visCols=${ctx.visibleCols}"
+                                if (imageDiagSeen.add(sig)) println("IMG-REFIT $sig")
                             }
                             // Cells beyond the re-fit footprint hold no slice; leave background.
                             if (imageCell.cellX < effCellsX && imageCell.cellY < effCellsY) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -302,15 +302,32 @@ data class CachedMeasurement(
     val firstBaseline: Float
 )
 
+internal data class ImageCellGrid(val columns: Int, val rows: Int)
+
+/**
+ * Re-fit an image's baked cell footprint to the columns reachable in the live
+ * pane while preserving its cell-grid aspect ratio.
+ */
+internal fun refitImageCellGrid(
+    totalColumns: Int,
+    totalRows: Int,
+    anchorColumn: Int,
+    visibleColumns: Int
+): ImageCellGrid {
+    val safeColumns = totalColumns.coerceAtLeast(1)
+    val safeRows = totalRows.coerceAtLeast(1)
+    val availableColumns = (visibleColumns - anchorColumn).coerceAtLeast(1)
+    if (safeColumns <= availableColumns) return ImageCellGrid(safeColumns, safeRows)
+
+    val fittedRows = ((safeRows * availableColumns + safeColumns / 2) / safeColumns).coerceAtLeast(1)
+    return ImageCellGrid(availableColumns, fittedRows)
+}
+
 /**
  * Terminal canvas renderer that handles all drawing operations.
  * Separates rendering logic from the composable for better maintainability.
  */
 object TerminalCanvasRenderer {
-
-    // Dedupe set for the image-geometry anomaly log below — each distinct
-    // geometry logs once, not once per frame.
-    private val imageDiagSeen = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
 
     /**
      * LRU cache for text measurements (issue #147 - special character rendering optimization).
@@ -784,27 +801,14 @@ object TerminalCanvasRenderer {
                             // compress the full bitmap into the columns actually reachable from
                             // the anchor, shrinking rows by the same factor to keep aspect.
                             val anchorCol = col - imageCell.cellX
-                            val availableCols = ctx.visibleCols - anchorCol
-                            val effCellsX: Int
-                            val effCellsY: Int
-                            if (imageCell.totalCellsX > availableCols) {
-                                effCellsX = availableCols.coerceAtLeast(1)
-                                effCellsY = ((imageCell.totalCellsY * effCellsX + imageCell.totalCellsX / 2) /
-                                        imageCell.totalCellsX).coerceAtLeast(1)
-                            } else {
-                                effCellsX = imageCell.totalCellsX
-                                effCellsY = imageCell.totalCellsY
-                            }
-                            // Anomaly flight-recorder (#326): draw-time geometry disagreeing
-                            // with the baked footprint is exactly the state that produced
-                            // silent image corruption before; log it (deduped) so a field
-                            // report comes with numbers. Healthy frames log nothing.
-                            if (effCellsX != imageCell.totalCellsX || anchorCol < 0) {
-                                val sig = "img=${imageCell.imageId} lineIdx=$lineIndex col=$col cellXY=(${imageCell.cellX},${imageCell.cellY}) " +
-                                        "total=(${imageCell.totalCellsX},${imageCell.totalCellsY}) eff=($effCellsX,$effCellsY) " +
-                                        "anchorCol=$anchorCol visCols=${ctx.visibleCols}"
-                                if (imageDiagSeen.add(sig)) println("IMG-REFIT $sig")
-                            }
+                            val effectiveGrid = refitImageCellGrid(
+                                totalColumns = imageCell.totalCellsX,
+                                totalRows = imageCell.totalCellsY,
+                                anchorColumn = anchorCol,
+                                visibleColumns = ctx.visibleCols
+                            )
+                            val effCellsX = effectiveGrid.columns
+                            val effCellsY = effectiveGrid.rows
                             // Cells beyond the re-fit footprint hold no slice; leave background.
                             if (imageCell.cellX < effCellsX && imageCell.cellY < effCellsY) {
                                 // Calculate source region - use exact boundaries to avoid gaps

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -772,34 +772,56 @@ object TerminalCanvasRenderer {
                     if (image != null) {
                         val bitmap = ImageRenderer.getOrDecodeImage(image)
                         if (bitmap != null) {
-                            // Calculate source region - use exact boundaries to avoid gaps
-                            val srcX1 = imageCell.cellX * bitmap.width / imageCell.totalCellsX
-                            val srcX2 = (imageCell.cellX + 1) * bitmap.width / imageCell.totalCellsX
-                            val srcY1 = imageCell.cellY * bitmap.height / imageCell.totalCellsY
-                            val srcY2 = (imageCell.cellY + 1) * bitmap.height / imageCell.totalCellsY
-                            val srcX = srcX1
-                            val srcY = srcY1
-                            val srcW = (srcX2 - srcX1).coerceAtLeast(1)
-                            val srcH = (srcY2 - srcY1).coerceAtLeast(1)
+                            // The cell footprint (totalCellsX/Y) is a one-time snapshot of the
+                            // grid at insertion time; the live grid can be narrower (insertion
+                            // raced pane layout, or the pane shrank since). Slicing against the
+                            // stale footprint would hard-crop every column past visibleCols for
+                            // the image's whole buffer lifetime. Re-fit at draw time instead:
+                            // compress the full bitmap into the columns actually reachable from
+                            // the anchor, shrinking rows by the same factor to keep aspect.
+                            val anchorCol = col - imageCell.cellX
+                            val availableCols = ctx.visibleCols - anchorCol
+                            val effCellsX: Int
+                            val effCellsY: Int
+                            if (imageCell.totalCellsX > availableCols) {
+                                effCellsX = availableCols.coerceAtLeast(1)
+                                effCellsY = ((imageCell.totalCellsY * effCellsX + imageCell.totalCellsX / 2) /
+                                        imageCell.totalCellsX).coerceAtLeast(1)
+                            } else {
+                                effCellsX = imageCell.totalCellsX
+                                effCellsY = imageCell.totalCellsY
+                            }
+                            // Cells beyond the re-fit footprint hold no slice; leave background.
+                            if (imageCell.cellX < effCellsX && imageCell.cellY < effCellsY) {
+                                // Calculate source region - use exact boundaries to avoid gaps
+                                val srcX1 = imageCell.cellX * bitmap.width / effCellsX
+                                val srcX2 = (imageCell.cellX + 1) * bitmap.width / effCellsX
+                                val srcY1 = imageCell.cellY * bitmap.height / effCellsY
+                                val srcY2 = (imageCell.cellY + 1) * bitmap.height / effCellsY
+                                val srcX = srcX1
+                                val srcY = srcY1
+                                val srcW = (srcX2 - srcX1).coerceAtLeast(1)
+                                val srcH = (srcY2 - srcY1).coerceAtLeast(1)
 
-                            // Destination - use exact boundaries to avoid gaps
-                            val dstX1 = (visualCol * ctx.cellWidth).toInt()
-                            val dstX2 = ((visualCol + 1) * ctx.cellWidth).toInt()
-                            val dstY1 = (row * ctx.cellHeight).toInt()
-                            val dstY2 = ((row + 1) * ctx.cellHeight).toInt()
-                            val dstX = dstX1
-                            val dstY = dstY1
-                            val dstW = (dstX2 - dstX1).coerceAtLeast(1)
-                            val dstH = (dstY2 - dstY1).coerceAtLeast(1)
+                                // Destination - use exact boundaries to avoid gaps
+                                val dstX1 = (visualCol * ctx.cellWidth).toInt()
+                                val dstX2 = ((visualCol + 1) * ctx.cellWidth).toInt()
+                                val dstY1 = (row * ctx.cellHeight).toInt()
+                                val dstY2 = ((row + 1) * ctx.cellHeight).toInt()
+                                val dstX = dstX1
+                                val dstY = dstY1
+                                val dstW = (dstX2 - dstX1).coerceAtLeast(1)
+                                val dstH = (dstY2 - dstY1).coerceAtLeast(1)
 
-                            // Draw the portion of the image for this cell
-                            drawImage(
-                                image = bitmap,
-                                srcOffset = androidx.compose.ui.unit.IntOffset(srcX, srcY),
-                                srcSize = androidx.compose.ui.unit.IntSize(srcW, srcH),
-                                dstOffset = androidx.compose.ui.unit.IntOffset(dstX, dstY),
-                                dstSize = androidx.compose.ui.unit.IntSize(dstW, dstH)
-                            )
+                                // Draw the portion of the image for this cell
+                                drawImage(
+                                    image = bitmap,
+                                    srcOffset = androidx.compose.ui.unit.IntOffset(srcX, srcY),
+                                    srcSize = androidx.compose.ui.unit.IntSize(srcW, srcH),
+                                    dstOffset = androidx.compose.ui.unit.IntOffset(dstX, dstY),
+                                    dstSize = androidx.compose.ui.unit.IntSize(dstW, dstH)
+                                )
+                            }
                         }
                     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -316,6 +316,9 @@ internal fun refitImageCellGrid(
 ): ImageCellGrid {
     val safeColumns = totalColumns.coerceAtLeast(1)
     val safeRows = totalRows.coerceAtLeast(1)
+    // A negative anchor means the image is clipped on the left. Count those
+    // virtual off-screen cells intentionally so the remaining slice indices stay
+    // aligned with the original image grid rather than re-fitting a second time.
     val availableColumns = (visibleColumns - anchorColumn).coerceAtLeast(1)
     if (safeColumns <= availableColumns) return ImageCellGrid(safeColumns, safeRows)
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -109,6 +109,11 @@ import java.awt.datatransfer.DataFlavor
 import java.io.File
 import javax.swing.JFileChooser
 
+/**
+ * UI-thread confined. Both onGloballyPositioned and jobs launched by
+ * rememberCoroutineScope run on Compose's UI dispatcher; callers must preserve
+ * that confinement if this tracker is moved or reused elsewhere.
+ */
 private class GridStabilityTracker {
   var scheduledColumns: Int = -1
   var scheduledRows: Int = -1

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -953,15 +953,19 @@ fun ProperTerminal(
               }
               // Force redraw with new buffer dimensions (critical for initial size)
               display.requestImmediateRedraw()
-              if (!hasPerformedInitialResize) {
-                // First layout pass complete: real grid applied above, and cell metrics
-                // pushed here explicitly — the LaunchedEffect(cellWidth, cellHeight) that
-                // normally pushes them has no ordering guarantee vs. this layout callback.
-                // MCP show_image gates image placement on this latch (issue #324).
-                terminal.setCellDimensions(cellWidth, cellHeight)
-                terminal.markUiLayoutReady()
-              }
               hasPerformedInitialResize = true
+            }
+            // Layout latch for MCP show_image (issue #324): this terminal has now
+            // been measured by a real layout pass — real cell metrics pushed
+            // explicitly (the LaunchedEffect that normally pushes them has no
+            // ordering guarantee vs. this callback), grid resize applied above
+            // if needed. Keyed on the TERMINAL's own latch, NOT on
+            // hasPerformedInitialResize: this composition is reused across tab
+            // switches, so the composition-scoped flag is already true when a
+            // freshly created tab's session first lands here.
+            if (!terminal.isUiLayoutReady) {
+              terminal.setCellDimensions(cellWidth, cellHeight)
+              terminal.markUiLayoutReady()
             }
           }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -108,6 +108,13 @@ import androidx.compose.ui.draganddrop.awtTransferable
 import java.awt.datatransfer.DataFlavor
 import java.io.File
 import javax.swing.JFileChooser
+
+private class GridStabilityTracker {
+  var scheduledColumns: Int = -1
+  var scheduledRows: Int = -1
+  var job: Job? = null
+}
+
 /**
  * Proper terminal implementation using BossTerm's emulator.
  * This uses the real BossTerminal, BossEmulator, and TerminalTextBuffer from the core module.
@@ -184,10 +191,10 @@ fun ProperTerminal(
   val terminal = tab.terminal
   val textBuffer = tab.textBuffer
   val display = tab.display
-  var gridStabilityJob by remember(terminal) { mutableStateOf<Job?>(null) }
+  val gridStabilityTracker = remember(terminal) { GridStabilityTracker() }
 
   DisposableEffect(terminal) {
-    onDispose { gridStabilityJob?.cancel() }
+    onDispose { gridStabilityTracker.job?.cancel() }
   }
 
   // Command blocks captured for this session (OSC 133). Collected so the gutter
@@ -949,9 +956,8 @@ fun ProperTerminal(
             // Tiny panes are valid; geometry-dependent MCP content separately waits
             // for consecutive stable samples so a transient first pass is not trusted.
             if (!hasPerformedInitialResize || currentCols != newCols || currentRows != newRows) {
-              val newTermSize = TermSize(newCols, newRows)
               // Resize terminal buffer and notify PTY process (sends SIGWINCH)
-              terminal.resize(newTermSize, RequestOrigin.User)
+              terminal.resize(TermSize(newCols, newRows), RequestOrigin.User)
               // Clear type-ahead predictions on resize (terminal state is no longer predictable)
               tab.typeAheadManager?.onResize()
               // Reset scroll to bottom on resize - history size may have changed, making old offset invalid
@@ -976,6 +982,8 @@ fun ProperTerminal(
             // paths use the separate grid-stability gate below before trusting
             // the measured dimensions.
             if (!terminal.isUiLayoutReady) {
+              // This deliberately duplicates the LaunchedEffect metric push:
+              // this layout callback is the ordering boundary for the ready latch.
               terminal.setDisplayScale(density.density)
               terminal.setCellDimensions(cellWidth, cellHeight)
               terminal.markUiLayoutReady()
@@ -984,11 +992,24 @@ fun ProperTerminal(
             // outlive the transient first layout pass. This also covers show_image
             // calls that reuse an existing tiny pane and therefore do not run the
             // freshly-created-pane readiness gate in BossTermMcpServer.
-            gridStabilityJob?.cancel()
-            gridStabilityJob = scope.launch {
-              kotlinx.coroutines.delay(180)
-              if (textBuffer.width == newCols && textBuffer.height == newRows) {
-                terminal.markCurrentGridStable()
+            if (gridStabilityTracker.scheduledColumns != newCols ||
+              gridStabilityTracker.scheduledRows != newRows
+            ) {
+              gridStabilityTracker.scheduledColumns = newCols
+              gridStabilityTracker.scheduledRows = newRows
+              gridStabilityTracker.job?.cancel()
+              gridStabilityTracker.job = scope.launch {
+                kotlinx.coroutines.delay(180)
+                if (textBuffer.width == newCols && textBuffer.height == newRows) {
+                  terminal.markGridStable(newCols, newRows)
+                } else if (gridStabilityTracker.scheduledColumns == newCols &&
+                  gridStabilityTracker.scheduledRows == newRows
+                ) {
+                  // An external resize won the race. Let the next layout callback
+                  // schedule this measured grid again instead of treating it as done.
+                  gridStabilityTracker.scheduledColumns = -1
+                  gridStabilityTracker.scheduledRows = -1
+                }
               }
             }
           }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -184,6 +184,11 @@ fun ProperTerminal(
   val terminal = tab.terminal
   val textBuffer = tab.textBuffer
   val display = tab.display
+  var gridStabilityJob by remember(terminal) { mutableStateOf<Job?>(null) }
+
+  DisposableEffect(terminal) {
+    onDispose { gridStabilityJob?.cancel() }
+  }
 
   // Command blocks captured for this session (OSC 133). Collected so the gutter
   // and scrollbar markers repaint as commands start and finish. Falls back to a
@@ -935,18 +940,15 @@ fun ProperTerminal(
           // Ensure we have valid dimensions (minimum 10x10 pixels to prevent crashes)
           if (newWidth >= 10 && newHeight >= 10 && cellWidth > 0f && cellHeight > 0f) {
             // Use floor division to ensure we don't calculate more rows than actually fit
-            val newCols = (newWidth / cellWidth).toInt().coerceAtLeast(2)
+            val newCols = (newWidth / cellWidth).toInt().coerceAtLeast(5)
             val newRows = (newHeight / cellHeight).toInt().coerceAtLeast(2)
             val currentCols = textBuffer.width
             val currentRows = textBuffer.height
 
             // Resize on first render OR when dimensions change (ensures PTY gets correct size on startup).
-            // Floor of 3 rows / 4 cols: a fresh tab's layout can transiently measure a
-            // near-zero canvas (rows would clamp to 2) before settling; applying that
-            // artifact resizes the buffer to a grid no real pane has, and anything
-            // sized against it mid-blip (MCP show_image) bakes wrong permanently.
-            // Skipping keeps the previous grid until a plausible measure arrives.
-            if ((!hasPerformedInitialResize || (currentCols != newCols || currentRows != newRows)) && newCols >= 4 && newRows >= 3) {
+            // Tiny panes are valid; geometry-dependent MCP content separately waits
+            // for consecutive stable samples so a transient first pass is not trusted.
+            if (!hasPerformedInitialResize || currentCols != newCols || currentRows != newRows) {
               val newTermSize = TermSize(newCols, newRows)
               // Resize terminal buffer and notify PTY process (sends SIGWINCH)
               terminal.resize(newTermSize, RequestOrigin.User)
@@ -964,19 +966,30 @@ fun ProperTerminal(
               hasPerformedInitialResize = true
             }
             // Layout latch for MCP show_image (issue #324): this terminal has now
-            // been measured by a real (sane) layout pass — real cell metrics pushed
+            // been measured by a layout pass — real cell metrics pushed
             // explicitly (the LaunchedEffect that normally pushes them has no
             // ordering guarantee vs. this callback), grid resize applied above
             // if needed. Keyed on the TERMINAL's own latch, NOT on
             // hasPerformedInitialResize: this composition is reused across tab
             // switches, so the composition-scoped flag is already true when a
-            // freshly created tab's session first lands here. The sane-dims
-            // guard keeps a transient degenerate pass from latching readiness
-            // while the buffer still holds its unmeasured initial grid.
-            if (!terminal.isUiLayoutReady && newCols >= 4 && newRows >= 3) {
+            // freshly created tab's session first lands here. Geometry-dependent
+            // paths use the separate grid-stability gate below before trusting
+            // the measured dimensions.
+            if (!terminal.isUiLayoutReady) {
               terminal.setDisplayScale(density.density)
               terminal.setCellDimensions(cellWidth, cellHeight)
               terminal.markUiLayoutReady()
+            }
+            // Trust small grids only after they remain unchanged long enough to
+            // outlive the transient first layout pass. This also covers show_image
+            // calls that reuse an existing tiny pane and therefore do not run the
+            // freshly-created-pane readiness gate in BossTermMcpServer.
+            gridStabilityJob?.cancel()
+            gridStabilityJob = scope.launch {
+              kotlinx.coroutines.delay(180)
+              if (textBuffer.width == newCols && textBuffer.height == newRows) {
+                terminal.markCurrentGridStable()
+              }
             }
           }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -953,6 +953,14 @@ fun ProperTerminal(
               }
               // Force redraw with new buffer dimensions (critical for initial size)
               display.requestImmediateRedraw()
+              if (!hasPerformedInitialResize) {
+                // First layout pass complete: real grid applied above, and cell metrics
+                // pushed here explicitly — the LaunchedEffect(cellWidth, cellHeight) that
+                // normally pushes them has no ordering guarantee vs. this layout callback.
+                // MCP show_image gates image placement on this latch (issue #324).
+                terminal.setCellDimensions(cellWidth, cellHeight)
+                terminal.markUiLayoutReady()
+              }
               hasPerformedInitialResize = true
             }
           }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -937,8 +937,13 @@ fun ProperTerminal(
             val currentCols = textBuffer.width
             val currentRows = textBuffer.height
 
-            // Resize on first render OR when dimensions change (ensures PTY gets correct size on startup)
-            if ((!hasPerformedInitialResize || (currentCols != newCols || currentRows != newRows)) && newCols >= 2 && newRows >= 2) {
+            // Resize on first render OR when dimensions change (ensures PTY gets correct size on startup).
+            // Floor of 3 rows / 4 cols: a fresh tab's layout can transiently measure a
+            // near-zero canvas (rows would clamp to 2) before settling; applying that
+            // artifact resizes the buffer to a grid no real pane has, and anything
+            // sized against it mid-blip (MCP show_image) bakes wrong permanently.
+            // Skipping keeps the previous grid until a plausible measure arrives.
+            if ((!hasPerformedInitialResize || (currentCols != newCols || currentRows != newRows)) && newCols >= 4 && newRows >= 3) {
               val newTermSize = TermSize(newCols, newRows)
               // Resize terminal buffer and notify PTY process (sends SIGWINCH)
               terminal.resize(newTermSize, RequestOrigin.User)
@@ -956,14 +961,16 @@ fun ProperTerminal(
               hasPerformedInitialResize = true
             }
             // Layout latch for MCP show_image (issue #324): this terminal has now
-            // been measured by a real layout pass — real cell metrics pushed
+            // been measured by a real (sane) layout pass — real cell metrics pushed
             // explicitly (the LaunchedEffect that normally pushes them has no
             // ordering guarantee vs. this callback), grid resize applied above
             // if needed. Keyed on the TERMINAL's own latch, NOT on
             // hasPerformedInitialResize: this composition is reused across tab
             // switches, so the composition-scoped flag is already true when a
-            // freshly created tab's session first lands here.
-            if (!terminal.isUiLayoutReady) {
+            // freshly created tab's session first lands here. The sane-dims
+            // guard keeps a transient degenerate pass from latching readiness
+            // while the buffer still holds its unmeasured initial grid.
+            if (!terminal.isUiLayoutReady && newCols >= 4 && newRows >= 3) {
               terminal.setCellDimensions(cellWidth, cellHeight)
               terminal.markUiLayoutReady()
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -663,8 +663,11 @@ fun ProperTerminal(
   // Calculate line spacing gap (extra space added by line spacing)
   val lineSpacingGap = cellHeight - baseCellHeight
 
-  // Update terminal with actual cell dimensions for accurate image placement
-  LaunchedEffect(cellWidth, cellHeight) {
+  // Update terminal with actual cell dimensions for accurate image placement.
+  // Cell metrics are DEVICE px; the display scale lets image sizing interpret
+  // intrinsic/px-spec image dimensions as logical px (half-size otherwise on 2x).
+  LaunchedEffect(cellWidth, cellHeight, density) {
+    terminal.setDisplayScale(density.density)
     terminal.setCellDimensions(cellWidth, cellHeight)
   }
 
@@ -971,6 +974,7 @@ fun ProperTerminal(
             // guard keeps a transient degenerate pass from latching readiness
             // while the buffer still holds its unmeasured initial grid.
             if (!terminal.isUiLayoutReady && newCols >= 4 && newRows >= 3) {
+              terminal.setDisplayScale(density.density)
               terminal.setCellDimensions(cellWidth, cellHeight)
               terminal.markUiLayoutReady()
             }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/ImageDimensionCalculatorTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/ImageDimensionCalculatorTest.kt
@@ -93,6 +93,27 @@ class ImageDimensionCalculatorTest {
     }
 
     @Test
+    fun autoAutoOnRetinaTargetsLogicalSize() {
+        // On a 2x display, cell metrics arrive in device px. Without pixelScale
+        // a 400x200 image spans only 400 device px = 200 logical px (half size).
+        // With pixelScale=2 it must span 800 device px, i.e. its logical size.
+        val image = autoImage(400, 200)
+        val dims = ImageDimensionCalculator.calculate(
+            image = image,
+            terminalWidthCells = cols,
+            terminalHeightCells = rows,
+            cellWidthPx = cellW * 2,   // device px on 2x
+            cellHeightPx = cellH * 2,
+            pixelScale = 2f
+        )
+        assertEquals(800, dims.pixelWidth)
+        assertEquals(400, dims.pixelHeight)
+        // Cell footprint is device-px / device-cell — same count as on a 1x display.
+        assertEquals(40, dims.cellWidth)
+        assertEquals(10, dims.cellHeight)
+    }
+
+    @Test
     fun explicitPercentSpecsAreFittedWithinBounds() {
         // Sanity check on the pre-existing "both specified" branch.
         val image = TerminalImage(

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/ImageDimensionCalculatorTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/ImageDimensionCalculatorTest.kt
@@ -1,0 +1,111 @@
+package ai.rever.bossterm.compose.mcp
+
+import ai.rever.bossterm.terminal.model.image.DimensionSpec
+import ai.rever.bossterm.terminal.model.image.ImageDimensionCalculator
+import ai.rever.bossterm.terminal.model.image.TerminalImage
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [ImageDimensionCalculator], the pure sizing function behind
+ * inline images (`show_image` / OSC 1337).
+ *
+ * Regression coverage for issue #323: the Auto+Auto branch used to clamp only
+ * width overflow, so a landscape image narrower than the pane but taller than
+ * it rendered at full intrinsic size and clipped vertically. Both dimensions
+ * must now be fitted by the most-constrained axis.
+ */
+class ImageDimensionCalculatorTest {
+
+    // 100 cols x 20 rows at 10x20px cells -> 1000x400 px pane
+    // (a wide-but-short pane, like a bottom horizontal split).
+    private val cols = 100
+    private val rows = 20
+    private val cellW = 10f
+    private val cellH = 20f
+    private val paneWidthPx = cols * cellW
+    private val paneHeightPx = rows * cellH
+
+    private fun autoImage(intrinsicWidth: Int, intrinsicHeight: Int) = TerminalImage(
+        data = ByteArray(1),
+        intrinsicWidth = intrinsicWidth,
+        intrinsicHeight = intrinsicHeight,
+        widthSpec = DimensionSpec.Auto,
+        heightSpec = DimensionSpec.Auto,
+        preserveAspectRatio = true
+    )
+
+    private fun calculate(image: TerminalImage) = ImageDimensionCalculator.calculate(
+        image = image,
+        terminalWidthCells = cols,
+        terminalHeightCells = rows,
+        cellWidthPx = cellW,
+        cellHeightPx = cellH
+    )
+
+    private fun assertAspectPreserved(image: TerminalImage, pixelWidth: Int, pixelHeight: Int) {
+        val intrinsic = image.intrinsicWidth.toFloat() / image.intrinsicHeight
+        val actual = pixelWidth.toFloat() / pixelHeight
+        assertTrue(
+            abs(intrinsic - actual) / intrinsic < 0.02f,
+            "aspect ratio drifted: intrinsic=$intrinsic actual=$actual"
+        )
+    }
+
+    @Test
+    fun autoAutoKeepsIntrinsicSizeWhenItFits() {
+        val dims = calculate(autoImage(500, 300))
+        assertEquals(500, dims.pixelWidth)
+        assertEquals(300, dims.pixelHeight)
+    }
+
+    @Test
+    fun autoAutoScalesDownWidthOverflow() {
+        val image = autoImage(2000, 300)
+        val dims = calculate(image)
+        assertTrue(dims.pixelWidth <= paneWidthPx.toInt(), "width still overflows: ${dims.pixelWidth}")
+        assertTrue(dims.pixelHeight <= paneHeightPx.toInt(), "height overflows: ${dims.pixelHeight}")
+        assertAspectPreserved(image, dims.pixelWidth, dims.pixelHeight)
+    }
+
+    @Test
+    fun autoAutoScalesDownHeightOverflow() {
+        // Issue #323: 960x560 landscape image in a 1000x400px pane. Width fits,
+        // height does not — the old code rendered it 960x560 and clipped the
+        // bottom 160px past the pane boundary.
+        val image = autoImage(960, 560)
+        val dims = calculate(image)
+        assertTrue(dims.pixelHeight <= paneHeightPx.toInt(), "height still overflows: ${dims.pixelHeight}")
+        assertTrue(dims.pixelWidth <= paneWidthPx.toInt(), "width overflows: ${dims.pixelWidth}")
+        assertTrue(dims.cellHeight <= rows, "cell span exceeds pane rows: ${dims.cellHeight}")
+        assertAspectPreserved(image, dims.pixelWidth, dims.pixelHeight)
+    }
+
+    @Test
+    fun autoAutoScalesDownWhenBothDimensionsOverflow() {
+        val image = autoImage(2000, 800)
+        val dims = calculate(image)
+        assertTrue(dims.pixelWidth <= paneWidthPx.toInt())
+        assertTrue(dims.pixelHeight <= paneHeightPx.toInt())
+        assertAspectPreserved(image, dims.pixelWidth, dims.pixelHeight)
+    }
+
+    @Test
+    fun explicitPercentSpecsAreFittedWithinBounds() {
+        // Sanity check on the pre-existing "both specified" branch.
+        val image = TerminalImage(
+            data = ByteArray(1),
+            intrinsicWidth = 960,
+            intrinsicHeight = 560,
+            widthSpec = DimensionSpec.Percent(90),
+            heightSpec = DimensionSpec.Percent(90),
+            preserveAspectRatio = true
+        )
+        val dims = calculate(image)
+        assertTrue(dims.pixelWidth <= (paneWidthPx * 0.9f).toInt() + 1)
+        assertTrue(dims.pixelHeight <= (paneHeightPx * 0.9f).toInt() + 1)
+        assertAspectPreserved(image, dims.pixelWidth, dims.pixelHeight)
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/rendering/ImageCellGridTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/rendering/ImageCellGridTest.kt
@@ -1,0 +1,46 @@
+package ai.rever.bossterm.compose.rendering
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ImageCellGridTest {
+
+    @Test
+    fun keepsBakedGridWhenItFitsFromAnchor() {
+        assertEquals(
+            ImageCellGrid(columns = 6, rows = 4),
+            refitImageCellGrid(
+                totalColumns = 6,
+                totalRows = 4,
+                anchorColumn = 2,
+                visibleColumns = 10
+            )
+        )
+    }
+
+    @Test
+    fun refitsGridToReachableColumnsAndPreservesAspect() {
+        assertEquals(
+            ImageCellGrid(columns = 5, rows = 3),
+            refitImageCellGrid(
+                totalColumns = 10,
+                totalRows = 6,
+                anchorColumn = 3,
+                visibleColumns = 8
+            )
+        )
+    }
+
+    @Test
+    fun accountsForColumnsClippedLeftOfViewport() {
+        assertEquals(
+            ImageCellGrid(columns = 10, rows = 6),
+            refitImageCellGrid(
+                totalColumns = 10,
+                totalRows = 6,
+                anchorColumn = -2,
+                visibleColumns = 8
+            )
+        )
+    }
+}


### PR DESCRIPTION
Fixes the three `show_image` / OSC 1337 inline-image bugs filed together — each lives in a different layer of the pipeline, so all three are needed for images to render correctly.

## #323 — Auto+Auto sizing never clamped height

`ImageDimensionCalculator.calculate()`'s Auto+Auto branch only scaled down when the image was **wider** than the terminal. A landscape image narrower than the pane but taller than it (e.g. 960×560 in a wide-but-short horizontal split) rendered at full intrinsic size and clipped vertically.

**Fix**: fit by the most-constrained axis — compute width and height scale factors, apply `min(widthScale, heightScale)`, the same approach the "both explicitly specified" branch already used.

## #324 — fresh panes sized against the placeholder 80×24 @ 10×20px grid

`awaitPromptReady()` waited only for the shell prompt (OSC 133;A). Real cell metrics and the real grid arrive via an independent Compose layout path with no ordering guarantee, and the prompt usually wins the race — so images (including explicit `%` specs) were sized against `terminalWidthPx = 800, terminalHeightPx = 480` regardless of actual pane size.

**Fix**:
- `BossTerminal` gains a one-way `isUiLayoutReady` latch (`markUiLayoutReady()`).
- `ProperTerminal`'s initial layout resize (in `onGloballyPositioned`) now pushes `setCellDimensions(cellWidth, cellHeight)` explicitly and sets the latch — the pre-existing `LaunchedEffect` push has no ordering guarantee relative to the layout callback.
- The MCP server's wait (renamed `awaitPaneReady`) awaits **both** prompt readiness and the layout latch under the same timeout.

## #325 — baked cell footprint permanently cropped images

`ImageCell.totalCellsX/Y` is a one-time snapshot of the grid at insertion, but `TerminalCanvasRenderer` iterates `col < visibleCols` computed live per frame. If the baked footprint exceeded the live width, the columns past the pane edge were simply never visited — a crisp, hard, **permanent** crop (the buffer footprint is never revisited, so it didn't self-heal even after the grid settled).

**Fix**: re-fit at draw time. The renderer derives the anchor column (`col - cellX`) and the columns actually reachable this frame; if the baked span exceeds that, the full bitmap is sliced across the available columns with the row count shrunk proportionally to preserve aspect ratio. Self-healing: if the pane widens again, the image returns to its original span.

Side finding confirming the issue's suspicion: `ImageRenderer.renderImages()` has **zero call sites** — the per-cell path in `TerminalCanvasRenderer` is the only live inline-image renderer. Left in place to keep this PR focused.

## Tests

New `ImageDimensionCalculatorTest` (compose-ui desktopTest): the #323 regression case (960×560 in a 1000×400px pane), width-only overflow, both-axis overflow, fits-unchanged, and explicit-percent sanity — 5/5 green. All touched modules compile.

Manual check suggested before release: `show_image` with a landscape PNG into a fresh `horizontal_split` should now come out full-size and uncropped.

Fixes #323
Fixes #324
Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)