### PR TITLE
fix(mcp): bake the configured port, not a fallback-walked one, into Claude Code registrations

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -234,6 +234,11 @@ class BossTermMcpManager(
     }
 
     private suspend fun reconcile(desired: McpRuntimeConfig) {
+        // Publish the configured (pre-fallback-walk) port so registration-URL
+        // builders bake a stable default instead of a walked bound port. See
+        // McpTerminalRegistry.configuredMcpPort for why baking the bound port
+        // cross-wires CLI registrations after this instance quits.
+        registry.setConfiguredPort(desired.port)
         mutex.withLock {
             val currentPort = runningPort
             val currentlyRunning = runningEngine != null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -110,11 +110,20 @@ enum class McpAttachTarget(
         // env of each `claude` process (verified against Claude Code 2.x,
         // user scope). Our PTYs export the per-embedder port var, so a
         // session inside one of our terminals dials THIS instance's actual
-        // bound port; sessions outside any of our terminals fall back to
-        // [port], which the manager's auto-reattach keeps current. The
-        // other CLIs have no documented expansion — they stay on plain URLs.
-        override fun registrationUrl(serverName: String, port: Int): String =
-            "http://127.0.0.1:\${${McpTerminalRegistry.portEnvVarName(serverName)}:-$port}"
+        // bound port; sessions outside any of our terminals use the `:-`
+        // fallback. That fallback is the CONFIGURED port, not [port]: when
+        // the server fallback-walked off its configured port (something else
+        // held it at launch), [port] is a transient collision artifact, and
+        // baking it into the CLI's persistent config points the registration
+        // at whichever app owns that port after this instance quits — e.g. a
+        // stale `bossterm` fallback of 7677 dialing BossConsole's `boss`
+        // server and mirroring its entire toolset under a second name. The
+        // other CLIs have no documented expansion — they stay on plain URLs
+        // with the live bound port.
+        override fun registrationUrl(serverName: String, port: Int): String {
+            val fallback = McpTerminalRegistry.configuredMcpPort ?: port
+            return "http://127.0.0.1:\${${McpTerminalRegistry.portEnvVarName(serverName)}:-$fallback}"
+        }
     },
     CODEX(
         displayName = "Codex",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpTerminalRegistry.kt
@@ -130,6 +130,30 @@ object McpTerminalRegistry {
     }
 
     /**
+     * The embedder's *configured* MCP port — the settings value the manager
+     * tries to bind first, before any fallback-walk. Published by
+     * [BossTermMcpManager] on every reconcile; null until the first one.
+     *
+     * Claude Code registrations bake this (not the walked bound port) into
+     * the `${VAR:-port}` URL fallback. The bound port can be a transient
+     * collision artifact — e.g. another process squatting our default at
+     * launch — and freezing it into the CLI's persistent config points the
+     * registration at whoever owns that port after we quit. That is how a
+     * standalone `bossterm` registration ended up dialing BossConsole's
+     * `boss` server on 7677 and mirroring its whole toolset under a second
+     * name. The configured port is where this app will be found on a normal
+     * launch; sessions inside our own terminals never consult the fallback
+     * at all (the injected env var carries the live bound port).
+     */
+    @Volatile var configuredMcpPort: Int? = null
+        private set
+
+    /** @suppress Manager-only (nullable so tests can reset). */
+    internal fun setConfiguredPort(port: Int?) {
+        configuredMcpPort = port
+    }
+
+    /**
      * Name of the env var carrying this embedder's actually-bound MCP port,
      * injected into every PTY this app spawns. Claude Code registrations use
      * it via `${VAR:-default}` URL expansion, so a session inside one of our

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationUrlTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationUrlTest.kt
@@ -19,6 +19,30 @@ class McpRegistrationUrlTest {
     }
 
     @Test
+    fun `claude code fallback is the configured port even when the server walked to another`() {
+        // Configured 7676 was busy at launch; the server fallback-walked and
+        // bound 7677. The registered URL's `:-` default must stay 7676 — baking
+        // the walked 7677 would leave a persistent registration that dials
+        // whatever app owns 7677 after this instance quits (BossConsole's
+        // `boss` server), mirroring its toolset under a second name.
+        McpTerminalRegistry.setConfiguredPort(7676)
+        try {
+            assertEquals(
+                "http://127.0.0.1:\${BOSSTERM_MCP_PORT:-7676}",
+                McpAttachTarget.CLAUDE_CODE.registrationUrl("bossterm", 7677)
+            )
+            // Plain-URL CLIs have no env expansion: only the live bound port
+            // works for them, so they keep registering it.
+            assertEquals(
+                "http://127.0.0.1:7677",
+                McpAttachTarget.CODEX.registrationUrl("bossterm", 7677)
+            )
+        } finally {
+            McpTerminalRegistry.setConfiguredPort(null)
+        }
+    }
+
+    @Test
     fun `other clis keep the plain url`() {
         for (target in McpAttachTarget.entries - McpAttachTarget.CLAUDE_CODE) {
             assertEquals("http://127.0.0.1:7677", target.registrationUrl("boss", 7677))


### PR DESCRIPTION
## Problem

Two MCP servers (`boss` and `bossterm`) showed up connected with identical 90-tool sets. Root cause: when the MCP server can't bind its configured port it fallback-walks to the next free one, and auto-reattach froze that **transient bound port** into the `${VAR:-port}` default of the persistent Claude Code registration. A standalone BossTerm run that walked from its configured 7676 onto 7677 left behind

```
bossterm -> http://127.0.0.1:${BOSSTERM_MCP_PORT:-7677}
```

After BossTerm quit, BossConsole's terminal-tab took 7677 as `boss` — so in any session without `BOSSTERM_MCP_PORT` set, the stale `bossterm` registration dialed BossConsole's server and mirrored its entire toolset under a second name. The polite `/identity` probe (#321) only guards the rewrite path, not what a client later dials.

## Fix

- `BossTermMcpManager` publishes the **configured** (pre-walk) port on `McpTerminalRegistry` at every reconcile.
- `CLAUDE_CODE.registrationUrl` bakes that configured port into the `:-` fallback instead of the walked bound port.

In-terminal sessions are unaffected — the injected per-embedder env var carries the live bound port. Out-of-terminal sessions now fall back to where the app actually lives on a normal launch instead of a collision artifact. Plain-URL CLIs (Codex/Gemini/OpenCode) keep registering the bound port: they have no env expansion, so only the live port works for them.

No public API changes — every `McpCliAttacher.attach` call site (including terminal-tab's) inherits the fix with the next library bump.

## Testing

- New test: configured 7676 + walked-to-7677 bind registers `${BOSSTERM_MCP_PORT:-7676}` for Claude Code while Codex keeps the plain bound-port URL.
- `:compose-ui:desktopTest --tests 'ai.rever.bossterm.compose.mcp.*'` — 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
