### PR TITLE
fix(mcp): serve streamable HTTP at /mcp so Codex registrations actually connect

### DIFF
--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -130,6 +130,11 @@ kotlin {
                 // otherwise be inaccessible from a downstream module.
                 api("io.modelcontextprotocol:kotlin-sdk-server:0.8.3")
                 implementation("io.ktor:ktor-server-cio:3.2.3")
+                // Streamable HTTP MCP endpoint (/mcp, for Codex): the SDK's
+                // JSON-response mode replies via call.respond(JSONRPCMessage),
+                // which needs server-side content negotiation (route-scoped to
+                // /mcp, wired to the SDK's McpJson).
+                implementation("io.ktor:ktor-server-content-negotiation:3.2.3")
                 // Session sharing (issue #276): WebSocket endpoint for the web viewer.
                 implementation("io.ktor:ktor-server-websockets:3.2.3")
                 // QR code for the share dialog (pure-Java, no Android deps).
@@ -137,7 +142,13 @@ kotlin {
             }
         }
 
-        val desktopTest by getting
+        val desktopTest by getting {
+            dependencies {
+                // In-process ktor app for the streamable HTTP MCP endpoint
+                // contract test (StreamableMcpSessionsTest).
+                implementation("io.ktor:ktor-server-test-host:3.2.3")
+            }
+        }
     }
 }
 

--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -129,6 +129,12 @@ kotlin {
                 // hook exposes the SDK's Server type to embedders, which would
                 // otherwise be inaccessible from a downstream module.
                 api("io.modelcontextprotocol:kotlin-sdk-server:0.8.3")
+                // The 3.2.3 declared on the ktor-server artifacts is a floor,
+                // not the effective version: Gradle conflict resolution lifts
+                // the whole ktor graph (client 3.3.2 above included) to the
+                // MCP SDK's transitive ktor — 3.4.3 as of SDK 0.8.3 — so all
+                // ktor artifacts land on one version at runtime. Verify with
+                // :compose-ui:dependencies before bumping anything here.
                 implementation("io.ktor:ktor-server-cio:3.2.3")
                 // Streamable HTTP MCP endpoint (/mcp, for Codex): the SDK's
                 // JSON-response mode replies via call.respond(JSONRPCMessage),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -4,7 +4,6 @@ import ai.rever.bossterm.compose.settings.SettingsManager
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.call
 import io.ktor.server.application.install
@@ -15,16 +14,12 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.request.host
 import io.ktor.server.request.httpMethod
 import io.ktor.server.response.respondText
-import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
-import io.ktor.server.routing.post
+import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import io.ktor.server.sse.SSE
-import io.ktor.server.sse.sse
-import io.modelcontextprotocol.kotlin.sdk.server.Server
-import io.modelcontextprotocol.kotlin.sdk.server.StreamableHttpServerTransport
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -33,6 +28,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -105,6 +101,11 @@ class BossTermMcpManager(
     private var watcherJob: Job? = null
     private var disabledToolsWatcherJob: Job? = null
     private var preferredShellWatcherJob: Job? = null
+
+    // Streamable HTTP (Codex) session bookkeeping for the running engine.
+    // Guarded by [mutex] like the engine fields; null while stopped.
+    private var streamableSessions: StreamableMcpSessions? = null
+    private var streamableSweeperJob: Job? = null
 
     // Caches caller-tab resolution by the client's ephemeral TCP port. That
     // port is stable for a connection's lifetime and its owning PID can't
@@ -396,7 +397,7 @@ class BossTermMcpManager(
     private fun tryStartOnPort(port: Int, desiredPort: Int): StartOutcome {
         val mcpServerWrapper = BossTermMcpServer(registry, config, settingsManager)
         val mcpServer = mcpServerWrapper.createServer()
-        val streamableTransports = ConcurrentHashMap<String, StreamableHttpServerTransport>()
+        val streamable = StreamableMcpSessions(mcpServer)
         val allowedHosts = setOf("127.0.0.1", "localhost", "127.0.0.1:$port", "localhost:$port")
         try {
             if (port == desiredPort) {
@@ -488,30 +489,7 @@ class BossTermMcpManager(
                             ContentType.Application.Json
                         )
                     }
-                    post(STREAMABLE_PATH) {
-                        val transport = streamableTransportForPost(
-                            call,
-                            streamableTransports,
-                            mcpServer
-                        ) ?: return@post
-                        transport.handlePostRequest(null, call)
-                    }
-                    sse(STREAMABLE_PATH) {
-                        val transport = streamableTransportForSession(
-                            call,
-                            streamableTransports
-                        ) ?: return@sse
-                        transport.handleGetRequest(this, call)
-                    }
-                    delete(STREAMABLE_PATH) {
-                        val sessionId = call.streamableSessionId()
-                        val transport = streamableTransportForSession(
-                            call,
-                            streamableTransports
-                        ) ?: return@delete
-                        transport.handleDeleteRequest(call)
-                        sessionId?.let(streamableTransports::remove)
-                    }
+                    route(STREAMABLE_PATH) { mountStreamableMcp(streamable) }
                     mcp { mcpServer }
                 }
             }
@@ -519,6 +497,19 @@ class BossTermMcpManager(
             runningEngine = engine
             runningPort = port
             runningServer = mcpServerWrapper
+            streamableSessions = streamable
+            // Streamable HTTP clients that vanish without DELETE (crashed or
+            // just exited, as codex does per invocation) leave sessions behind;
+            // sweep them so a long-running app doesn't accrete one per run.
+            streamableSweeperJob = parentScope.launch {
+                while (true) {
+                    delay(STREAMABLE_SWEEP_INTERVAL_MS)
+                    val evicted = streamable.evictIdle(STREAMABLE_IDLE_TTL_MS)
+                    if (evicted > 0) {
+                        log.info("Evicted {} idle streamable MCP session(s)", evicted)
+                    }
+                }
+            }
             registry.setRunning(port)
             // The marker is gated on the "use run_command as default shell"
             // setting: it exists ONLY while the user has opted in, so the
@@ -535,6 +526,9 @@ class BossTermMcpManager(
             return StartOutcome.Started
         } catch (e: Throwable) {
             mcpServerWrapper.detachServer()
+            streamableSweeperJob?.cancel()
+            streamableSweeperJob = null
+            streamableSessions = null
             runningEngine = null
             runningPort = null
             runningServer = null
@@ -569,50 +563,6 @@ class BossTermMcpManager(
             log.error("BossTerm MCP server failed to start on {}:{}", HOST, port, e)
             return StartOutcome.HardFailed
         }
-    }
-
-    private suspend fun streamableTransportForPost(
-        call: ApplicationCall,
-        streamableTransports: ConcurrentHashMap<String, StreamableHttpServerTransport>,
-        mcpServer: Server
-    ): StreamableHttpServerTransport? {
-        val sessionId = call.streamableSessionId()
-        if (sessionId != null) {
-            return streamableTransports[sessionId] ?: rejectStreamableSession(call, "Session not found.")
-        }
-
-        val transport = StreamableHttpServerTransport(
-            enableJsonResponse = true,
-            enableDnsRebindingProtection = false
-        )
-        transport.setOnSessionInitialized { initializedSessionId ->
-            streamableTransports[initializedSessionId] = transport
-        }
-        transport.setOnSessionClosed { closedSessionId ->
-            streamableTransports.remove(closedSessionId)
-        }
-        mcpServer.createSession(transport)
-        return transport
-    }
-
-    private suspend fun streamableTransportForSession(
-        call: ApplicationCall,
-        streamableTransports: ConcurrentHashMap<String, StreamableHttpServerTransport>
-    ): StreamableHttpServerTransport? {
-        val sessionId = call.streamableSessionId()
-            ?: return rejectStreamableSession(call, "Missing mcp-session-id header.")
-        return streamableTransports[sessionId] ?: rejectStreamableSession(call, "Session not found.")
-    }
-
-    private fun ApplicationCall.streamableSessionId(): String? =
-        request.headers[STREAMABLE_SESSION_ID_HEADER]?.takeIf { it.isNotBlank() }
-
-    private suspend fun rejectStreamableSession(
-        call: ApplicationCall,
-        message: String
-    ): StreamableHttpServerTransport? {
-        call.respondText(message, status = HttpStatusCode.BadRequest)
-        return null
     }
 
     /**
@@ -741,6 +691,12 @@ class BossTermMcpManager(
         } catch (e: Throwable) {
             log.warn("Error while stopping BossTerm MCP server on port {}: {}", port, e.message)
         } finally {
+            streamableSweeperJob?.cancel()
+            streamableSweeperJob = null
+            // Close streamable transports so their ServerSessions leave the
+            // (about-to-be-detached) Server rather than lingering until GC.
+            streamableSessions?.closeAll()
+            streamableSessions = null
             // Detach the wrapper first so any in-flight manage_tools handler
             // (or a stray applyDisabledSet from the watcher) becomes a no-op
             // instead of mutating a Server that's no longer bound to any
@@ -824,7 +780,14 @@ class BossTermMcpManager(
         private const val PATH = "/"
         /** Streamable HTTP endpoint for clients such as Codex. */
         private const val STREAMABLE_PATH = "/mcp"
-        private const val STREAMABLE_SESSION_ID_HEADER = "mcp-session-id"
+
+        /**
+         * Idle TTL for streamable sessions. Generous on purpose: an evicted
+         * client just gets 404 and re-initializes (the spec requires it), so
+         * the only cost of a long TTL is a small lingering session object.
+         */
+        private const val STREAMABLE_IDLE_TTL_MS = 2 * 60 * 60 * 1000L
+        private const val STREAMABLE_SWEEP_INTERVAL_MS = 15 * 60 * 1000L
         private const val STOP_GRACE_MS = 500L
         private const val STOP_TIMEOUT_MS = 1500L
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -4,6 +4,7 @@ import ai.rever.bossterm.compose.settings.SettingsManager
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.call
 import io.ktor.server.application.install
@@ -14,11 +15,16 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.request.host
 import io.ktor.server.request.httpMethod
 import io.ktor.server.response.respondText
+import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import io.ktor.server.sse.SSE
+import io.ktor.server.sse.sse
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.StreamableHttpServerTransport
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -390,6 +396,7 @@ class BossTermMcpManager(
     private fun tryStartOnPort(port: Int, desiredPort: Int): StartOutcome {
         val mcpServerWrapper = BossTermMcpServer(registry, config, settingsManager)
         val mcpServer = mcpServerWrapper.createServer()
+        val streamableTransports = ConcurrentHashMap<String, StreamableHttpServerTransport>()
         val allowedHosts = setOf("127.0.0.1", "localhost", "127.0.0.1:$port", "localhost:$port")
         try {
             if (port == desiredPort) {
@@ -481,6 +488,30 @@ class BossTermMcpManager(
                             ContentType.Application.Json
                         )
                     }
+                    post(STREAMABLE_PATH) {
+                        val transport = streamableTransportForPost(
+                            call,
+                            streamableTransports,
+                            mcpServer
+                        ) ?: return@post
+                        transport.handlePostRequest(null, call)
+                    }
+                    sse(STREAMABLE_PATH) {
+                        val transport = streamableTransportForSession(
+                            call,
+                            streamableTransports
+                        ) ?: return@sse
+                        transport.handleGetRequest(this, call)
+                    }
+                    delete(STREAMABLE_PATH) {
+                        val sessionId = call.streamableSessionId()
+                        val transport = streamableTransportForSession(
+                            call,
+                            streamableTransports
+                        ) ?: return@delete
+                        transport.handleDeleteRequest(call)
+                        sessionId?.let(streamableTransports::remove)
+                    }
                     mcp { mcpServer }
                 }
             }
@@ -497,8 +528,8 @@ class BossTermMcpManager(
                 writePortMarker(port)
             }
             log.info(
-                "BossTerm MCP server ready: http://{}:{}{} (SSE transport, {} state(s) registered)",
-                HOST, port, PATH, registry.stateCount()
+                "BossTerm MCP server ready: http://{}:{}{} (SSE), http://{}:{}{} (streamable HTTP, {} state(s) registered)",
+                HOST, port, PATH, HOST, port, STREAMABLE_PATH, registry.stateCount()
             )
             launchAutoReattach(port)
             return StartOutcome.Started
@@ -538,6 +569,50 @@ class BossTermMcpManager(
             log.error("BossTerm MCP server failed to start on {}:{}", HOST, port, e)
             return StartOutcome.HardFailed
         }
+    }
+
+    private suspend fun streamableTransportForPost(
+        call: ApplicationCall,
+        streamableTransports: ConcurrentHashMap<String, StreamableHttpServerTransport>,
+        mcpServer: Server
+    ): StreamableHttpServerTransport? {
+        val sessionId = call.streamableSessionId()
+        if (sessionId != null) {
+            return streamableTransports[sessionId] ?: rejectStreamableSession(call, "Session not found.")
+        }
+
+        val transport = StreamableHttpServerTransport(
+            enableJsonResponse = true,
+            enableDnsRebindingProtection = false
+        )
+        transport.setOnSessionInitialized { initializedSessionId ->
+            streamableTransports[initializedSessionId] = transport
+        }
+        transport.setOnSessionClosed { closedSessionId ->
+            streamableTransports.remove(closedSessionId)
+        }
+        mcpServer.createSession(transport)
+        return transport
+    }
+
+    private suspend fun streamableTransportForSession(
+        call: ApplicationCall,
+        streamableTransports: ConcurrentHashMap<String, StreamableHttpServerTransport>
+    ): StreamableHttpServerTransport? {
+        val sessionId = call.streamableSessionId()
+            ?: return rejectStreamableSession(call, "Missing mcp-session-id header.")
+        return streamableTransports[sessionId] ?: rejectStreamableSession(call, "Session not found.")
+    }
+
+    private fun ApplicationCall.streamableSessionId(): String? =
+        request.headers[STREAMABLE_SESSION_ID_HEADER]?.takeIf { it.isNotBlank() }
+
+    private suspend fun rejectStreamableSession(
+        call: ApplicationCall,
+        message: String
+    ): StreamableHttpServerTransport? {
+        call.respondText(message, status = HttpStatusCode.BadRequest)
+        return null
     }
 
     /**
@@ -747,6 +822,9 @@ class BossTermMcpManager(
         private const val HOST = "127.0.0.1"
         /** Path the SSE/POST endpoints are reachable at. SDK 0.8.3 only honors root. */
         private const val PATH = "/"
+        /** Streamable HTTP endpoint for clients such as Codex. */
+        private const val STREAMABLE_PATH = "/mcp"
+        private const val STREAMABLE_SESSION_ID_HEADER = "mcp-session-id"
         private const val STOP_GRACE_MS = 500L
         private const val STOP_TIMEOUT_MS = 1500L
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -504,9 +504,21 @@ class BossTermMcpManager(
             streamableSweeperJob = parentScope.launch {
                 while (true) {
                     delay(STREAMABLE_SWEEP_INTERVAL_MS)
-                    val evicted = streamable.evictIdle(STREAMABLE_IDLE_TTL_MS)
-                    if (evicted > 0) {
-                        log.info("Evicted {} idle streamable MCP session(s)", evicted)
+                    // evictIdle contains its own per-transport failure handling;
+                    // this guard is belt-and-suspenders so no future exception
+                    // can kill the sweeper for the life of the engine and
+                    // silently reintroduce the leak it exists to prevent.
+                    // Cancellation must still propagate or stop() would hang
+                    // the loop forever.
+                    try {
+                        val evicted = streamable.evictIdle(STREAMABLE_IDLE_TTL_MS)
+                        if (evicted > 0) {
+                            log.info("Evicted {} idle streamable MCP session(s)", evicted)
+                        }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        log.warn("Streamable MCP sweep failed; retrying next interval: {}", e.message)
                     }
                 }
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -48,13 +48,11 @@ private const val OPENCODE_REMOVE_SCRIPT = "" +
  * the embedder's `BossTermMcpConfig.serverName` (or `"bossterm"` for the
  * default app), and `{URL}` with the target's [McpAttachTarget.registrationUrl]
  * — plain `http://127.0.0.1:<port>` for most CLIs, the `${VAR:-port}`
- * env-expanded form for Claude Code.
+ * env-expanded form for Claude Code, and the streamable HTTP `/mcp` URL for Codex.
  *
  * Tested CLI shapes (last verified May 2026):
  *  - Claude Code: `claude mcp add --transport sse <name> <url>` (verified)
- *  - Codex 0.130: `codex mcp add <name> --url <url>` (registers OK, but
- *      Codex only speaks streamable HTTP — runtime connection to BossTerm's
- *      current SSE-only SDK will fail until the SDK is upgraded)
+ *  - Codex 0.130: `codex mcp add <name> --url <url>/mcp` (streamable HTTP)
  *  - Gemini 0.28: `gemini mcp add <name> --transport sse <url>` (verified)
  *  - OpenCode 1.1: `opencode mcp add` is interactive in this version, no
  *      flags accepted — will exit non-zero, clipboard fallback fires.
@@ -129,21 +127,19 @@ enum class McpAttachTarget(
         displayName = "Codex",
         persistenceKey = "CODEX",
         // codex-cli 0.130 uses `--url <url>` and only supports streamable
-        // HTTP (no SSE client). The registration will succeed but at
-        // runtime Codex won't actually connect to BossTerm's SDK-0.8.3
-        // SSE endpoint — that needs an SDK upgrade to expose streamable
-        // HTTP transport. Tracked as a follow-up.
+        // HTTP (no SSE client), so it gets BossTerm's /mcp endpoint rather
+        // than the SSE root used by Claude/Gemini/OpenCode.
         removeCommand = listOf("codex", "mcp", "remove", "{NAME}"),
         addCommand = listOf("codex", "mcp", "add", "{NAME}", "--url", "{URL}"),
         clipboardFallback = """
             # Append to ~/.codex/config.toml
-            # Note: codex only speaks streamable HTTP; BossTerm currently
-            # serves SSE so the runtime connection will fail until the SDK
-            # is upgraded.
             [mcp_servers.{NAME}]
             url = "{URL}"
         """.trimIndent()
-    ),
+    ) {
+        override fun registrationUrl(serverName: String, port: Int): String =
+            "http://127.0.0.1:$port/mcp"
+    },
     GEMINI(
         displayName = "Gemini CLI",
         persistenceKey = "GEMINI",
@@ -205,7 +201,8 @@ enum class McpAttachTarget(
     /**
      * The URL string registered with this CLI for a server named [serverName]
      * bound to [port]. Plain `http://127.0.0.1:<port>` by default; CLAUDE_CODE
-     * overrides with the `${VAR:-port}` env-expanded form (see its entry).
+     * overrides with the `${VAR:-port}` env-expanded form and CODEX appends
+     * the streamable HTTP path.
      */
     open fun registrationUrl(serverName: String, port: Int): String =
         "http://127.0.0.1:$port"
@@ -275,11 +272,8 @@ object McpCliAttacher {
         quiet: Boolean = false
     ): McpAttachResult =
         withContext(Dispatchers.IO) {
-            // SDK 0.8.3 mounts SSE+POST at the application root; the path
-            // overload is broken (see BossTermMcpManager kdoc). So the URL
-            // we register with each CLI is loopback + port, no path suffix.
             // Per-target form: Claude Code gets the ${VAR:-port} env-expanded
-            // variant so in-terminal sessions track this instance's live port.
+            // variant, Codex gets /mcp, and SSE clients keep the root URL.
             val url = target.registrationUrl(serverName, port)
             try {
                 // First, best-effort remove. Many CLIs' `mcp add` is not

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -128,7 +128,10 @@ enum class McpAttachTarget(
         persistenceKey = "CODEX",
         // codex-cli 0.130 uses `--url <url>` and only supports streamable
         // HTTP (no SSE client), so it gets BossTerm's /mcp endpoint rather
-        // than the SSE root used by Claude/Gemini/OpenCode.
+        // than the SSE root used by Claude/Gemini/OpenCode. An older note
+        // here claimed streamable HTTP "needs an SDK upgrade" — wrong: MCP
+        // SDK 0.8.3 (the pinned version) already ships the server transport,
+        // exercised end-to-end by StreamableMcpSessionsTest. Don't re-add it.
         removeCommand = listOf("codex", "mcp", "remove", "{NAME}"),
         addCommand = listOf("codex", "mcp", "add", "{NAME}", "--url", "{URL}"),
         clipboardFallback = """

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
@@ -15,6 +15,8 @@ import io.ktor.server.routing.post
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.StreamableHttpServerTransport
 import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -73,6 +75,9 @@ internal class StreamableMcpSessions(
     private suspend fun initializeSession(call: ApplicationCall) {
         val transport = StreamableHttpServerTransport(
             enableJsonResponse = true,
+            // Not dropped, just not duplicated: the manager's app-level
+            // intercept already 403s any non-loopback Host header before
+            // routing, so it covers /mcp along with every other route.
             enableDnsRebindingProtection = false
         )
         transport.setOnSessionInitialized { id ->
@@ -80,13 +85,19 @@ internal class StreamableMcpSessions(
         }
         transport.setOnSessionClosed { id -> sessions.remove(id) }
         mcpServer.createSession(transport)
-        transport.handlePostRequest(null, call)
-        if (transport.sessionId == null) {
-            // The SDK rejected the request (not an initialize, or malformed)
-            // without minting a session id. Close the transport so the
-            // ServerSession created above leaves the shared server's registry
-            // instead of leaking one entry per stray POST.
-            transport.close()
+        try {
+            transport.handlePostRequest(null, call)
+        } finally {
+            if (transport.sessionId == null) {
+                // No session id was minted: the SDK rejected the request (not
+                // an initialize, or malformed), or the handler threw / the
+                // call was cancelled mid-flight. Close the transport so the
+                // ServerSession created above leaves the shared server's
+                // registry instead of leaking one entry per stray POST.
+                // NonCancellable because close() suspends and this finally
+                // may already be running on a cancelled call.
+                withContext(NonCancellable) { transport.close() }
+            }
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
@@ -124,7 +124,10 @@ internal class StreamableMcpSessions(
      * when a burst of codex invocations lands between two idle sweeps.
      * [protectId] (the session that just initialized) is never a candidate:
      * with millisecond clock granularity a burst can produce timestamp ties,
-     * and the newcomer must not lose its own tie-break.
+     * and the newcomer must not lose its own tie-break. Two initializes
+     * racing AT the cap could still evict each other's newcomer (each call
+     * protects only its own) — accepted: reaching it needs 256 live sessions
+     * plus a same-instant double-initialize, and the loser just re-inits.
      */
     private suspend fun enforceSessionCap(protectId: String) {
         while (sessions.size > maxSessions) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
@@ -44,11 +44,17 @@ import java.util.concurrent.ConcurrentHashMap
  *    client that crashes — or simply exits without DELETE, as each `codex`
  *    invocation does — would park its session here forever. [evictIdle] sweeps
  *    those; an evicted client that returns sees 404 and re-initializes.
+ *  - [maxSessions] bounds accretion between sweeps: steady state is roughly
+ *    one abandoned session per codex invocation inside the idle TTL, so a
+ *    burst of invocations could otherwise pile up unbounded until the next
+ *    sweep. Initializing past the cap evicts the longest-idle session first
+ *    (which, evicted, just re-initializes if it ever comes back).
  *
  * [clock] is injectable for tests; production uses wall time.
  */
 internal class StreamableMcpSessions(
     private val mcpServer: Server,
+    private val maxSessions: Int = DEFAULT_MAX_SESSIONS,
     private val clock: () -> Long = System::currentTimeMillis
 ) {
 
@@ -90,6 +96,11 @@ internal class StreamableMcpSessions(
             sessions[id] = Entry(transport).apply { lastActivityMs = clock() }
         }
         transport.setOnSessionClosed { id -> sessions.remove(id) }
+        // The create-then-maybe-teardown shape (rather than checking the
+        // method first) is forced by the SDK: it owns body parsing inside
+        // handlePostRequest, so peeking at the method up front would need
+        // double-receive plumbing. A stray anonymous POST therefore churns
+        // one ServerSession create+close — loopback-gated, acceptable.
         mcpServer.createSession(transport)
         try {
             transport.handlePostRequest(null, call)
@@ -101,6 +112,27 @@ internal class StreamableMcpSessions(
                 // ServerSession created above leaves the shared server's
                 // registry instead of leaking one entry per stray POST.
                 transport.closeQuietly()
+            }
+        }
+        if (transport.sessionId != null) {
+            enforceSessionCap()
+        }
+    }
+
+    /**
+     * Evict longest-idle sessions until the map is back within [maxSessions].
+     * Runs after each successful initialize, so the map size is bounded even
+     * when a burst of codex invocations lands between two idle sweeps.
+     */
+    private suspend fun enforceSessionCap() {
+        while (sessions.size > maxSessions) {
+            val oldest = sessions.entries.minByOrNull { it.value.lastActivityMs } ?: return
+            if (sessions.remove(oldest.key, oldest.value)) {
+                oldest.value.transport.closeQuietly()
+                log.info(
+                    "Streamable MCP session cap {} reached; evicted longest-idle session {}",
+                    maxSessions, oldest.key
+                )
             }
         }
     }
@@ -191,6 +223,13 @@ internal class StreamableMcpSessions(
     companion object {
         /** Session id header defined by the MCP streamable HTTP transport. */
         const val SESSION_ID_HEADER = "mcp-session-id"
+
+        /**
+         * Generous soft cap: real concurrent clients number in the single
+         * digits; everything past that is abandoned codex sessions awaiting
+         * the idle sweep, and evicting those early is harmless (see kdoc).
+         */
+        const val DEFAULT_MAX_SESSIONS = 256
     }
 }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
@@ -67,6 +67,7 @@ internal class StreamableMcpSessions(
 
     private val sessions = ConcurrentHashMap<String, Entry>()
 
+    /** Observability for tests (and future diagnostics); unused in prod paths. */
     val sessionCount: Int
         get() = sessions.size
 
@@ -114,19 +115,22 @@ internal class StreamableMcpSessions(
                 transport.closeQuietly()
             }
         }
-        if (transport.sessionId != null) {
-            enforceSessionCap()
-        }
+        transport.sessionId?.let { enforceSessionCap(protectId = it) }
     }
 
     /**
      * Evict longest-idle sessions until the map is back within [maxSessions].
      * Runs after each successful initialize, so the map size is bounded even
      * when a burst of codex invocations lands between two idle sweeps.
+     * [protectId] (the session that just initialized) is never a candidate:
+     * with millisecond clock granularity a burst can produce timestamp ties,
+     * and the newcomer must not lose its own tie-break.
      */
-    private suspend fun enforceSessionCap() {
+    private suspend fun enforceSessionCap(protectId: String) {
         while (sessions.size > maxSessions) {
-            val oldest = sessions.entries.minByOrNull { it.value.lastActivityMs } ?: return
+            val oldest = sessions.entries
+                .filter { it.key != protectId }
+                .minByOrNull { it.value.lastActivityMs } ?: return
             if (sessions.remove(oldest.key, oldest.value)) {
                 oldest.value.transport.closeQuietly()
                 log.info(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
@@ -17,6 +17,7 @@ import io.modelcontextprotocol.kotlin.sdk.server.StreamableHttpServerTransport
 import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -51,6 +52,8 @@ internal class StreamableMcpSessions(
     private val clock: () -> Long = System::currentTimeMillis
 ) {
 
+    private val log = LoggerFactory.getLogger(StreamableMcpSessions::class.java)
+
     private class Entry(val transport: StreamableHttpServerTransport) {
         @Volatile
         var lastActivityMs: Long = 0L
@@ -69,6 +72,9 @@ internal class StreamableMcpSessions(
         }
         val entry = sessions[sessionId] ?: return call.rejectUnknownSession()
         entry.lastActivityMs = clock()
+        // Unlike initializeSession there is deliberately no teardown guard:
+        // an established session must survive a single failed request; only
+        // DELETE, idle eviction, or engine stop end it.
         entry.transport.handlePostRequest(null, call)
     }
 
@@ -94,9 +100,7 @@ internal class StreamableMcpSessions(
                 // call was cancelled mid-flight. Close the transport so the
                 // ServerSession created above leaves the shared server's
                 // registry instead of leaking one entry per stray POST.
-                // NonCancellable because close() suspends and this finally
-                // may already be running on a cancelled call.
-                withContext(NonCancellable) { transport.close() }
+                transport.closeQuietly()
             }
         }
     }
@@ -137,7 +141,7 @@ internal class StreamableMcpSessions(
         var evicted = 0
         for ((id, entry) in sessions) {
             if (entry.lastActivityMs <= cutoff && sessions.remove(id, entry)) {
-                entry.transport.close()
+                entry.transport.closeQuietly()
                 evicted++
             }
         }
@@ -148,8 +152,25 @@ internal class StreamableMcpSessions(
     suspend fun closeAll() {
         for ((id, entry) in sessions) {
             if (sessions.remove(id, entry)) {
-                entry.transport.close()
+                entry.transport.closeQuietly()
             }
+        }
+    }
+
+    /**
+     * Close without letting the caller's context interfere: NonCancellable
+     * because every call site can run on an already-cancelled job (request
+     * finally, sweeper cancel, engine stop) and close() suspends on a mutex —
+     * a cancelled caller would abort at that suspension point and skip the
+     * cleanup. Failures are logged, not thrown: by the time this runs the map
+     * entry is already gone, so one bad transport must not abort the rest of
+     * a sweep/closeAll or mask a request's original exception.
+     */
+    private suspend fun StreamableHttpServerTransport.closeQuietly() {
+        try {
+            withContext(NonCancellable) { close() }
+        } catch (e: Throwable) {
+            log.warn("Failed to close streamable MCP transport (session {}): {}", sessionId, e.message)
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
@@ -135,6 +135,13 @@ internal class StreamableMcpSessions(
     /**
      * Close sessions with no activity for [idleTtlMs], reclaiming their
      * transports and `ServerSession`s. Returns how many were evicted.
+     *
+     * Known benign race: a POST that stamps [Entry.lastActivityMs] while a
+     * sweep is reading the pre-stamp value can have its transport closed
+     * mid-request. Reaching it requires the request to land in the same
+     * instant the session crosses the idle TTL (hours), and the cost is one
+     * failed response on a session the client re-initializes anyway — not
+     * worth a per-entry lock.
      */
     suspend fun evictIdle(idleTtlMs: Long): Int {
         val cutoff = clock() - idleTtlMs
@@ -192,6 +199,11 @@ internal class StreamableMcpSessions(
  * route-scoped and wired to the SDK's own [McpJson]: the SDK's JSON-response
  * mode replies via `call.respond(JSONRPCMessage)`, which needs a server-side
  * converter — and must not leak onto the root SSE/identity routes.
+ *
+ * Precondition: mount only inside an application that already rejects
+ * non-loopback Host headers (BossTermMcpManager's app-level intercept).
+ * The transports are built with `enableDnsRebindingProtection = false` on
+ * that assumption — mounted elsewhere, /mcp would be open to DNS rebinding.
  */
 internal fun Route.mountStreamableMcp(sessions: StreamableMcpSessions) {
     install(ContentNegotiation) { json(McpJson) }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessions.kt
@@ -1,0 +1,169 @@
+package ai.rever.bossterm.compose.mcp
+
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.header
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.StreamableHttpServerTransport
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Streamable HTTP MCP endpoint for clients that don't speak SSE (Codex).
+ *
+ * One [StreamableHttpServerTransport] per client session, JSON-response mode
+ * (no server-initiated SSE stream). Each transport gets its own `ServerSession`
+ * inside the shared [mcpServer] via [Server.createSession], so streamable
+ * clients and the SSE clients on the root path multiplex without sharing
+ * connection state.
+ *
+ * Session lifecycle:
+ *  - POST without `mcp-session-id` may only be an `initialize` request. The
+ *    SDK enforces that (anything else is rejected 400 before a session id is
+ *    minted), and [handlePost] closes the speculatively created transport when
+ *    initialization didn't happen, so a stray POST can't park a phantom
+ *    `ServerSession` in [mcpServer]'s registry.
+ *  - Unknown session ids get 404 (per the streamable HTTP spec, telling the
+ *    client to re-initialize), matching the SDK's own `validateSession`.
+ *  - DELETE tears the session down via the transport, whose
+ *    `onSessionClosed` callback drops the map entry and whose close cascades
+ *    (transport → ServerSession.onClose) to registry removal in [mcpServer].
+ *  - Streamable HTTP has no connection whose drop the server could observe: a
+ *    client that crashes — or simply exits without DELETE, as each `codex`
+ *    invocation does — would park its session here forever. [evictIdle] sweeps
+ *    those; an evicted client that returns sees 404 and re-initializes.
+ *
+ * [clock] is injectable for tests; production uses wall time.
+ */
+internal class StreamableMcpSessions(
+    private val mcpServer: Server,
+    private val clock: () -> Long = System::currentTimeMillis
+) {
+
+    private class Entry(val transport: StreamableHttpServerTransport) {
+        @Volatile
+        var lastActivityMs: Long = 0L
+    }
+
+    private val sessions = ConcurrentHashMap<String, Entry>()
+
+    val sessionCount: Int
+        get() = sessions.size
+
+    suspend fun handlePost(call: ApplicationCall) {
+        val sessionId = call.sessionIdHeader()
+        if (sessionId == null) {
+            initializeSession(call)
+            return
+        }
+        val entry = sessions[sessionId] ?: return call.rejectUnknownSession()
+        entry.lastActivityMs = clock()
+        entry.transport.handlePostRequest(null, call)
+    }
+
+    private suspend fun initializeSession(call: ApplicationCall) {
+        val transport = StreamableHttpServerTransport(
+            enableJsonResponse = true,
+            enableDnsRebindingProtection = false
+        )
+        transport.setOnSessionInitialized { id ->
+            sessions[id] = Entry(transport).apply { lastActivityMs = clock() }
+        }
+        transport.setOnSessionClosed { id -> sessions.remove(id) }
+        mcpServer.createSession(transport)
+        transport.handlePostRequest(null, call)
+        if (transport.sessionId == null) {
+            // The SDK rejected the request (not an initialize, or malformed)
+            // without minting a session id. Close the transport so the
+            // ServerSession created above leaves the shared server's registry
+            // instead of leaking one entry per stray POST.
+            transport.close()
+        }
+    }
+
+    /**
+     * GET opens the spec's optional server→client SSE stream, which
+     * JSON-response transports don't offer; 405 tells the client to carry on
+     * with plain POSTs. Served as a regular GET route on purpose: a ktor
+     * `sse()` handler has already committed a 200 event-stream response by the
+     * time it runs, so the SDK's 405 reject inside one would strand the client
+     * on an empty stream instead.
+     */
+    suspend fun handleGet(call: ApplicationCall) {
+        call.response.header(HttpHeaders.Allow, "POST, DELETE")
+        call.respondText(
+            "Method Not Allowed: this endpoint serves JSON responses, not an SSE stream.",
+            status = HttpStatusCode.MethodNotAllowed
+        )
+    }
+
+    suspend fun handleDelete(call: ApplicationCall) {
+        val sessionId = call.sessionIdHeader() ?: return call.respondText(
+            "Missing $SESSION_ID_HEADER header.",
+            status = HttpStatusCode.BadRequest
+        )
+        val entry = sessions[sessionId] ?: return call.rejectUnknownSession()
+        // Fires onSessionClosed (drops the map entry) and closes the
+        // transport, which cascades to ServerSession removal in [mcpServer].
+        entry.transport.handleDeleteRequest(call)
+    }
+
+    /**
+     * Close sessions with no activity for [idleTtlMs], reclaiming their
+     * transports and `ServerSession`s. Returns how many were evicted.
+     */
+    suspend fun evictIdle(idleTtlMs: Long): Int {
+        val cutoff = clock() - idleTtlMs
+        var evicted = 0
+        for ((id, entry) in sessions) {
+            if (entry.lastActivityMs <= cutoff && sessions.remove(id, entry)) {
+                entry.transport.close()
+                evicted++
+            }
+        }
+        return evicted
+    }
+
+    /** Engine stop: close every transport so nothing outlives the bind. */
+    suspend fun closeAll() {
+        for ((id, entry) in sessions) {
+            if (sessions.remove(id, entry)) {
+                entry.transport.close()
+            }
+        }
+    }
+
+    private fun ApplicationCall.sessionIdHeader(): String? =
+        request.headers[SESSION_ID_HEADER]?.takeIf { it.isNotBlank() }
+
+    private suspend fun ApplicationCall.rejectUnknownSession() {
+        respondText("Session not found.", status = HttpStatusCode.NotFound)
+    }
+
+    companion object {
+        /** Session id header defined by the MCP streamable HTTP transport. */
+        const val SESSION_ID_HEADER = "mcp-session-id"
+    }
+}
+
+/**
+ * Mount the streamable HTTP endpoint on this route. Content negotiation is
+ * route-scoped and wired to the SDK's own [McpJson]: the SDK's JSON-response
+ * mode replies via `call.respond(JSONRPCMessage)`, which needs a server-side
+ * converter — and must not leak onto the root SSE/identity routes.
+ */
+internal fun Route.mountStreamableMcp(sessions: StreamableMcpSessions) {
+    install(ContentNegotiation) { json(McpJson) }
+    post { sessions.handlePost(call) }
+    get { sessions.handleGet(call) }
+    delete { sessions.handleDelete(call) }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScannerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationScannerTest.kt
@@ -84,7 +84,7 @@ class McpRegistrationScannerTest {
             model = "gpt-5"
 
             [mcp_servers.boss]
-            url = "http://127.0.0.1:7677"
+            url = "http://127.0.0.1:7677/mcp"
 
             [other_section]
             url = "https://remote.example.com"

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationUrlTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpRegistrationUrlTest.kt
@@ -34,7 +34,7 @@ class McpRegistrationUrlTest {
             // Plain-URL CLIs have no env expansion: only the live bound port
             // works for them, so they keep registering it.
             assertEquals(
-                "http://127.0.0.1:7677",
+                "http://127.0.0.1:7677/mcp",
                 McpAttachTarget.CODEX.registrationUrl("bossterm", 7677)
             )
         } finally {
@@ -43,8 +43,16 @@ class McpRegistrationUrlTest {
     }
 
     @Test
+    fun `codex registers the streamable http path`() {
+        assertEquals(
+            "http://127.0.0.1:7677/mcp",
+            McpAttachTarget.CODEX.registrationUrl("boss", 7677)
+        )
+    }
+
+    @Test
     fun `other clis keep the plain url`() {
-        for (target in McpAttachTarget.entries - McpAttachTarget.CLAUDE_CODE) {
+        for (target in McpAttachTarget.entries - McpAttachTarget.CLAUDE_CODE - McpAttachTarget.CODEX) {
             assertEquals("http://127.0.0.1:7677", target.registrationUrl("boss", 7677))
         }
     }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessionsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessionsTest.kt
@@ -129,6 +129,21 @@ class StreamableMcpSessionsTest {
     }
 
     @Test
+    fun `established session survives a failed request`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+        val sessionId = client.initializeSession()
+
+        // Deliberate contract: a single bad request must not tear the
+        // session down — only DELETE, idle eviction, or engine stop do.
+        assertEquals(HttpStatusCode.BadRequest, client.mcpPost("""{"jsonrpc": garbage""", sessionId).status)
+
+        assertEquals(1, sessions.sessionCount)
+        assertEquals(1, server.sessions.size)
+        assertEquals(HttpStatusCode.OK, client.mcpPost(TOOLS_LIST, sessionId).status)
+    }
+
+    @Test
     fun `unknown session id gets 404 so the client re-initializes`() = testApplication {
         freshSessions()
         mountEndpoint()

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessionsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessionsTest.kt
@@ -1,0 +1,202 @@
+package ai.rever.bossterm.compose.mcp
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Contract test for the streamable HTTP MCP endpoint ([StreamableMcpSessions]
+ * mounted via [mountStreamableMcp]) — the transport Codex speaks. Exercises
+ * the real SDK transport + a real (tool-less) SDK [Server] through an
+ * in-process ktor app, so it locks in the session lifecycle AND proves the
+ * SDK-0.8.3 handler surface actually works end-to-end (the registration-URL
+ * tests can't catch a handler-path or serialization regression).
+ */
+class StreamableMcpSessionsTest {
+
+    private var now: Long = 0L
+    private lateinit var server: Server
+    private lateinit var sessions: StreamableMcpSessions
+
+    private fun freshSessions(): StreamableMcpSessions {
+        now = 0L
+        server = Server(
+            serverInfo = Implementation(name = "test-server", version = "0.0.1"),
+            options = ServerOptions(
+                capabilities = ServerCapabilities(tools = ServerCapabilities.Tools(listChanged = true))
+            )
+        )
+        sessions = StreamableMcpSessions(server) { now }
+        return sessions
+    }
+
+    private fun ApplicationTestBuilder.mountEndpoint() {
+        application {
+            routing {
+                route("/mcp") { mountStreamableMcp(sessions) }
+            }
+        }
+    }
+
+    private suspend fun HttpClient.mcpPost(body: String, sessionId: String? = null): HttpResponse =
+        post("/mcp") {
+            header(HttpHeaders.Accept, "application/json, text/event-stream")
+            contentType(ContentType.Application.Json)
+            sessionId?.let { header(StreamableMcpSessions.SESSION_ID_HEADER, it) }
+            setBody(body)
+        }
+
+    private suspend fun HttpClient.initializeSession(): String {
+        val response = mcpPost(INITIALIZE)
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        return assertNotNull(
+            response.headers[StreamableMcpSessions.SESSION_ID_HEADER],
+            "initialize response must carry a session id"
+        )
+    }
+
+    @Test
+    fun `initialize mints a session and returns its id`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+
+        val response = client.mcpPost(INITIALIZE)
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        assertNotNull(response.headers[StreamableMcpSessions.SESSION_ID_HEADER])
+        assertTrue(response.bodyAsText().contains("serverInfo"))
+        assertEquals(1, sessions.sessionCount)
+        assertEquals(1, server.sessions.size)
+    }
+
+    @Test
+    fun `established session serves requests`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+        val sessionId = client.initializeSession()
+
+        val response = client.mcpPost(TOOLS_LIST, sessionId)
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        assertTrue(response.bodyAsText().contains("\"tools\""))
+    }
+
+    @Test
+    fun `non-initialize post without session id is rejected and leaks no session`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+
+        val response = client.mcpPost(TOOLS_LIST)
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertEquals(0, sessions.sessionCount)
+        // The speculative transport's ServerSession must be torn down again —
+        // otherwise every stray POST parks one in the shared Server forever.
+        assertEquals(0, server.sessions.size)
+    }
+
+    @Test
+    fun `unknown session id gets 404 so the client re-initializes`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+
+        assertEquals(HttpStatusCode.NotFound, client.mcpPost(TOOLS_LIST, "no-such-session").status)
+        assertEquals(HttpStatusCode.NotFound, client.delete("/mcp") {
+            header(StreamableMcpSessions.SESSION_ID_HEADER, "no-such-session")
+        }.status)
+    }
+
+    @Test
+    fun `get is answered with 405 not a hung stream`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+
+        val response = client.get("/mcp")
+
+        assertEquals(HttpStatusCode.MethodNotAllowed, response.status)
+        assertEquals("POST, DELETE", response.headers[HttpHeaders.Allow])
+    }
+
+    @Test
+    fun `delete without session id is a 400`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+
+        assertEquals(HttpStatusCode.BadRequest, client.delete("/mcp").status)
+    }
+
+    @Test
+    fun `delete tears the session down everywhere`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+        val sessionId = client.initializeSession()
+
+        val response = client.delete("/mcp") {
+            header(StreamableMcpSessions.SESSION_ID_HEADER, sessionId)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(0, sessions.sessionCount)
+        assertEquals(0, server.sessions.size)
+        // The id is gone for good — a returning client must re-initialize.
+        assertEquals(HttpStatusCode.NotFound, client.mcpPost(TOOLS_LIST, sessionId).status)
+    }
+
+    @Test
+    fun `idle sessions are evicted, active ones survive`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+        val stale = client.initializeSession()
+        now = 10_000L
+        val fresh = client.initializeSession()
+        assertEquals(2, sessions.sessionCount)
+
+        val evicted = sessions.evictIdle(idleTtlMs = 5_000L)
+
+        assertEquals(1, evicted)
+        assertEquals(1, sessions.sessionCount)
+        assertEquals(1, server.sessions.size)
+        assertEquals(HttpStatusCode.NotFound, client.mcpPost(TOOLS_LIST, stale).status)
+        assertEquals(HttpStatusCode.OK, client.mcpPost(TOOLS_LIST, fresh).status)
+    }
+
+    @Test
+    fun `closeAll empties both registries`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+        client.initializeSession()
+        client.initializeSession()
+        assertEquals(2, sessions.sessionCount)
+
+        sessions.closeAll()
+
+        assertEquals(0, sessions.sessionCount)
+        assertEquals(0, server.sessions.size)
+    }
+
+    private companion object {
+        const val INITIALIZE = """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}"""
+        const val TOOLS_LIST = """{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"""
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessionsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessionsTest.kt
@@ -39,7 +39,7 @@ class StreamableMcpSessionsTest {
     private lateinit var server: Server
     private lateinit var sessions: StreamableMcpSessions
 
-    private fun freshSessions(): StreamableMcpSessions {
+    private fun freshSessions(maxSessions: Int = StreamableMcpSessions.DEFAULT_MAX_SESSIONS): StreamableMcpSessions {
         now = 0L
         server = Server(
             serverInfo = Implementation(name = "test-server", version = "0.0.1"),
@@ -47,7 +47,7 @@ class StreamableMcpSessionsTest {
                 capabilities = ServerCapabilities(tools = ServerCapabilities.Tools(listChanged = true))
             )
         )
-        sessions = StreamableMcpSessions(server) { now }
+        sessions = StreamableMcpSessions(server, maxSessions) { now }
         return sessions
     }
 
@@ -206,6 +206,23 @@ class StreamableMcpSessionsTest {
         assertEquals(1, server.sessions.size)
         assertEquals(HttpStatusCode.NotFound, client.mcpPost(TOOLS_LIST, stale).status)
         assertEquals(HttpStatusCode.OK, client.mcpPost(TOOLS_LIST, fresh).status)
+    }
+
+    @Test
+    fun `session cap evicts the longest-idle session`() = testApplication {
+        freshSessions(maxSessions = 2)
+        mountEndpoint()
+        val oldest = client.initializeSession()
+        now = 1_000L
+        val middle = client.initializeSession()
+        now = 2_000L
+        val newest = client.initializeSession()
+
+        assertEquals(2, sessions.sessionCount)
+        assertEquals(2, server.sessions.size)
+        assertEquals(HttpStatusCode.NotFound, client.mcpPost(TOOLS_LIST, oldest).status)
+        assertEquals(HttpStatusCode.OK, client.mcpPost(TOOLS_LIST, middle).status)
+        assertEquals(HttpStatusCode.OK, client.mcpPost(TOOLS_LIST, newest).status)
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessionsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessionsTest.kt
@@ -117,6 +117,18 @@ class StreamableMcpSessionsTest {
     }
 
     @Test
+    fun `malformed body without session id is rejected and leaks no session`() = testApplication {
+        freshSessions()
+        mountEndpoint()
+
+        val response = client.mcpPost("""{"jsonrpc": garbage""")
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertEquals(0, sessions.sessionCount)
+        assertEquals(0, server.sessions.size)
+    }
+
+    @Test
     fun `unknown session id gets 404 so the client re-initializes`() = testApplication {
         freshSessions()
         mountEndpoint()

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessionsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/StreamableMcpSessionsTest.kt
@@ -226,6 +226,20 @@ class StreamableMcpSessionsTest {
     }
 
     @Test
+    fun `session cap never evicts the just-initialized session on a timestamp tie`() = testApplication {
+        freshSessions(maxSessions = 1)
+        mountEndpoint()
+        // Both sessions initialize at now = 0: with millisecond granularity a
+        // burst produces ties, and the newcomer must win its own tie-break.
+        val first = client.initializeSession()
+        val second = client.initializeSession()
+
+        assertEquals(1, sessions.sessionCount)
+        assertEquals(HttpStatusCode.NotFound, client.mcpPost(TOOLS_LIST, first).status)
+        assertEquals(HttpStatusCode.OK, client.mcpPost(TOOLS_LIST, second).status)
+    }
+
+    @Test
     fun `closeAll empties both registries`() = testApplication {
         freshSessions()
         mountEndpoint()


### PR DESCRIPTION
## Problem

Codex CLI only speaks streamable HTTP — it has no SSE client. `codex mcp add` against BossTerm's SSE-only MCP server registered fine, but the runtime connection always failed. That was previously documented as "needs an SDK upgrade" — wrong, as it turns out: the pinned MCP SDK 0.8.3 already ships `StreamableHttpServerTransport`, now proven end-to-end by the contract test in this PR.

## Fix

- **`StreamableMcpSessions`** (new): owns the streamable HTTP endpoint at **`/mcp`**, one JSON-response-mode `StreamableHttpServerTransport` per client session, each with its own `ServerSession` in the shared SDK `Server` (which multiplexes sessions by design — SSE clients on the root path are unaffected). Mounted with route-scoped `ContentNegotiation(McpJson)`: the SDK's JSON mode replies via `call.respond(JSONRPCMessage)`, which fails without a server-side converter — `ktor-server-content-negotiation` is a new (small) dependency.
- **Session contract**: POST without a session id may only be `initialize` (anything else is rejected 400 by the SDK **and** the speculative transport is torn down, so stray POSTs can't leak phantom `ServerSession`s); unknown session ids get **404** so clients re-initialize per spec; DELETE tears down the session everywhere; GET is a plain **405** route (a ktor `sse()` route would have already committed a 200 event-stream before the SDK's reject ran, stranding clients).
- **Leak control**: sessions idle past 2h are swept every 15min — streamable HTTP has no connection drop to observe, and each `codex` invocation abandons its session without DELETE. Engine stop closes all transports.
- **`McpCliAttacher`**: `CODEX.registrationUrl` now points at `http://127.0.0.1:<port>/mcp` (Claude/Gemini/OpenCode keep their existing URLs). Codex bakes the literal bound port like the other plain-URL CLIs; a stale port after restart is handled by the existing reconcile/auto-reattach machinery.

## Testing

- New `StreamableMcpSessionsTest` (9 tests): drives the real SDK transport + `Server` through an in-process ktor app — initialize mints a session, established sessions serve `tools/list`, stray POSTs leak nothing (asserted against `Server.sessions` too), unknown ids 404, GET 405, DELETE and idle-eviction empty both registries.
- `:compose-ui:desktopTest --tests "ai.rever.bossterm.compose.mcp.*"` — all 52 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
