### PR TITLE
fix(ai-menu): replace removed codex --full-auto with modern sandbox/approval flags

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantDefinition.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantDefinition.kt
@@ -183,7 +183,8 @@ object AIAssistants {
             id = AIAssistantIds.CODEX,
             displayName = "Codex (OpenAI)",
             command = "codex",
-            yoloFlag = "--full-auto",
+            // Codex CLI >= 0.44 removed --full-auto; this is its documented replacement
+            yoloFlag = "--sandbox workspace-write --ask-for-approval never",
             yoloLabel = "Full Auto",
             installCommand = "npm install -g @openai/codex",
             npmInstallCommand = "npm install -g @openai/codex",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantDefinition.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantDefinition.kt
@@ -183,7 +183,7 @@ object AIAssistants {
             id = AIAssistantIds.CODEX,
             displayName = "Codex (OpenAI)",
             command = "codex",
-            // Codex CLI >= 0.44 removed --full-auto; this is its documented replacement
+            // Codex CLI dropped --full-auto (gone as of codex-cli 0.144.0); this is its documented replacement
             yoloFlag = "--sandbox workspace-write --ask-for-approval never",
             yoloLabel = "Full Auto",
             installCommand = "npm install -g @openai/codex",

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ai/AIAssistantLaunchCommandTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ai/AIAssistantLaunchCommandTest.kt
@@ -1,0 +1,60 @@
+package ai.rever.bossterm.compose.ai
+
+import ai.rever.bossterm.compose.settings.AIAssistantConfigData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+/**
+ * Pins the launch commands the AI Assistant context menu writes to the PTY.
+ * The yolo flags live in [AIAssistants.BUILTIN] as plain data, so a silent
+ * upstream CLI change (e.g. Codex dropping --full-auto) only surfaces at
+ * launch time — these tests document the expected flag strings instead.
+ */
+class AIAssistantLaunchCommandTest {
+
+    private val provider = ToolCommandProvider()
+
+    private fun builtin(id: String): AIAssistantDefinition {
+        val assistant = AIAssistants.BUILTIN.find { it.id == id }
+        assertNotNull(assistant, "missing built-in assistant: $id")
+        return assistant
+    }
+
+    @Test
+    fun `codex launches with sandboxed auto flags`() {
+        // Codex CLI rejects the old --full-auto; the replacement keeps the
+        // sandbox --full-auto implied instead of a full approval bypass.
+        assertEquals(
+            "codex --sandbox workspace-write --ask-for-approval never\n",
+            provider.getLaunchCommand(builtin(AIAssistantIds.CODEX))
+        )
+    }
+
+    @Test
+    fun `no built-in assistant uses the removed full-auto flag`() {
+        AIAssistants.BUILTIN.forEach { assistant ->
+            assertFalse(
+                assistant.yoloFlag.contains("--full-auto"),
+                "${assistant.id} still uses --full-auto, which Codex CLI removed"
+            )
+        }
+    }
+
+    @Test
+    fun `yolo disabled launches the bare command`() {
+        assertEquals(
+            "codex\n",
+            provider.getLaunchCommand(builtin(AIAssistantIds.CODEX), AIAssistantConfigData(yoloEnabled = false))
+        )
+    }
+
+    @Test
+    fun `custom yolo flag overrides the built-in default`() {
+        assertEquals(
+            "codex --my-flag\n",
+            provider.getLaunchCommand(builtin(AIAssistantIds.CODEX), AIAssistantConfigData(customYoloFlag = "--my-flag"))
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Right-click → AI Assistant → **Codex (OpenAI)** launches `codex --full-auto`, which fails on current Codex CLI releases:

```
❯ codex --full-auto
error: unexpected argument '--full-auto' found
```

The Codex CLI removed the `--full-auto` convenience flag from the interactive command (verified on `codex-cli 0.144.0`). It was an alias for sandboxed automatic execution.

## Fix

Replace the built-in Codex YOLO flag with the documented modern equivalent:

```
codex --sandbox workspace-write --ask-for-approval never
```

- `--sandbox workspace-write` — commands run sandboxed with write access limited to the workspace (same protection `--full-auto` implied)
- `--ask-for-approval never` — no interactive approval prompts (failures are returned to the model), matching the "Full Auto" label

Deliberately **not** using `--dangerously-bypass-approvals-and-sandbox`: that disables the sandbox entirely, which is stronger than what "Full Auto" ever meant (and stronger than what the old flag did).

## Notes

- Settings only persist a user's *custom* override (`customYoloFlag`); the built-in default is read from `AIAssistants.BUILTIN` at runtime, so existing installs pick up the fix without migration.
- Flag parsing verified against `codex-cli 0.144.0`: `codex --sandbox workspace-write --ask-for-approval never --version` parses and exits cleanly.
- Compile check: `./gradlew :compose-ui:compileKotlinDesktop` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
