### PR TITLE
fix(mcp): don't let auto-reattach outlive stop() — crash on host plugin hot-swap

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -102,6 +102,14 @@ class BossTermMcpManager(
     private var disabledToolsWatcherJob: Job? = null
     private var preferredShellWatcherJob: Job? = null
 
+    // In-flight auto-reattach fan-out (see launchAutoReattach). Tracked so stop()
+    // can cancel it: when an embedding host unloads this instance's classloader
+    // (BOSS plugin hot-swap/update), an orphaned reattach coroutine that keeps
+    // running past dispose crashes with NoClassDefFoundError on its next lazy
+    // class load. Also cancelled by the next launchAutoReattach so two fan-outs
+    // never race each other's CLI-config rewrites.
+    private var reattachJob: Job? = null
+
     // Streamable HTTP (Codex) session bookkeeping for the running engine.
     // Guarded by [mutex] like the engine fields; null while stopped.
     private var streamableSessions: StreamableMcpSessions? = null
@@ -233,6 +241,8 @@ class BossTermMcpManager(
         disabledToolsWatcherJob = null
         preferredShellWatcherJob?.cancel()
         preferredShellWatcherJob = null
+        reattachJob?.cancel()
+        reattachJob = null
         // Async shutdown so callers (including Compose onDispose on the UI
         // thread) don't block waiting for Ktor's grace period.
         parentScope.launch(Dispatchers.IO) {
@@ -642,7 +652,10 @@ class BossTermMcpManager(
         val targets = registry.attachedTargets.value
         if (targets.isEmpty()) return
         log.info("Auto-reattaching {} CLI(s) to new endpoint…", targets.size)
-        parentScope.launch(Dispatchers.IO) {
+        // A rebind supersedes any still-running fan-out from the previous bind —
+        // let the newer port win instead of racing two writers over CLI configs.
+        reattachJob?.cancel()
+        reattachJob = parentScope.launch(Dispatchers.IO) {
             // One identity probe per distinct registered port (several CLIs
             // usually point at the same default), before the fan-out.
             val registeredPorts = targets.associateWith { target ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -107,8 +107,18 @@ class BossTermMcpManager(
     // (BOSS plugin hot-swap/update), an orphaned reattach coroutine that keeps
     // running past dispose crashes with NoClassDefFoundError on its next lazy
     // class load. Also cancelled by the next launchAutoReattach so two fan-outs
-    // never race each other's CLI-config rewrites.
-    private var reattachJob: Job? = null
+    // never race each other's CLI-config rewrites. Unlike the watcher jobs above
+    // (written only from single-threaded start()), this is written under [mutex]
+    // from reconcile — so stop() cancels it inside the same lock, giving the
+    // read a happens-before edge and closing the assign-vs-cancel race.
+    // Internal (not private) for the lifecycle tests.
+    internal var reattachJob: Job? = null
+
+    // Test seam: replaces the reattach fan-out body so lifecycle tests can hold
+    // the job open without shelling out to real CLIs (which would rewrite the
+    // developer's actual CLI configs) or probing real registration files.
+    // Null in production.
+    internal var reattachBodyOverrideForTest: (suspend (Int) -> Unit)? = null
 
     // Streamable HTTP (Codex) session bookkeeping for the running engine.
     // Guarded by [mutex] like the engine fields; null while stopped.
@@ -241,12 +251,19 @@ class BossTermMcpManager(
         disabledToolsWatcherJob = null
         preferredShellWatcherJob?.cancel()
         preferredShellWatcherJob = null
-        reattachJob?.cancel()
-        reattachJob = null
         // Async shutdown so callers (including Compose onDispose on the UI
-        // thread) don't block waiting for Ktor's grace period.
+        // thread) don't block waiting for Ktor's grace period. The reattach
+        // fan-out is cancelled inside the lock — its writer (launchAutoReattach,
+        // reached from reconcile) assigns under the same mutex, so cancelling
+        // here can't race a concurrent assignment or read a stale reference.
+        // No new fan-out can start after this block: watcherJob (the only
+        // reconcile trigger) was cancelled synchronously above.
         parentScope.launch(Dispatchers.IO) {
-            mutex.withLock { stopRunningEngineLocked() }
+            mutex.withLock {
+                reattachJob?.cancel()
+                reattachJob = null
+                stopRunningEngineLocked()
+            }
         }
     }
 
@@ -648,7 +665,7 @@ class BossTermMcpManager(
      * (the Settings/Toolbox button) stays impolite on purpose: the user
      * asked THIS instance to own the registration.
      */
-    private fun launchAutoReattach(port: Int) {
+    internal fun launchAutoReattach(port: Int) {
         val targets = registry.attachedTargets.value
         if (targets.isEmpty()) return
         log.info("Auto-reattaching {} CLI(s) to new endpoint…", targets.size)
@@ -656,6 +673,7 @@ class BossTermMcpManager(
         // let the newer port win instead of racing two writers over CLI configs.
         reattachJob?.cancel()
         reattachJob = parentScope.launch(Dispatchers.IO) {
+            reattachBodyOverrideForTest?.let { it(port); return@launch }
             // One identity probe per distinct registered port (several CLIs
             // usually point at the same default), before the fan-out.
             val registeredPorts = targets.associateWith { target ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -267,6 +267,10 @@ object McpCliAttacher {
         // (BOSS plugin hot-swap/update), any lazy class load there dies with
         // NoClassDefFoundError. Touching them at object init pins them for
         // the classloader's lifetime.
+        //
+        // NOT dead code: evaluating each `::class.java` literal is the intended
+        // side effect (it forces the JVM to load the class). Removing this
+        // "unused" list silently reintroduces the hot-swap crash.
         listOf(
             McpAttachResult.Success::class.java,
             McpAttachResult.CopiedToClipboard::class.java,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpCliAttacher.kt
@@ -258,6 +258,22 @@ object McpCliAttacher {
     /** Per-process timeout for any single shell-out. */
     private const val PROCESS_TIMEOUT_SECONDS = 15L
 
+    init {
+        // Force-load the classes attach() needs on the stretch between
+        // runProcess() returning and the next suspension point. runProcess
+        // blocks uninterruptibly in waitFor(), so even a cancelled coroutine
+        // executes that stretch before it can observe cancellation — and when
+        // an embedding host has unloaded this classloader in the meantime
+        // (BOSS plugin hot-swap/update), any lazy class load there dies with
+        // NoClassDefFoundError. Touching them at object init pins them for
+        // the classloader's lifetime.
+        listOf(
+            McpAttachResult.Success::class.java,
+            McpAttachResult.CopiedToClipboard::class.java,
+            ProcessOutcome::class.java,
+        )
+    }
+
     /**
      * Attempt to register the BossTerm MCP server with [target].
      *

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpReattachLifecycleTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpReattachLifecycleTest.kt
@@ -1,0 +1,87 @@
+package ai.rever.bossterm.compose.mcp
+
+import ai.rever.bossterm.compose.settings.SettingsManager
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the lifecycle contract of the auto-reattach fan-out job: it must not
+ * outlive [BossTermMcpManager.stop] (an orphaned fan-out that keeps running
+ * after an embedding host unloads this classloader — BOSS plugin hot-swap —
+ * crashes with NoClassDefFoundError on its next lazy class load), and a rebind
+ * must supersede the previous in-flight fan-out so two fan-outs never race
+ * each other's CLI-config rewrites.
+ *
+ * The fan-out body is replaced via [BossTermMcpManager.reattachBodyOverrideForTest]:
+ * the real body shells out `<cli> mcp add` against the developer's actual CLI
+ * configs, which a unit test must never do.
+ */
+class McpReattachLifecycleTest {
+
+    private val scope = CoroutineScope(SupervisorJob())
+    private val settingsDir = createTempDirectory("mcp-reattach-test").toFile().apply { deleteOnExit() }
+
+    private fun newManager() = BossTermMcpManager(
+        registry = McpTerminalRegistry,
+        settingsManager = SettingsManager(File(settingsDir, "settings.json").absolutePath),
+        parentScope = scope,
+    )
+
+    @AfterTest
+    fun tearDown() {
+        McpTerminalRegistry.markDetached(McpAttachTarget.CLAUDE_CODE)
+        scope.cancel()
+    }
+
+    @Test
+    fun `stop cancels an in-flight reattach fan-out`() = runBlocking {
+        val manager = newManager()
+        McpTerminalRegistry.markAttached(McpAttachTarget.CLAUDE_CODE)
+        val gate = CompletableDeferred<Unit>() // never completed — holds the fan-out open
+        manager.reattachBodyOverrideForTest = { gate.await() }
+
+        manager.launchAutoReattach(port = 7699)
+        val job = manager.reattachJob
+        assertNotNull(job)
+        assertTrue(job.isActive)
+
+        manager.stop()
+
+        withTimeout(5_000) { job.join() }
+        assertTrue(job.isCancelled, "stop() must cancel the in-flight fan-out")
+    }
+
+    @Test
+    fun `a rebind supersedes the previous in-flight fan-out`() = runBlocking {
+        val manager = newManager()
+        McpTerminalRegistry.markAttached(McpAttachTarget.CLAUDE_CODE)
+        val gate = CompletableDeferred<Unit>()
+        manager.reattachBodyOverrideForTest = { gate.await() }
+
+        manager.launchAutoReattach(port = 7699)
+        val first = manager.reattachJob
+        assertNotNull(first)
+
+        manager.launchAutoReattach(port = 7700)
+        val second = manager.reattachJob
+        assertNotNull(second)
+
+        withTimeout(5_000) { first.join() }
+        assertTrue(first.isCancelled, "the newer fan-out must cancel the previous one")
+        assertTrue(second.isActive)
+
+        manager.stop()
+        withTimeout(5_000) { second.join() }
+        assertTrue(second.isCancelled)
+    }
+}


### PR DESCRIPTION
## Problem

Observed live in BossConsole (2026-07-10): the host hot-swapped its plugin API layer (boss-plugin-api 1.0.63→1.0.64), which disposes the terminal-tab plugin and unloads its classloader. The MCP auto-reattach fan-out was mid-flight (`McpCliAttacher — Attaching Codex via: codex mcp add …`); its subprocess finished ~0.5s after the unload, and the coroutine's next lazy class load crashed the CrashHandler with:

```
java.lang.NoClassDefFoundError: ai/rever/bossterm/compose/mcp/McpAttachResult$Success
    at ai.rever.bossterm.compose.mcp.McpCliAttacher$attach$2.invokeSuspend(McpCliAttacher.kt:311)
    ...
Caused by: java.lang.ClassNotFoundException: ai.rever.bossterm.compose.mcp.McpAttachResult$Success
    at ai.rever.boss.plugin.loader.PluginClassLoader.loadClassChildFirst(PluginClassLoader.kt:191)
```

Root cause: `launchAutoReattach` launches fire-and-forget on `parentScope` and is never tracked, so `BossTermMcpManager.stop()` (called from the plugin's `dispose()`) cancels the three settings watcher jobs but leaves the reattach fan-out running past the classloader's death.

## Fix (two layers)

1. **Track and cancel.** The fan-out is now held in `reattachJob` and cancelled in `stop()` — same pattern as the sibling watcher jobs. A rebind also cancels the previous in-flight fan-out, so two fan-outs never race each other's CLI-config rewrites (newer port wins).
2. **Eager class preload.** `runProcess` blocks uninterruptibly in `waitFor()`, so even a *cancelled* coroutine still executes the stretch between the subprocess finishing and the next suspension point — cancellation alone can't prevent the crash. `McpCliAttacher`'s init now force-loads `McpAttachResult.Success`, `McpAttachResult.CopiedToClipboard`, and `ProcessOutcome`, pinning them for the classloader's lifetime so that stretch needs no lazy load after unload.

Self-healing either way (the reloaded plugin instance re-attaches fine) — this removes the uncaught-exception crash noise on every hot-swap that lands mid-attach.

## Testing

- `:compose-ui:desktopTest` fully green (402 tests).
- The cancel path matches the existing watcher-job pattern; the preload is a class-init side effect exercised by every attach.

Generated with [Claude Code](https://claude.com/claude-code)