### PR TITLE
fix(mcp): survive engine teardown after the host closes our classloader — crash on plugin hot-reload

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -90,7 +90,9 @@ class BossTermMcpManager(
 
     // Guarded by [mutex]. The Server itself is hoisted to a class-level field
     // and re-bound to a transport each time the engine restarts.
-    private var runningEngine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
+    // internal (not private) so McpEngineTeardownTest can install a stub
+    // engine and exercise stopRunningEngineLocked without binding a port.
+    internal var runningEngine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
     private var runningPort: Int? = null
 
     // Holds the live BossTermMcpServer wrapper so the disabled-tools watcher
@@ -124,6 +126,13 @@ class BossTermMcpManager(
     // Guarded by [mutex] like the engine fields; null while stopped.
     private var streamableSessions: StreamableMcpSessions? = null
     private var streamableSweeperJob: Job? = null
+
+    // Substitutes the closeAll step in [stopRunningEngineLocked]. The failure
+    // that step guards against (NoClassDefFoundError from a classloader the
+    // host closed after dispose — see [stop]) can't be produced in a unit
+    // test, so McpEngineTeardownTest injects a throwing close here to pin the
+    // contract that the bookkeeping below the guard still runs.
+    internal var closeAllOverrideForTest: (suspend () -> Unit)? = null
 
     // Caches caller-tab resolution by the client's ephemeral TCP port. That
     // port is stable for a connection's lifetime and its owning PID can't
@@ -275,6 +284,12 @@ class BossTermMcpManager(
                     reattachJob = null
                     stopRunningEngineLocked()
                 }
+            } catch (e: CancellationException) {
+                // parentScope cancellation, not a teardown failure — let the
+                // coroutine complete as cancelled rather than mis-logging it
+                // below. Rethrowing needs no lazy load: CancellationException
+                // aliases the (parent-loader) JDK class.
+                throw e
             } catch (t: Throwable) {
                 log.warn("MCP engine teardown after stop() failed (classloader likely closed): {}", t.toString())
             }
@@ -541,9 +556,15 @@ class BossTermMcpManager(
             // an embedding host closes the classloader at that point — a
             // first-time load of the class there crashed the host with
             // NoClassDefFoundError. Same eager-preload pattern as
-            // McpCliAttacher (#331); calling it IS the intended side effect.
-            // Launched before the engine accepts connections so the no-op
-            // can't race (and close) a real client's freshly-minted session.
+            // McpCliAttacher (#331); calling it IS the intended side effect —
+            // launched, not awaited, because warming a suspend fun's class
+            // requires invoking it. Scheduled before the engine accepts
+            // connections: the session map is empty here and a client needs a
+            // connect + initialize round-trip to mint a session, so the no-op
+            // close finishing first is practically certain. If it ever did
+            // observe a freshly-minted session, closing it is the same benign
+            // eviction the idle sweeper and session cap already impose — the
+            // client sees 404 and re-initializes.
             parentScope.launch { streamable.closeAll() }
             engine.start(wait = false)
             runningEngine = engine
@@ -748,7 +769,9 @@ class BossTermMcpManager(
         }
     }
 
-    private suspend fun stopRunningEngineLocked() {
+    // internal (not private) for McpEngineTeardownTest; production callers
+    // hold [mutex].
+    internal suspend fun stopRunningEngineLocked() {
         val engine = runningEngine ?: return
         val port = runningPort
         try {
@@ -768,7 +791,14 @@ class BossTermMcpManager(
             // see stop()): closing live sessions can need a first-time class
             // load the warm-up at bind time couldn't reach (closeQuietly).
             try {
-                streamableSessions?.closeAll()
+                val closeOverride = closeAllOverrideForTest
+                if (closeOverride != null) closeOverride() else streamableSessions?.closeAll()
+            } catch (e: CancellationException) {
+                // Deliberately NOT rethrown: everything below is plain
+                // non-suspending bookkeeping that must still run, and the
+                // cancelled job still completes as cancelled once this
+                // function returns. Logged as what it is, not as a failure.
+                log.info("Streamable MCP session close cancelled during engine stop; finishing bookkeeping")
             } catch (t: Throwable) {
                 log.warn("Failed to close streamable MCP sessions during engine stop: {}", t.toString())
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -258,11 +258,25 @@ class BossTermMcpManager(
         // here can't race a concurrent assignment or read a stale reference.
         // No new fan-out can start after this block: watcherJob (the only
         // reconcile trigger) was cancelled synchronously above.
+        // Nothing in this coroutine may escape uncaught: it runs AFTER stop()
+        // (and, in an embedding host, dispose()) has returned, and a plugin
+        // hot-swap closes this instance's classloader at that point — so any
+        // first-time lazy class load in the teardown path throws
+        // NoClassDefFoundError from the closed loader and would crash the host
+        // (this killed BOSS via StreamableMcpSessions.closeAll's state-machine
+        // class; same failure mode as the #331 reattach orphan). Plain
+        // try/catch on purpose: it compiles inline and needs no class of its
+        // own. Cleanup past the failure point is forfeited, which is fine —
+        // the engine stop has already been requested and the instance is dying.
         parentScope.launch(Dispatchers.IO) {
-            mutex.withLock {
-                reattachJob?.cancel()
-                reattachJob = null
-                stopRunningEngineLocked()
+            try {
+                mutex.withLock {
+                    reattachJob?.cancel()
+                    reattachJob = null
+                    stopRunningEngineLocked()
+                }
+            } catch (t: Throwable) {
+                log.warn("MCP engine teardown after stop() failed (classloader likely closed): {}", t.toString())
             }
         }
     }
@@ -520,6 +534,17 @@ class BossTermMcpManager(
                     mcp { mcpServer }
                 }
             }
+            // Warm closeAll's suspend state-machine class while this
+            // classloader can still load classes (a no-op on the empty session
+            // map). The engine teardown in stop() runs on a background
+            // coroutine after dispose() has returned, and a plugin hot-swap in
+            // an embedding host closes the classloader at that point — a
+            // first-time load of the class there crashed the host with
+            // NoClassDefFoundError. Same eager-preload pattern as
+            // McpCliAttacher (#331); calling it IS the intended side effect.
+            // Launched before the engine accepts connections so the no-op
+            // can't race (and close) a real client's freshly-minted session.
+            parentScope.launch { streamable.closeAll() }
             engine.start(wait = false)
             runningEngine = engine
             runningPort = port
@@ -738,7 +763,15 @@ class BossTermMcpManager(
             streamableSweeperJob = null
             // Close streamable transports so their ServerSessions leave the
             // (about-to-be-detached) Server rather than lingering until GC.
-            streamableSessions?.closeAll()
+            // Guarded so the bookkeeping below still runs when this teardown
+            // executes after the host closed our classloader (post-hot-swap,
+            // see stop()): closing live sessions can need a first-time class
+            // load the warm-up at bind time couldn't reach (closeQuietly).
+            try {
+                streamableSessions?.closeAll()
+            } catch (t: Throwable) {
+                log.warn("Failed to close streamable MCP sessions during engine stop: {}", t.toString())
+            }
             streamableSessions = null
             // Detach the wrapper first so any in-flight manage_tools handler
             // (or a stray applyDisabledSet from the watcher) becomes a no-op

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -291,7 +291,10 @@ class BossTermMcpManager(
                 // aliases the (parent-loader) JDK class.
                 throw e
             } catch (t: Throwable) {
-                log.warn("MCP engine teardown after stop() failed (classloader likely closed): {}", t.toString())
+                // Full stack on purpose: anything landing here is an unknown
+                // failure mode, and the trace is what identifies the next
+                // StreamableMcpSessions-style lazy-load site.
+                log.warn("MCP engine teardown after stop() failed (classloader likely closed)", t)
             }
         }
     }
@@ -565,7 +568,17 @@ class BossTermMcpManager(
             // observe a freshly-minted session, closing it is the same benign
             // eviction the idle sweeper and session cap already impose — the
             // client sees 404 and re-initializes.
-            parentScope.launch { streamable.closeAll() }
+            parentScope.launch {
+                // On the fresh empty map closeAll cannot throw — this guard
+                // exists so no future change to closeAll can ever cancel
+                // parentScope (not guaranteed to be a SupervisorJob) from a
+                // fire-and-forget warm-up.
+                try {
+                    streamable.closeAll()
+                } catch (t: Throwable) {
+                    log.warn("Streamable MCP closeAll warm-up failed: {}", t.toString())
+                }
+            }
             engine.start(wait = false)
             runningEngine = engine
             runningPort = port
@@ -875,8 +888,16 @@ class BossTermMcpManager(
         }
     }
 
+    // The production path is fixed at ~/.bossterm/mcp.port on purpose: the
+    // PreToolUse hook reads exactly that file, and embedders that relocate
+    // the settings dir (bossterm.settings.dir) must still publish the marker
+    // where the hook looks. The override exists so tests exercising
+    // stopRunningEngineLocked can't delete a developer's real marker.
+    internal var portMarkerFileOverrideForTest: File? = null
+
     private fun mcpPortMarkerFile(): File =
-        File(System.getProperty("user.home"), ".bossterm/mcp.port")
+        portMarkerFileOverrideForTest
+            ?: File(System.getProperty("user.home"), ".bossterm/mcp.port")
 
     private data class McpRuntimeConfig(val enabled: Boolean, val port: Int)
 

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpEngineTeardownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpEngineTeardownTest.kt
@@ -1,0 +1,80 @@
+package ai.rever.bossterm.compose.mcp
+
+import ai.rever.bossterm.compose.settings.SettingsManager
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+/**
+ * Pins the contract of the guarded closeAll step in
+ * [BossTermMcpManager.stopRunningEngineLocked]: when closing the streamable
+ * sessions blows up (in production: NoClassDefFoundError, because the engine
+ * teardown runs on a background coroutine after an embedding host's plugin
+ * hot-swap has closed this classloader — see [BossTermMcpManager.stop]), the
+ * bookkeeping below the guard must still run, so the registry never keeps
+ * reporting a running server that is gone.
+ *
+ * The real failure (a closed classloader) can't be produced in a unit test,
+ * so the close step is substituted via
+ * [BossTermMcpManager.closeAllOverrideForTest], and the engine is a stub that
+ * was never started so no port is bound.
+ */
+class McpEngineTeardownTest {
+
+    private val scope = CoroutineScope(SupervisorJob())
+    private val settingsDir = createTempDirectory("mcp-teardown-test").toFile().apply { deleteOnExit() }
+
+    // stopRunningEngineLocked's finally deletes the REAL ~/.bossterm/mcp.port
+    // (the PreToolUse-hook marker); snapshot and restore it so running this
+    // test on a developer machine can't disturb an opted-in setup.
+    private val portMarker = File(System.getProperty("user.home"), ".bossterm/mcp.port")
+    private var savedPortMarker: ByteArray? = null
+
+    private fun newManager() = BossTermMcpManager(
+        registry = McpTerminalRegistry,
+        settingsManager = SettingsManager(File(settingsDir, "settings.json").absolutePath),
+        parentScope = scope,
+    )
+
+    @BeforeTest
+    fun snapshotPortMarker() {
+        savedPortMarker = if (portMarker.exists()) portMarker.readBytes() else null
+    }
+
+    @AfterTest
+    fun tearDown() {
+        savedPortMarker?.let { portMarker.writeBytes(it) }
+        McpTerminalRegistry.setStopped()
+        scope.cancel()
+    }
+
+    @Test
+    fun `engine-stop bookkeeping survives a throwing closeAll`() = runBlocking {
+        val manager = newManager()
+        manager.runningEngine = embeddedServer(CIO, host = "127.0.0.1", port = 0) {}
+        McpTerminalRegistry.setRunning(7699)
+        manager.closeAllOverrideForTest = {
+            throw NoClassDefFoundError("ai/rever/bossterm/compose/mcp/StreamableMcpSessions\$closeAll\$1")
+        }
+
+        manager.stopRunningEngineLocked() // must not throw
+
+        assertNull(
+            manager.runningEngine,
+            "engine reference must be cleared even when closeAll throws"
+        )
+        assertNull(
+            McpTerminalRegistry.runningPort.value,
+            "registry must report stopped even when closeAll throws"
+        )
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpEngineTeardownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpEngineTeardownTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.runBlocking
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertNull
 
@@ -26,33 +25,26 @@ import kotlin.test.assertNull
  * The real failure (a closed classloader) can't be produced in a unit test,
  * so the close step is substituted via
  * [BossTermMcpManager.closeAllOverrideForTest], and the engine is a stub that
- * was never started so no port is bound.
+ * was never started so no port is bound. The port marker is redirected into
+ * the temp settings dir ([BossTermMcpManager.portMarkerFileOverrideForTest])
+ * so the teardown's marker delete can't touch a developer's real
+ * `~/.bossterm/mcp.port`.
  */
 class McpEngineTeardownTest {
 
     private val scope = CoroutineScope(SupervisorJob())
     private val settingsDir = createTempDirectory("mcp-teardown-test").toFile().apply { deleteOnExit() }
 
-    // stopRunningEngineLocked's finally deletes the REAL ~/.bossterm/mcp.port
-    // (the PreToolUse-hook marker); snapshot and restore it so running this
-    // test on a developer machine can't disturb an opted-in setup.
-    private val portMarker = File(System.getProperty("user.home"), ".bossterm/mcp.port")
-    private var savedPortMarker: ByteArray? = null
-
     private fun newManager() = BossTermMcpManager(
         registry = McpTerminalRegistry,
         settingsManager = SettingsManager(File(settingsDir, "settings.json").absolutePath),
         parentScope = scope,
-    )
-
-    @BeforeTest
-    fun snapshotPortMarker() {
-        savedPortMarker = if (portMarker.exists()) portMarker.readBytes() else null
+    ).apply {
+        portMarkerFileOverrideForTest = File(settingsDir, "mcp.port")
     }
 
     @AfterTest
     fun tearDown() {
-        savedPortMarker?.let { portMarker.writeBytes(it) }
         McpTerminalRegistry.setStopped()
         scope.cancel()
     }


### PR DESCRIPTION
## Problem

Hot-reloading the terminal-tab plugin in BOSS crashed the host app with:

```
java.lang.NoClassDefFoundError: ai... (sanitized as "ai[PATH]" in the crash dialog)
 at ai.rever.bossterm.compose.mcp.StreamableMcpSessions.closeAll(StreamableMcpSessions.kt)
 at ai.rever.bossterm.compose.mcp.BossTermMcpManager.stopRunningEngineLocked(BossTermMcpManager.kt:710)
 at ai.rever.bossterm.compose.mcp.BossTermMcpManager$stop$1.invokeSuspend(BossTermMcpManager.kt:239)
```

`stop()` tears the Ktor engine down on a background coroutine by design (callers, including Compose `onDispose`, must not block on the stop grace period). But an embedding host closes the plugin's classloader as soon as `dispose()` returns — and the teardown coroutine then made the process's **first-ever** call to `StreamableMcpSessions.closeAll()`. First call to a suspend function lazily loads its compiler-generated state-machine class (`$closeAll$1`); loading from a closed classloader throws `NoClassDefFoundError`, which escaped (the `try/catch` in `stopRunningEngineLocked` only wraps `engine.stop`) and killed the host via the uncaught-exception handler.

Same failure family as #331, but `StreamableMcpSessions` shipped in #329 after that hardening pass, so its teardown path never got the eager-preload treatment.

## Fix

Three layers in `BossTermMcpManager`:

1. **Warm `closeAll` at bind time** — a no-op call on the empty session map, launched before `engine.start()` so it cannot race (and close) a real client's freshly-minted session. Same eager-preload pattern as `McpCliAttacher` (#331); the comment documents that calling it IS the intended side effect so a future cleanup can't remove it as dead code. With the class loaded up front, the common (no live Codex sessions) teardown completes fully even after classloader close.
2. **Guard the `closeAll` call** inside `stopRunningEngineLocked`'s `finally` — closing *live* sessions can still need a first-time class load the warm-up couldn't reach (`closeQuietly`'s own state machine), and the bookkeeping after it (`detachServer`, `setStopped`, port-marker delete) must still run.
3. **Guard the entire async teardown coroutine** in `stop()` — the complete backstop: synthetic classes can't all be enumerated, so nothing in the post-dispose path may escape uncaught. Plain `try/catch` on purpose — it compiles inline and needs no class of its own (a `runCatching` lambda would itself be a lazily-loaded class).

Cleanup past a failure point is forfeited, which is fine: the engine stop has already been requested and the instance is going away with its classloader.

## Testing

- `:compose-ui:desktopTest --tests "ai.rever.bossterm.compose.mcp.*"` — 58 tests, 0 failures (includes `StreamableMcpSessionsTest` and `McpReattachLifecycleTest`).
- Reproduced the crash live: BOSS (terminal-tab 2.5.12 / bossterm 1.2.128) hot reload → crash dialog with the exact trace above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
