### PR TITLE
fix(rendering): don't crash the window when a glyph lands outside the canvas

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -401,6 +401,10 @@ object TerminalCanvasRenderer {
      * shrink the window (live resize, the update banner squeezing the terminal)
      * and the drawn x crosses the edge → crash. Such glyphs are clipped by the
      * canvas anyway, so skipping them is visually identical.
+     *
+     * The `>=` check is slightly stricter than the throw condition: a glyph
+     * exactly on the edge would measure at zero-width constraints without
+     * throwing, but it renders nothing, so it is skipped too.
      */
     internal fun DrawScope.drawTextClipped(
         textMeasurer: TextMeasurer,
@@ -1433,6 +1437,11 @@ object TerminalCanvasRenderer {
         val centerX = x + (allocatedWidth - scaledWidth) / 2f
 
         scale(scaleX = scaleValue, scaleY = scaleValue, pivot = Offset(x, y + ctx.cellHeight / 2f)) {
+            // topLeft is a pre-scale coordinate but the clip guard (like Compose's own
+            // constraint math) compares it against the unscaled canvas size, so for
+            // scaleValue < 1 an edge glyph whose rendered position is in-bounds may be
+            // skipped rather than clip-drawn. Intentionally conservative: that exact
+            // case is the one that used to throw.
             drawTextClipped(
                 textMeasurer = ctx.textMeasurer,
                 text = grapheme.text,
@@ -1614,6 +1623,9 @@ object TerminalCanvasRenderer {
             val centerX = x + (allocatedWidth - scaledWidth) / 2f
 
             scale(scaleX = scaleValue, scaleY = scaleValue, pivot = Offset(x, y + ctx.cellHeight / 2f)) {
+                // Pre-scale topLeft vs unscaled canvas size: intentionally conservative
+                // for scaleValue < 1 — an edge glyph may be skipped rather than
+                // clip-drawn (see the same note in renderZWJSequence).
                 drawTextClipped(
                     textMeasurer = ctx.textMeasurer,
                     text = textToRender,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -386,6 +386,38 @@ object TerminalCanvasRenderer {
     }
 
     /**
+     * [drawText] that skips glyphs whose [topLeft] falls outside the canvas.
+     *
+     * Compose's `drawText(textMeasurer, …)` lays the text out with
+     * `maxWidth = canvasWidth - topLeft.x` / `maxHeight = canvasHeight - topLeft.y`
+     * (unclamped), so a topLeft past the right/bottom edge produces negative
+     * constraints and `Constraints()` throws IllegalArgumentException
+     * ("maxWidth must be >= than minWidth…"), killing the whole window.
+     *
+     * That happens whenever visual columns outrun the canvas: glyphs the buffer
+     * stores in one cell but the renderer draws two cells wide (emoji, ambiguous-
+     * width symbols) push `visualCol` past `visibleCols`, which is clamped in
+     * BUFFER columns. At full window width the overshoot stays inside the canvas;
+     * shrink the window (live resize, the update banner squeezing the terminal)
+     * and the drawn x crosses the edge → crash. Such glyphs are clipped by the
+     * canvas anyway, so skipping them is visually identical.
+     */
+    internal fun DrawScope.drawTextClipped(
+        textMeasurer: TextMeasurer,
+        text: String,
+        topLeft: Offset,
+        style: TextStyle
+    ) {
+        if (topLeft.x >= size.width || topLeft.y >= size.height) return
+        drawText(
+            textMeasurer = textMeasurer,
+            text = text,
+            topLeft = topLeft,
+            style = style
+        )
+    }
+
+    /**
      * Main rendering entry point. Renders the entire terminal buffer.
      * Uses a 3-pass system:
      * - Pass 1: Draw all backgrounds (and cache character analysis)
@@ -734,7 +766,7 @@ object TerminalCanvasRenderer {
                             else androidx.compose.ui.text.font.FontStyle.Normal
                     ).also { variants[variantIndex] = it }
 
-                    drawText(
+                    drawTextClipped(
                         textMeasurer = ctx.textMeasurer,
                         text = batchText.toString(),
                         topLeft = Offset(x, y),
@@ -1401,7 +1433,7 @@ object TerminalCanvasRenderer {
         val centerX = x + (allocatedWidth - scaledWidth) / 2f
 
         scale(scaleX = scaleValue, scaleY = scaleValue, pivot = Offset(x, y + ctx.cellHeight / 2f)) {
-            drawText(
+            drawTextClipped(
                 textMeasurer = ctx.textMeasurer,
                 text = grapheme.text,
                 topLeft = Offset(x + (centerX - x) / scaleValue, y),
@@ -1540,7 +1572,7 @@ object TerminalCanvasRenderer {
             if (glyphWidth < ctx.cellWidth * 1.5f) {
                 val scaleX = allocatedWidth / glyphWidth.coerceAtLeast(1f)
                 scale(scaleX = scaleX, scaleY = 1f, pivot = Offset(x, y + ctx.cellWidth)) {
-                    drawText(
+                    drawTextClipped(
                         textMeasurer = ctx.textMeasurer,
                         text = textToRender,
                         topLeft = Offset(x, y),
@@ -1550,7 +1582,7 @@ object TerminalCanvasRenderer {
             } else {
                 val emptySpace = (allocatedWidth - glyphWidth).coerceAtLeast(0f)
                 val centeringOffset = emptySpace / 2f
-                drawText(
+                drawTextClipped(
                     textMeasurer = ctx.textMeasurer,
                     text = textToRender,
                     topLeft = Offset(x + centeringOffset, y),
@@ -1582,7 +1614,7 @@ object TerminalCanvasRenderer {
             val centerX = x + (allocatedWidth - scaledWidth) / 2f
 
             scale(scaleX = scaleValue, scaleY = scaleValue, pivot = Offset(x, y + ctx.cellHeight / 2f)) {
-                drawText(
+                drawTextClipped(
                     textMeasurer = ctx.textMeasurer,
                     text = textToRender,
                     topLeft = Offset(x + (centerX - x) / scaleValue, y),
@@ -1594,7 +1626,7 @@ object TerminalCanvasRenderer {
             val cached = getCachedMeasurement(ctx, charTextToRender, fontForChar, textStyle)
             val glyphWidth = cached.width
             val centeringOffset = ((ctx.cellWidth - glyphWidth) / 2f).coerceAtLeast(0f)
-            drawText(
+            drawTextClipped(
                 textMeasurer = ctx.textMeasurer,
                 text = charTextToRender,
                 topLeft = Offset(x + centeringOffset, y),
@@ -1608,14 +1640,14 @@ object TerminalCanvasRenderer {
             val baselineAlignmentOffset = ctx.cellBaseline - glyphBaseline
             val centeringOffset = ((ctx.cellWidth - glyphWidth) / 2f).coerceAtLeast(0f)
 
-            drawText(
+            drawTextClipped(
                 textMeasurer = ctx.textMeasurer,
                 text = charTextToRender,
                 topLeft = Offset(x + centeringOffset, y + baselineAlignmentOffset),
                 style = textStyle
             )
         } else {
-            drawText(
+            drawTextClipped(
                 textMeasurer = ctx.textMeasurer,
                 text = charTextToRender,
                 topLeft = Offset(x, y),

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/rendering/DrawTextClippedTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/rendering/DrawTextClippedTest.kt
@@ -1,0 +1,117 @@
+package ai.rever.bossterm.compose.rendering
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.sp
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the live-resize / update-banner crash: the window died
+ * with "maxWidth must be >= than minWidth, maxHeight must be >= than minHeight,
+ * minWidth and minHeight must be >= 0" whenever a glyph's topLeft ended up past
+ * the canvas edge, because Compose's drawText derives text-layout constraints
+ * from `canvasSize - topLeft` without clamping.
+ *
+ * [TerminalCanvasRenderer.drawTextClipped] guards every glyph draw against
+ * this; these tests pin both the framework behavior being guarded against and
+ * the guard itself.
+ */
+class DrawTextClippedTest {
+
+    private val measurer = TextMeasurer(
+        defaultFontFamilyResolver = createFontFamilyResolver(),
+        defaultDensity = Density(1f),
+        defaultLayoutDirection = LayoutDirection.Ltr
+    )
+    private val style = TextStyle(fontSize = 12.sp)
+
+    private fun draw(width: Int, height: Int, block: DrawScope.() -> Unit): ImageBitmap {
+        val bitmap = ImageBitmap(width, height)
+        CanvasDrawScope().draw(
+            density = Density(1f),
+            layoutDirection = LayoutDirection.Ltr,
+            canvas = Canvas(bitmap),
+            size = Size(width.toFloat(), height.toFloat()),
+            block = block
+        )
+        return bitmap
+    }
+
+    // Documents the Compose behavior the guard exists for: drawText with a
+    // topLeft right of the canvas throws from Constraints(). If this test ever
+    // fails, Compose has started clamping internally and drawTextClipped can go.
+    @Test
+    fun frameworkDrawTextThrowsWhenTopLeftIsRightOfCanvas() {
+        assertFailsWith<IllegalArgumentException> {
+            draw(100, 50) {
+                drawText(textMeasurer = measurer, text = "A", topLeft = Offset(150f, 0f), style = style)
+            }
+        }
+    }
+
+    @Test
+    fun frameworkDrawTextThrowsWhenTopLeftIsBelowCanvas() {
+        assertFailsWith<IllegalArgumentException> {
+            draw(100, 50) {
+                drawText(textMeasurer = measurer, text = "A", topLeft = Offset(0f, 90f), style = style)
+            }
+        }
+    }
+
+    @Test
+    fun drawTextClippedSkipsOutOfBoundsGlyphsInsteadOfCrashing() {
+        draw(100, 50) {
+            with(TerminalCanvasRenderer) {
+                drawTextClipped(measurer, "A", Offset(150f, 0f), style)   // right of canvas
+                drawTextClipped(measurer, "A", Offset(0f, 90f), style)    // below canvas
+                drawTextClipped(measurer, "A", Offset(150f, 90f), style)  // both
+                drawTextClipped(measurer, "A", Offset(100f, 0f), style)   // exactly on the edge
+            }
+        }
+    }
+
+    @Test
+    fun drawTextClippedStillDrawsInBoundsGlyphs() {
+        val bitmap = draw(100, 50) {
+            with(TerminalCanvasRenderer) {
+                drawTextClipped(measurer, "██", Offset(2f, 2f), style.copy(color = Color.White))
+            }
+        }
+        val pixels = bitmap.toPixelMap()
+        var drewSomething = false
+        outer@ for (y in 0 until pixels.height) {
+            for (x in 0 until pixels.width) {
+                if (pixels[x, y].alpha > 0f) {
+                    drewSomething = true
+                    break@outer
+                }
+            }
+        }
+        assertTrue(drewSomething, "an in-bounds glyph must still be rendered")
+    }
+
+    // Negative topLeft must keep drawing (partially visible glyphs while
+    // scrolled): constraints only go invalid past the right/bottom edge.
+    @Test
+    fun drawTextClippedKeepsNegativeTopLeft() {
+        draw(100, 50) {
+            with(TerminalCanvasRenderer) {
+                drawTextClipped(measurer, "A", Offset(-5f, -5f), style)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Resizing the window — or the update banner appearing and squeezing the terminal — sometimes kills the whole window with a native error dialog:

> maxWidth must be >= than minWidth, maxHeight must be >= than minHeight, minWidth and minHeight must be >= 0

## Root cause

Compose's `drawText(textMeasurer, …)` derives text-layout constraints from `canvasSize - topLeft` **without clamping** (verified in `TextPainterKt.textLayoutConstraints` bytecode for Compose 1.9.3 — plain `fsub`/`ceil`, no `coerceAtLeast(0)`). Any glyph whose `topLeft` falls past the right/bottom canvas edge produces negative constraints, and `Constraints()` throws the message above. Compose Desktop's default `WindowExceptionHandler` turns that into the fatal error dialog.

`TerminalCanvasRenderer` can produce such glyphs whenever **visual columns outrun buffer columns**: emoji / ambiguous-width symbols (Claude Code's ✳ spinner, braille spinners, ⚡ …) occupy one buffer cell but render two cells wide, so `x = visualCol * cellWidth` can pass `size.width` even though the render loop clamps *buffer* columns to `visibleCols`. At full window width the overshoot stays just inside; shrink the canvas (live resize, update banner reflow) and the draw crosses the edge → crash. The existing whole-canvas guard in `ProperTerminal` ("prevents drawText constraint failures") only rejects sub-cell canvases, so this hole remained.

## Fix

Route all 8 glyph `drawText` call sites through a new `drawTextClipped` helper that skips draws whose `topLeft` is outside the canvas. Those glyphs are clipped by the canvas's `clipToBounds()` anyway, so skipping is visually identical. Negative `topLeft` (partially scrolled glyphs) keeps drawing — constraints only go invalid past the right/bottom edge.

## Tests

`DrawTextClippedTest` (compose-ui desktopTest) pins both sides:
- the framework really does throw `IllegalArgumentException` on this Compose version for out-of-bounds `topLeft` (right of / below canvas) — if Compose ever clamps internally, these tests fail and the guard can be dropped
- `drawTextClipped` skips out-of-bounds and edge draws instead of crashing, still renders in-bounds glyphs (pixel-checked), and keeps negative-`topLeft` draws

All compose-ui desktop tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)