### PR TITLE
feat(hyperlinks): route CLI open requests through the host link handler

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -590,7 +590,7 @@ class EmbeddableTerminalState {
         // Registered at creation (not in the composition) so requests from a
         // hidden/uncomposed terminal keep working.
         session?.terminal?.addCustomCommandListener(
-            ai.rever.bossterm.compose.osc.OpenTargetOSCListener { openTargetLinkHandler }
+            ai.rever.bossterm.compose.osc.OpenTargetOSCListener(handlerProvider = { openTargetLinkHandler })
         )
 
         // Start process in session's coroutine scope

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -293,6 +293,12 @@ fun EmbeddableTerminal(
         }
     }
 
+    // Keep CLI-originated open requests (OSC 1341;OpenTarget) routed through
+    // the same onLinkClick handler as Ctrl/Cmd+click. The listener itself is
+    // registered at session creation (see initializeSession); here we only
+    // keep the handler current.
+    SideEffect { effectiveState.openTargetLinkHandler = onLinkClick }
+
     // Fire onReady when connected
     val connectionState = session?.connectionState?.value
     LaunchedEffect(connectionState) {
@@ -525,6 +531,16 @@ class EmbeddableTerminalState {
     private var initialized = false
 
     /**
+     * Handler for CLI-originated open requests (OSC 1341;OpenTarget from the
+     * shell-integration open/xdg-open/$BROWSER shim). Kept on the state (not
+     * the composition) so requests are still routed while the composable is
+     * not composed. Wired by EmbeddableTerminal to its onLinkClick parameter.
+     * When null or returning false, the target opens with the system default.
+     * Invoked on the emulator thread.
+     */
+    var openTargetLinkHandler: ((HyperlinkInfo) -> Boolean)? = null
+
+    /**
      * Whether the terminal is connected to a shell process.
      */
     val isConnected: Boolean
@@ -568,6 +584,14 @@ class EmbeddableTerminalState {
 
         // Create session
         session = createTerminalSession(settings, onOutput)
+
+        // Route CLI-originated open requests (OSC 1341;OpenTarget) through the
+        // same handler as Ctrl/Cmd+click links; system default when unhandled.
+        // Registered at creation (not in the composition) so requests from a
+        // hidden/uncomposed terminal keep working.
+        session?.terminal?.addCustomCommandListener(
+            ai.rever.bossterm.compose.osc.OpenTargetOSCListener { openTargetLinkHandler }
+        )
 
         // Start process in session's coroutine scope
         session?.coroutineScope?.launch {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -536,7 +536,7 @@ class EmbeddableTerminalState {
      * the composition) so requests are still routed while the composable is
      * not composed. Wired by EmbeddableTerminal to its onLinkClick parameter.
      * When null or returning false, the target opens with the system default.
-     * Invoked on the emulator thread.
+     * Invoked on the main thread, like the Ctrl/Cmd+click path.
      */
     var openTargetLinkHandler: ((HyperlinkInfo) -> Boolean)? = null
 
@@ -951,6 +951,9 @@ private suspend fun initializeProcess(
             put("TERM", "xterm-256color")
             put("COLORTERM", "truecolor")
             put("TERM_PROGRAM", "BossTerm")
+            // Authenticates OSC 1341;OpenTarget requests from the open/xdg-open
+            // shim — see OpenTargetToken.
+            put("BOSSTERM_OPEN_TOKEN", ai.rever.bossterm.compose.osc.OpenTargetToken.value)
             // Identify the local Boss/BossTerm MCP server so in-shell programs
             // (e.g. Claude Code) pick the matching `mcp__<name>__*` toolset. An
             // explicit override in `environment` still wins (applied last).

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -257,6 +257,31 @@ fun TabbedTerminal(
         )
     }
 
+    // Shared link-open handler: SSH URLs open a new tab with an SSH connection,
+    // everything else is delegated to the caller's onLinkClick (false = let the
+    // terminal open the system default). Used for Ctrl/Cmd+click (via
+    // SplitContainer) and for CLI-originated open requests (OSC
+    // 1341;OpenTarget, via TabController) so both paths behave identically.
+    val linkOpenHandler: (HyperlinkInfo) -> Boolean = remember(onLinkClick, tabController) {
+        { info ->
+            if (info.scheme == "ssh" || info.patternId == "builtin:ssh") {
+                val sshInfo = HyperlinkDetector.parseSshConnection(info.url)
+                if (sshInfo != null) {
+                    // Open new tab with SSH command
+                    tabController.createTab(initialCommand = sshInfo.toCommand())
+                    true // Handled
+                } else {
+                    // Parse failed, delegate to user callback or default
+                    onLinkClick?.invoke(info) ?: false
+                }
+            } else {
+                // Not SSH, delegate to user callback or default
+                onLinkClick?.invoke(info) ?: false
+            }
+        }
+    }
+    SideEffect { tabController.openTargetLinkHandler = linkOpenHandler }
+
     // Track window focus state reactively for overlay
     val isWindowFocusedState by remember { derivedStateOf { isWindowFocused() } }
 
@@ -1715,24 +1740,9 @@ fun TabbedTerminal(
                 splitFocusBorderEnabled = settings.splitFocusBorderEnabled,
                 splitFocusBorderColor = settings.splitFocusBorderColorValue,
                 splitMinimumSize = settings.splitMinimumSize,
-                // Wrap onLinkClick to handle SSH URLs by opening new tab with SSH connection
-                onLinkClick = { info ->
-                    // Check if this is an SSH URL
-                    if (info.scheme == "ssh" || info.patternId == "builtin:ssh") {
-                        val sshInfo = HyperlinkDetector.parseSshConnection(info.url)
-                        if (sshInfo != null) {
-                            // Open new tab with SSH command
-                            tabController.createTab(initialCommand = sshInfo.toCommand())
-                            true // Handled
-                        } else {
-                            // Parse failed, delegate to user callback or default
-                            onLinkClick?.invoke(info) ?: false
-                        }
-                    } else {
-                        // Not SSH, delegate to user callback or default
-                        onLinkClick?.invoke(info) ?: false
-                    }
-                },
+                // Shared handler: SSH URLs open a new tab, everything else
+                // delegates to the caller's onLinkClick (see linkOpenHandler).
+                onLinkClick = linkOpenHandler,
                 customContextMenuItems = contextMenuItems,
                 // Combine user-provided items with AI assistant and VCS items
                 customContextMenuItemsProvider = {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListener.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListener.kt
@@ -1,0 +1,110 @@
+package ai.rever.bossterm.compose.osc
+
+import ai.rever.bossterm.compose.hyperlinks.HyperlinkDetector
+import ai.rever.bossterm.compose.hyperlinks.HyperlinkInfo
+import ai.rever.bossterm.compose.hyperlinks.HyperlinkType
+import ai.rever.bossterm.terminal.TerminalCustomCommandListener
+import java.io.File
+import java.net.URI
+import java.util.Base64
+
+/**
+ * A TerminalCustomCommandListener for CLI-originated open requests.
+ *
+ * The shell-integration `open`/`xdg-open`/`$BROWSER` shim forwards plain
+ * "open this URL or file" invocations from CLI commands as:
+ *
+ *     OSC 1341;OpenTarget;<base64(target)> BEL
+ *
+ * which arrives here as args ["OpenTarget", "<base64>"]. The target is
+ * classified into a [HyperlinkInfo] and dispatched through the same
+ * link-open handler used for Ctrl/Cmd+click, so embedding hosts can route
+ * it (e.g. show an open-with dialog). When no handler is wired, or the
+ * handler declines, the target opens with the system default — matching
+ * what the shimmed command would have done anyway.
+ *
+ * The handler is read through a provider on every event because the host
+ * wires it from the composition, after the session (and this listener)
+ * already exists.
+ *
+ * Thread safety: called from the emulator processing thread. Handlers must
+ * not assume the UI thread.
+ */
+class OpenTargetOSCListener(
+    private val handlerProvider: () -> ((HyperlinkInfo) -> Boolean)?
+) : TerminalCustomCommandListener {
+
+    override fun process(args: MutableList<String?>) {
+        if (args.size < 2 || args[0] != OPEN_TARGET_COMMAND) return
+        val target = decodeTarget(args[1]) ?: return
+        val info = classifyOpenTarget(target) ?: return
+        val handled = handlerProvider()?.invoke(info) ?: false
+        if (!handled) {
+            HyperlinkDetector.openUrl(info.url)
+        }
+    }
+
+    companion object {
+        const val OPEN_TARGET_COMMAND = "OpenTarget"
+
+        private fun decodeTarget(encoded: String?): String? {
+            if (encoded.isNullOrBlank()) return null
+            return try {
+                String(Base64.getDecoder().decode(encoded.trim()), Charsets.UTF_8)
+                    .takeIf { it.isNotBlank() }
+            } catch (e: IllegalArgumentException) {
+                null
+            }
+        }
+    }
+}
+
+/**
+ * Classify a raw open-request target (URL or file path) into [HyperlinkInfo],
+ * mirroring the semantics of [ai.rever.bossterm.compose.hyperlinks.toHyperlinkInfo].
+ * Returns null for targets that can't be meaningfully opened (blank input).
+ */
+internal fun classifyOpenTarget(target: String): HyperlinkInfo? {
+    val trimmed = target.trim()
+    if (trimmed.isEmpty()) return null
+
+    val scheme = trimmed.substringBefore("://", "").lowercase().takeIf {
+        it.isNotEmpty() && it != trimmed.lowercase()
+    }
+
+    val file: File? = when {
+        trimmed.startsWith("file:") -> try {
+            File(URI(trimmed))
+        } catch (e: Exception) {
+            null
+        }
+        scheme == null && !trimmed.startsWith("mailto:") -> File(trimmed)
+        else -> null
+    }
+    val isFile = file?.isFile == true
+    val isFolder = file?.isDirectory == true
+
+    val type = when {
+        scheme == "http" || scheme == "https" -> HyperlinkType.HTTP
+        scheme == "ftp" || scheme == "ftps" -> HyperlinkType.FTP
+        trimmed.startsWith("mailto:") -> HyperlinkType.EMAIL
+        isFolder -> HyperlinkType.FOLDER
+        isFile -> HyperlinkType.FILE
+        else -> HyperlinkType.CUSTOM
+    }
+
+    // For filesystem targets hand hosts the resolved absolute path (the shim
+    // already absolutizes plain paths; file: URLs are resolved here).
+    val url = if (isFile || isFolder) file!!.absolutePath else trimmed
+
+    return HyperlinkInfo(
+        url = url,
+        type = type,
+        patternId = "osc:open-target",
+        matchedText = trimmed,
+        isFile = isFile,
+        isFolder = isFolder,
+        scheme = scheme ?: "mailto".takeIf { trimmed.startsWith("mailto:") },
+        isBuiltin = false
+    )
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListener.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListener.kt
@@ -4,13 +4,17 @@ import ai.rever.bossterm.compose.hyperlinks.HyperlinkDetector
 import ai.rever.bossterm.compose.hyperlinks.HyperlinkInfo
 import ai.rever.bossterm.compose.hyperlinks.HyperlinkType
 import ai.rever.bossterm.terminal.TerminalCustomCommandListener
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.net.URI
 import java.net.URISyntaxException
+import java.security.MessageDigest
 import java.util.Base64
 import java.util.UUID
 
@@ -57,7 +61,8 @@ object OpenTargetToken {
 class OpenTargetOSCListener(
     private val handlerProvider: () -> ((HyperlinkInfo) -> Boolean)?,
     private val fallbackOpener: (String) -> Unit = HyperlinkDetector::openUrl,
-    dispatchScope: CoroutineScope? = null
+    dispatchScope: CoroutineScope? = null,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : TerminalCustomCommandListener {
 
     // Dispatch on the main thread so handlers see the same threading as the
@@ -67,20 +72,40 @@ class OpenTargetOSCListener(
     override fun process(args: MutableList<String?>) {
         if (args.size < 3 || args[0] != OPEN_TARGET_COMMAND) return
         // Unauthenticated request (missing/stale token): ignore silently —
-        // this is exactly the crafted-content injection case.
-        if (args[1] != OpenTargetToken.value) return
-        val target = decodeTarget(args[2]) ?: return
-        val info = classifyOpenTarget(target) ?: return
+        // this is exactly the crafted-content injection case. Constant-time
+        // comparison out of caution; there is no realistic timing oracle here.
+        val token = args[1] ?: return
+        if (!MessageDigest.isEqual(
+                token.toByteArray(Charsets.UTF_8),
+                OpenTargetToken.value.toByteArray(Charsets.UTF_8)
+            )
+        ) {
+            return
+        }
+        val encoded = args[2]
         scope.launch {
-            val handled = handlerProvider()?.invoke(info) ?: false
-            if (!handled) {
-                fallbackOpener(info.url)
+            // Classification touches the filesystem (isFile/isDirectory), so
+            // it runs on IO — never on the emulator parse thread (which called
+            // process()) and not on Main either, in case of a hung mount.
+            val info = withContext(ioDispatcher) {
+                decodeTarget(encoded)?.let { classifyOpenTarget(it) }
+            } ?: return@launch
+            try {
+                val handled = handlerProvider()?.invoke(info) ?: false
+                if (!handled) {
+                    fallbackOpener(info.url)
+                }
+            } catch (e: Exception) {
+                // A throwing host handler must not crash the main thread.
+                LOG.warn("Open-target handler failed for ${info.url}", e)
             }
         }
     }
 
     companion object {
         const val OPEN_TARGET_COMMAND = "OpenTarget"
+
+        private val LOG = LoggerFactory.getLogger(OpenTargetOSCListener::class.java)
 
         private fun decodeTarget(encoded: String?): String? {
             if (encoded.isNullOrBlank()) return null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListener.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListener.kt
@@ -4,9 +4,30 @@ import ai.rever.bossterm.compose.hyperlinks.HyperlinkDetector
 import ai.rever.bossterm.compose.hyperlinks.HyperlinkInfo
 import ai.rever.bossterm.compose.hyperlinks.HyperlinkType
 import ai.rever.bossterm.terminal.TerminalCustomCommandListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import java.io.File
 import java.net.URI
+import java.net.URISyntaxException
 import java.util.Base64
+import java.util.UUID
+
+/**
+ * Process-wide secret authenticating open requests from the shell shim.
+ *
+ * Injected into every session's environment as BOSSTERM_OPEN_TOKEN and echoed
+ * back by the shim inside the OSC payload. Content merely *displayed* in the
+ * terminal (cat of a crafted file, curl of attacker-controlled output, a log
+ * line) cannot know it, so [OpenTargetOSCListener] ignores any OpenTarget
+ * sequence that doesn't carry it — auto-opening stays gated on the shim,
+ * which only forwards what a locally executed command explicitly asked to
+ * open.
+ */
+object OpenTargetToken {
+    val value: String by lazy { UUID.randomUUID().toString() }
+}
 
 /**
  * A TerminalCustomCommandListener for CLI-originated open requests.
@@ -14,33 +35,47 @@ import java.util.Base64
  * The shell-integration `open`/`xdg-open`/`$BROWSER` shim forwards plain
  * "open this URL or file" invocations from CLI commands as:
  *
- *     OSC 1341;OpenTarget;<base64(target)> BEL
+ *     OSC 1341;OpenTarget;<token>;<base64(target)> BEL
  *
- * which arrives here as args ["OpenTarget", "<base64>"]. The target is
- * classified into a [HyperlinkInfo] and dispatched through the same
- * link-open handler used for Ctrl/Cmd+click, so embedding hosts can route
- * it (e.g. show an open-with dialog). When no handler is wired, or the
- * handler declines, the target opens with the system default — matching
- * what the shimmed command would have done anyway.
+ * which arrives here as args ["OpenTarget", "<token>", "<base64>"]. After
+ * verifying the token ([OpenTargetToken]), the target is validated and
+ * classified into a [HyperlinkInfo] and dispatched — on the main thread,
+ * like Ctrl/Cmd+click — through the same link-open handler, so embedding
+ * hosts can route it (e.g. show an open-with dialog). When no handler is
+ * wired, or the handler declines, the target opens with the system default,
+ * matching what the shimmed command would have done anyway.
+ *
+ * Because no user click gates this path, only targets a CLI could
+ * legitimately ask to open are honored (see [classifyOpenTarget]): http/https
+ * URLs and existing absolute filesystem paths. ssh://, mailto:, custom
+ * schemes, and relative or non-existing paths are refused.
  *
  * The handler is read through a provider on every event because the host
  * wires it from the composition, after the session (and this listener)
  * already exists.
- *
- * Thread safety: called from the emulator processing thread. Handlers must
- * not assume the UI thread.
  */
 class OpenTargetOSCListener(
-    private val handlerProvider: () -> ((HyperlinkInfo) -> Boolean)?
+    private val handlerProvider: () -> ((HyperlinkInfo) -> Boolean)?,
+    private val fallbackOpener: (String) -> Unit = HyperlinkDetector::openUrl,
+    dispatchScope: CoroutineScope? = null
 ) : TerminalCustomCommandListener {
 
+    // Dispatch on the main thread so handlers see the same threading as the
+    // Ctrl/Cmd+click path (tab creation, snapshot state, focus).
+    private val scope = dispatchScope ?: CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
     override fun process(args: MutableList<String?>) {
-        if (args.size < 2 || args[0] != OPEN_TARGET_COMMAND) return
-        val target = decodeTarget(args[1]) ?: return
+        if (args.size < 3 || args[0] != OPEN_TARGET_COMMAND) return
+        // Unauthenticated request (missing/stale token): ignore silently —
+        // this is exactly the crafted-content injection case.
+        if (args[1] != OpenTargetToken.value) return
+        val target = decodeTarget(args[2]) ?: return
         val info = classifyOpenTarget(target) ?: return
-        val handled = handlerProvider()?.invoke(info) ?: false
-        if (!handled) {
-            HyperlinkDetector.openUrl(info.url)
+        scope.launch {
+            val handled = handlerProvider()?.invoke(info) ?: false
+            if (!handled) {
+                fallbackOpener(info.url)
+            }
         }
     }
 
@@ -60,51 +95,57 @@ class OpenTargetOSCListener(
 }
 
 /**
- * Classify a raw open-request target (URL or file path) into [HyperlinkInfo],
- * mirroring the semantics of [ai.rever.bossterm.compose.hyperlinks.toHyperlinkInfo].
- * Returns null for targets that can't be meaningfully opened (blank input).
+ * Validate and classify an open-request target. This is deliberately an
+ * allow-list, not a general classifier like `Hyperlink.toHyperlinkInfo()`:
+ * with no user click gating this path, anything outside "web URL or existing
+ * absolute filesystem path" is refused by returning null.
  */
 internal fun classifyOpenTarget(target: String): HyperlinkInfo? {
     val trimmed = target.trim()
     if (trimmed.isEmpty()) return null
 
-    val scheme = trimmed.substringBefore("://", "").lowercase().takeIf {
-        it.isNotEmpty() && it != trimmed.lowercase()
+    if (trimmed.startsWith("http://", ignoreCase = true) ||
+        trimmed.startsWith("https://", ignoreCase = true)
+    ) {
+        return HyperlinkInfo(
+            url = trimmed,
+            type = HyperlinkType.HTTP,
+            patternId = "osc:open-target",
+            matchedText = trimmed,
+            isFile = false,
+            isFolder = false,
+            scheme = trimmed.substringBefore("://").lowercase(),
+            isBuiltin = false
+        )
     }
 
+    // Filesystem target: a file: URL or an absolute path. Relative paths are
+    // refused rather than resolved — resolving against the JVM working
+    // directory would be wrong (the shim absolutizes against the shell's cwd
+    // before sending), and an injected relative path must not resolve at all.
     val file: File? = when {
         trimmed.startsWith("file:") -> try {
             File(URI(trimmed))
-        } catch (e: Exception) {
+        } catch (e: URISyntaxException) {
+            null
+        } catch (e: IllegalArgumentException) {
             null
         }
-        scheme == null && !trimmed.startsWith("mailto:") -> File(trimmed)
-        else -> null
+        else -> File(trimmed).takeIf { it.isAbsolute }
     }
-    val isFile = file?.isFile == true
-    val isFolder = file?.isDirectory == true
-
-    val type = when {
-        scheme == "http" || scheme == "https" -> HyperlinkType.HTTP
-        scheme == "ftp" || scheme == "ftps" -> HyperlinkType.FTP
-        trimmed.startsWith("mailto:") -> HyperlinkType.EMAIL
-        isFolder -> HyperlinkType.FOLDER
-        isFile -> HyperlinkType.FILE
-        else -> HyperlinkType.CUSTOM
+    if (file != null && (file.isFile || file.isDirectory)) {
+        val isFolder = file.isDirectory
+        return HyperlinkInfo(
+            url = file.absolutePath,
+            type = if (isFolder) HyperlinkType.FOLDER else HyperlinkType.FILE,
+            patternId = "osc:open-target",
+            matchedText = trimmed,
+            isFile = !isFolder,
+            isFolder = isFolder,
+            scheme = "file".takeIf { trimmed.startsWith("file:") },
+            isBuiltin = false
+        )
     }
 
-    // For filesystem targets hand hosts the resolved absolute path (the shim
-    // already absolutizes plain paths; file: URLs are resolved here).
-    val url = if (isFile || isFolder) file!!.absolutePath else trimmed
-
-    return HyperlinkInfo(
-        url = url,
-        type = type,
-        patternId = "osc:open-target",
-        matchedText = trimmed,
-        isFile = isFile,
-        isFolder = isFolder,
-        scheme = scheme ?: "mailto".takeIf { trimmed.startsWith("mailto:") },
-        isBuiltin = false
-    )
+    return null
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/ShellIntegrationInjector.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/ShellIntegrationInjector.kt
@@ -25,13 +25,15 @@ object ShellIntegrationInjector {
         "bossterm_shell_integration.zsh",
         "bash-loader",
         "bossterm_shell_integration.bash",
-        "fish/vendor_conf.d/bossterm_shell_integration.fish"
+        "fish/vendor_conf.d/bossterm_shell_integration.fish",
+        "bin/boss-open"
     )
 
     // Lazy-initialized integration directory
     private val integrationDir: File by lazy {
         File(System.getProperty("user.home"), ".bossterm/shell-integration").also { dir ->
             extractAllResources(dir)
+            installOpenShims(dir)
         }
     }
 
@@ -169,7 +171,7 @@ object ShellIntegrationInjector {
                     // Make scripts executable
                     if (resource.endsWith(".bash") || resource.endsWith(".zsh") ||
                         resource.endsWith(".fish") || resource == "bash-loader" ||
-                        resource == ".zshenv") {
+                        resource == ".zshenv" || resource.startsWith("bin/")) {
                         targetFile.setExecutable(true)
                     }
                 } else {
@@ -177,6 +179,30 @@ object ShellIntegrationInjector {
                 }
             } catch (e: Exception) {
                 System.err.println("[ShellIntegration] Error extracting $resource: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Install the open-request shim under the names CLI tools actually spawn.
+     * The integration scripts prepend bin/ to PATH, so plain `open <url>` /
+     * `xdg-open <url>` calls from CLI commands are forwarded to the terminal
+     * as OSC 1341;OpenTarget instead of going straight to the OS default.
+     */
+    private fun installOpenShims(dir: File) {
+        val shim = File(dir, "bin/boss-open")
+        if (!shim.isFile) return
+        val names = buildList {
+            add("xdg-open")
+            if (ai.rever.bossterm.compose.shell.ShellCustomizationUtils.isMacOS()) add("open")
+        }
+        for (name in names) {
+            try {
+                val target = File(dir, "bin/$name")
+                shim.copyTo(target, overwrite = true)
+                target.setExecutable(true)
+            } catch (e: Exception) {
+                System.err.println("[ShellIntegration] Error installing open shim '$name': ${e.message}")
             }
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/ShellIntegrationInjector.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/ShellIntegrationInjector.kt
@@ -202,7 +202,7 @@ object ShellIntegrationInjector {
                 shim.copyTo(target, overwrite = true)
                 target.setExecutable(true)
             } catch (e: Exception) {
-                System.err.println("[ShellIntegration] Error installing open shim '$name': ${e.message}")
+                LOG.warn("Error installing open shim '$name'", e)
             }
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -71,6 +71,17 @@ class TabController(
         private set
 
     /**
+     * Handler for CLI-originated open requests (OSC 1341;OpenTarget from the
+     * shell-integration open/xdg-open/$BROWSER shim). Wired by TabbedTerminal
+     * to the same handler used for Ctrl/Cmd+click links, so embedding hosts
+     * route both paths identically. Registered at session creation (not in the
+     * composition) so requests from background tabs are still handled. When
+     * null or returning false, the target opens with the system default.
+     * Invoked on the emulator thread.
+     */
+    var openTargetLinkHandler: ((ai.rever.bossterm.compose.hyperlinks.HyperlinkInfo) -> Boolean)? = null
+
+    /**
      * Derive a tab title from a working directory (Warp-style): home → "~",
      * otherwise the directory's base name. Null/blank → "~".
      */
@@ -398,6 +409,12 @@ class TabController(
         // Register OSC 7 listener for working directory tracking (Phase 4)
         val oscListener = WorkingDirectoryOSCListener(workingDirectoryState)
         terminal.addCustomCommandListener(oscListener)
+
+        // Route CLI-originated open requests (OSC 1341;OpenTarget) through the
+        // same handler as Ctrl/Cmd+click links; system default when unhandled.
+        terminal.addCustomCommandListener(
+            ai.rever.bossterm.compose.osc.OpenTargetOSCListener { openTargetLinkHandler }
+        )
 
         // Register window title listener for reactive updates (OSC 0/1/2 sequences)
         terminal.addApplicationTitleListener(object : TerminalApplicationTitleListener {
@@ -772,6 +789,12 @@ class TabController(
         val oscListener = WorkingDirectoryOSCListener(workingDirectoryState)
         terminal.addCustomCommandListener(oscListener)
 
+        // Route CLI-originated open requests (OSC 1341;OpenTarget) through the
+        // same handler as Ctrl/Cmd+click links; system default when unhandled.
+        terminal.addCustomCommandListener(
+            ai.rever.bossterm.compose.osc.OpenTargetOSCListener { openTargetLinkHandler }
+        )
+
         // Register window title listener for reactive updates (OSC 0/1/2 sequences)
         terminal.addApplicationTitleListener(object : TerminalApplicationTitleListener {
             override fun onApplicationTitleChanged(newApplicationTitle: String) {
@@ -1012,6 +1035,12 @@ class TabController(
 
         val oscListener = WorkingDirectoryOSCListener(workingDirectoryState)
         terminal.addCustomCommandListener(oscListener)
+
+        // Route CLI-originated open requests (OSC 1341;OpenTarget) through the
+        // same handler as Ctrl/Cmd+click links; system default when unhandled.
+        terminal.addCustomCommandListener(
+            ai.rever.bossterm.compose.osc.OpenTargetOSCListener { openTargetLinkHandler }
+        )
 
         terminal.addApplicationTitleListener(object : TerminalApplicationTitleListener {
             override fun onApplicationTitleChanged(newApplicationTitle: String) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -413,7 +413,7 @@ class TabController(
         // Route CLI-originated open requests (OSC 1341;OpenTarget) through the
         // same handler as Ctrl/Cmd+click links; system default when unhandled.
         terminal.addCustomCommandListener(
-            ai.rever.bossterm.compose.osc.OpenTargetOSCListener { openTargetLinkHandler }
+            ai.rever.bossterm.compose.osc.OpenTargetOSCListener(handlerProvider = { openTargetLinkHandler })
         )
 
         // Register window title listener for reactive updates (OSC 0/1/2 sequences)
@@ -792,7 +792,7 @@ class TabController(
         // Route CLI-originated open requests (OSC 1341;OpenTarget) through the
         // same handler as Ctrl/Cmd+click links; system default when unhandled.
         terminal.addCustomCommandListener(
-            ai.rever.bossterm.compose.osc.OpenTargetOSCListener { openTargetLinkHandler }
+            ai.rever.bossterm.compose.osc.OpenTargetOSCListener(handlerProvider = { openTargetLinkHandler })
         )
 
         // Register window title listener for reactive updates (OSC 0/1/2 sequences)
@@ -1039,7 +1039,7 @@ class TabController(
         // Route CLI-originated open requests (OSC 1341;OpenTarget) through the
         // same handler as Ctrl/Cmd+click links; system default when unhandled.
         terminal.addCustomCommandListener(
-            ai.rever.bossterm.compose.osc.OpenTargetOSCListener { openTargetLinkHandler }
+            ai.rever.bossterm.compose.osc.OpenTargetOSCListener(handlerProvider = { openTargetLinkHandler })
         )
 
         terminal.addApplicationTitleListener(object : TerminalApplicationTitleListener {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -77,7 +77,7 @@ class TabController(
      * route both paths identically. Registered at session creation (not in the
      * composition) so requests from background tabs are still handled. When
      * null or returning false, the target opens with the system default.
-     * Invoked on the emulator thread.
+     * Invoked on the main thread, like the Ctrl/Cmd+click path.
      */
     var openTargetLinkHandler: ((ai.rever.bossterm.compose.hyperlinks.HyperlinkInfo) -> Boolean)? = null
 
@@ -1221,6 +1221,9 @@ class TabController(
                 put("COLORTERM", "truecolor")
                 put("TERM_PROGRAM", "BossTerm")
                 put("TERM_FEATURES", "T2:M:H:Ts0:Ts1:Ts2:Sc0:Sc1:Sc2:B:U:Aw")
+                // Authenticates OSC 1341;OpenTarget requests from the open/
+                // xdg-open shim — see OpenTargetToken.
+                put("BOSSTERM_OPEN_TOKEN", ai.rever.bossterm.compose.osc.OpenTargetToken.value)
                 // Tells programs in the shell (e.g. Claude Code) which Boss/BossTerm
                 // MCP server is local to THIS host, so they pick the matching
                 // `mcp__<name>__*` toolset instead of a sibling app's. "boss" in
@@ -1406,6 +1409,9 @@ class TabController(
                     put("COLORTERM", "truecolor")
                     put("TERM_PROGRAM", "BossTerm")
                     put("TERM_FEATURES", "T2:M:H:Ts0:Ts1:Ts2:Sc0:Sc1:Sc2:B:U:Aw")
+                    // Authenticates OSC 1341;OpenTarget requests from the open/
+                    // xdg-open shim — see OpenTargetToken.
+                    put("BOSSTERM_OPEN_TOKEN", ai.rever.bossterm.compose.osc.OpenTargetToken.value)
                     // Identify the local Boss/BossTerm MCP server so in-shell
                     // programs (e.g. Claude Code) pick the matching `mcp__<name>__*`
                     // toolset. (This pre-connect path takes no caller-supplied

--- a/compose-ui/src/desktopMain/resources/shell-integration/bin/boss-open
+++ b/compose-ui/src/desktopMain/resources/shell-integration/bin/boss-open
@@ -47,11 +47,16 @@ passthrough() {
 
 # Only intercept directly inside a BossTerm session. Nested terminals set
 # their own TERM_PROGRAM, and tmux/screen may not pass raw OSC through.
+# BOSSTERM_OPEN_TOKEN authenticates the request to the emulator: the listener
+# ignores OpenTarget sequences without it, so displayed content can't forge
+# open requests.
 [ "$TERM_PROGRAM" = "BossTerm" ] || passthrough "$@"
+[ -n "$BOSSTERM_OPEN_TOKEN" ] || passthrough "$@"
 [ -n "$BOSSTERM_DISABLE_OPEN_INTERCEPT" ] && passthrough "$@"
 [ -n "$TMUX" ] && passthrough "$@"
 [ -n "$STY" ] && passthrough "$@"
 [ "$#" -eq 1 ] || passthrough "$@"
+command -v base64 >/dev/null 2>&1 || passthrough "$@"
 
 target=$1
 case $target in
@@ -73,5 +78,5 @@ esac
 # Need a writable controlling terminal to reach the emulator.
 [ -w /dev/tty ] || passthrough "$@"
 b64=$(printf '%s' "$target" | base64 | tr -d '\n')
-{ printf '\033]1341;OpenTarget;%s\007' "$b64" >/dev/tty; } 2>/dev/null || passthrough "$@"
+{ printf '\033]1341;OpenTarget;%s;%s\007' "$BOSSTERM_OPEN_TOKEN" "$b64" >/dev/tty; } 2>/dev/null || passthrough "$@"
 exit 0

--- a/compose-ui/src/desktopMain/resources/shell-integration/bin/boss-open
+++ b/compose-ui/src/desktopMain/resources/shell-integration/bin/boss-open
@@ -71,7 +71,10 @@ http://* | https://* | file://*)
     # Only intercept existing regular files; directories and everything else
     # (app names, mailto:, custom schemes, ...) keep their system behavior.
     [ -f "$target" ] || passthrough "$@"
-    target=$(CDPATH= cd -- "$(dirname -- "$target")" && pwd)/$(basename -- "$target")
+    # Absolutize against the shell's cwd; if that fails (untraversable
+    # parent), fall through rather than emitting a bogus path.
+    target_dir=$(CDPATH= cd -- "$(dirname -- "$target")" 2>/dev/null && pwd) || passthrough "$@"
+    target=$target_dir/$(basename -- "$target")
     ;;
 esac
 

--- a/compose-ui/src/desktopMain/resources/shell-integration/bin/boss-open
+++ b/compose-ui/src/desktopMain/resources/shell-integration/bin/boss-open
@@ -1,0 +1,77 @@
+#!/bin/sh
+# BossTerm open-request shim.
+#
+# Installed as `open` / `xdg-open` / `boss-open` ($BROWSER) at the front of
+# PATH for BossTerm shell-integration sessions. A plain "open this URL or
+# existing file" invocation is forwarded to the hosting terminal as an
+# OSC 1341;OpenTarget escape so the host application can decide how to open
+# the target (e.g. show a chooser dialog). Every other invocation — options,
+# multiple arguments, directories, app names — falls through to the real
+# binary unchanged.
+#
+# Set BOSSTERM_DISABLE_OPEN_INTERCEPT=1 to always fall through.
+
+self_name=$(basename -- "$0")
+self_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+# Print the path of the real command named $1, skipping this shim directory.
+find_real() {
+    _oldifs=$IFS
+    IFS=:
+    for _dir in $PATH; do
+        [ -z "$_dir" ] && _dir=.
+        if [ "$_dir" != "$self_dir" ] && [ -x "$_dir/$1" ] && [ ! -d "$_dir/$1" ]; then
+            IFS=$_oldifs
+            printf '%s\n' "$_dir/$1"
+            return 0
+        fi
+    done
+    IFS=$_oldifs
+    return 1
+}
+
+passthrough() {
+    if _real=$(find_real "$self_name"); then
+        exec "$_real" "$@"
+    fi
+    # boss-open ($BROWSER) has no real counterpart: use the platform opener.
+    if [ -x /usr/bin/open ]; then
+        exec /usr/bin/open "$@"
+    fi
+    if _real=$(find_real xdg-open); then
+        exec "$_real" "$@"
+    fi
+    echo "$self_name: no system opener found" >&2
+    exit 127
+}
+
+# Only intercept directly inside a BossTerm session. Nested terminals set
+# their own TERM_PROGRAM, and tmux/screen may not pass raw OSC through.
+[ "$TERM_PROGRAM" = "BossTerm" ] || passthrough "$@"
+[ -n "$BOSSTERM_DISABLE_OPEN_INTERCEPT" ] && passthrough "$@"
+[ -n "$TMUX" ] && passthrough "$@"
+[ -n "$STY" ] && passthrough "$@"
+[ "$#" -eq 1 ] || passthrough "$@"
+
+target=$1
+case $target in
+-*)
+    # Any option (open -a App, xdg-open --version, ...): not a plain open.
+    passthrough "$@"
+    ;;
+http://* | https://* | file://*)
+    : # URL: intercept as-is
+    ;;
+*)
+    # Only intercept existing regular files; directories and everything else
+    # (app names, mailto:, custom schemes, ...) keep their system behavior.
+    [ -f "$target" ] || passthrough "$@"
+    target=$(CDPATH= cd -- "$(dirname -- "$target")" && pwd)/$(basename -- "$target")
+    ;;
+esac
+
+# Need a writable controlling terminal to reach the emulator.
+[ -w /dev/tty ] || passthrough "$@"
+b64=$(printf '%s' "$target" | base64 | tr -d '\n')
+{ printf '\033]1341;OpenTarget;%s\007' "$b64" >/dev/tty; } 2>/dev/null || passthrough "$@"
+exit 0

--- a/compose-ui/src/desktopMain/resources/shell-integration/bossterm_shell_integration.bash
+++ b/compose-ui/src/desktopMain/resources/shell-integration/bossterm_shell_integration.bash
@@ -73,5 +73,17 @@ else
 fi
 unset __bossterm_old_debug_trap
 
+# Route plain `open <url|file>` / `xdg-open <target>` / `$BROWSER` calls from
+# CLI commands back to the terminal (OSC 1341;OpenTarget) so the host app can
+# choose how to open them. Opt out with BOSSTERM_DISABLE_OPEN_INTERCEPT=1.
+__bossterm_shim_bin="$HOME/.bossterm/shell-integration/bin"
+if [[ -z "${BOSSTERM_DISABLE_OPEN_INTERCEPT-}" && -x "$__bossterm_shim_bin/boss-open" ]]; then
+    if [[ ":$PATH:" != *":$__bossterm_shim_bin:"* ]]; then
+        export PATH="$__bossterm_shim_bin:$PATH"
+    fi
+    [[ -z "${BROWSER-}" ]] && export BROWSER="$__bossterm_shim_bin/boss-open"
+fi
+unset __bossterm_shim_bin
+
 # Emit initial prompt marker
 printf '\e]133;A\a'

--- a/compose-ui/src/desktopMain/resources/shell-integration/bossterm_shell_integration.zsh
+++ b/compose-ui/src/desktopMain/resources/shell-integration/bossterm_shell_integration.zsh
@@ -69,5 +69,17 @@ autoload -Uz add-zsh-hook
 add-zsh-hook precmd _bossterm_precmd
 add-zsh-hook preexec _bossterm_preexec
 
+# Route plain `open <url|file>` / `xdg-open <target>` / `$BROWSER` calls from
+# CLI commands back to the terminal (OSC 1341;OpenTarget) so the host app can
+# choose how to open them. Opt out with BOSSTERM_DISABLE_OPEN_INTERCEPT=1.
+__bossterm_shim_bin="$HOME/.bossterm/shell-integration/bin"
+if [[ -z "${BOSSTERM_DISABLE_OPEN_INTERCEPT-}" && -x "$__bossterm_shim_bin/boss-open" ]]; then
+    if [[ ":$PATH:" != *":$__bossterm_shim_bin:"* ]]; then
+        export PATH="$__bossterm_shim_bin:$PATH"
+    fi
+    [[ -z "${BROWSER-}" ]] && export BROWSER="$__bossterm_shim_bin/boss-open"
+fi
+unset __bossterm_shim_bin
+
 # Emit initial prompt marker
 printf '\e]133;A\a'

--- a/compose-ui/src/desktopMain/resources/shell-integration/fish/vendor_conf.d/bossterm_shell_integration.fish
+++ b/compose-ui/src/desktopMain/resources/shell-integration/fish/vendor_conf.d/bossterm_shell_integration.fish
@@ -56,5 +56,18 @@ function __bossterm_fish_postexec --on-event fish_postexec
     set -g __bossterm_last_status $status
 end
 
+# Route plain `open <url|file>` / `xdg-open <target>` / `$BROWSER` calls from
+# CLI commands back to the terminal (OSC 1341;OpenTarget) so the host app can
+# choose how to open them. Opt out with BOSSTERM_DISABLE_OPEN_INTERCEPT=1.
+set -l __bossterm_shim_bin "$HOME/.bossterm/shell-integration/bin"
+if not set -q BOSSTERM_DISABLE_OPEN_INTERCEPT; and test -x "$__bossterm_shim_bin/boss-open"
+    if not contains -- "$__bossterm_shim_bin" $PATH
+        set -gx PATH "$__bossterm_shim_bin" $PATH
+    end
+    if not set -q BROWSER
+        set -gx BROWSER "$__bossterm_shim_bin/boss-open"
+    end
+end
+
 # Emit initial prompt marker
 printf '\e]133;A\a'

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListenerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListenerTest.kt
@@ -1,0 +1,112 @@
+package ai.rever.bossterm.compose.osc
+
+import ai.rever.bossterm.compose.hyperlinks.HyperlinkInfo
+import ai.rever.bossterm.compose.hyperlinks.HyperlinkType
+import java.io.File
+import java.util.Base64
+import kotlin.test.*
+
+/**
+ * Unit tests for OpenTargetOSCListener and classifyOpenTarget: the routing of
+ * CLI-originated open requests (OSC 1341;OpenTarget from the open/xdg-open
+ * shim) into HyperlinkInfo dispatched via the link-open handler.
+ */
+class OpenTargetOSCListenerTest {
+
+    private fun encode(target: String): String =
+        Base64.getEncoder().encodeToString(target.toByteArray(Charsets.UTF_8))
+
+    // ---- classifyOpenTarget ----
+
+    @Test
+    fun `http and https URLs classify as HTTP`() {
+        val http = classifyOpenTarget("http://example.com/a?b=c")
+        assertEquals(HyperlinkType.HTTP, http?.type)
+        assertEquals("http://example.com/a?b=c", http?.url)
+        assertEquals("http", http?.scheme)
+
+        val https = classifyOpenTarget("https://example.com")
+        assertEquals(HyperlinkType.HTTP, https?.type)
+        assertEquals("https", https?.scheme)
+        assertFalse(https!!.isFile)
+        assertFalse(https.isFolder)
+    }
+
+    @Test
+    fun `existing plain file path classifies as FILE with absolute url`() {
+        val tmp = File.createTempFile("open-target", ".txt")
+        try {
+            val info = classifyOpenTarget(tmp.absolutePath)
+            assertEquals(HyperlinkType.FILE, info?.type)
+            assertEquals(tmp.absolutePath, info?.url)
+            assertTrue(info!!.isFile)
+            assertFalse(info.isFolder)
+        } finally {
+            tmp.delete()
+        }
+    }
+
+    @Test
+    fun `existing file url classifies as FILE and resolves to path`() {
+        val tmp = File.createTempFile("open-target", ".txt")
+        try {
+            val info = classifyOpenTarget(tmp.toURI().toString())
+            assertEquals(HyperlinkType.FILE, info?.type)
+            assertEquals(tmp.absolutePath, info?.url)
+        } finally {
+            tmp.delete()
+        }
+    }
+
+    @Test
+    fun `directory classifies as FOLDER`() {
+        val dir = System.getProperty("java.io.tmpdir")
+        val info = classifyOpenTarget(dir)
+        assertEquals(HyperlinkType.FOLDER, info?.type)
+        assertTrue(info!!.isFolder)
+    }
+
+    @Test
+    fun `mailto classifies as EMAIL`() {
+        val info = classifyOpenTarget("mailto:someone@example.com")
+        assertEquals(HyperlinkType.EMAIL, info?.type)
+        assertEquals("mailto", info?.scheme)
+    }
+
+    @Test
+    fun `non-existing path classifies as CUSTOM`() {
+        val info = classifyOpenTarget("/definitely/not/a/real/path-12345")
+        assertEquals(HyperlinkType.CUSTOM, info?.type)
+    }
+
+    @Test
+    fun `blank target returns null`() {
+        assertNull(classifyOpenTarget("   "))
+    }
+
+    // ---- listener dispatch ----
+
+    @Test
+    fun `dispatches decoded target to handler`() {
+        var received: HyperlinkInfo? = null
+        val listener = OpenTargetOSCListener {
+            { info -> received = info; true }
+        }
+        listener.process(mutableListOf("OpenTarget", encode("https://example.com")))
+        assertEquals("https://example.com", received?.url)
+        assertEquals(HyperlinkType.HTTP, received?.type)
+    }
+
+    @Test
+    fun `ignores other custom commands and malformed payloads`() {
+        var called = false
+        val listener = OpenTargetOSCListener {
+            { _ -> called = true; true }
+        }
+        listener.process(mutableListOf("BossTermCmd", encode("https://example.com")))
+        listener.process(mutableListOf("OpenTarget"))
+        listener.process(mutableListOf("OpenTarget", "!!! not base64 !!!"))
+        listener.process(mutableListOf("OpenTarget", null))
+        assertFalse(called)
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListenerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListenerTest.kt
@@ -2,6 +2,8 @@ package ai.rever.bossterm.compose.osc
 
 import ai.rever.bossterm.compose.hyperlinks.HyperlinkInfo
 import ai.rever.bossterm.compose.hyperlinks.HyperlinkType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import java.io.File
 import java.util.Base64
 import kotlin.test.*
@@ -9,14 +11,32 @@ import kotlin.test.*
 /**
  * Unit tests for OpenTargetOSCListener and classifyOpenTarget: the routing of
  * CLI-originated open requests (OSC 1341;OpenTarget from the open/xdg-open
- * shim) into HyperlinkInfo dispatched via the link-open handler.
+ * shim) into HyperlinkInfo dispatched via the link-open handler. Covers the
+ * token authentication and the allow-list refusing non-web schemes.
  */
 class OpenTargetOSCListenerTest {
 
     private fun encode(target: String): String =
         Base64.getEncoder().encodeToString(target.toByteArray(Charsets.UTF_8))
 
-    // ---- classifyOpenTarget ----
+    private val token = OpenTargetToken.value
+
+    /** Listener under test with synchronous dispatch and a recorded fallback. */
+    private class Harness(handler: ((HyperlinkInfo) -> Boolean)?) {
+        var received: HyperlinkInfo? = null
+        val fallbacks = mutableListOf<String>()
+        val listener = OpenTargetOSCListener(
+            handlerProvider = {
+                handler?.let { h ->
+                    { info: HyperlinkInfo -> received = info; h(info) }
+                }
+            },
+            fallbackOpener = { fallbacks.add(it) },
+            dispatchScope = CoroutineScope(Dispatchers.Unconfined)
+        )
+    }
+
+    // ---- classifyOpenTarget: allowed targets ----
 
     @Test
     fun `http and https URLs classify as HTTP`() {
@@ -33,7 +53,7 @@ class OpenTargetOSCListenerTest {
     }
 
     @Test
-    fun `existing plain file path classifies as FILE with absolute url`() {
+    fun `existing absolute file path classifies as FILE`() {
         val tmp = File.createTempFile("open-target", ".txt")
         try {
             val info = classifyOpenTarget(tmp.absolutePath)
@@ -53,6 +73,7 @@ class OpenTargetOSCListenerTest {
             val info = classifyOpenTarget(tmp.toURI().toString())
             assertEquals(HyperlinkType.FILE, info?.type)
             assertEquals(tmp.absolutePath, info?.url)
+            assertEquals("file", info?.scheme)
         } finally {
             tmp.delete()
         }
@@ -66,47 +87,74 @@ class OpenTargetOSCListenerTest {
         assertTrue(info!!.isFolder)
     }
 
+    // ---- classifyOpenTarget: refused targets (no click gates this path) ----
+
     @Test
-    fun `mailto classifies as EMAIL`() {
-        val info = classifyOpenTarget("mailto:someone@example.com")
-        assertEquals(HyperlinkType.EMAIL, info?.type)
-        assertEquals("mailto", info?.scheme)
+    fun `non-web schemes are refused`() {
+        assertNull(classifyOpenTarget("ssh://attacker-host"))
+        assertNull(classifyOpenTarget("mailto:someone@example.com"))
+        assertNull(classifyOpenTarget("ftp://example.com/file"))
+        assertNull(classifyOpenTarget("javascript:alert(1)"))
+        assertNull(classifyOpenTarget("myapp://deep-link"))
     }
 
     @Test
-    fun `non-existing path classifies as CUSTOM`() {
-        val info = classifyOpenTarget("/definitely/not/a/real/path-12345")
-        assertEquals(HyperlinkType.CUSTOM, info?.type)
-    }
-
-    @Test
-    fun `blank target returns null`() {
+    fun `relative and non-existing paths are refused`() {
+        assertNull(classifyOpenTarget("relative/path.txt"))
+        assertNull(classifyOpenTarget("."))
+        assertNull(classifyOpenTarget("/definitely/not/a/real/path-12345"))
         assertNull(classifyOpenTarget("   "))
     }
 
     // ---- listener dispatch ----
 
     @Test
-    fun `dispatches decoded target to handler`() {
-        var received: HyperlinkInfo? = null
-        val listener = OpenTargetOSCListener {
-            { info -> received = info; true }
-        }
-        listener.process(mutableListOf("OpenTarget", encode("https://example.com")))
-        assertEquals("https://example.com", received?.url)
-        assertEquals(HyperlinkType.HTTP, received?.type)
+    fun `dispatches decoded target to handler with valid token`() {
+        val h = Harness { true }
+        h.listener.process(mutableListOf("OpenTarget", token, encode("https://example.com")))
+        assertEquals("https://example.com", h.received?.url)
+        assertEquals(HyperlinkType.HTTP, h.received?.type)
+        assertTrue(h.fallbacks.isEmpty(), "handled request must not hit the fallback")
+    }
+
+    @Test
+    fun `unhandled request falls back to system opener`() {
+        val declining = Harness { false }
+        declining.listener.process(mutableListOf("OpenTarget", token, encode("https://example.com")))
+        assertEquals(listOf("https://example.com"), declining.fallbacks)
+
+        val unwired = Harness(null)
+        unwired.listener.process(mutableListOf("OpenTarget", token, encode("https://example.com")))
+        assertEquals(listOf("https://example.com"), unwired.fallbacks)
+    }
+
+    @Test
+    fun `wrong or missing token is ignored`() {
+        val h = Harness { true }
+        h.listener.process(mutableListOf("OpenTarget", "not-the-token", encode("https://example.com")))
+        h.listener.process(mutableListOf("OpenTarget", encode("https://example.com")))
+        h.listener.process(mutableListOf("OpenTarget", null, encode("https://example.com")))
+        assertNull(h.received)
+        assertTrue(h.fallbacks.isEmpty())
+    }
+
+    @Test
+    fun `refused targets are not dispatched and do not fall back`() {
+        val h = Harness { true }
+        h.listener.process(mutableListOf("OpenTarget", token, encode("ssh://attacker-host")))
+        h.listener.process(mutableListOf("OpenTarget", token, encode("relative/path.txt")))
+        assertNull(h.received)
+        assertTrue(h.fallbacks.isEmpty())
     }
 
     @Test
     fun `ignores other custom commands and malformed payloads`() {
-        var called = false
-        val listener = OpenTargetOSCListener {
-            { _ -> called = true; true }
-        }
-        listener.process(mutableListOf("BossTermCmd", encode("https://example.com")))
-        listener.process(mutableListOf("OpenTarget"))
-        listener.process(mutableListOf("OpenTarget", "!!! not base64 !!!"))
-        listener.process(mutableListOf("OpenTarget", null))
-        assertFalse(called)
+        val h = Harness { true }
+        h.listener.process(mutableListOf("BossTermCmd", token, encode("https://example.com")))
+        h.listener.process(mutableListOf("OpenTarget"))
+        h.listener.process(mutableListOf("OpenTarget", token, "!!! not base64 !!!"))
+        h.listener.process(mutableListOf("OpenTarget", token, null))
+        assertNull(h.received)
+        assertTrue(h.fallbacks.isEmpty())
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListenerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/osc/OpenTargetOSCListenerTest.kt
@@ -32,7 +32,9 @@ class OpenTargetOSCListenerTest {
                 }
             },
             fallbackOpener = { fallbacks.add(it) },
-            dispatchScope = CoroutineScope(Dispatchers.Unconfined)
+            // Unconfined for both keeps process() fully synchronous in tests.
+            dispatchScope = CoroutineScope(Dispatchers.Unconfined),
+            ioDispatcher = Dispatchers.Unconfined
         )
     }
 


### PR DESCRIPTION
## Summary

CLI commands that spawn `open <url|file>` / `xdg-open` / `$BROWSER` (e.g. `claude /login`, `gh auth login`) used to launch the OS default handler directly — the terminal never saw the request, so embedding hosts couldn't offer their link-open UX.

- **Shell-integration shim**: `bin/boss-open` is extracted with the integration scripts and installed as `open` (macOS), `xdg-open`, and `$BROWSER` at the front of `PATH` for BossTerm sessions (bash/zsh/fish). Plain single-target URL/existing-file invocations are forwarded to the terminal as `OSC 1341;OpenTarget;<base64>`; everything else (option flags, multi-arg, directories, app names, non-existing paths) passes through to the real binary unchanged.
- **Guards**: intercepts only directly inside BossTerm (`TERM_PROGRAM=BossTerm`, writable `/dev/tty`), skips tmux/screen; kill switch `BOSSTERM_DISABLE_OPEN_INTERCEPT=1`; existing `$BROWSER` is never clobbered.
- **New `OpenTargetOSCListener`** classifies the decoded target into `HyperlinkInfo` (patternId `osc:open-target`) and dispatches it through the **same `onLinkClick` path as Ctrl/Cmd+click**, falling back to `HyperlinkDetector.openUrl` (system default) when unhandled — standalone BossTerm behavior is unchanged.
- **Wiring**: listeners are registered at session creation — `TabController.openTargetLinkHandler` (set by `TabbedTerminal`'s extracted shared `linkOpenHandler`, which also keeps the SSH-URL wrapping in one place) and `EmbeddableTerminalState.openTargetLinkHandler` — so requests from background/uncomposed panes are still routed.

In BossConsole this makes CLI-originated opens show the terminal-link dialog (companion PR: risa-labs-inc/BossConsole#863 adds a System Default option there). Ships to terminal-tab via the usual auto-bump on the next BossTerm release.

## Testing

- New `OpenTargetOSCListenerTest` (classification + dispatch + malformed payloads); full `compose-ui` desktopTest suite green.
- Shim exercised at the shell level: 7 passthrough scenarios verified, and under a real pty it emits correct OSC payloads (URL preserved, relative file paths absolutized). PATH/$BROWSER wiring verified in zsh and bash (no duplicate prepend on re-source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
