### PR TITLE
Use danger-full-access for Codex auto mode

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantDefinition.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantDefinition.kt
@@ -183,8 +183,8 @@ object AIAssistants {
             id = AIAssistantIds.CODEX,
             displayName = "Codex (OpenAI)",
             command = "codex",
-            // Codex CLI dropped --full-auto (gone as of codex-cli 0.144.0); this is its documented replacement
-            yoloFlag = "--sandbox workspace-write --ask-for-approval never",
+            // Auto mode should let Codex operate across the full filesystem without sandbox restrictions.
+            yoloFlag = "--sandbox danger-full-access",
             yoloLabel = "Full Auto",
             installCommand = "npm install -g @openai/codex",
             npmInstallCommand = "npm install -g @openai/codex",

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ai/AIAssistantLaunchCommandTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ai/AIAssistantLaunchCommandTest.kt
@@ -23,11 +23,9 @@ class AIAssistantLaunchCommandTest {
     }
 
     @Test
-    fun `codex launches with sandboxed auto flags`() {
-        // Codex CLI rejects the old --full-auto; the replacement keeps the
-        // sandbox --full-auto implied instead of a full approval bypass.
+    fun `codex launches with danger full access sandbox`() {
         assertEquals(
-            "codex --sandbox workspace-write --ask-for-approval never\n",
+            "codex --sandbox danger-full-access\n",
             provider.getLaunchCommand(builtin(AIAssistantIds.CODEX))
         )
     }


### PR DESCRIPTION
Changes Codex Full Auto from --sandbox workspace-write --ask-for-approval never to --sandbox danger-full-access and updates its regression test. Root cause: the right-click AI Assistant mapping retained workspace-only sandboxing despite the Full Auto label. Impact: standalone BossTerm uses full filesystem access; terminal-tab inherits it with the next BossTerm bundle. Validation: focused compose-ui desktop test passed, and Codex CLI 0.144.6 confirms danger-full-access is valid.