### PR TITLE
fix: keep per-session blocking loops off the shared coroutine pools (terminal freeze at ~20 sessions)

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -23,13 +23,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicReference
 import ai.rever.bossterm.compose.ai.AIAssistantDefinition
@@ -938,6 +941,10 @@ private suspend fun initializeProcess(
     // True while this function owns a TerminalSessionSlots reservation that no
     // completion hook will release — the outer catch must return it on failure.
     var slotsHeld = false
+    // Set once spawned; lets the catch blocks reap a half-started process whose
+    // exit monitor was never armed (killing it also unwinds any reader/emulator
+    // loops already launched against it, freeing their dispatcher permits).
+    var spawnedHandle: PlatformServices.ProcessService.ProcessHandle? = null
     try {
         // Determine shell arguments (login shell)
         val args = if (command.endsWith("/zsh") || command.endsWith("/bash") ||
@@ -1006,6 +1013,7 @@ private suspend fun initializeProcess(
             session.connectionState.value = ConnectionState.Error("Failed to spawn process")
             return
         }
+        spawnedHandle = processHandle
 
         session.processHandle.value = processHandle
         session.connectionState.value = ConnectionState.Connected(processHandle)
@@ -1127,11 +1135,26 @@ private suspend fun initializeProcess(
         // Ownership transferred: the exit monitor's completion hook releases from here on.
         slotsHeld = false
 
+    } catch (e: CancellationException) {
+        // Dispose mid-init — not an error. Reap the half-started process (so any
+        // reader/emulator loops already launched unwind and free their permits),
+        // return the reservation, and propagate instead of logging a spurious Error.
+        if (slotsHeld) {
+            spawnedHandle?.let { h -> withContext(NonCancellable) { runCatching { h.kill() } } }
+            TerminalSessionSlots.release()
+        }
+        throw e
     } catch (e: Exception) {
         // Anything thrown between reserving and arming the exit monitor (e.g.
-        // spawnProcess throwing instead of returning null) lands here — return
-        // the reservation or capacity shrinks permanently.
-        if (slotsHeld) TerminalSessionSlots.release()
+        // spawnProcess throwing instead of returning null) lands here. Kill the
+        // half-started process FIRST so the reader/emulator loops launched above
+        // unwind — isAlive() flips false and their permits free — instead of
+        // running orphaned, then return the reservation or capacity shrinks
+        // permanently.
+        if (slotsHeld) {
+            spawnedHandle?.let { h -> runCatching { h.kill() } }
+            TerminalSessionSlots.release()
+        }
         session.connectionState.value = ConnectionState.Error(e.message ?: "Failed to start process")
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -996,8 +996,9 @@ private suspend fun initializeProcess(
         session.processHandle.value = processHandle
         session.connectionState.value = ConnectionState.Connected(processHandle)
 
-        // Start emulator coroutine
-        session.coroutineScope.launch(Dispatchers.Default) {
+        // Start emulator coroutine. Blocks in dataStream.char between chunks, so it
+        // must not hold one of Dispatchers.Default's nCPU permits.
+        session.coroutineScope.launch(TerminalSessionDispatcher) {
             try {
                 while (processHandle.isAlive()) {
                     try {
@@ -1016,8 +1017,9 @@ private suspend fun initializeProcess(
             }
         }
 
-        // Start output reader coroutine
-        session.coroutineScope.launch(Dispatchers.IO) {
+        // Start output reader coroutine — blocks in processHandle.read() for the
+        // session's whole life, kept off the shared Dispatchers.IO permits.
+        session.coroutineScope.launch(TerminalSessionDispatcher) {
             while (processHandle.isAlive()) {
                 val output = processHandle.read()
                 if (output != null) {
@@ -1098,8 +1100,8 @@ private suspend fun initializeProcess(
             }
         }
 
-        // Monitor process exit
-        session.coroutineScope.launch(Dispatchers.IO) {
+        // Monitor process exit (waitFor parks a TerminalSessionDispatcher thread)
+        session.coroutineScope.launch(TerminalSessionDispatcher) {
             val exitCode = processHandle.waitFor()
             session.connectionState.value = ConnectionState.Error("Process exited with code $exitCode")
             onExit?.invoke(exitCode)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -1020,7 +1020,7 @@ private suspend fun initializeProcess(
 
         // Start emulator coroutine. Blocks in dataStream.char between chunks, so it
         // must not hold one of Dispatchers.Default's nCPU permits.
-        session.coroutineScope.launch(TerminalSessionDispatcher) {
+        val emulatorJob = session.coroutineScope.launch(TerminalSessionDispatcher) {
             try {
                 while (processHandle.isAlive()) {
                     try {
@@ -1041,7 +1041,7 @@ private suspend fun initializeProcess(
 
         // Start output reader coroutine — blocks in processHandle.read() for the
         // session's whole life, kept off the shared Dispatchers.IO permits.
-        session.coroutineScope.launch(TerminalSessionDispatcher) {
+        val readerJob = session.coroutineScope.launch(TerminalSessionDispatcher) {
             while (processHandle.isAlive()) {
                 val output = processHandle.read()
                 if (output != null) {
@@ -1123,16 +1123,23 @@ private suspend fun initializeProcess(
         }
 
         // Monitor process exit (waitFor parks a TerminalSessionDispatcher thread).
-        // Its completion — normal exit or scope cancellation on dispose — returns the
-        // session's TerminalSessionSlots reservation.
-        session.coroutineScope.launch(TerminalSessionDispatcher) {
+        val exitMonitorJob = session.coroutineScope.launch(TerminalSessionDispatcher) {
             val exitCode = processHandle.waitFor()
             session.connectionState.value = ConnectionState.Error("Process exited with code $exitCode")
             onExit?.invoke(exitCode)
-        }.invokeOnCompletion {
-            TerminalSessionSlots.release()
         }
-        // Ownership transferred: the exit monitor's completion hook releases from here on.
+
+        // Release the reservation only after ALL three session loops have completed —
+        // normal exit or scope cancellation on dispose — so the accounting never runs
+        // ahead of the physically occupied permits during a mass close.
+        // invokeOnCompletion fires even for already-completed or never-started jobs.
+        val remainingLoops = java.util.concurrent.atomic.AtomicInteger(3)
+        listOf(emulatorJob, readerJob, exitMonitorJob).forEach { job ->
+            job.invokeOnCompletion {
+                if (remainingLoops.decrementAndGet() == 0) TerminalSessionSlots.release()
+            }
+        }
+        // Ownership transferred: the loop-completion countdown releases from here on.
         slotsHeld = false
 
     } catch (e: CancellationException) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -935,6 +935,9 @@ private suspend fun initializeProcess(
     onExit: ((Int) -> Unit)?,
     platformServices: PlatformServices = getPlatformServices()
 ) {
+    // True while this function owns a TerminalSessionSlots reservation that no
+    // completion hook will release — the outer catch must return it on failure.
+    var slotsHeld = false
     try {
         // Determine shell arguments (login shell)
         val args = if (command.endsWith("/zsh") || command.endsWith("/bash") ||
@@ -992,11 +995,13 @@ private suspend fun initializeProcess(
             session.connectionState.value = ConnectionState.Error(TerminalSessionSlots.EXHAUSTED_MESSAGE)
             return
         }
+        slotsHeld = true
 
         // Spawn PTY process
         val processHandle = platformServices.getProcessService().spawnProcess(processConfig)
 
         if (processHandle == null) {
+            slotsHeld = false
             TerminalSessionSlots.release()
             session.connectionState.value = ConnectionState.Error("Failed to spawn process")
             return
@@ -1119,8 +1124,14 @@ private suspend fun initializeProcess(
         }.invokeOnCompletion {
             TerminalSessionSlots.release()
         }
+        // Ownership transferred: the exit monitor's completion hook releases from here on.
+        slotsHeld = false
 
     } catch (e: Exception) {
+        // Anything thrown between reserving and arming the exit monitor (e.g.
+        // spawnProcess throwing instead of returning null) lands here — return
+        // the reservation or capacity shrinks permanently.
+        if (slotsHeld) TerminalSessionSlots.release()
         session.connectionState.value = ConnectionState.Error(e.message ?: "Failed to start process")
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -985,10 +985,19 @@ private suspend fun initializeProcess(
             workingDirectory = effectiveWorkingDir
         )
 
+        // Reserve the session's three long-lived threads (reader, emulator, waitFor)
+        // before spawning — a refused session must not spawn a process it can never
+        // read from. Released when the exit monitor below completes.
+        if (!TerminalSessionSlots.tryReserve()) {
+            session.connectionState.value = ConnectionState.Error(TerminalSessionSlots.EXHAUSTED_MESSAGE)
+            return
+        }
+
         // Spawn PTY process
         val processHandle = platformServices.getProcessService().spawnProcess(processConfig)
 
         if (processHandle == null) {
+            TerminalSessionSlots.release()
             session.connectionState.value = ConnectionState.Error("Failed to spawn process")
             return
         }
@@ -1100,11 +1109,15 @@ private suspend fun initializeProcess(
             }
         }
 
-        // Monitor process exit (waitFor parks a TerminalSessionDispatcher thread)
+        // Monitor process exit (waitFor parks a TerminalSessionDispatcher thread).
+        // Its completion — normal exit or scope cancellation on dispose — returns the
+        // session's TerminalSessionSlots reservation.
         session.coroutineScope.launch(TerminalSessionDispatcher) {
             val exitCode = processHandle.waitFor()
             session.connectionState.value = ConnectionState.Error("Process exited with code $exitCode")
             onExit?.invoke(exitCode)
+        }.invokeOnCompletion {
+            TerminalSessionSlots.release()
         }
 
     } catch (e: Exception) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/PlatformServices.desktop.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/PlatformServices.desktop.kt
@@ -253,7 +253,9 @@ class DesktopProcessService : PlatformServices.ProcessService {
             }
         }
 
-        override suspend fun waitFor(): Int = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+        // Parks a thread for the process's whole life — must stay off the shared
+        // Dispatchers.IO permits (see TerminalSessionDispatcher).
+        override suspend fun waitFor(): Int = kotlinx.coroutines.withContext(TerminalSessionDispatcher) {
             process.waitFor()
         }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -292,9 +292,10 @@ fun TabbedTerminal(
             title = { Text("No terminal threads available") },
             text = {
                 Text(
-                    "All ${TerminalSessionSlots.MAX_THREADS} terminal session threads are in use, " +
+                    "All ${TerminalSessionSlots.maxThreads} terminal session threads are in use, " +
                         "so this terminal could not start a shell. Close some terminal tabs or " +
-                        "splits to free threads, then try again."
+                        "splits to free threads, then try again — or raise the budget in " +
+                        "Settings → Performance → Sessions."
                 )
             },
             confirmButton = {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Surface
@@ -281,6 +282,28 @@ fun TabbedTerminal(
         }
     }
     SideEffect { tabController.openTargetLinkHandler = linkOpenHandler }
+
+    // Shown when a new terminal was refused because every TerminalSessionDispatcher
+    // thread is pinned by a live session — the only remedy is closing terminals.
+    val showSessionCapacityDialog by tabController.showSessionCapacityDialog.collectAsState()
+    if (showSessionCapacityDialog) {
+        AlertDialog(
+            onDismissRequest = { tabController.dismissSessionCapacityDialog() },
+            title = { Text("No terminal threads available") },
+            text = {
+                Text(
+                    "All ${TerminalSessionSlots.MAX_THREADS} terminal session threads are in use " +
+                        "(${TerminalSessionSlots.usedThreads} reserved), so this terminal could not " +
+                        "start a shell. Close some terminal tabs or splits to free threads, then try again."
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { tabController.dismissSessionCapacityDialog() }) {
+                    Text("OK")
+                }
+            }
+        )
+    }
 
     // Track window focus state reactively for overlay
     val isWindowFocusedState by remember { derivedStateOf { isWindowFocused() } }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -292,9 +292,9 @@ fun TabbedTerminal(
             title = { Text("No terminal threads available") },
             text = {
                 Text(
-                    "All ${TerminalSessionSlots.MAX_THREADS} terminal session threads are in use " +
-                        "(${TerminalSessionSlots.usedThreads} reserved), so this terminal could not " +
-                        "start a shell. Close some terminal tabs or splits to free threads, then try again."
+                    "All ${TerminalSessionSlots.MAX_THREADS} terminal session threads are in use, " +
+                        "so this terminal could not start a shell. Close some terminal tabs or " +
+                        "splits to free threads, then try again."
                 )
             },
             confirmButton = {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
@@ -25,3 +25,46 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 @OptIn(ExperimentalCoroutinesApi::class)
 val TerminalSessionDispatcher: CoroutineDispatcher =
     Dispatchers.IO.limitedParallelism(256, "bossterm-session")
+
+/**
+ * Advisory accounting for [TerminalSessionDispatcher]'s permit budget.
+ *
+ * Session owners reserve their long-lived thread count up front and release it
+ * when the session dies. When the budget is exhausted, a new session is REFUSED
+ * outright (error state + a "close some terminals" dialog) instead of being
+ * queued on the dispatcher — a queued session would silently never start,
+ * which is exactly the failure mode this exists to make visible.
+ */
+object TerminalSessionSlots {
+    /** Permit budget of [TerminalSessionDispatcher]. */
+    const val MAX_THREADS = 256
+
+    /** Long-lived threads a full local session pins: PTY reader + emulator loop + waitFor. */
+    const val THREADS_PER_SESSION = 3
+
+    /** Message shown in the pane (and echoed by the capacity dialog) when a session is refused. */
+    const val EXHAUSTED_MESSAGE =
+        "No terminal threads available — close some terminal tabs or splits, then try again."
+
+    private val used = java.util.concurrent.atomic.AtomicInteger(0)
+
+    /** Currently reserved threads; UI may show this alongside [MAX_THREADS]. */
+    val usedThreads: Int get() = used.get()
+
+    /**
+     * Reserve [n] session-loop threads. Returns false — reserving nothing — when
+     * the budget can't fit them; the caller must not start its session loops.
+     */
+    fun tryReserve(n: Int = THREADS_PER_SESSION): Boolean {
+        while (true) {
+            val current = used.get()
+            if (current + n > MAX_THREADS) return false
+            if (used.compareAndSet(current, current + n)) return true
+        }
+    }
+
+    /** Return [n] previously reserved threads. Callers must pair this 1:1 with a successful [tryReserve]. */
+    fun release(n: Int = THREADS_PER_SESSION) {
+        used.addAndGet(-n)
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
@@ -22,15 +22,16 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  * the shared pools. 256 accounted threads ≈ 85 concurrent sessions; threads
  * are created lazily, so idle cost is zero.
  *
- * The view's parallelism is [TerminalSessionSlots.MAX_THREADS] plus a little
- * headroom: [TerminalSessionSlots] accounting is advisory (a session's
- * reservation can be released slightly before its loops finish unwinding
- * during teardown), so short-lived work on the view must never depend on a
- * permit being free at exactly the accounted budget.
+ * The view's parallelism is [TerminalSessionSlots.HARD_MAX_THREADS] plus a
+ * little headroom — the ceiling of the configurable budget, since the view is
+ * created once and cannot be resized at runtime. The headroom also covers the
+ * advisory nature of the accounting (a session's reservation can be released
+ * slightly before its loops finish unwinding during teardown), so short-lived
+ * work on the view never depends on a permit being free at exactly the budget.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 val TerminalSessionDispatcher: CoroutineDispatcher =
-    Dispatchers.IO.limitedParallelism(TerminalSessionSlots.MAX_THREADS + 4, "bossterm-session")
+    Dispatchers.IO.limitedParallelism(TerminalSessionSlots.HARD_MAX_THREADS + 4, "bossterm-session")
 
 /**
  * Advisory accounting for [TerminalSessionDispatcher]'s permit budget.
@@ -52,15 +53,17 @@ val TerminalSessionDispatcher: CoroutineDispatcher =
  */
 object TerminalSessionSlots {
     /**
-     * Permit budget of [TerminalSessionDispatcher]. A fixed cap, deliberately not
-     * scaled to cores or memory: parked session threads cost little beyond their
-     * stacks, and hitting the cap degrades gracefully into the refusal dialog.
-     * The process's real terminal-thread ceiling is this budget (plus the view's
-     * small headroom) plus one dedicated exit-monitor OS thread per DAEMON
-     * session (see TerminalSessionCore) until the pty4j-reaper exit-callback
-     * follow-up removes those.
+     * Absolute ceiling for the accounting budget. Also sizes the dispatcher view
+     * (plus headroom), which is created once and cannot be resized at runtime —
+     * so [maxThreads] may move freely below this via settings, never above.
+     * The process's real terminal-thread ceiling is this plus one dedicated
+     * exit-monitor OS thread per DAEMON session (see TerminalSessionCore) until
+     * the pty4j-reaper exit-callback follow-up removes those.
      */
-    const val MAX_THREADS = 256
+    const val HARD_MAX_THREADS = 512
+
+    /** Smallest configurable budget — keeps a degenerate setting from bricking terminals. */
+    const val MIN_THREADS = 32
 
     /** Long-lived threads a full local session pins: PTY reader + emulator loop + waitFor. */
     const val THREADS_PER_SESSION = 3
@@ -69,9 +72,38 @@ object TerminalSessionSlots {
     const val EXHAUSTED_MESSAGE =
         "No terminal threads available — close some terminal tabs or splits, then try again."
 
+    /**
+     * Machine-scaled default budget: 16 threads (~5 sessions) per CPU core,
+     * clamped to [128, [HARD_MAX_THREADS]]. Parked session threads cost little
+     * beyond their stacks, so this scales with how many sessions a machine's
+     * owner plausibly runs rather than with any hard resource limit.
+     */
+    fun defaultMaxThreads(): Int =
+        (Runtime.getRuntime().availableProcessors() * 16).coerceIn(128, HARD_MAX_THREADS)
+
+    /**
+     * Current accounting budget. Machine-scaled by default, user-configurable
+     * via settings (`TerminalSettings.maxSessionThreads` → [applyConfiguredBudget]).
+     * Lowering it below current usage simply refuses NEW sessions until enough
+     * close — live sessions are never touched.
+     */
+    @Volatile
+    var maxThreads: Int = defaultMaxThreads()
+        private set
+
+    /**
+     * Apply the configured budget from settings: `<= 0` means automatic
+     * (machine-scaled [defaultMaxThreads]); anything else is clamped to
+     * [[MIN_THREADS], [HARD_MAX_THREADS]].
+     */
+    fun applyConfiguredBudget(configured: Int) {
+        maxThreads = if (configured <= 0) defaultMaxThreads()
+        else configured.coerceIn(MIN_THREADS, HARD_MAX_THREADS)
+    }
+
     private val used = java.util.concurrent.atomic.AtomicInteger(0)
 
-    /** Currently reserved threads; UI may show this alongside [MAX_THREADS]. */
+    /** Currently reserved threads; UI may show this alongside [maxThreads]. */
     val usedThreads: Int get() = used.get()
 
     /**
@@ -81,7 +113,7 @@ object TerminalSessionSlots {
     fun tryReserve(n: Int = THREADS_PER_SESSION): Boolean {
         while (true) {
             val current = used.get()
-            if (current + n > MAX_THREADS) return false
+            if (current + n > maxThreads) return false
             if (used.compareAndSet(current, current + n)) return true
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
@@ -24,10 +24,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  *
  * The view's parallelism is [TerminalSessionSlots.HARD_MAX_THREADS] plus a
  * little headroom — the ceiling of the configurable budget, since the view is
- * created once and cannot be resized at runtime. The headroom also covers the
- * advisory nature of the accounting (a session's reservation can be released
- * slightly before its loops finish unwinding during teardown), so short-lived
- * work on the view never depends on a permit being free at exactly the budget.
+ * created once and cannot be resized at runtime. TabController releases only
+ * after the session Job (including its child loops) completes, and
+ * EmbeddableTerminal counts down all three loop jobs, so their accounting
+ * never runs ahead of the physically occupied permits. The daemon path
+ * (TerminalSessionCore) still releases in close() while its loops unwind —
+ * a small constant headroom, NOT proportional to concurrent daemon closes,
+ * which is acceptable because the loops exit as soon as the killed PTY's
+ * isAlive() flips false.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 val TerminalSessionDispatcher: CoroutineDispatcher =

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
@@ -1,0 +1,27 @@
+package ai.rever.bossterm.compose
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Dispatcher for per-session blocking terminal loops: the PTY reader, the
+ * emulator-processing loop, and the process exit wait ([PlatformServices
+ * .ProcessService.ProcessHandle.waitFor]). Each live session parks ~3 threads
+ * in these loops for its entire lifetime.
+ *
+ * They must NOT run on the shared pools: `Dispatchers.Default` has only nCPU
+ * permits and `Dispatchers.IO` 64, so enough open tabs pin both pools and
+ * starve every other coroutine in the process — observed in the BOSS host at
+ * ~20 sessions as frozen terminals, new tabs that never spawn a shell, and
+ * Supabase Realtime heartbeat timeouts, while the rest of the app stayed up.
+ *
+ * A [limitedParallelism][CoroutineDispatcher.limitedParallelism] view of
+ * `Dispatchers.IO` draws from its own permit budget (threads created for it
+ * do not count against the global 64), so session loops can never exhaust
+ * the shared pools. 256 permits ≈ 85 concurrent sessions; threads are
+ * created lazily, so idle cost is zero.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+val TerminalSessionDispatcher: CoroutineDispatcher =
+    Dispatchers.IO.limitedParallelism(256, "bossterm-session")

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
@@ -19,12 +19,18 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  * A [limitedParallelism][CoroutineDispatcher.limitedParallelism] view of
  * `Dispatchers.IO` draws from its own permit budget (threads created for it
  * do not count against the global 64), so session loops can never exhaust
- * the shared pools. 256 permits ≈ 85 concurrent sessions; threads are
- * created lazily, so idle cost is zero.
+ * the shared pools. 256 accounted threads ≈ 85 concurrent sessions; threads
+ * are created lazily, so idle cost is zero.
+ *
+ * The view's parallelism is [TerminalSessionSlots.MAX_THREADS] plus a little
+ * headroom: [TerminalSessionSlots] accounting is advisory (a session's
+ * reservation can be released slightly before its loops finish unwinding
+ * during teardown), so short-lived work on the view must never depend on a
+ * permit being free at exactly the accounted budget.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 val TerminalSessionDispatcher: CoroutineDispatcher =
-    Dispatchers.IO.limitedParallelism(256, "bossterm-session")
+    Dispatchers.IO.limitedParallelism(TerminalSessionSlots.MAX_THREADS + 4, "bossterm-session")
 
 /**
  * Advisory accounting for [TerminalSessionDispatcher]'s permit budget.
@@ -34,6 +40,15 @@ val TerminalSessionDispatcher: CoroutineDispatcher =
  * outright (error state + a "close some terminals" dialog) instead of being
  * queued on the dispatcher — a queued session would silently never start,
  * which is exactly the failure mode this exists to make visible.
+ *
+ * Two rules for callers:
+ * - [tryReserve] must run OUTSIDE [TerminalSessionDispatcher] (synchronously on
+ *   the caller's thread, before dispatching): at exact saturation every view
+ *   thread is parked in a live loop, so a coroutine dispatched just to check
+ *   and report the refusal would itself queue forever.
+ * - every successful [tryReserve] must be paired with exactly one [release],
+ *   on ALL exit paths — including exceptions thrown between reserving and
+ *   arming whatever completion hook normally releases.
  */
 object TerminalSessionSlots {
     /** Permit budget of [TerminalSessionDispatcher]. */
@@ -63,8 +78,12 @@ object TerminalSessionSlots {
         }
     }
 
-    /** Return [n] previously reserved threads. Callers must pair this 1:1 with a successful [tryReserve]. */
+    /**
+     * Return [n] previously reserved threads. Callers must pair this 1:1 with a
+     * successful [tryReserve]; clamped at zero so a mis-paired release can't
+     * corrupt the budget into admitting sessions the dispatcher can't run.
+     */
     fun release(n: Int = THREADS_PER_SESSION) {
-        used.addAndGet(-n)
+        used.updateAndGet { (it - n).coerceAtLeast(0) }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSessionDispatcher.kt
@@ -51,7 +51,15 @@ val TerminalSessionDispatcher: CoroutineDispatcher =
  *   arming whatever completion hook normally releases.
  */
 object TerminalSessionSlots {
-    /** Permit budget of [TerminalSessionDispatcher]. */
+    /**
+     * Permit budget of [TerminalSessionDispatcher]. A fixed cap, deliberately not
+     * scaled to cores or memory: parked session threads cost little beyond their
+     * stacks, and hitting the cap degrades gracefully into the refusal dialog.
+     * The process's real terminal-thread ceiling is this budget (plus the view's
+     * small headroom) plus one dedicated exit-monitor OS thread per DAEMON
+     * session (see TerminalSessionCore) until the pty4j-reaper exit-callback
+     * follow-up removes those.
+     */
     const val MAX_THREADS = 256
 
     /** Long-lived threads a full local session pins: PTY reader + emulator loop + waitFor. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
@@ -2,6 +2,7 @@ package ai.rever.bossterm.compose.daemon
 
 import ai.rever.bossterm.compose.PlatformServices
 import ai.rever.bossterm.compose.TerminalSessionDispatcher
+import ai.rever.bossterm.compose.TerminalSessionSlots
 import ai.rever.bossterm.compose.getPlatformServices
 import ai.rever.bossterm.compose.putBossTermGraphicsEnvironment
 import ai.rever.bossterm.compose.settings.TerminalSettings
@@ -98,6 +99,10 @@ class TerminalSessionCore(
     var onExit: (() -> Unit)? = null
     private val exitNotified = java.util.concurrent.atomic.AtomicBoolean(false)
 
+    // TerminalSessionSlots accounting: reserved in start(), released exactly once in close().
+    private var slotsReserved = false
+    private val slotsReleased = java.util.concurrent.atomic.AtomicBoolean(false)
+
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val started = java.util.concurrent.atomic.AtomicBoolean(false)
     @Volatile private var closed = false
@@ -156,6 +161,15 @@ class TerminalSessionCore(
     /** Spawn the PTY and start the read/emulate/exit-monitor loops. Idempotent. */
     fun start() {
         if (!started.compareAndSet(false, true)) return // atomic idempotency — never spawn two PTYs
+        // Reserve the session's long-lived threads (reader, emulator, waitFor) up front —
+        // a refused session must fail visibly instead of queueing on a starved dispatcher
+        // and silently never spawning its shell.
+        if (!TerminalSessionSlots.tryReserve()) {
+            _connectionState.value = State.Error(TerminalSessionSlots.EXHAUSTED_MESSAGE)
+            connected.complete(false)
+            return
+        }
+        slotsReserved = true
         launchWriteConsumer()
         scope.launch {
             try {
@@ -326,6 +340,7 @@ class TerminalSessionCore(
     fun close(): Thread? {
         if (closed) return null
         closed = true
+        if (slotsReserved && slotsReleased.compareAndSet(false, true)) TerminalSessionSlots.release()
         connected.complete(false) // release a write consumer still waiting to start
         writeChannel.close()
         val h = handle

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
@@ -158,7 +158,14 @@ class TerminalSessionCore(
     fun addRawOutputListener(listener: (String) -> Unit) = dataStream.addRawOutputListener(listener)
     fun removeRawOutputListener(listener: (String) -> Unit) = dataStream.removeRawOutputListener(listener)
 
-    /** Spawn the PTY and start the read/emulate/exit-monitor loops. Idempotent. */
+    /**
+     * Spawn the PTY and start the read/emulate/exit-monitor loops. Idempotent.
+     *
+     * A TerminalSessionSlots refusal is PERMANENT for this core: `started` is
+     * consumed before the reservation attempt, so a refused core stays a no-op
+     * even after capacity frees up. Intentional — start() is one-shot; a caller
+     * that wants to retry after the user closes sessions constructs a new core.
+     */
     fun start() {
         if (!started.compareAndSet(false, true)) return // atomic idempotency — never spawn two PTYs
         // Reserve the session's long-lived threads (reader, emulator, waitFor) up front —

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.compose.daemon
 
 import ai.rever.bossterm.compose.PlatformServices
+import ai.rever.bossterm.compose.TerminalSessionDispatcher
 import ai.rever.bossterm.compose.getPlatformServices
 import ai.rever.bossterm.compose.putBossTermGraphicsEnvironment
 import ai.rever.bossterm.compose.settings.TerminalSettings
@@ -188,7 +189,9 @@ class TerminalSessionCore(
                 (lastResize ?: (initCols to initRows)).let { (c, r) -> runCatching { h.resize(c, r) } }
 
                 // Emulator processing loop — drains the data stream into the terminal model.
-                launch(Dispatchers.Default) {
+                // Blocks in dataStream.char between chunks, so it must not hold one of
+                // Dispatchers.Default's nCPU permits.
+                launch(TerminalSessionDispatcher) {
                     try {
                         while (h.isAlive()) {
                             try {
@@ -208,7 +211,8 @@ class TerminalSessionCore(
                 }
 
                 // PTY reader loop — grapheme-safe chunking, matches TabController.startPtyReaderCoroutine.
-                launch(Dispatchers.IO) {
+                // Blocks in h.read() for the session's whole life, kept off the shared IO permits.
+                launch(TerminalSessionDispatcher) {
                     val maxChunkSize = 64 * 1024
                     try {
                         while (h.isAlive()) {
@@ -232,8 +236,9 @@ class TerminalSessionCore(
                 }
 
                 // Exit monitor on a DEDICATED thread — not this coroutine — so we don't pin a
-                // Dispatchers.IO pool thread (shared with the reader loops) in a blocking waitFor for
-                // the whole life of the session. On exit we self-close so the scope + write consumer
+                // coroutine pool thread in a blocking waitFor for the whole life of the session
+                // (waitFor itself parks a TerminalSessionDispatcher permit; see PlatformServices).
+                // On exit we self-close so the scope + write consumer
                 // + write channel are torn down (otherwise a naturally-exited shell leaks them).
                 Thread({
                     runCatching { runBlocking { h.waitFor() } }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
@@ -184,6 +184,9 @@ class TerminalSessionCore(
                 if (h == null) {
                     _connectionState.value = State.Error("Failed to spawn process")
                     connected.complete(false)
+                    // The exit monitor was never armed, so nothing else will run close() —
+                    // without it the TerminalSessionSlots reservation leaks permanently.
+                    close()
                     return@launch
                 }
                 handle = h
@@ -249,9 +252,11 @@ class TerminalSessionCore(
                     }
                 }
 
-                // Exit monitor on a DEDICATED thread — not this coroutine — so we don't pin a
-                // coroutine pool thread in a blocking waitFor for the whole life of the session
-                // (waitFor itself parks a TerminalSessionDispatcher permit; see PlatformServices).
+                // Exit monitor on a DEDICATED thread — not a `scope` coroutine — purely so the
+                // teardown below runs independently of scope.cancel() in close(). Note waitFor()
+                // parks a TerminalSessionDispatcher permit regardless (accounted as one of the
+                // session's three), so this thread no longer avoids any pool pinning; it becomes
+                // removable once the pty4j-reaper exit-callback follow-up lands.
                 // On exit we self-close so the scope + write consumer
                 // + write channel are torn down (otherwise a naturally-exited shell leaks them).
                 Thread({
@@ -265,6 +270,11 @@ class TerminalSessionCore(
                 _connectionState.value = State.Error("Terminal initialization failed: ${e.message}")
                 connected.complete(false)
                 log.error("session {} init failed: {}", id, e.message)
+                // The exit monitor was never armed, so nothing else will run close() —
+                // without it the TerminalSessionSlots reservation leaks permanently.
+                // close() also kills a half-spawned PTY via `handle`, and is a no-op
+                // if a concurrent closeSession already ran.
+                close()
             }
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.settings
 
+import ai.rever.bossterm.compose.TerminalSessionSlots
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -25,6 +26,17 @@ class SettingsManager(private val customSettingsPath: String? = null) {
      * Current settings as a StateFlow (reactive)
      */
     val settings: StateFlow<TerminalSettings> = _settings.asStateFlow()
+
+    /**
+     * Single funnel for every settings publication: updates the flow and applies
+     * settings-derived process-wide side effects (currently the terminal-session
+     * thread budget, which lives outside the flow so non-UI session owners like
+     * the daemon core see it without observing settings).
+     */
+    private fun publish(newSettings: TerminalSettings) {
+        _settings.value = newSettings
+        TerminalSessionSlots.applyConfiguredBudget(newSettings.maxSessionThreads)
+    }
 
     /**
      * `true` if the settings file did not exist when [loadFromFile] last ran
@@ -90,7 +102,7 @@ class SettingsManager(private val customSettingsPath: String? = null) {
      */
     fun updateSettings(newSettings: TerminalSettings) {
         synchronized(saveLock) {
-            _settings.value = newSettings
+            publish(newSettings)
             writeToFileLocked(newSettings)
         }
     }
@@ -119,7 +131,7 @@ class SettingsManager(private val customSettingsPath: String? = null) {
             val merged = json.encodeToJsonElement(TerminalSettings.serializer(), current).jsonObject.toMutableMap()
             for ((k, v) in ed) if (base[k] != v) merged[k] = v // field the user changed → apply over current
             val result = json.decodeFromJsonElement(TerminalSettings.serializer(), JsonObject(merged))
-            _settings.value = result
+            publish(result)
             writeToFileLocked(result)
         }
     }
@@ -136,7 +148,7 @@ class SettingsManager(private val customSettingsPath: String? = null) {
     fun updateSetting(updater: TerminalSettings.() -> TerminalSettings) {
         synchronized(saveLock) {
             val result = currentOnDiskOrMemory().updater()
-            _settings.value = result
+            publish(result)
             writeToFileLocked(result)
         }
     }
@@ -212,7 +224,7 @@ class SettingsManager(private val customSettingsPath: String? = null) {
                 wasFreshInstall = false
                 val jsonString = settingsFile.readText()
                 val loadedSettings = json.decodeFromString<TerminalSettings>(jsonString)
-                _settings.value = loadedSettings
+                publish(loadedSettings)
                 println("Settings loaded from: ${settingsFile.absolutePath}")
 
                 // Migrate (write new-default fields back) ONLY if re-encoding actually differs from disk.
@@ -230,7 +242,7 @@ class SettingsManager(private val customSettingsPath: String? = null) {
         } catch (e: Exception) {
             System.err.println("Failed to load settings, using defaults: ${e.message}")
             e.printStackTrace()
-            _settings.value = TerminalSettings.DEFAULT
+            publish(TerminalSettings.DEFAULT)
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -587,6 +587,15 @@ data class TerminalSettings(
     val bufferMaxLines: Int = 10000,
 
     /**
+     * Thread budget for concurrent terminal sessions (TerminalSessionSlots).
+     * Each full session pins ~3 threads (PTY reader, emulator loop, exit wait).
+     * 0 = automatic: scaled to the machine (16 × CPU cores, clamped 128–512).
+     * Non-zero values are clamped to 32–512. When the budget is exhausted, new
+     * terminals are refused with a dialog instead of hanging without a shell.
+     */
+    val maxSessionThreads: Int = 0,
+
+    /**
      * Cursor blink rate in milliseconds (0 = no blink)
      */
     val caretBlinkMs: Int = 500,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/PerformanceSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/PerformanceSettingsSection.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ai.rever.bossterm.compose.TerminalSessionSlots
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
 import ai.rever.bossterm.compose.settings.SystemInfoUtils
@@ -217,6 +218,21 @@ fun PerformanceSettingsSection(
                 onValueChange = { onSettingsChange(settings.copy(bufferMaxLines = it)) },
                 range = 1000..100000,
                 description = "Maximum lines in history (1000-100000)"
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Session thread budget
+        SettingsSection(title = "Sessions") {
+            SettingsNumberInput(
+                label = "Max Session Threads",
+                value = settings.maxSessionThreads,
+                onValueChange = { onSettingsChange(settings.copy(maxSessionThreads = it)) },
+                range = 0..TerminalSessionSlots.HARD_MAX_THREADS,
+                description = "Thread budget for terminal sessions, ~3 per session " +
+                    "(0 = auto: 16 × CPU cores, currently ${TerminalSessionSlots.defaultMaxThreads()}; " +
+                    "custom values clamp to ${TerminalSessionSlots.MIN_THREADS}-${TerminalSessionSlots.HARD_MAX_THREADS})"
             )
         }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/PerformanceSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/PerformanceSettingsSection.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -30,6 +31,10 @@ fun PerformanceSettingsSection(
     // Platform detection
     val isMacOS = ShellCustomizationUtils.isMacOS()
     val isWindows = ShellCustomizationUtils.isWindows()
+
+    // Machine-scaled auto value for the session thread budget — constant for the
+    // process lifetime, so no need to query Runtime on every recomposition.
+    val autoSessionThreads = remember { TerminalSessionSlots.defaultMaxThreads() }
 
     // Calculate dynamic GPU cache limits based on system memory and user's max percent setting
     // Computed directly (no remember) to ensure reactivity when max percent changes
@@ -231,7 +236,7 @@ fun PerformanceSettingsSection(
                 onValueChange = { onSettingsChange(settings.copy(maxSessionThreads = it)) },
                 range = 0..TerminalSessionSlots.HARD_MAX_THREADS,
                 description = "Thread budget for terminal sessions, ~3 per session " +
-                    "(0 = auto: 16 × CPU cores, currently ${TerminalSessionSlots.defaultMaxThreads()}; " +
+                    "(0 = auto: 16 × CPU cores, currently $autoSessionThreads; " +
                     "custom values clamp to ${TerminalSessionSlots.MIN_THREADS}-${TerminalSessionSlots.HARD_MAX_THREADS})"
             )
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -9,6 +9,8 @@ import ai.rever.bossterm.terminal.model.StyleState
 import ai.rever.bossterm.terminal.model.TerminalApplicationTitleListener
 import ai.rever.bossterm.terminal.model.TerminalTextBuffer
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import ai.rever.bossterm.compose.vcs.GitUtils
@@ -18,6 +20,7 @@ import ai.rever.bossterm.compose.ConnectionState
 import ai.rever.bossterm.compose.PlatformServices
 import ai.rever.bossterm.compose.putBossTermGraphicsEnvironment
 import ai.rever.bossterm.compose.TerminalSessionDispatcher
+import ai.rever.bossterm.compose.TerminalSessionSlots
 import ai.rever.bossterm.compose.debug.ChunkSource
 import ai.rever.bossterm.compose.terminal.BlockingTerminalDataStream
 import ai.rever.bossterm.compose.terminal.PerformanceMode
@@ -160,6 +163,41 @@ class TabController(
      * 3. SupervisorJob prevents individual failures from cancelling siblings
      */
     private val cleanupScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    /**
+     * Raised when a new session is refused because [TerminalSessionSlots] is exhausted
+     * (every TerminalSessionDispatcher thread is pinned by a live session). The hosting
+     * UI shows a dialog asking the user to close some terminals; the affected pane
+     * itself is put into [ConnectionState.Error] with the same message.
+     */
+    private val _showSessionCapacityDialog = MutableStateFlow(false)
+    val showSessionCapacityDialog: StateFlow<Boolean> get() = _showSessionCapacityDialog
+
+    fun dismissSessionCapacityDialog() {
+        _showSessionCapacityDialog.value = false
+    }
+
+    /**
+     * Launch the long-lived coroutine that owns a shell session (spawn → reader/emulator
+     * loops → waitFor). Reserves the session's thread budget from [TerminalSessionSlots]
+     * first: when the budget is exhausted the session is NOT started — the tab goes to an
+     * error state and [showSessionCapacityDialog] is raised — because launching anyway
+     * would queue on a starved dispatcher and silently never spawn a shell.
+     */
+    private fun launchSessionCoroutine(tab: TerminalTab, block: suspend CoroutineScope.() -> Unit) {
+        tab.coroutineScope.launch(TerminalSessionDispatcher) {
+            if (!TerminalSessionSlots.tryReserve()) {
+                tab.connectionState.value = ConnectionState.Error(TerminalSessionSlots.EXHAUSTED_MESSAGE)
+                _showSessionCapacityDialog.value = true
+                return@launch
+            }
+            try {
+                block()
+            } finally {
+                TerminalSessionSlots.release()
+            }
+        }
+    }
 
     /**
      * Add a session lifecycle listener.
@@ -682,6 +720,12 @@ class TabController(
         // (its panes are separate mirror sessions in the split tree), so it needs no parked thread.
         if (feedsStream) {
             scope.launch(TerminalSessionDispatcher) {
+                // Mirror drain loop pins one thread — account for it so exhaustion is detected.
+                if (!TerminalSessionSlots.tryReserve(1)) {
+                    tab.connectionState.value = ConnectionState.Error(TerminalSessionSlots.EXHAUSTED_MESSAGE)
+                    _showSessionCapacityDialog.value = true
+                    return@launch
+                }
                 try {
                     while (isActive) {
                         try {
@@ -691,6 +735,7 @@ class TabController(
                         }
                     }
                 } finally {
+                    TerminalSessionSlots.release(1)
                     runCatching { tab.dataStream.close() }
                 }
             }
@@ -1159,7 +1204,7 @@ class TabController(
 
         // Run pre-connection handler in coroutine. On TerminalSessionDispatcher:
         // this coroutine ends in handle.waitFor() and so lives as long as the shell.
-        tab.coroutineScope.launch(TerminalSessionDispatcher) {
+        launchSessionCoroutine(tab) {
             try {
                 // Create questioner that updates tab's connection state
                 val questioner = ComposeQuestioner { newState ->
@@ -1177,7 +1222,7 @@ class TabController(
                             closeTab(tabIndex)
                         }
                     }
-                    return@launch
+                    return@launchSessionCoroutine
                 }
 
                 // Update working directory from config
@@ -1407,7 +1452,7 @@ class TabController(
     ) {
         // On TerminalSessionDispatcher: this coroutine ends in handle.waitFor()
         // and so lives as long as the shell.
-        tab.coroutineScope.launch(TerminalSessionDispatcher) {
+        launchSessionCoroutine(tab) {
             try {
                 // Set TERM environment variables for TUI compatibility
                 val terminalEnvironment = buildMap {
@@ -1455,7 +1500,7 @@ class TabController(
                         message = "Failed to spawn process",
                         cause = null
                     )
-                    return@launch
+                    return@launchSessionCoroutine
                 }
 
                 tab.processHandle.value = handle

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -729,6 +729,9 @@ class TabController(
             if (!TerminalSessionSlots.tryReserve(1)) {
                 tab.connectionState.value = ConnectionState.Error(TerminalSessionSlots.EXHAUSTED_MESSAGE)
                 _showSessionCapacityDialog.value = true
+                // No drain loop will ever run — close the stream so writers don't feed
+                // a queue nobody reads. (The loop's finally does this on the normal path.)
+                runCatching { tab.dataStream.close() }
             } else {
                 scope.launch(TerminalSessionDispatcher) {
                     try {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -196,6 +196,10 @@ class TabController(
         }
         // invokeOnCompletion rather than try/finally: it also fires when the scope is
         // cancelled before the coroutine ever starts, so the reservation can't leak.
+        // A Job completes only after all its CHILDREN complete — and the session's
+        // reader/emulator loops are launched as children inside block() — so this
+        // release fires only after every loop has actually unwound, keeping the
+        // accounting from running ahead of the physically occupied permits.
         tab.coroutineScope.launch(TerminalSessionDispatcher) {
             block()
         }.invokeOnCompletion {
@@ -1240,8 +1244,10 @@ class TabController(
                     workingDirectoryState.value = config.workingDir
                 }
 
-                // Initialize terminal session with collected config
-                initializeTerminalSessionWithConfig(tab, config)
+                // Initialize terminal session with collected config. Passing this session
+                // coroutine's scope makes the reader/emulator loops its CHILDREN, so
+                // launchSessionCoroutine's release fires only after they unwind.
+                initializeTerminalSessionWithConfig(this, tab, config)
 
             } catch (e: Exception) {
                 tab.connectionState.value = ConnectionState.Error(
@@ -1258,6 +1264,7 @@ class TabController(
      * Initialize terminal session with pre-collected configuration.
      */
     private suspend fun initializeTerminalSessionWithConfig(
+        sessionScope: CoroutineScope,
         tab: TerminalTab,
         config: PreConnectConfig
     ) {
@@ -1371,7 +1378,11 @@ class TabController(
 
             // Start emulator processing coroutine. Blocks in dataStream.char between
             // chunks, so it must not hold one of Dispatchers.Default's nCPU permits.
-            tab.coroutineScope.launch(TerminalSessionDispatcher) {
+            // Launched in sessionScope — a CHILD of the session coroutine, not a
+            // sibling on tab.coroutineScope — so launchSessionCoroutine's release
+            // fires only after this loop unwinds and the accounting never runs
+            // ahead of the physically occupied permits.
+            sessionScope.launch(TerminalSessionDispatcher) {
                 try {
                     while (handle.isAlive()) {
                         try {
@@ -1391,11 +1402,11 @@ class TabController(
             }
 
             // Read PTY output in background (uses shared helper to eliminate duplication)
-            startPtyReaderCoroutine(tab.coroutineScope, tab, handle)
+            startPtyReaderCoroutine(sessionScope, tab, handle)
 
             // Start debug state capture coroutine if enabled
             tab.debugCollector?.let { collector ->
-                tab.coroutineScope.launch(Dispatchers.IO) {
+                sessionScope.launch(Dispatchers.IO) {
                     try {
                         while (handle.isAlive() && isActive) {
                             delay(settings.debugCaptureInterval)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -185,17 +185,21 @@ class TabController(
      * would queue on a starved dispatcher and silently never spawn a shell.
      */
     private fun launchSessionCoroutine(tab: TerminalTab, block: suspend CoroutineScope.() -> Unit) {
+        // Reserve synchronously on the caller's thread, BEFORE dispatching: at exact
+        // saturation every TerminalSessionDispatcher thread is parked in a live loop,
+        // so a coroutine dispatched just to check-and-report would itself queue
+        // forever — the silent hang this accounting exists to prevent.
+        if (!TerminalSessionSlots.tryReserve()) {
+            tab.connectionState.value = ConnectionState.Error(TerminalSessionSlots.EXHAUSTED_MESSAGE)
+            _showSessionCapacityDialog.value = true
+            return
+        }
+        // invokeOnCompletion rather than try/finally: it also fires when the scope is
+        // cancelled before the coroutine ever starts, so the reservation can't leak.
         tab.coroutineScope.launch(TerminalSessionDispatcher) {
-            if (!TerminalSessionSlots.tryReserve()) {
-                tab.connectionState.value = ConnectionState.Error(TerminalSessionSlots.EXHAUSTED_MESSAGE)
-                _showSessionCapacityDialog.value = true
-                return@launch
-            }
-            try {
-                block()
-            } finally {
-                TerminalSessionSlots.release()
-            }
+            block()
+        }.invokeOnCompletion {
+            TerminalSessionSlots.release()
         }
     }
 
@@ -719,24 +723,27 @@ class TabController(
         // Skipped for a container tab ([feedsStream] = false): it owns no remote pane of its own
         // (its panes are separate mirror sessions in the split tree), so it needs no parked thread.
         if (feedsStream) {
-            scope.launch(TerminalSessionDispatcher) {
-                // Mirror drain loop pins one thread — account for it so exhaustion is detected.
-                if (!TerminalSessionSlots.tryReserve(1)) {
-                    tab.connectionState.value = ConnectionState.Error(TerminalSessionSlots.EXHAUSTED_MESSAGE)
-                    _showSessionCapacityDialog.value = true
-                    return@launch
-                }
-                try {
-                    while (isActive) {
-                        try {
-                            tab.emulator.processChar(tab.dataStream.char, tab.terminal)
-                        } catch (_: Exception) {
-                            break // EOF on close, or stream error — stop the loop
+            // Mirror drain loop pins one thread — reserve it synchronously (never on
+            // the view itself; see launchSessionCoroutine) so exhaustion is reported
+            // instead of the loop queueing forever.
+            if (!TerminalSessionSlots.tryReserve(1)) {
+                tab.connectionState.value = ConnectionState.Error(TerminalSessionSlots.EXHAUSTED_MESSAGE)
+                _showSessionCapacityDialog.value = true
+            } else {
+                scope.launch(TerminalSessionDispatcher) {
+                    try {
+                        while (isActive) {
+                            try {
+                                tab.emulator.processChar(tab.dataStream.char, tab.terminal)
+                            } catch (_: Exception) {
+                                break // EOF on close, or stream error — stop the loop
+                            }
                         }
+                    } finally {
+                        runCatching { tab.dataStream.close() }
                     }
-                } finally {
+                }.invokeOnCompletion {
                     TerminalSessionSlots.release(1)
-                    runCatching { tab.dataStream.close() }
                 }
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -1391,6 +1391,8 @@ class TabController(
                             delay(settings.debugCaptureInterval)
                             collector.captureState()
                         }
+                    } catch (e: CancellationException) {
+                        throw e // normal tab close — nothing to log
                     } catch (e: Exception) {
                         println("DEBUG: State capture coroutine stopped: ${e.message}")
                     }
@@ -1419,6 +1421,8 @@ class TabController(
                 }
             }
 
+        } catch (e: CancellationException) {
+            throw e // normal tab close / dispose — not an initialization failure
         } catch (e: Exception) {
             tab.connectionState.value = ConnectionState.Error(
                 message = "Terminal initialization failed: ${e.message ?: "Unknown error"}",
@@ -1562,6 +1566,8 @@ class TabController(
                                 delay(settings.debugCaptureInterval)
                                 collector.captureState()
                             }
+                        } catch (e: CancellationException) {
+                            throw e // normal tab close — nothing to log
                         } catch (e: Exception) {
                             println("DEBUG: State capture coroutine stopped: ${e.message}")
                         }
@@ -1654,6 +1660,8 @@ class TabController(
                     }
                 }
 
+            } catch (e: CancellationException) {
+                throw e // normal tab close / dispose — not an initialization failure
             } catch (e: Exception) {
                 tab.connectionState.value = ConnectionState.Error(
                     message = "Terminal initialization failed: ${e.message ?: "Unknown error"}",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -17,6 +17,7 @@ import ai.rever.bossterm.compose.ComposeTerminalDisplay
 import ai.rever.bossterm.compose.ConnectionState
 import ai.rever.bossterm.compose.PlatformServices
 import ai.rever.bossterm.compose.putBossTermGraphicsEnvironment
+import ai.rever.bossterm.compose.TerminalSessionDispatcher
 import ai.rever.bossterm.compose.debug.ChunkSource
 import ai.rever.bossterm.compose.terminal.BlockingTerminalDataStream
 import ai.rever.bossterm.compose.terminal.PerformanceMode
@@ -680,7 +681,7 @@ class TabController(
         // Skipped for a container tab ([feedsStream] = false): it owns no remote pane of its own
         // (its panes are separate mirror sessions in the split tree), so it needs no parked thread.
         if (feedsStream) {
-            scope.launch(Dispatchers.Default) {
+            scope.launch(TerminalSessionDispatcher) {
                 try {
                     while (isActive) {
                         try {
@@ -1156,8 +1157,9 @@ class TabController(
 
         switchToTab(tabs.size - 1)
 
-        // Run pre-connection handler in coroutine
-        tab.coroutineScope.launch(Dispatchers.IO) {
+        // Run pre-connection handler in coroutine. On TerminalSessionDispatcher:
+        // this coroutine ends in handle.waitFor() and so lives as long as the shell.
+        tab.coroutineScope.launch(TerminalSessionDispatcher) {
             try {
                 // Create questioner that updates tab's connection state
                 val questioner = ComposeQuestioner { newState ->
@@ -1312,8 +1314,9 @@ class TabController(
                 tab.textBuffer.endBatch()
             }
 
-            // Start emulator processing coroutine
-            tab.coroutineScope.launch(Dispatchers.Default) {
+            // Start emulator processing coroutine. Blocks in dataStream.char between
+            // chunks, so it must not hold one of Dispatchers.Default's nCPU permits.
+            tab.coroutineScope.launch(TerminalSessionDispatcher) {
                 try {
                     while (handle.isAlive()) {
                         try {
@@ -1402,7 +1405,9 @@ class TabController(
         initialCommand: String? = null,
         onInitialCommandComplete: ((success: Boolean, exitCode: Int) -> Unit)? = null
     ) {
-        tab.coroutineScope.launch(Dispatchers.IO) {
+        // On TerminalSessionDispatcher: this coroutine ends in handle.waitFor()
+        // and so lives as long as the shell.
+        tab.coroutineScope.launch(TerminalSessionDispatcher) {
             try {
                 // Set TERM environment variables for TUI compatibility
                 val terminalEnvironment = buildMap {
@@ -1475,10 +1480,11 @@ class TabController(
                     }.also { tab.terminal.addCommandStateListener(it) }
                 }
 
-                // Start emulator processing coroutine
+                // Start emulator processing coroutine. Blocks in dataStream.char between
+                // chunks, so it must not hold one of Dispatchers.Default's nCPU permits.
                 // Note: Initial prompt will display via ModelListener → requestImmediateRedraw()
                 // when buffer content changes. No need for premature redraw here.
-                launch(Dispatchers.Default) {
+                launch(TerminalSessionDispatcher) {
                     try {
                         while (handle.isAlive()) {
                             try {
@@ -1630,7 +1636,9 @@ class TabController(
         tab: TerminalTab,
         handle: PlatformServices.ProcessService.ProcessHandle
     ) {
-        scope.launch(Dispatchers.IO) {
+        // Blocks in handle.read() (JNA pty poll) for the session's whole life —
+        // one pinned thread per session, kept off the shared Dispatchers.IO permits.
+        scope.launch(TerminalSessionDispatcher) {
             val maxChunkSize = 64 * 1024
 
             try {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/TerminalSessionSlotsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/TerminalSessionSlotsTest.kt
@@ -1,5 +1,7 @@
 package ai.rever.bossterm.compose
 
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -118,6 +120,54 @@ class TerminalSessionSlotsTest {
                 .coerceIn(128, TerminalSessionSlots.HARD_MAX_THREADS),
             TerminalSessionSlots.defaultMaxThreads()
         )
+    }
+
+    // --- wiring tests: the reserve → launch → invokeOnCompletion-release pattern ---
+    // These mirror launchSessionCoroutine's mechanism on the real dispatcher without
+    // constructing a TabController: the leak-prone cases are cancel-before-start and
+    // cancel-while-running, both of which must return the reservation.
+
+    @Test
+    fun `reservation is returned when the scope is cancelled before the coroutine starts`() {
+        val scope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.SupervisorJob())
+        scope.cancel()
+
+        assertTrue(TerminalSessionSlots.tryReserve())
+        val reserved = TerminalSessionSlots.usedThreads
+        val released = java.util.concurrent.CountDownLatch(1)
+
+        scope.launch(TerminalSessionDispatcher) {
+            // never runs — the scope is already cancelled
+        }.invokeOnCompletion {
+            TerminalSessionSlots.release()
+            released.countDown()
+        }
+
+        assertTrue(released.await(5, java.util.concurrent.TimeUnit.SECONDS), "completion hook must fire for a never-started job")
+        assertEquals(reserved - TerminalSessionSlots.THREADS_PER_SESSION, TerminalSessionSlots.usedThreads)
+    }
+
+    @Test
+    fun `reservation is returned when a running session coroutine is cancelled`() {
+        val scope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.SupervisorJob())
+
+        assertTrue(TerminalSessionSlots.tryReserve())
+        val reserved = TerminalSessionSlots.usedThreads
+        val running = java.util.concurrent.CountDownLatch(1)
+        val released = java.util.concurrent.CountDownLatch(1)
+
+        scope.launch(TerminalSessionDispatcher) {
+            running.countDown()
+            kotlinx.coroutines.awaitCancellation()
+        }.invokeOnCompletion {
+            TerminalSessionSlots.release()
+            released.countDown()
+        }
+
+        assertTrue(running.await(5, java.util.concurrent.TimeUnit.SECONDS))
+        scope.cancel()
+        assertTrue(released.await(5, java.util.concurrent.TimeUnit.SECONDS), "completion hook must fire on cancellation")
+        assertEquals(reserved - TerminalSessionSlots.THREADS_PER_SESSION, TerminalSessionSlots.usedThreads)
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/TerminalSessionSlotsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/TerminalSessionSlotsTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.compose
 
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -8,49 +9,56 @@ import kotlin.test.assertTrue
 
 /**
  * TerminalSessionSlots is the safety mechanism that turns dispatcher exhaustion
- * into a visible refusal instead of a silent hang, so its CAS reserve/release
- * invariants are pinned here: reserve up to the cap, refuse beyond it, release
- * restores capacity, mis-paired release clamps instead of corrupting the budget,
- * and the accounting stays balanced under concurrency.
+ * into a visible refusal instead of a silent hang, so its invariants are pinned
+ * here: reserve up to the budget, refuse beyond it, release restores capacity,
+ * mis-paired release clamps instead of corrupting the budget, the accounting
+ * stays balanced under concurrency, and the settings-driven budget clamps and
+ * falls back to the machine-scaled default correctly.
  */
 class TerminalSessionSlotsTest {
 
+    // Pin a deterministic budget: tests must not depend on this machine's cores.
+    private val budget = 256
+
+    @BeforeTest
+    fun pinBudget() {
+        TerminalSessionSlots.applyConfiguredBudget(budget)
+    }
+
     @AfterTest
-    fun drainReservations() {
+    fun restore() {
         // Tests pair reserve/release themselves, but drain defensively so one
         // failing assertion can't poison the singleton for later tests. Relies
-        // on release() clamping at zero.
-        TerminalSessionSlots.release(TerminalSessionSlots.MAX_THREADS)
+        // on release() clamping at zero. Then restore the automatic budget.
+        TerminalSessionSlots.release(TerminalSessionSlots.HARD_MAX_THREADS)
+        TerminalSessionSlots.applyConfiguredBudget(0)
     }
 
     @Test
-    fun `reserves up to the cap and refuses beyond it`() {
-        val fullSessions = TerminalSessionSlots.MAX_THREADS / TerminalSessionSlots.THREADS_PER_SESSION
+    fun `reserves up to the budget and refuses beyond it`() {
+        val fullSessions = budget / TerminalSessionSlots.THREADS_PER_SESSION
         repeat(fullSessions) { assertTrue(TerminalSessionSlots.tryReserve()) }
-        assertEquals(
-            fullSessions * TerminalSessionSlots.THREADS_PER_SESSION,
-            TerminalSessionSlots.usedThreads
-        )
+        assertEquals(fullSessions * TerminalSessionSlots.THREADS_PER_SESSION, TerminalSessionSlots.usedThreads)
 
         // 256 % 3 == 1: a full session no longer fits, a single mirror loop does.
-        assertFalse(TerminalSessionSlots.tryReserve(), "a full session must be refused at the cap")
+        assertFalse(TerminalSessionSlots.tryReserve(), "a full session must be refused at the budget")
         assertTrue(TerminalSessionSlots.tryReserve(1), "a mirror loop still fits in the remainder")
         assertFalse(TerminalSessionSlots.tryReserve(1), "nothing fits once the budget is exactly consumed")
-        assertEquals(TerminalSessionSlots.MAX_THREADS, TerminalSessionSlots.usedThreads)
+        assertEquals(budget, TerminalSessionSlots.usedThreads)
     }
 
     @Test
     fun `failed reserve reserves nothing`() {
-        repeat(TerminalSessionSlots.MAX_THREADS - 1) { assertTrue(TerminalSessionSlots.tryReserve(1)) }
+        repeat(budget - 1) { assertTrue(TerminalSessionSlots.tryReserve(1)) }
         assertFalse(TerminalSessionSlots.tryReserve(TerminalSessionSlots.THREADS_PER_SESSION))
         // The refused reserve must not have consumed the remaining permit.
-        assertEquals(TerminalSessionSlots.MAX_THREADS - 1, TerminalSessionSlots.usedThreads)
+        assertEquals(budget - 1, TerminalSessionSlots.usedThreads)
         assertTrue(TerminalSessionSlots.tryReserve(1))
     }
 
     @Test
     fun `release restores capacity`() {
-        repeat(TerminalSessionSlots.MAX_THREADS) { assertTrue(TerminalSessionSlots.tryReserve(1)) }
+        repeat(budget) { assertTrue(TerminalSessionSlots.tryReserve(1)) }
         assertFalse(TerminalSessionSlots.tryReserve(1))
 
         TerminalSessionSlots.release()
@@ -63,9 +71,9 @@ class TerminalSessionSlotsTest {
         TerminalSessionSlots.release(5)
         assertEquals(0, TerminalSessionSlots.usedThreads)
 
-        // The budget must still admit exactly MAX_THREADS afterwards — a negative
+        // The budget must still admit exactly `budget` afterwards — a negative
         // counter would admit more sessions than the dispatcher can run.
-        repeat(TerminalSessionSlots.MAX_THREADS) { assertTrue(TerminalSessionSlots.tryReserve(1)) }
+        repeat(budget) { assertTrue(TerminalSessionSlots.tryReserve(1)) }
         assertFalse(TerminalSessionSlots.tryReserve(1))
     }
 
@@ -75,8 +83,8 @@ class TerminalSessionSlotsTest {
             Thread {
                 repeat(5_000) {
                     if (TerminalSessionSlots.tryReserve()) {
-                        check(TerminalSessionSlots.usedThreads <= TerminalSessionSlots.MAX_THREADS) {
-                            "reserve overshot the cap"
+                        check(TerminalSessionSlots.usedThreads <= TerminalSessionSlots.maxThreads) {
+                            "reserve overshot the budget"
                         }
                         TerminalSessionSlots.release()
                     }
@@ -86,5 +94,42 @@ class TerminalSessionSlotsTest {
         workers.forEach { it.start() }
         workers.forEach { it.join() }
         assertEquals(0, TerminalSessionSlots.usedThreads)
+    }
+
+    @Test
+    fun `configured budget clamps to the supported range`() {
+        TerminalSessionSlots.applyConfiguredBudget(1)
+        assertEquals(TerminalSessionSlots.MIN_THREADS, TerminalSessionSlots.maxThreads)
+
+        TerminalSessionSlots.applyConfiguredBudget(Int.MAX_VALUE)
+        assertEquals(TerminalSessionSlots.HARD_MAX_THREADS, TerminalSessionSlots.maxThreads)
+
+        TerminalSessionSlots.applyConfiguredBudget(100)
+        assertEquals(100, TerminalSessionSlots.maxThreads)
+    }
+
+    @Test
+    fun `zero means the machine-scaled automatic default`() {
+        TerminalSessionSlots.applyConfiguredBudget(0)
+        assertEquals(TerminalSessionSlots.defaultMaxThreads(), TerminalSessionSlots.maxThreads)
+        // The formula: 16 per core, clamped to [128, HARD_MAX_THREADS].
+        assertEquals(
+            (Runtime.getRuntime().availableProcessors() * 16)
+                .coerceIn(128, TerminalSessionSlots.HARD_MAX_THREADS),
+            TerminalSessionSlots.defaultMaxThreads()
+        )
+    }
+
+    @Test
+    fun `lowering the budget below current usage refuses new sessions until enough close`() {
+        repeat(20) { assertTrue(TerminalSessionSlots.tryReserve(1)) }
+        TerminalSessionSlots.applyConfiguredBudget(TerminalSessionSlots.MIN_THREADS) // 32
+
+        assertTrue(TerminalSessionSlots.tryReserve(TerminalSessionSlots.THREADS_PER_SESSION)) // 23
+        repeat(9) { assertTrue(TerminalSessionSlots.tryReserve(1)) } // 32 — at the new budget
+        assertFalse(TerminalSessionSlots.tryReserve(1))
+
+        TerminalSessionSlots.release(1) // 31
+        assertTrue(TerminalSessionSlots.tryReserve(1), "capacity returns as sessions close")
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/TerminalSessionSlotsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/TerminalSessionSlotsTest.kt
@@ -1,0 +1,90 @@
+package ai.rever.bossterm.compose
+
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * TerminalSessionSlots is the safety mechanism that turns dispatcher exhaustion
+ * into a visible refusal instead of a silent hang, so its CAS reserve/release
+ * invariants are pinned here: reserve up to the cap, refuse beyond it, release
+ * restores capacity, mis-paired release clamps instead of corrupting the budget,
+ * and the accounting stays balanced under concurrency.
+ */
+class TerminalSessionSlotsTest {
+
+    @AfterTest
+    fun drainReservations() {
+        // Tests pair reserve/release themselves, but drain defensively so one
+        // failing assertion can't poison the singleton for later tests. Relies
+        // on release() clamping at zero.
+        TerminalSessionSlots.release(TerminalSessionSlots.MAX_THREADS)
+    }
+
+    @Test
+    fun `reserves up to the cap and refuses beyond it`() {
+        val fullSessions = TerminalSessionSlots.MAX_THREADS / TerminalSessionSlots.THREADS_PER_SESSION
+        repeat(fullSessions) { assertTrue(TerminalSessionSlots.tryReserve()) }
+        assertEquals(
+            fullSessions * TerminalSessionSlots.THREADS_PER_SESSION,
+            TerminalSessionSlots.usedThreads
+        )
+
+        // 256 % 3 == 1: a full session no longer fits, a single mirror loop does.
+        assertFalse(TerminalSessionSlots.tryReserve(), "a full session must be refused at the cap")
+        assertTrue(TerminalSessionSlots.tryReserve(1), "a mirror loop still fits in the remainder")
+        assertFalse(TerminalSessionSlots.tryReserve(1), "nothing fits once the budget is exactly consumed")
+        assertEquals(TerminalSessionSlots.MAX_THREADS, TerminalSessionSlots.usedThreads)
+    }
+
+    @Test
+    fun `failed reserve reserves nothing`() {
+        repeat(TerminalSessionSlots.MAX_THREADS - 1) { assertTrue(TerminalSessionSlots.tryReserve(1)) }
+        assertFalse(TerminalSessionSlots.tryReserve(TerminalSessionSlots.THREADS_PER_SESSION))
+        // The refused reserve must not have consumed the remaining permit.
+        assertEquals(TerminalSessionSlots.MAX_THREADS - 1, TerminalSessionSlots.usedThreads)
+        assertTrue(TerminalSessionSlots.tryReserve(1))
+    }
+
+    @Test
+    fun `release restores capacity`() {
+        repeat(TerminalSessionSlots.MAX_THREADS) { assertTrue(TerminalSessionSlots.tryReserve(1)) }
+        assertFalse(TerminalSessionSlots.tryReserve(1))
+
+        TerminalSessionSlots.release()
+        assertTrue(TerminalSessionSlots.tryReserve(), "releasing a session must readmit a session")
+        assertFalse(TerminalSessionSlots.tryReserve(1))
+    }
+
+    @Test
+    fun `unpaired release clamps at zero instead of corrupting the budget`() {
+        TerminalSessionSlots.release(5)
+        assertEquals(0, TerminalSessionSlots.usedThreads)
+
+        // The budget must still admit exactly MAX_THREADS afterwards — a negative
+        // counter would admit more sessions than the dispatcher can run.
+        repeat(TerminalSessionSlots.MAX_THREADS) { assertTrue(TerminalSessionSlots.tryReserve(1)) }
+        assertFalse(TerminalSessionSlots.tryReserve(1))
+    }
+
+    @Test
+    fun `concurrent reserve and release stay balanced`() {
+        val workers = (1..8).map {
+            Thread {
+                repeat(5_000) {
+                    if (TerminalSessionSlots.tryReserve()) {
+                        check(TerminalSessionSlots.usedThreads <= TerminalSessionSlots.MAX_THREADS) {
+                            "reserve overshot the cap"
+                        }
+                        TerminalSessionSlots.release()
+                    }
+                }
+            }
+        }
+        workers.forEach { it.start() }
+        workers.forEach { it.join() }
+        assertEquals(0, TerminalSessionSlots.usedThreads)
+    }
+}


### PR DESCRIPTION
## Problem

Every terminal session permanently parks ~3 threads: the PTY reader (blocking JNA `Pty.poll`), the emulator-processing loop (blocking `dataStream.char`), and the process exit wait. These ran on the shared `Dispatchers.Default` (nCPU permits) and `Dispatchers.IO` (64 permits) pools.

Observed live in the BOSS host app with ~20 sessions open (14 tabs + splits): all 16 Default permits were held by emulator loops and the IO pool sat at its 64-thread cap (80 workers = 16 + 64, both pools maxed). Result: existing terminals froze, new tabs opened but never spawned a shell (the spawn coroutine queued forever on the starved dispatcher), and Supabase Realtime logged heartbeat timeouts — while the UI, MCP server, and browser tabs stayed responsive. No deadlock; pure starvation, and a cliff rather than gradual degradation.

## Fix

**`88284b8` — isolate session loops.** New `TerminalSessionDispatcher = Dispatchers.IO.limitedParallelism(256, "bossterm-session")`, a view with its own permit budget (its threads don't count against the global 64 or the Default pool). All long-lived session loops move onto it:

- `TabController`: emulator loops (previously on `Dispatchers.Default` — the binding constraint), PTY reader, remote-mirror drain loops, and the session coroutines that end in `waitFor()`
- `EmbeddableTerminal`: emulator, reader, exit monitor
- `TerminalSessionCore` (daemon): emulator, reader
- `PtyProcessHandle.waitFor`: its internal `withContext(Dispatchers.IO)` re-dispatched the blocking wait onto a global IO permit regardless of caller — this had silently defeated `TerminalSessionCore`'s dedicated exit-monitor thread, whose whole point was to avoid pinning the IO pool

256 permits ≈ 85 concurrent sessions; threads are created lazily so idle cost is zero.

**`b3a5746` — fail visibly at the new limit.** `TerminalSessionSlots` adds advisory reserve/release accounting (3 threads per full session, 1 per mirror loop). When the budget can't fit a new session it is refused outright instead of queueing — the pane shows a clear `ConnectionState.Error` and `TabbedTerminal` raises an alert dialog telling the user to close some terminal tabs or splits to free threads. Covered paths: tabs/splits, pre-connect tabs, mirrors, `EmbeddableTerminal`, and the daemon core (release exactly once in `close()`).

**`b8644ed` — log hygiene.** Closing a tab cancels its scope; the generic `catch` logged the resulting `JobCancellationException` as `ERROR: Terminal initialization failed` with a stack trace. Rethrow `CancellationException` so routine closes stay quiet.

## Verification

- `:compose-ui:compileKotlinDesktop` + full `desktopTest` green (421 tests, 0 failures)
- Dev app run: thread dump confirms the emulator loop now executes via a `LimitedDispatcher$Worker` frame (impossible on raw `Dispatchers.Default`), i.e. on the session view; tabs/splits open and close cleanly with slot accounting balanced

## Follow-ups (intentionally out of scope)

- Convert `BlockingTerminalDataStream` to a suspending `Channel` so the parse loop suspends instead of pinning a thread
- Replace the parked `waitFor` thread with an exit callback from pty4j's reaper (which already exists per process)
