### PR TITLE
Fix cursor rendering and inline image flicker

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -168,6 +168,8 @@ class BossTerminal(
     }
 
     override fun disconnected() {
+        terminalTextBuffer.abortBatches()
+        myDisplay.setSynchronizedUpdate(false)
         myDisplay.setCursorVisible(false)
     }
 

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
@@ -293,6 +293,9 @@ class TerminalTextBuffer internal constructor(
    * Batches can be nested - only the outermost endBatch() fires the event.
    *
    * Use this to coalesce notifications for related operations (e.g., clear line + write text).
+   * The outermost begin, every nested begin, and the matching [endBatch] calls are
+   * thread-confined: they must all run on the same thread. Concurrent batches are
+   * unsupported and fail fast; snapshot reads remain independently thread-safe.
    */
   fun beginBatch() {
     synchronized(batchStateLock) {
@@ -307,10 +310,11 @@ class TerminalTextBuffer internal constructor(
 
   /**
    * End a batch of operations. If this is the outermost batch and changes occurred,
-   * fires a single modelChanged event.
+   * fires a single modelChanged event. Must run on the thread that owns the batch;
+   * an unmatched or cross-thread call fails fast.
    */
   fun endBatch() {
-    synchronized(batchStateLock) {
+    val shouldNotify = synchronized(batchStateLock) {
       check(batchDepth > 0) { "endBatch() called without a matching beginBatch()" }
       check(batchOwner === Thread.currentThread()) {
         "endBatch() must run on the thread that called beginBatch()"
@@ -320,10 +324,15 @@ class TerminalTextBuffer internal constructor(
         batchOwner = null
         if (batchHasChanges) {
           batchHasChanges = false
-          notifyModelChanged()
+          true
+        } else {
+          false
         }
+      } else {
+        false
       }
     }
+    if (shouldNotify) notifyModelChanged()
   }
 
   /**
@@ -337,18 +346,19 @@ class TerminalTextBuffer internal constructor(
    * batch is active is a no-op, which also makes it safe on normal disconnects.
    */
   internal fun abortBatches() {
-    synchronized(batchStateLock) {
-      if (batchDepth == 0) return
+    val shouldNotify = synchronized(batchStateLock) {
+      if (batchDepth == 0) return@synchronized false
       check(batchOwner === Thread.currentThread()) {
         "abortBatches() must run on the thread that called beginBatch()"
       }
 
-      val shouldNotify = batchHasChanges
+      val hadChanges = batchHasChanges
       batchDepth = 0
       batchHasChanges = false
       batchOwner = null
-      if (shouldNotify) notifyModelChanged()
+      hadChanges
     }
+    if (shouldNotify) notifyModelChanged()
   }
 
   /**
@@ -365,14 +375,16 @@ class TerminalTextBuffer internal constructor(
   }
 
   private fun fireModelChangeEvent() {
-    synchronized(batchStateLock) {
+    val shouldNotify = synchronized(batchStateLock) {
       if (batchDepth > 0) {
         // Inside a batch - just mark that changes occurred
         batchHasChanges = true
+        false
       } else {
-        notifyModelChanged()
+        true
       }
     }
+    if (shouldNotify) notifyModelChanged()
   }
 
   private fun notifyModelChanged() {

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
@@ -100,6 +100,8 @@ class TerminalTextBuffer internal constructor(
 
   // ===== BATCH CHANGE TRACKING =====
   // Suppresses intermediate modelChanged events during rapid sequences like clear+write.
+  // This coalesces redraw requests; it does not make independent snapshot reads atomic.
+  // Applications that require atomic presentation must use DEC synchronized updates (?2026).
   private val batchStateLock = Any()
   private var batchDepth: Int = 0
   private var batchHasChanges: Boolean = false
@@ -342,21 +344,29 @@ class TerminalTextBuffer internal constructor(
    * callback, the emulator's teardown path must clear the batch so future model
    * notifications are not suppressed forever.
    *
-   * This must run on the emulator thread that began the batch. Calling it when no
-   * batch is active is a no-op, which also makes it safe on normal disconnects.
+   * Production drains invoke this on the emulator thread that began the batch.
+   * As a last-resort recovery path it also resets a mismatched owner after logging,
+   * rather than throwing and preventing the terminal from clearing synchronized
+   * update mode. Calling it when no batch is active remains a no-op.
    */
   internal fun abortBatches() {
+    var mismatchedOwner: Thread? = null
     val shouldNotify = synchronized(batchStateLock) {
       if (batchDepth == 0) return@synchronized false
-      check(batchOwner === Thread.currentThread()) {
-        "abortBatches() must run on the thread that called beginBatch()"
-      }
+      if (batchOwner !== Thread.currentThread()) mismatchedOwner = batchOwner
 
       val hadChanges = batchHasChanges
       batchDepth = 0
       batchHasChanges = false
       batchOwner = null
       hadChanges
+    }
+    mismatchedOwner?.let { owner ->
+      LOG.warn(
+        "abortBatches() recovered a batch owned by thread '{}' from teardown thread '{}'",
+        owner.name,
+        Thread.currentThread().name
+      )
     }
     if (shouldNotify) notifyModelChanged()
   }

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
@@ -14,7 +14,6 @@ import ai.rever.bossterm.terminal.util.CharUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.math.max
 import kotlin.math.min
@@ -71,7 +70,7 @@ class TerminalTextBuffer internal constructor(
   val screenLinesCount: Int
     get() = screenLinesStorage.size
 
-  private val myLock: Lock = ReentrantLock()
+  private val myLock = ReentrantLock()
 
   /**
    * Incremental snapshot builder for optimized copy-on-write snapshots.
@@ -99,7 +98,7 @@ class TerminalTextBuffer internal constructor(
   }
 
   // ===== BATCH CHANGE TRACKING =====
-  // Suppresses intermediate modelChanged events during rapid sequences like clear+write
+  // Keeps rapid sequences like clear+write invisible until the complete update is ready.
   @Volatile
   private var batchDepth: Int = 0
   @Volatile
@@ -290,11 +289,14 @@ class TerminalTextBuffer internal constructor(
 
   /**
    * Begin a batch of operations. Model change events are suppressed until endBatch() is called.
+   * Snapshots are also excluded for the lifetime of the batch, so an immediate redraw cannot
+   * observe a partially applied PTY chunk (notably a half-rewritten Kitty image placeholder).
    * Batches can be nested - only the outermost endBatch() fires the event.
    *
    * Use this to group related operations (e.g., clear line + write text) into an atomic update.
    */
   fun beginBatch() {
+    myLock.lock()
     batchDepth++
   }
 
@@ -303,7 +305,9 @@ class TerminalTextBuffer internal constructor(
    * fires a single modelChanged event.
    */
   fun endBatch() {
-    if (batchDepth > 0) {
+    check(myLock.isHeldByCurrentThread) { "endBatch() must run on the thread that called beginBatch()" }
+    try {
+      check(batchDepth > 0) { "endBatch() called without a matching beginBatch()" }
       batchDepth--
       if (batchDepth == 0 && batchHasChanges) {
         batchHasChanges = false
@@ -311,6 +315,8 @@ class TerminalTextBuffer internal constructor(
           modelListener.modelChanged()
         }
       }
+    } finally {
+      myLock.unlock()
     }
   }
 

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
@@ -14,6 +14,7 @@ import ai.rever.bossterm.terminal.util.CharUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.math.max
 import kotlin.math.min
@@ -70,7 +71,7 @@ class TerminalTextBuffer internal constructor(
   val screenLinesCount: Int
     get() = screenLinesStorage.size
 
-  private val myLock = ReentrantLock()
+  private val myLock: Lock = ReentrantLock()
 
   /**
    * Incremental snapshot builder for optimized copy-on-write snapshots.
@@ -98,11 +99,11 @@ class TerminalTextBuffer internal constructor(
   }
 
   // ===== BATCH CHANGE TRACKING =====
-  // Keeps rapid sequences like clear+write invisible until the complete update is ready.
-  @Volatile
+  // Suppresses intermediate modelChanged events during rapid sequences like clear+write.
+  private val batchStateLock = Any()
   private var batchDepth: Int = 0
-  @Volatile
   private var batchHasChanges: Boolean = false
+  private var batchOwner: Thread? = null
 
   @JvmOverloads
   constructor(width: Int, height: Int, styleState: StyleState, maxHistoryLinesCount: Int = LinesStorage.DEFAULT_MAX_LINES_COUNT) : this(
@@ -289,15 +290,19 @@ class TerminalTextBuffer internal constructor(
 
   /**
    * Begin a batch of operations. Model change events are suppressed until endBatch() is called.
-   * Snapshots are also excluded for the lifetime of the batch, so an immediate redraw cannot
-   * observe a partially applied PTY chunk (notably a half-rewritten Kitty image placeholder).
    * Batches can be nested - only the outermost endBatch() fires the event.
    *
-   * Use this to group related operations (e.g., clear line + write text) into an atomic update.
+   * Use this to coalesce notifications for related operations (e.g., clear line + write text).
    */
   fun beginBatch() {
-    myLock.lock()
-    batchDepth++
+    synchronized(batchStateLock) {
+      val currentThread = Thread.currentThread()
+      check(batchDepth == 0 || batchOwner === currentThread) {
+        "Nested beginBatch() must run on the thread that owns the active batch"
+      }
+      if (batchDepth == 0) batchOwner = currentThread
+      batchDepth++
+    }
   }
 
   /**
@@ -305,23 +310,49 @@ class TerminalTextBuffer internal constructor(
    * fires a single modelChanged event.
    */
   fun endBatch() {
-    check(myLock.isHeldByCurrentThread) { "endBatch() must run on the thread that called beginBatch()" }
-    try {
+    synchronized(batchStateLock) {
       check(batchDepth > 0) { "endBatch() called without a matching beginBatch()" }
+      check(batchOwner === Thread.currentThread()) {
+        "endBatch() must run on the thread that called beginBatch()"
+      }
       batchDepth--
-      if (batchDepth == 0 && batchHasChanges) {
-        batchHasChanges = false
-        for (modelListener in listeners) {
-          modelListener.modelChanged()
+      if (batchDepth == 0) {
+        batchOwner = null
+        if (batchHasChanges) {
+          batchHasChanges = false
+          notifyModelChanged()
         }
       }
-    } finally {
-      myLock.unlock()
     }
   }
 
   /**
-   * Execute a block of operations as an atomic batch.
+   * Finish every outstanding batch after the emulator exits unexpectedly.
+   *
+   * If interpretation throws before the data stream can invoke its chunk-end
+   * callback, the emulator's teardown path must clear the batch so future model
+   * notifications are not suppressed forever.
+   *
+   * This must run on the emulator thread that began the batch. Calling it when no
+   * batch is active is a no-op, which also makes it safe on normal disconnects.
+   */
+  internal fun abortBatches() {
+    synchronized(batchStateLock) {
+      if (batchDepth == 0) return
+      check(batchOwner === Thread.currentThread()) {
+        "abortBatches() must run on the thread that called beginBatch()"
+      }
+
+      val shouldNotify = batchHasChanges
+      batchDepth = 0
+      batchHasChanges = false
+      batchOwner = null
+      if (shouldNotify) notifyModelChanged()
+    }
+  }
+
+  /**
+   * Execute a block while coalescing its model change notifications.
    * Suppresses intermediate model change events, firing only once at the end.
    */
   inline fun <T> batch(block: () -> T): T {
@@ -334,14 +365,19 @@ class TerminalTextBuffer internal constructor(
   }
 
   private fun fireModelChangeEvent() {
-    if (batchDepth > 0) {
-      // Inside a batch - just mark that changes occurred
-      batchHasChanges = true
-    } else {
-      // Not batched - fire immediately
-      for (modelListener in listeners) {
-        modelListener.modelChanged()
+    synchronized(batchStateLock) {
+      if (batchDepth > 0) {
+        // Inside a batch - just mark that changes occurred
+        batchHasChanges = true
+      } else {
+        notifyModelChanged()
       }
+    }
+  }
+
+  private fun notifyModelChanged() {
+    for (modelListener in listeners) {
+      modelListener.modelChanged()
     }
   }
 

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/image/ImageDataCache.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/image/ImageDataCache.kt
@@ -66,6 +66,14 @@ class ImageDataCache(
     fun hasImage(imageId: Long): Boolean = images.containsKey(imageId)
 
     /**
+     * Capture the image objects backing one render frame. The returned map owns
+     * its entries, so a Kitty hard-delete can remove an image from this cache
+     * without making an already captured frame temporarily lose its bitmap.
+     */
+    @Synchronized
+    fun snapshotImages(): Map<Long, TerminalImage> = images.toMap()
+
+    /**
      * Remove image from cache.
      * Called when image cells are cleared from buffer (text overwrite, scroll out).
      */

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
@@ -1,0 +1,76 @@
+package ai.rever.bossterm.terminal.model
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TerminalTextBufferBatchTest {
+
+    @Test
+    fun snapshotWaitsUntilImagePlaceholderBatchIsComplete() {
+        val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = StyleState())
+        buffer.getLine(0) // Materialize the lazily allocated first screen row.
+        val firstCellWritten = CountDownLatch(1)
+        val finishBatch = CountDownLatch(1)
+        val snapshotStarted = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            val writer = executor.submit {
+                buffer.beginBatch()
+                try {
+                    buffer.writeImagePlaceholderCell(
+                        row = 0,
+                        col = 0,
+                        imageId = 42,
+                        cellX = 0,
+                        cellY = 0,
+                        cellWidth = 2,
+                        cellHeight = 1
+                    )
+                    firstCellWritten.countDown()
+                    assertTrue(finishBatch.await(2, TimeUnit.SECONDS))
+                    buffer.writeImagePlaceholderCell(
+                        row = 0,
+                        col = 1,
+                        imageId = 42,
+                        cellX = 1,
+                        cellY = 0,
+                        cellWidth = 2,
+                        cellHeight = 1
+                    )
+                } finally {
+                    buffer.endBatch()
+                }
+            }
+
+            assertTrue(firstCellWritten.await(2, TimeUnit.SECONDS))
+            val snapshot = executor.submit<BufferSnapshot> {
+                snapshotStarted.countDown()
+                buffer.createSnapshot()
+            }
+            assertTrue(snapshotStarted.await(2, TimeUnit.SECONDS))
+
+            // A redraw requested between the two writes must wait instead of exposing
+            // the first cell by itself for one frame.
+            assertFailsWith<TimeoutException> {
+                snapshot.get(100, TimeUnit.MILLISECONDS)
+            }
+
+            finishBatch.countDown()
+            writer.get(2, TimeUnit.SECONDS)
+            assertEquals(
+                setOf(0, 1),
+                snapshot.get(2, TimeUnit.SECONDS).getLine(0).getAllImageCells().keys
+            )
+        } finally {
+            finishBatch.countDown()
+            executor.shutdownNow()
+        }
+    }
+}

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
@@ -77,7 +77,7 @@ class TerminalTextBufferBatchTest {
                 firstCellWritten.countDown()
                 assertTrue(disconnect.await(2, TimeUnit.SECONDS))
 
-                // Mirrors TerminalStarter's finally path after processChar() throws.
+                // Mirrors the production emulator drain's finally path after processChar() throws.
                 terminal.disconnected()
             }
 

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
@@ -98,6 +98,68 @@ class TerminalTextBufferBatchTest {
         }
     }
 
+    @Test
+    fun disconnectClearsNestedBatchAndPublishesOnce() {
+        val styleState = StyleState()
+        val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = styleState)
+        val terminal = BossTerminal(NoopTerminalDisplay(), buffer, styleState)
+        val modelChanges = AtomicInteger()
+        buffer.addModelListener(object : TerminalModelListener {
+            override fun modelChanged() {
+                modelChanges.incrementAndGet()
+            }
+        })
+
+        buffer.beginBatch()
+        buffer.beginBatch()
+        buffer.writeImagePlaceholderCell(
+            row = 0,
+            col = 0,
+            imageId = 42,
+            cellX = 0,
+            cellY = 0,
+            cellWidth = 1,
+            cellHeight = 1
+        )
+
+        terminal.disconnected()
+
+        assertEquals(1, modelChanges.get())
+        buffer.beginBatch()
+        buffer.endBatch()
+    }
+
+    @Test
+    fun mismatchedTeardownThreadStillClearsBatchAndSynchronizedUpdate() {
+        val styleState = StyleState()
+        val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = styleState)
+        val display = NoopTerminalDisplay()
+        val terminal = BossTerminal(display, buffer, styleState)
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            display.setSynchronizedUpdate(true)
+            buffer.beginBatch()
+            buffer.writeImagePlaceholderCell(
+                row = 0,
+                col = 0,
+                imageId = 42,
+                cellX = 0,
+                cellY = 0,
+                cellWidth = 1,
+                cellHeight = 1
+            )
+
+            executor.submit { terminal.disconnected() }.get(2, TimeUnit.SECONDS)
+
+            assertEquals(false, display.synchronizedUpdateEnabled)
+            buffer.beginBatch()
+            buffer.endBatch()
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
     private class NoopTerminalDisplay : TerminalDisplay {
         var synchronizedUpdateEnabled: Boolean? = null
         override var windowTitle: String? = null

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
@@ -15,6 +15,37 @@ import kotlin.test.assertTrue
 class TerminalTextBufferBatchTest {
 
     @Test
+    fun modelListenerRunsOutsideBatchStateLock() {
+        val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = StyleState())
+        buffer.getLine(0)
+        val executor = Executors.newSingleThreadExecutor()
+        buffer.addModelListener(object : TerminalModelListener {
+            override fun modelChanged() {
+                executor.submit {
+                    buffer.beginBatch()
+                    buffer.endBatch()
+                }.get(2, TimeUnit.SECONDS)
+            }
+        })
+
+        try {
+            buffer.beginBatch()
+            buffer.writeImagePlaceholderCell(
+                row = 0,
+                col = 0,
+                imageId = 42,
+                cellX = 0,
+                cellY = 0,
+                cellWidth = 1,
+                cellHeight = 1
+            )
+            buffer.endBatch()
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun snapshotsStayResponsiveAndDisconnectClearsAbandonedBatch() {
         val styleState = StyleState()
         val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = styleState)

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
@@ -1,76 +1,89 @@
 package ai.rever.bossterm.terminal.model
 
+import ai.rever.bossterm.terminal.CursorShape
+import ai.rever.bossterm.terminal.TerminalDisplay
+import ai.rever.bossterm.terminal.emulator.mouse.MouseFormat
+import ai.rever.bossterm.terminal.emulator.mouse.MouseMode
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class TerminalTextBufferBatchTest {
 
     @Test
-    fun snapshotWaitsUntilImagePlaceholderBatchIsComplete() {
-        val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = StyleState())
+    fun snapshotsStayResponsiveAndDisconnectClearsAbandonedBatch() {
+        val styleState = StyleState()
+        val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = styleState)
+        val display = NoopTerminalDisplay()
+        val terminal = BossTerminal(display, buffer, styleState)
         buffer.getLine(0) // Materialize the lazily allocated first screen row.
+        val modelChanges = AtomicInteger()
+        buffer.addModelListener(object : TerminalModelListener {
+            override fun modelChanged() {
+                modelChanges.incrementAndGet()
+            }
+        })
         val firstCellWritten = CountDownLatch(1)
-        val finishBatch = CountDownLatch(1)
-        val snapshotStarted = CountDownLatch(1)
-        val executor = Executors.newFixedThreadPool(2)
+        val disconnect = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
 
         try {
-            val writer = executor.submit {
+            val emulator = executor.submit {
                 buffer.beginBatch()
-                try {
-                    buffer.writeImagePlaceholderCell(
-                        row = 0,
-                        col = 0,
-                        imageId = 42,
-                        cellX = 0,
-                        cellY = 0,
-                        cellWidth = 2,
-                        cellHeight = 1
-                    )
-                    firstCellWritten.countDown()
-                    assertTrue(finishBatch.await(2, TimeUnit.SECONDS))
-                    buffer.writeImagePlaceholderCell(
-                        row = 0,
-                        col = 1,
-                        imageId = 42,
-                        cellX = 1,
-                        cellY = 0,
-                        cellWidth = 2,
-                        cellHeight = 1
-                    )
-                } finally {
-                    buffer.endBatch()
-                }
+                buffer.writeImagePlaceholderCell(
+                    row = 0,
+                    col = 0,
+                    imageId = 42,
+                    cellX = 0,
+                    cellY = 0,
+                    cellWidth = 1,
+                    cellHeight = 1
+                )
+                firstCellWritten.countDown()
+                assertTrue(disconnect.await(2, TimeUnit.SECONDS))
+
+                // Mirrors TerminalStarter's finally path after processChar() throws.
+                terminal.disconnected()
             }
 
             assertTrue(firstCellWritten.await(2, TimeUnit.SECONDS))
-            val snapshot = executor.submit<BufferSnapshot> {
-                snapshotStarted.countDown()
-                buffer.createSnapshot()
-            }
-            assertTrue(snapshotStarted.await(2, TimeUnit.SECONDS))
+            val snapshotDuringBatch = buffer.createSnapshot()
+            assertEquals(setOf(0), snapshotDuringBatch.getLine(0).getAllImageCells().keys)
+            assertEquals(0, modelChanges.get(), "batch changes stay suppressed until teardown")
 
-            // A redraw requested between the two writes must wait instead of exposing
-            // the first cell by itself for one frame.
-            assertFailsWith<TimeoutException> {
-                snapshot.get(100, TimeUnit.MILLISECONDS)
-            }
+            disconnect.countDown()
+            emulator.get(2, TimeUnit.SECONDS)
 
-            finishBatch.countDown()
-            writer.get(2, TimeUnit.SECONDS)
-            assertEquals(
-                setOf(0, 1),
-                snapshot.get(2, TimeUnit.SECONDS).getLine(0).getAllImageCells().keys
-            )
+            assertEquals(1, modelChanges.get(), "disconnect publishes the partial final state once")
+            assertEquals(false, display.synchronizedUpdateEnabled)
+            assertEquals(setOf(0), buffer.createSnapshot().getLine(0).getAllImageCells().keys)
         } finally {
-            finishBatch.countDown()
+            disconnect.countDown()
             executor.shutdownNow()
+        }
+    }
+
+    private class NoopTerminalDisplay : TerminalDisplay {
+        var synchronizedUpdateEnabled: Boolean? = null
+        override var windowTitle: String? = null
+        override var iconTitle: String? = null
+        override val selection: TerminalSelection? = null
+
+        override fun setCursor(x: Int, y: Int) = Unit
+        override fun setCursorShape(cursorShape: CursorShape?) = Unit
+        override fun beep() = Unit
+        override fun scrollArea(scrollRegionTop: Int, scrollRegionSize: Int, dy: Int) = Unit
+        override fun setCursorVisible(isCursorVisible: Boolean) = Unit
+        override fun useAlternateScreenBuffer(useAlternateScreenBuffer: Boolean) = Unit
+        override fun terminalMouseModeSet(mouseMode: MouseMode) = Unit
+        override fun setMouseFormat(mouseFormat: MouseFormat) = Unit
+        override fun ambiguousCharsAreDoubleWidth(): Boolean = false
+        override fun setSynchronizedUpdate(enabled: Boolean) {
+            synchronizedUpdateEnabled = enabled
         }
     }
 }

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/image/ImageDataCacheTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/image/ImageDataCacheTest.kt
@@ -47,4 +47,17 @@ class ImageDataCacheTest {
         assertEquals(listOf(1L), removed)
         assertEquals(1, cache.imageCount)
     }
+
+    @Test
+    fun frameSnapshotRetainsImageAfterLiveCacheDeletion() {
+        val cache = ImageDataCache()
+        val image = TerminalImage(id = 42, data = ByteArray(4))
+        cache.storeImage(image)
+
+        val frameImages = cache.snapshotImages()
+        cache.removeImage(image.id)
+
+        assertEquals(image, frameImages[image.id])
+        assertEquals(null, cache.getImage(image.id))
+    }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
@@ -90,6 +90,7 @@ class ComposeTerminalDisplay : TerminalDisplay {
     private val syncUpdateLock = Any()
     @Volatile private var _synchronizedUpdateEnabled = false
     @Volatile private var _pendingRedrawDuringSync = false
+    private var synchronizedUpdateGeneration = 0L
     private val _windowTitle = MutableStateFlow("")
     private val _iconTitle = MutableStateFlow("")
     private val _mouseMode = mutableStateOf(MouseMode.MOUSE_REPORTING_NONE)
@@ -427,6 +428,29 @@ class ComposeTerminalDisplay : TerminalDisplay {
     }
 
     /**
+     * Capture render data only when it did not overlap a synchronized update.
+     *
+     * Checking only at redraw-request time is insufficient: Compose may execute
+     * the corresponding recomposition after a later ?2026h has started. The
+     * generation check also catches a complete h/l pair that occurs while
+     * [capture] is running. The display lock is deliberately not held during
+     * [capture], because buffer mutations can request redraws while holding the
+     * terminal buffer lock and the opposite lock order would deadlock.
+     */
+    fun <T> captureStableRenderFrame(capture: () -> T): T? {
+        val generation = synchronized(syncUpdateLock) {
+            if (_synchronizedUpdateEnabled) null else synchronizedUpdateGeneration
+        } ?: return null
+
+        val result = capture()
+        return synchronized(syncUpdateLock) {
+            result.takeIf {
+                !_synchronizedUpdateEnabled && synchronizedUpdateGeneration == generation
+            }
+        }
+    }
+
+    /**
      * Set synchronized update mode (DEC Private Mode 2026).
      * When enabled, redraws are suppressed until mode is disabled.
      * When disabled, if any redraws were pending, one redraw is triggered.
@@ -445,13 +469,19 @@ class ComposeTerminalDisplay : TerminalDisplay {
         val shouldRedraw: Boolean
         synchronized(syncUpdateLock) {
             if (enabled) {
-                _synchronizedUpdateEnabled = true
-                _pendingRedrawDuringSync = false
+                if (!_synchronizedUpdateEnabled) {
+                    _synchronizedUpdateEnabled = true
+                    _pendingRedrawDuringSync = false
+                    synchronizedUpdateGeneration++
+                }
                 shouldRedraw = false
             } else {
-                shouldRedraw = _pendingRedrawDuringSync
-                _synchronizedUpdateEnabled = false
-                _pendingRedrawDuringSync = false
+                shouldRedraw = _synchronizedUpdateEnabled && _pendingRedrawDuringSync
+                if (_synchronizedUpdateEnabled) {
+                    _synchronizedUpdateEnabled = false
+                    _pendingRedrawDuringSync = false
+                    synchronizedUpdateGeneration++
+                }
             }
         }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -50,6 +50,7 @@ import ai.rever.bossterm.compose.shell.ShellCustomizationMenuProvider
 import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import ai.rever.bossterm.compose.terminal.BlockingTerminalDataStream
 import ai.rever.bossterm.compose.terminal.PerformanceMode
+import ai.rever.bossterm.compose.terminal.drainTerminalEmulator
 import ai.rever.bossterm.compose.ui.ProperTerminal
 import ai.rever.bossterm.compose.util.loadTerminalFont
 import ai.rever.bossterm.compose.features.ContextMenuController
@@ -1021,22 +1022,15 @@ private suspend fun initializeProcess(
         // Start emulator coroutine. Blocks in dataStream.char between chunks, so it
         // must not hold one of Dispatchers.Default's nCPU permits.
         val emulatorJob = session.coroutineScope.launch(TerminalSessionDispatcher) {
-            try {
-                while (processHandle.isAlive()) {
-                    try {
-                        session.emulator.processChar(session.dataStream.char, session.terminal)
-                    } catch (e: java.io.EOFException) {
-                        break
-                    } catch (e: Exception) {
-                        if (e !is ai.rever.bossterm.terminal.TerminalDataStream.EOF) {
-                            println("WARNING: Error processing terminal output: ${e.message}")
-                        }
-                        break
-                    }
-                }
-            } finally {
-                session.dataStream.close()
-            }
+            drainTerminalEmulator(
+                emulator = session.emulator,
+                dataStream = session.dataStream,
+                terminal = session.terminal,
+                shouldContinue = processHandle::isAlive,
+                onProcessingError = { e ->
+                    println("WARNING: Error processing terminal output: ${e.message}")
+                },
+            )
         }
 
         // Start output reader coroutine — blocks in processHandle.read() for the

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/TerminalSessionCore.kt
@@ -10,6 +10,7 @@ import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import ai.rever.bossterm.compose.tabs.ShellIntegrationInjector
 import ai.rever.bossterm.compose.terminal.BlockingTerminalDataStream
 import ai.rever.bossterm.compose.terminal.PerformanceMode
+import ai.rever.bossterm.compose.terminal.drainTerminalEmulator
 import ai.rever.bossterm.core.util.TermSize
 import ai.rever.bossterm.terminal.RequestOrigin
 import ai.rever.bossterm.terminal.TerminalCustomCommandListener
@@ -33,7 +34,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
-import java.io.EOFException
 import java.net.URI
 import java.util.UUID
 
@@ -216,22 +216,15 @@ class TerminalSessionCore(
                 // Blocks in dataStream.char between chunks, so it must not hold one of
                 // Dispatchers.Default's nCPU permits.
                 launch(TerminalSessionDispatcher) {
-                    try {
-                        while (h.isAlive()) {
-                            try {
-                                emulator.processChar(dataStream.char, terminal)
-                            } catch (_: EOFException) {
-                                break
-                            } catch (e: Exception) {
-                                if (e !is ai.rever.bossterm.terminal.TerminalDataStream.EOF) {
-                                    log.warn("emulator processing error: {}", e.message)
-                                }
-                                break
-                            }
-                        }
-                    } finally {
-                        dataStream.close()
-                    }
+                    drainTerminalEmulator(
+                        emulator = emulator,
+                        dataStream = dataStream,
+                        terminal = terminal,
+                        shouldContinue = h::isAlive,
+                        onProcessingError = { e ->
+                            log.warn("emulator processing error: {}", e.message)
+                        },
+                    )
                 }
 
                 // PTY reader loop — grapheme-safe chunking, matches TabController.startPtyReaderCoroutine.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -1383,17 +1383,21 @@ object TerminalCanvasRenderer {
         // xterm uses a one-CSS-pixel underline/bar (scaled by DPR), not a
         // percentage of the cell. Compose dp has the same logical-pixel behavior.
         val edgeThickness = 1.dp.toPx().coerceAtMost(minOf(w, h))
-        val layerBounds = Rect(
-            left = x.coerceAtLeast(0f),
-            top = y.coerceAtLeast(0f),
-            right = right.coerceAtMost(size.width),
-            bottom = bottom.coerceAtMost(size.height),
-        )
 
         // Isolate DstOut to this small cursor layer. The image alpha below then
         // removes the cursor only where an inline image has pixels: opaque Codex
         // Pet pixels stay pristine, while transparent parts still reveal the caret.
-        drawContext.canvas.saveLayer(layerBounds, Paint())
+        // The common no-image path draws directly and avoids an offscreen layer.
+        val needsOcclusionLayer = imageOcclusion != null
+        if (needsOcclusionLayer) {
+            val layerBounds = Rect(
+                left = x.coerceAtLeast(0f),
+                top = y.coerceAtLeast(0f),
+                right = right.coerceAtMost(size.width),
+                bottom = bottom.coerceAtMost(size.height),
+            )
+            drawContext.canvas.saveLayer(layerBounds, Paint())
+        }
         try {
             when (cursorShape) {
                 CursorShape.BLINK_BLOCK, CursorShape.STEADY_BLOCK, null -> {
@@ -1430,7 +1434,9 @@ object TerminalCanvasRenderer {
                 )
             }
         } finally {
-            drawContext.canvas.restore()
+            if (needsOcclusionLayer) {
+                drawContext.canvas.restore()
+            }
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -1,9 +1,13 @@
 package ai.rever.bossterm.compose.rendering
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.text.TextMeasurer
@@ -23,13 +27,14 @@ import ai.rever.bossterm.terminal.CursorShape
 import ai.rever.bossterm.terminal.model.TerminalLine
 import ai.rever.bossterm.terminal.model.pool.VersionedBufferSnapshot
 import ai.rever.bossterm.terminal.model.image.ImageCell
-import ai.rever.bossterm.terminal.model.image.ImageDataCache
+import ai.rever.bossterm.terminal.model.image.TerminalImage
 import ai.rever.bossterm.terminal.util.CharUtils
 import ai.rever.bossterm.terminal.util.ColumnConversionUtils
 import ai.rever.bossterm.terminal.util.GraphemeUtils
 import ai.rever.bossterm.terminal.util.UnicodeConstants
 import ai.rever.bossterm.terminal.TextStyle as BossTextStyle
 import org.jetbrains.skia.FontMgr
+import kotlin.math.floor
 
 /**
  * Holds all the state needed for terminal rendering.
@@ -93,7 +98,7 @@ data class RenderingContext(
     val blinkProbe: BooleanArray? = null,
 
     // Cell-based image rendering (images flow with text)
-    val imageDataCache: ImageDataCache? = null,
+    val imageDataById: Map<Long, TerminalImage> = emptyMap(),
     val terminalWidthCells: Int = 80,
     val terminalHeightCells: Int = 24,
 
@@ -307,6 +312,22 @@ data class CachedMeasurement(
 internal data class ImageCellGrid(val columns: Int, val rows: Int)
 
 /**
+ * The source and destination rectangle for one terminal image cell.
+ *
+ * Keeping this calculation shared between the text pass and cursor pass is
+ * important: the cursor uses the image cell's alpha as an occlusion mask, so
+ * even a resized/re-fitted image must line up with the pixels already drawn by
+ * the text canvas.
+ */
+data class ImageCellSlice(
+    val bitmap: ImageBitmap,
+    val srcOffset: androidx.compose.ui.unit.IntOffset,
+    val srcSize: androidx.compose.ui.unit.IntSize,
+    val dstOffset: androidx.compose.ui.unit.IntOffset,
+    val dstSize: androidx.compose.ui.unit.IntSize,
+)
+
+/**
  * Re-fit an image's baked cell footprint to the columns reachable in the live
  * pane while preserving its cell-grid aspect ratio.
  */
@@ -326,6 +347,52 @@ internal fun refitImageCellGrid(
 
     val fittedRows = ((safeRows * availableColumns + safeColumns / 2) / safeColumns).coerceAtLeast(1)
     return ImageCellGrid(availableColumns, fittedRows)
+}
+
+internal fun imageCellSlice(
+    imageCell: ImageCell,
+    bitmap: ImageBitmap,
+    visualColumn: Int,
+    screenRow: Int,
+    visibleColumns: Int,
+    cellWidth: Float,
+    cellHeight: Float,
+): ImageCellSlice? {
+    val anchorColumn = visualColumn - imageCell.cellX
+    val effectiveGrid = refitImageCellGrid(
+        totalColumns = imageCell.totalCellsX,
+        totalRows = imageCell.totalCellsY,
+        anchorColumn = anchorColumn,
+        visibleColumns = visibleColumns,
+    )
+    val effectiveColumns = effectiveGrid.columns
+    val effectiveRows = effectiveGrid.rows
+    if (imageCell.cellX !in 0 until effectiveColumns || imageCell.cellY !in 0 until effectiveRows) {
+        return null
+    }
+
+    val srcX1 = imageCell.cellX * bitmap.width / effectiveColumns
+    val srcX2 = (imageCell.cellX + 1) * bitmap.width / effectiveColumns
+    val srcY1 = imageCell.cellY * bitmap.height / effectiveRows
+    val srcY2 = (imageCell.cellY + 1) * bitmap.height / effectiveRows
+    val dstX1 = (visualColumn * cellWidth).toInt()
+    val dstX2 = ((visualColumn + 1) * cellWidth).toInt()
+    val dstY1 = (screenRow * cellHeight).toInt()
+    val dstY2 = ((screenRow + 1) * cellHeight).toInt()
+
+    return ImageCellSlice(
+        bitmap = bitmap,
+        srcOffset = androidx.compose.ui.unit.IntOffset(srcX1, srcY1),
+        srcSize = androidx.compose.ui.unit.IntSize(
+            (srcX2 - srcX1).coerceAtLeast(1),
+            (srcY2 - srcY1).coerceAtLeast(1),
+        ),
+        dstOffset = androidx.compose.ui.unit.IntOffset(dstX1, dstY1),
+        dstSize = androidx.compose.ui.unit.IntSize(
+            (dstX2 - dstX1).coerceAtLeast(1),
+            (dstY2 - dstY1).coerceAtLeast(1),
+        ),
+    )
 }
 
 /**
@@ -835,55 +902,28 @@ object TerminalCanvasRenderer {
                     flushBatch()
 
                     // Render this cell's portion of the image
-                    val image = ctx.imageDataCache?.getImage(imageCell.imageId)
+                    val image = ctx.imageDataById[imageCell.imageId]
                     if (image != null) {
                         val bitmap = ImageRenderer.getOrDecodeImage(image)
                         if (bitmap != null) {
-                            // The cell footprint (totalCellsX/Y) is a one-time snapshot of the
-                            // grid at insertion time; the live grid can be narrower (insertion
-                            // raced pane layout, or the pane shrank since). Slicing against the
-                            // stale footprint would hard-crop every column past visibleCols for
-                            // the image's whole buffer lifetime. Re-fit at draw time instead:
-                            // compress the full bitmap into the columns actually reachable from
-                            // the anchor, shrinking rows by the same factor to keep aspect.
-                            val anchorCol = visualCol - imageCell.cellX
-                            val effectiveGrid = refitImageCellGrid(
-                                totalColumns = imageCell.totalCellsX,
-                                totalRows = imageCell.totalCellsY,
-                                anchorColumn = anchorCol,
-                                visibleColumns = ctx.visibleCols
-                            )
-                            val effCellsX = effectiveGrid.columns
-                            val effCellsY = effectiveGrid.rows
-                            // Cells beyond the re-fit footprint hold no slice; leave background.
-                            if (imageCell.cellX < effCellsX && imageCell.cellY < effCellsY) {
-                                // Calculate source region - use exact boundaries to avoid gaps
-                                val srcX1 = imageCell.cellX * bitmap.width / effCellsX
-                                val srcX2 = (imageCell.cellX + 1) * bitmap.width / effCellsX
-                                val srcY1 = imageCell.cellY * bitmap.height / effCellsY
-                                val srcY2 = (imageCell.cellY + 1) * bitmap.height / effCellsY
-                                val srcX = srcX1
-                                val srcY = srcY1
-                                val srcW = (srcX2 - srcX1).coerceAtLeast(1)
-                                val srcH = (srcY2 - srcY1).coerceAtLeast(1)
-
-                                // Destination - use exact boundaries to avoid gaps
-                                val dstX1 = (visualCol * ctx.cellWidth).toInt()
-                                val dstX2 = ((visualCol + 1) * ctx.cellWidth).toInt()
-                                val dstY1 = (row * ctx.cellHeight).toInt()
-                                val dstY2 = ((row + 1) * ctx.cellHeight).toInt()
-                                val dstX = dstX1
-                                val dstY = dstY1
-                                val dstW = (dstX2 - dstX1).coerceAtLeast(1)
-                                val dstH = (dstY2 - dstY1).coerceAtLeast(1)
-
-                                // Draw the portion of the image for this cell
+                            // The footprint is a one-time snapshot of the insertion grid. Re-fit
+                            // against the live width, then use the same slice calculation as the
+                            // cursor occlusion pass so animated image pixels and cursor masking align.
+                            imageCellSlice(
+                                imageCell = imageCell,
+                                bitmap = bitmap,
+                                visualColumn = visualCol,
+                                screenRow = row,
+                                visibleColumns = ctx.visibleCols,
+                                cellWidth = ctx.cellWidth,
+                                cellHeight = ctx.cellHeight,
+                            )?.let { slice ->
                                 drawImage(
-                                    image = bitmap,
-                                    srcOffset = androidx.compose.ui.unit.IntOffset(srcX, srcY),
-                                    srcSize = androidx.compose.ui.unit.IntSize(srcW, srcH),
-                                    dstOffset = androidx.compose.ui.unit.IntOffset(dstX, dstY),
-                                    dstSize = androidx.compose.ui.unit.IntSize(dstW, dstH)
+                                    image = slice.bitmap,
+                                    srcOffset = slice.srcOffset,
+                                    srcSize = slice.srcSize,
+                                    dstOffset = slice.dstOffset,
+                                    dstSize = slice.dstSize,
                                 )
                             }
                         }
@@ -1285,11 +1325,10 @@ object TerminalCanvasRenderer {
      * changes on the ~0.5s blink, and Compose's Canvas has no partial invalidation — reading
      * the blink flag inside the text pass forced a full re-render of every visible cell twice
      * a second. Drawing the cursor in a dedicated layer means a blink repaints only this tiny
-     * Canvas. The cursor is a translucent overlay (it never inverts the glyph underneath), so
-     * stacking it in a separate layer is visually identical to drawing it last in one canvas.
+     * Canvas. Inline-image alpha is applied as an occlusion mask within this layer so the cursor
+     * behaves as if it were behind image pixels instead of tinting animated Kitty/Sixel content.
      *
-     * Parameters are passed explicitly (rather than via [RenderingContext]) so the cursor layer
-     * needs no buffer snapshot — only cheap, composition-scoped cursor state. [visibleRows] is
+     * Parameters are passed explicitly (rather than via [RenderingContext]); [visibleRows] is
      * derived from the DrawScope size, matching the text canvas's own bounds computation.
      */
     fun DrawScope.renderCursorOverlay(
@@ -1303,10 +1342,11 @@ object TerminalCanvasRenderer {
         cellHeight: Float,
         isFocused: Boolean,
         cursorColor: Color?,
-        focusedAlpha: Float = 0.7f,
+        focusedAlpha: Float = 1f,
         unfocusedAlpha: Float = 0.3f,
+        imageOcclusion: ImageCellSlice? = null,
     ) {
-        if (!cursorVisible) return
+        if (!cursorVisible || cellWidth <= 0f || cellHeight <= 0f) return
         // cursorY is 1-indexed in the screen buffer, adjust to 0-indexed
         val bufferCursorY = (cursorY - 1).coerceAtLeast(0)
         // Convert buffer position to screen position by adding scrollOffset
@@ -1327,38 +1367,70 @@ object TerminalCanvasRenderer {
 
         if (!shouldShowCursor) return
 
-        val x = cursorX * cellWidth
-        val y = cursorScreenRow * cellHeight
-        // Calculate size as difference to next cell to avoid floating-point gaps
-        val w = (cursorX + 1) * cellWidth - x
-        val h = (cursorScreenRow + 1) * cellHeight - y
-        val cursorAlpha = if (isFocused) focusedAlpha else unfocusedAlpha
-        val drawColor = (cursorColor ?: Color.White).copy(alpha = cursorAlpha)
+        // Align every cursor edge to the same device-pixel cell boundaries used by
+        // inline images. Sub-pixel rectangles can antialias into a neighboring cell,
+        // which is especially visible against a transparent animated sprite.
+        val x = floor(cursorX * cellWidth)
+        val y = floor(cursorScreenRow * cellHeight)
+        val right = floor((cursorX + 1) * cellWidth)
+        val bottom = floor((cursorScreenRow + 1) * cellHeight)
+        val w = right - x
+        val h = bottom - y
+        if (w <= 0f || h <= 0f || right <= 0f || bottom <= 0f || x >= size.width || y >= size.height) return
 
-        when (cursorShape) {
-            CursorShape.BLINK_BLOCK, CursorShape.STEADY_BLOCK, null -> {
-                drawRect(
-                    color = drawColor,
-                    topLeft = Offset(x, y),
-                    size = Size(w, h)
+        val cursorAlpha = (if (isFocused) focusedAlpha else unfocusedAlpha).coerceIn(0f, 1f)
+        val drawColor = (cursorColor ?: Color.White).copy(alpha = cursorAlpha)
+        // xterm uses a one-CSS-pixel underline/bar (scaled by DPR), not a
+        // percentage of the cell. Compose dp has the same logical-pixel behavior.
+        val edgeThickness = 1.dp.toPx().coerceAtMost(minOf(w, h))
+        val layerBounds = Rect(
+            left = x.coerceAtLeast(0f),
+            top = y.coerceAtLeast(0f),
+            right = right.coerceAtMost(size.width),
+            bottom = bottom.coerceAtMost(size.height),
+        )
+
+        // Isolate DstOut to this small cursor layer. The image alpha below then
+        // removes the cursor only where an inline image has pixels: opaque Codex
+        // Pet pixels stay pristine, while transparent parts still reveal the caret.
+        drawContext.canvas.saveLayer(layerBounds, Paint())
+        try {
+            when (cursorShape) {
+                CursorShape.BLINK_BLOCK, CursorShape.STEADY_BLOCK, null -> {
+                    drawRect(
+                        color = drawColor,
+                        topLeft = Offset(x, y),
+                        size = Size(w, h)
+                    )
+                }
+                CursorShape.BLINK_UNDERLINE, CursorShape.STEADY_UNDERLINE -> {
+                    drawRect(
+                        color = drawColor,
+                        topLeft = Offset(x, bottom - edgeThickness),
+                        size = Size(w, edgeThickness)
+                    )
+                }
+                CursorShape.BLINK_VERTICAL_BAR, CursorShape.STEADY_VERTICAL_BAR -> {
+                    drawRect(
+                        color = drawColor,
+                        topLeft = Offset(x, y),
+                        size = Size(edgeThickness, h)
+                    )
+                }
+            }
+
+            imageOcclusion?.let { slice ->
+                drawImage(
+                    image = slice.bitmap,
+                    srcOffset = slice.srcOffset,
+                    srcSize = slice.srcSize,
+                    dstOffset = slice.dstOffset,
+                    dstSize = slice.dstSize,
+                    blendMode = BlendMode.DstOut,
                 )
             }
-            CursorShape.BLINK_UNDERLINE, CursorShape.STEADY_UNDERLINE -> {
-                val underlineHeight = h * 0.2f
-                drawRect(
-                    color = drawColor,
-                    topLeft = Offset(x, y + h - underlineHeight),
-                    size = Size(w, underlineHeight)
-                )
-            }
-            CursorShape.BLINK_VERTICAL_BAR, CursorShape.STEADY_VERTICAL_BAR -> {
-                val barWidth = w * 0.15f
-                drawRect(
-                    color = drawColor,
-                    topLeft = Offset(x, y),
-                    size = Size(barWidth, h)
-                )
-            }
+        } finally {
+            drawContext.canvas.restore()
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
@@ -17,8 +17,9 @@ internal fun migrateCursorRenderingDefaults(
 ): TerminalSettings {
     if (hasCursorRenderingVersion) return settings
 
-    // 0.7 was the old focused default. Upgrade that value once to xterm parity, while
-    // preserving every non-default opacity a user may already have chosen.
+    // 0.7 was the old focused default. There is no persisted provenance that can
+    // distinguish it from an explicitly selected 70%, so legacy 0.7 values are
+    // intentionally treated as the old default and upgraded once to xterm parity.
     return if (settings.cursorFocusedAlpha == 0.7f) {
         settings.copy(cursorFocusedAlpha = 1f, cursorRenderingVersion = 2)
     } else {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
@@ -241,7 +241,7 @@ class SettingsManager(private val customSettingsPath: String? = null) {
                 val jsonString = settingsFile.readText()
                 val rawSettings = json.parseToJsonElement(jsonString).jsonObject
                 val loadedSettings = migrateCursorRenderingDefaults(
-                    settings = json.decodeFromString<TerminalSettings>(jsonString),
+                    settings = json.decodeFromJsonElement(TerminalSettings.serializer(), rawSettings),
                     hasCursorRenderingVersion = "cursorRenderingVersion" in rawSettings,
                 )
                 publish(loadedSettings)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
@@ -11,6 +11,21 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 import java.io.File
 
+internal fun migrateCursorRenderingDefaults(
+    settings: TerminalSettings,
+    hasCursorRenderingVersion: Boolean,
+): TerminalSettings {
+    if (hasCursorRenderingVersion) return settings
+
+    // 0.7 was the old focused default. Upgrade that value once to xterm parity, while
+    // preserving every non-default opacity a user may already have chosen.
+    return if (settings.cursorFocusedAlpha == 0.7f) {
+        settings.copy(cursorFocusedAlpha = 1f, cursorRenderingVersion = 2)
+    } else {
+        settings.copy(cursorRenderingVersion = 2)
+    }
+}
+
 /**
  * Manager for terminal settings with persistence support.
  * Settings are saved to ~/.bossterm/settings.json by default,
@@ -223,7 +238,11 @@ class SettingsManager(private val customSettingsPath: String? = null) {
             if (settingsFile.exists()) {
                 wasFreshInstall = false
                 val jsonString = settingsFile.readText()
-                val loadedSettings = json.decodeFromString<TerminalSettings>(jsonString)
+                val rawSettings = json.parseToJsonElement(jsonString).jsonObject
+                val loadedSettings = migrateCursorRenderingDefaults(
+                    settings = json.decodeFromString<TerminalSettings>(jsonString),
+                    hasCursorRenderingVersion = "cursorRenderingVersion" in rawSettings,
+                )
                 publish(loadedSettings)
                 println("Settings loaded from: ${settingsFile.absolutePath}")
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -602,10 +602,16 @@ data class TerminalSettings(
 
     /**
      * Cursor opacity while the terminal is focused (0.0 = invisible, 1.0 = fully opaque).
-     * Default 0.7 keeps a translucent block/bar; raise to 1.0 to disable transparency
-     * entirely, e.g. if the cursor is hard to see against a light theme.
+     * The fully opaque default matches the browser viewer (xterm) and keeps the active
+     * cursor crisp against both light and dark themes.
      */
-    val cursorFocusedAlpha: Float = 0.7f,
+    val cursorFocusedAlpha: Float = 1f,
+
+    /**
+     * Schema marker for one-time cursor rendering migrations. This is persisted so choosing
+     * the former 70% opacity manually after upgrading remains a stable user preference.
+     */
+    val cursorRenderingVersion: Int = 2,
 
     /**
      * Cursor opacity while the terminal is unfocused (0.0 = invisible, 1.0 = fully opaque).

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/PerformanceSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/PerformanceSettingsSection.kt
@@ -264,7 +264,7 @@ fun PerformanceSettingsSection(
                 valueRange = 0f..1f,
                 steps = 9,
                 valueDisplay = { "${(it * 100).toInt()}%" },
-                description = "Cursor opacity while the terminal is focused. Raise to 100% to disable transparency."
+                description = "Cursor opacity while the terminal is focused. 100% matches the browser viewer."
             )
 
             SettingsSlider(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -669,7 +669,7 @@ class TabController(
         val dataStream = BlockingTerminalDataStream(
             performanceMode = PerformanceMode.fromString(settings.performanceMode)
         )
-        // Batch each appended chunk so a clear+write renders atomically (no flicker).
+        // Batch each appended chunk so clear+write sequences request one redraw.
         dataStream.onChunkStart = { textBuffer.beginBatch() }
         dataStream.onChunkEnd = { textBuffer.endBatch() }
         val emulator = BossEmulator(dataStream, terminal, settings.allowKittyFileTransfers)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -24,6 +24,7 @@ import ai.rever.bossterm.compose.TerminalSessionSlots
 import ai.rever.bossterm.compose.debug.ChunkSource
 import ai.rever.bossterm.compose.terminal.BlockingTerminalDataStream
 import ai.rever.bossterm.compose.terminal.PerformanceMode
+import ai.rever.bossterm.compose.terminal.drainTerminalEmulator
 import ai.rever.bossterm.compose.features.ContextMenuController
 import ai.rever.bossterm.compose.getPlatformServices
 import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
@@ -40,7 +41,6 @@ import ai.rever.bossterm.compose.TerminalSession
 import ai.rever.bossterm.core.typeahead.TerminalTypeAheadManager
 import ai.rever.bossterm.core.typeahead.TypeAheadTerminalModel
 import ai.rever.bossterm.terminal.util.GraphemeBoundaryUtils
-import java.io.EOFException
 
 /**
  * Controller for managing multiple terminal tabs.
@@ -738,17 +738,12 @@ class TabController(
                 runCatching { tab.dataStream.close() }
             } else {
                 scope.launch(TerminalSessionDispatcher) {
-                    try {
-                        while (isActive) {
-                            try {
-                                tab.emulator.processChar(tab.dataStream.char, tab.terminal)
-                            } catch (_: Exception) {
-                                break // EOF on close, or stream error — stop the loop
-                            }
-                        }
-                    } finally {
-                        runCatching { tab.dataStream.close() }
-                    }
+                    drainTerminalEmulator(
+                        emulator = tab.emulator,
+                        dataStream = tab.dataStream,
+                        terminal = tab.terminal,
+                        shouldContinue = { isActive },
+                    )
                 }.invokeOnCompletion {
                     TerminalSessionSlots.release(1)
                 }
@@ -1383,22 +1378,15 @@ class TabController(
             // fires only after this loop unwinds and the accounting never runs
             // ahead of the physically occupied permits.
             sessionScope.launch(TerminalSessionDispatcher) {
-                try {
-                    while (handle.isAlive()) {
-                        try {
-                            tab.emulator.processChar(tab.dataStream.char, tab.terminal)
-                        } catch (_: EOFException) {
-                            break
-                        } catch (e: Exception) {
-                            if (e !is ai.rever.bossterm.terminal.TerminalDataStream.EOF) {
-                                println("WARNING: Error processing terminal output: ${e.message}")
-                            }
-                            break
-                        }
-                    }
-                } finally {
-                    tab.dataStream.close()
-                }
+                drainTerminalEmulator(
+                    emulator = tab.emulator,
+                    dataStream = tab.dataStream,
+                    terminal = tab.terminal,
+                    shouldContinue = handle::isAlive,
+                    onProcessingError = { e ->
+                        println("WARNING: Error processing terminal output: ${e.message}")
+                    },
+                )
             }
 
             // Read PTY output in background (uses shared helper to eliminate duplication)
@@ -1555,25 +1543,15 @@ class TabController(
                 // Note: Initial prompt will display via ModelListener → requestImmediateRedraw()
                 // when buffer content changes. No need for premature redraw here.
                 launch(TerminalSessionDispatcher) {
-                    try {
-                        while (handle.isAlive()) {
-                            try {
-                                tab.emulator.processChar(tab.dataStream.char, tab.terminal)
-                                // Note: Redraws are triggered by scrollArea() when buffer changes
-                                // No need for explicit requestRedraw() here - it causes redundant requests
-                                // scrollArea() now uses smart priority (IMMEDIATE for interactive, debounced for bulk)
-                            } catch (_: EOFException) {
-                                break
-                            } catch (e: Exception) {
-                                if (e !is ai.rever.bossterm.terminal.TerminalDataStream.EOF) {
-                                    println("WARNING: Error processing terminal output: ${e.message}")
-                                }
-                                break
-                            }
-                        }
-                    } finally {
-                        tab.dataStream.close()
-                    }
+                    drainTerminalEmulator(
+                        emulator = tab.emulator,
+                        dataStream = tab.dataStream,
+                        terminal = tab.terminal,
+                        shouldContinue = handle::isAlive,
+                        onProcessingError = { e ->
+                            println("WARNING: Error processing terminal output: ${e.message}")
+                        },
+                    )
                 }
 
                 // Read PTY output in background (uses shared helper to eliminate duplication)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/terminal/TerminalEmulatorDrain.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/terminal/TerminalEmulatorDrain.kt
@@ -1,0 +1,40 @@
+package ai.rever.bossterm.compose.terminal
+
+import ai.rever.bossterm.terminal.Terminal
+import ai.rever.bossterm.terminal.TerminalDataStream
+import ai.rever.bossterm.terminal.emulator.BossEmulator
+import java.io.EOFException
+
+/**
+ * Drain a production terminal data stream and always reset terminal-only state on exit.
+ *
+ * [Terminal.disconnected] must run on this emulator thread: it clears an abandoned
+ * text-buffer batch owned by the thread and disables DEC synchronized-update mode.
+ * Without this finally path, EOF after `?2026h` leaves every later render capture gated.
+ */
+internal fun drainTerminalEmulator(
+    emulator: BossEmulator,
+    dataStream: BlockingTerminalDataStream,
+    terminal: Terminal,
+    shouldContinue: () -> Boolean,
+    onProcessingError: (Exception) -> Unit = {},
+) {
+    try {
+        while (shouldContinue()) {
+            try {
+                emulator.processChar(dataStream.char, terminal)
+            } catch (_: EOFException) {
+                break
+            } catch (e: Exception) {
+                if (e !is TerminalDataStream.EOF) onProcessingError(e)
+                break
+            }
+        }
+    } finally {
+        try {
+            terminal.disconnected()
+        } finally {
+            dataStream.close()
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/terminal/TerminalEmulatorDrain.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/terminal/TerminalEmulatorDrain.kt
@@ -34,7 +34,9 @@ internal fun drainTerminalEmulator(
         try {
             terminal.disconnected()
         } finally {
-            dataStream.close()
+            // Closing is idempotent and best-effort during teardown. Do not let a
+            // future stream implementation's close failure replace the emulator error.
+            runCatching { dataStream.close() }
         }
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -134,13 +134,14 @@ private data class StableTerminalRenderFrame(
   val cursorShape: CursorShape?,
 )
 
-/** UI-thread-confined retention of the last frame accepted by the sync gate. */
+/** UI-thread-confined retention committed only after an accepted composition applies. */
 internal class StableRenderFrameHolder<T : Any> {
   private var frame: T? = null
 
-  fun retain(candidate: T?): T? {
-    if (candidate != null) frame = candidate
-    return frame
+  fun frameFor(candidate: T?): T? = candidate ?: frame
+
+  fun commit(candidate: T) {
+    frame = candidate
   }
 }
 
@@ -1867,19 +1868,22 @@ fun ProperTerminal(
         val stableFrameHolder = remember(textBuffer, display) {
           StableRenderFrameHolder<StableTerminalRenderFrame>()
         }
-        val renderFrame = remember(currentTrigger, textBuffer.width, textBuffer.height) {
-          stableFrameHolder.retain(
-            display.captureStableRenderFrame {
-              StableTerminalRenderFrame(
-                buffer = textBuffer.createIncrementalSnapshot(),
-                imagesById = imageDataCache.snapshotImages(),
-                cursorX = display.cursorXSnapshot,
-                cursorY = display.cursorYSnapshot,
-                cursorVisible = display.cursorVisibleSnapshot,
-                cursorShape = display.cursorShapeSnapshot,
-              )
-            }
-          )
+        val capturedFrame = remember(currentTrigger, textBuffer.width, textBuffer.height) {
+          display.captureStableRenderFrame {
+            StableTerminalRenderFrame(
+              buffer = textBuffer.createIncrementalSnapshot(),
+              imagesById = imageDataCache.snapshotImages(),
+              cursorX = display.cursorXSnapshot,
+              cursorY = display.cursorYSnapshot,
+              cursorVisible = display.cursorVisibleSnapshot,
+              cursorShape = display.cursorShapeSnapshot,
+            )
+          }
+        }
+        val renderFrame = stableFrameHolder.frameFor(capturedFrame)
+        SideEffect {
+          // Only frames from a composition that reached apply become future fallbacks.
+          capturedFrame?.let(stableFrameHolder::commit)
         }
         // A first mount during ?2026 has no trusted fallback frame yet. Leave only
         // terminal-dependent layers empty until the synchronized update publishes

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -52,6 +52,8 @@ import ai.rever.bossterm.terminal.emulator.mouse.MouseButtonCodes
 import ai.rever.bossterm.terminal.emulator.mouse.MouseMode
 import ai.rever.bossterm.terminal.model.BufferSnapshot
 import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import ai.rever.bossterm.terminal.model.image.TerminalImage
+import ai.rever.bossterm.terminal.model.pool.VersionedBufferSnapshot
 import ai.rever.bossterm.terminal.util.CharUtils
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -83,7 +85,9 @@ import ai.rever.bossterm.compose.scrollbar.rememberTerminalScrollbarAdapter
 import ai.rever.bossterm.compose.search.SearchBar
 import ai.rever.bossterm.compose.rendering.RenderingContext
 import ai.rever.bossterm.compose.rendering.RenderableBlock
+import ai.rever.bossterm.compose.rendering.ImageRenderer
 import ai.rever.bossterm.compose.rendering.TerminalCanvasRenderer
+import ai.rever.bossterm.compose.rendering.imageCellSlice
 import ai.rever.bossterm.compose.blocks.BlockState
 import ai.rever.bossterm.compose.selection.SelectionEngine
 import ai.rever.bossterm.compose.settings.SettingsManager
@@ -119,6 +123,20 @@ private class GridStabilityTracker {
   var scheduledRows: Int = -1
   var job: Job? = null
 }
+
+/** A complete immutable frame retained while an application performs ?2026 updates. */
+private data class StableTerminalRenderFrame(
+  val buffer: VersionedBufferSnapshot,
+  val imagesById: Map<Long, TerminalImage>,
+  val cursorX: Int,
+  val cursorY: Int,
+  val cursorVisible: Boolean,
+  val cursorShape: CursorShape?,
+)
+
+private class StableTerminalRenderFrameHolder(
+  var frame: StableTerminalRenderFrame,
+)
 
 /**
  * Proper terminal implementation using BossTerm's emulator.
@@ -1839,14 +1857,38 @@ fun ProperTerminal(
         // Snapshot cached by Compose - recreated when display triggers redraw OR buffer dimensions change
         // Cursor state is captured atomically to prevent flickering from partial updates
         val currentTrigger = display.redrawTrigger.value
-        val bufferSnapshot = remember(currentTrigger, textBuffer.width, textBuffer.height) {
-          textBuffer.createIncrementalSnapshot()
+        val imageDataCache = terminal.getImageDataCache()
+        val stableFrameHolder = remember(textBuffer, display) {
+          StableTerminalRenderFrameHolder(
+            StableTerminalRenderFrame(
+              buffer = textBuffer.createIncrementalSnapshot(),
+              imagesById = imageDataCache.snapshotImages(),
+              cursorX = display.cursorXSnapshot,
+              cursorY = display.cursorYSnapshot,
+              cursorVisible = display.cursorVisibleSnapshot,
+              cursorShape = display.cursorShapeSnapshot,
+            )
+          )
         }
-        // Capture cursor state atomically with redrawTrigger - prevents partial updates
-        val cursorX = remember(currentTrigger) { display.cursorXSnapshot }
-        val cursorY = remember(currentTrigger) { display.cursorYSnapshot }
-        val cursorVisible = remember(currentTrigger) { display.cursorVisibleSnapshot }
-        val cursorShape = remember(currentTrigger) { display.cursorShapeSnapshot }
+        val renderFrame = remember(currentTrigger, textBuffer.width, textBuffer.height) {
+          display.captureStableRenderFrame {
+            StableTerminalRenderFrame(
+              buffer = textBuffer.createIncrementalSnapshot(),
+              imagesById = imageDataCache.snapshotImages(),
+              cursorX = display.cursorXSnapshot,
+              cursorY = display.cursorYSnapshot,
+              cursorVisible = display.cursorVisibleSnapshot,
+              cursorShape = display.cursorShapeSnapshot,
+            )
+          }?.also { stableFrameHolder.frame = it } ?: stableFrameHolder.frame
+        }
+        val bufferSnapshot = renderFrame.buffer
+        // Cursor and content must come from the same committed ?2026 frame. Kitty
+        // image updates temporarily move the real cursor to the placement anchor.
+        val cursorX = renderFrame.cursorX
+        val cursorY = renderFrame.cursorY
+        val cursorVisible = renderFrame.cursorVisible
+        val cursorShape = renderFrame.cursorShape
         // Type-ahead manager can override cursor X for local echo prediction
         val effectiveCursorX = tab.typeAheadManager?.let { it.cursorX - 1 } ?: cursorX
 
@@ -1959,7 +2001,7 @@ fun ProperTerminal(
             isModifierPressed = isModifierPressed,
             slowBlinkVisible = slowBlinkVisible,
             rapidBlinkVisible = rapidBlinkVisible,
-            imageDataCache = terminal.getImageDataCache(),
+            imageDataById = renderFrame.imagesById,
             terminalWidthCells = bufferSnapshot.width,
             terminalHeightCells = bufferSnapshot.height,
             precomputedHyperlinks = precomputedHyperlinks,
@@ -1990,8 +2032,8 @@ fun ProperTerminal(
         // cursorBlinkVisible, so the ~0.5s blink invalidates just this tiny layer instead of
         // re-running the full text render. Cursor position is read from the same
         // composition-scoped snapshots the text canvas uses, so it stays in sync as content
-        // and scroll change. The cursor is a translucent overlay, so a separate layer is
-        // visually identical to drawing it last in one canvas.
+        // and scroll change. If the cursor intersects an inline image, that cell's alpha masks
+        // the cursor so animated sprite pixels remain above it, matching browser compositing.
         Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
           if (size.width < cellWidth || size.height < cellHeight) return@Canvas
           val customCursorColor = terminal.cursorColor
@@ -1999,6 +2041,24 @@ fun ProperTerminal(
             Color(customCursorColor.red, customCursorColor.green, customCursorColor.blue)
           } else activeTheme.cursorColor
           with(TerminalCanvasRenderer) {
+            val bufferCursorRow = (cursorY - 1).coerceAtLeast(0)
+            val cursorScreenRow = bufferCursorRow + scrollOffset
+            val cursorImageCell = bufferSnapshot.getLine(bufferCursorRow).getImageCellAt(effectiveCursorX)
+            val cursorImageSlice = cursorImageCell?.let { imageCell ->
+              renderFrame.imagesById[imageCell.imageId]?.let { image ->
+                ImageRenderer.getOrDecodeImage(image)
+              }?.let { bitmap ->
+                imageCellSlice(
+                  imageCell = imageCell,
+                  bitmap = bitmap,
+                  visualColumn = effectiveCursorX,
+                  screenRow = cursorScreenRow,
+                  visibleColumns = (size.width / cellWidth).toInt().coerceAtMost(bufferSnapshot.width),
+                  cellWidth = cellWidth,
+                  cellHeight = cellHeight,
+                )
+              }
+            }
             renderCursorOverlay(
               cursorVisible = cursorVisible,
               cursorBlinkVisible = cursorBlinkVisible,
@@ -2012,6 +2072,7 @@ fun ProperTerminal(
               cursorColor = baseCursorColor,
               focusedAlpha = settings.cursorFocusedAlpha,
               unfocusedAlpha = settings.cursorUnfocusedAlpha,
+              imageOcclusion = cursorImageSlice,
             )
           }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -1881,225 +1881,227 @@ fun ProperTerminal(
             }
           )
         }
-        // A first mount during ?2026 has no trusted fallback frame yet. Leave the
-        // terminal canvas empty until the synchronized update publishes its redraw.
-        renderFrame ?: return@Box
-        val bufferSnapshot = renderFrame.buffer
-        // Cursor and content must come from the same committed ?2026 frame. Kitty
-        // image updates temporarily move the real cursor to the placement anchor.
-        val cursorX = renderFrame.cursorX
-        val cursorY = renderFrame.cursorY
-        val cursorVisible = renderFrame.cursorVisible
-        val cursorShape = renderFrame.cursorShape
-        // Type-ahead manager can override cursor X for local echo prediction
-        val effectiveCursorX = tab.typeAheadManager?.let { it.cursorX - 1 } ?: cursorX
+        // A first mount during ?2026 has no trusted fallback frame yet. Leave only
+        // terminal-dependent layers empty until the synchronized update publishes
+        // its redraw; sibling overlays such as search remain composed.
+        if (renderFrame != null) {
+          val bufferSnapshot = renderFrame.buffer
+          // Cursor and content must come from the same committed ?2026 frame. Kitty
+          // image updates temporarily move the real cursor to the placement anchor.
+          val cursorX = renderFrame.cursorX
+          val cursorY = renderFrame.cursorY
+          val cursorVisible = renderFrame.cursorVisible
+          val cursorShape = renderFrame.cursorShape
+          // Type-ahead manager can override cursor X for local echo prediction
+          val effectiveCursorX = tab.typeAheadManager?.let { it.cursorX - 1 } ?: cursorX
 
-        Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
-          // Guard against invalid canvas sizes during resize - prevents drawText constraint failures
-          if (size.width < cellWidth || size.height < cellHeight) return@Canvas
+          Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
+            // Guard against invalid canvas sizes during resize - prevents drawText constraint failures
+            if (size.width < cellWidth || size.height < cellHeight) return@Canvas
 
-          // Capture canvas size for auto-scroll bounds detection in pointer event handlers
-          canvasSize = size
+            // Capture canvas size for auto-scroll bounds detection in pointer event handlers
+            canvasSize = size
 
-          // Calculate visible bounds - limit rendering to what fits in canvas
-          // Use ceil for rows to include partially visible bottom row (Canvas clips automatically)
-          val visibleCols = (size.width / cellWidth).toInt().coerceAtMost(bufferSnapshot.width)
-          val visibleRows = kotlin.math.ceil(size.height / cellHeight).toInt().coerceAtMost(bufferSnapshot.height)
+            // Calculate visible bounds - limit rendering to what fits in canvas
+            // Use ceil for rows to include partially visible bottom row (Canvas clips automatically)
+            val visibleCols = (size.width / cellWidth).toInt().coerceAtMost(bufferSnapshot.width)
+            val visibleRows = kotlin.math.ceil(size.height / cellHeight).toInt().coerceAtMost(bufferSnapshot.height)
 
-          // Get cursor color from terminal (OSC 12), falling back to the active theme's
-          // cursor color so the cursor stays visible against light and dark backgrounds
-          // alike when no app has overridden it.
-          val customCursorColor = terminal.cursorColor
-          val baseCursorColor = if (customCursorColor != null) {
-            Color(customCursorColor.red, customCursorColor.green, customCursorColor.blue)
-          } else activeTheme.cursorColor
+            // Get cursor color from terminal (OSC 12), falling back to the active theme's
+            // cursor color so the cursor stays visible against light and dark backgrounds
+            // alike when no app has overridden it.
+            val customCursorColor = terminal.cursorColor
+            val baseCursorColor = if (customCursorColor != null) {
+              Color(customCursorColor.red, customCursorColor.green, customCursorColor.blue)
+            } else activeTheme.cursorColor
 
-          // Version-based hyperlink caching: compute hash including scroll position
-          // since visible content changes with scroll even if buffer content is same
-          val currentVersionHash = bufferSnapshot.computeVersionHash() * 31 + scrollOffset
+            // Version-based hyperlink caching: compute hash including scroll position
+            // since visible content changes with scroll even if buffer content is same
+            val currentVersionHash = bufferSnapshot.computeVersionHash() * 31 + scrollOffset
 
-          // Reuse cached hyperlinks if buffer content and scroll position unchanged
-          val precomputedHyperlinks = if (currentVersionHash == lastHyperlinkVersionHash &&
-                                          cachedHyperlinks.isNotEmpty()) {
-            cachedHyperlinks
-          } else {
-            null // Force fresh detection
-          }
-
-          // Resolve content-anchored selection to current coordinates
-          // This allows selection to follow content as terminal scrolls
-          // selectionTracker is the single source of truth for selection
-          val resolvedSelection = selectionTracker.resolveToCoordinates(bufferSnapshot)
-          val effectiveSelectionStart = resolvedSelection?.toStartPair()
-          val effectiveSelectionEnd = resolvedSelection?.toEndPair()
-          val effectiveSelectionMode = resolvedSelection?.mode ?: selectionMode
-
-          // Resolve command blocks to on-screen rows (empty unless the feature is
-          // enabled). Reading the collected `commandBlocks` state here subscribes
-          // the draw to block changes so the gutter repaints as commands run.
-          val resolvedCommandBlocks: List<RenderableBlock> = if (settings.commandBlocksEnabled) {
-            commandBlocks.mapNotNull { block ->
-              val startBuf = selectionTracker.resolveAnchorRow(block.startAnchor, bufferSnapshot)
-                ?: return@mapNotNull null
-              val endBuf = block.endAnchor?.let { selectionTracker.resolveAnchorRow(it, bufferSnapshot) }
-              val startScreen = startBuf + scrollOffset
-              val endScreen = endBuf?.let { it + scrollOffset } ?: visibleRows
-              if (endScreen < 0 || startScreen > visibleRows) return@mapNotNull null
-              val color = when (block.state) {
-                BlockState.SUCCESS -> settings.commandBlockSuccessColorValue
-                BlockState.ERROR -> settings.commandBlockErrorColorValue
-                BlockState.RUNNING -> settings.commandBlockRunningColorValue
-              }
-              RenderableBlock(
-                startRow = startScreen.coerceAtLeast(0),
-                endRow = endScreen.coerceIn(0, visibleRows),
-                color = color
-              )
+            // Reuse cached hyperlinks if buffer content and scroll position unchanged
+            val precomputedHyperlinks = if (currentVersionHash == lastHyperlinkVersionHash &&
+                                            cachedHyperlinks.isNotEmpty()) {
+              cachedHyperlinks
+            } else {
+              null // Force fresh detection
             }
-          } else {
-            emptyList()
-          }
 
-          // Reset the per-frame blink probe; renderText() sets an entry true if it
-          // draws a SLOW_BLINK / RAPID_BLINK cell in the visible region this frame.
-          blinkProbe[0] = false
-          blinkProbe[1] = false
+            // Resolve content-anchored selection to current coordinates
+            // This allows selection to follow content as terminal scrolls
+            // selectionTracker is the single source of truth for selection
+            val resolvedSelection = selectionTracker.resolveToCoordinates(bufferSnapshot)
+            val effectiveSelectionStart = resolvedSelection?.toStartPair()
+            val effectiveSelectionEnd = resolvedSelection?.toEndPair()
+            val effectiveSelectionMode = resolvedSelection?.mode ?: selectionMode
 
-          // Build rendering context with all state
-          val renderingContext = RenderingContext(
-            bufferSnapshot = bufferSnapshot,
-            blinkProbe = blinkProbe,
-            cellWidth = cellWidth,
-            cellHeight = cellHeight,
-            baseCellHeight = baseCellHeight,
-            cellBaseline = cellMetrics.third,
-            scrollOffset = scrollOffset,
-            visibleCols = visibleCols,
-            visibleRows = visibleRows,
-            textMeasurer = textMeasurer,
-            measurementFontFamily = sharedFont,
-            fontSize = effectiveFontSize,
-            settings = settings,
-            ambiguousCharsAreDoubleWidth = display.ambiguousCharsAreDoubleWidth(),
-            selectionStart = effectiveSelectionStart,
-            selectionEnd = effectiveSelectionEnd,
-            selectionMode = effectiveSelectionMode,
-            searchVisible = searchVisible,
-            searchQuery = searchQuery,
-            searchMatches = searchMatches,
-            currentMatchIndex = currentMatchIndex,
-            cursorX = effectiveCursorX,
-            cursorY = cursorY,
-            cursorVisible = cursorVisible,
-            // The text pass no longer draws the cursor (it lives in its own overlay Canvas
-            // below), so pass a constant here. Reading the real cursorBlinkVisible state in
-            // this draw lambda would re-subscribe the whole text canvas to the blink and
-            // defeat the optimization.
-            cursorBlinkVisible = true,
-            cursorShape = cursorShape,
-            cursorColor = baseCursorColor,
-            isFocused = isFocused,
-            hoveredHyperlink = hoveredHyperlink,
-            isModifierPressed = isModifierPressed,
-            slowBlinkVisible = slowBlinkVisible,
-            rapidBlinkVisible = rapidBlinkVisible,
-            imageDataById = renderFrame.imagesById,
-            terminalWidthCells = bufferSnapshot.width,
-            terminalHeightCells = bufferSnapshot.height,
-            precomputedHyperlinks = precomputedHyperlinks,
-            workingDirectory = tab.workingDirectory.value,
-            detectFilePaths = settings.detectFilePaths,
-            hyperlinkRegistry = hyperlinkRegistry,
-            commandBlocks = resolvedCommandBlocks
-          )
-
-          // Render terminal using extracted renderer - returns detected hyperlinks
-          with(TerminalCanvasRenderer) {
-            val detectedHyperlinks = renderTerminal(renderingContext)
-            // Update cache for next frame
-            cachedHyperlinks = detectedHyperlinks
-            lastHyperlinkVersionHash = currentVersionHash
-          }
-
-          // Reflect the renderer's blink-presence findings into composition state. Only
-          // an actual change notifies (mutableStateOf uses structural equality), so this
-          // re-arms/parks the blink loops on transitions and is a no-op otherwise — no
-          // per-frame recomposition. Reads here are in the draw phase, not composition.
-          if (hasSlowBlinkText != blinkProbe[0]) hasSlowBlinkText = blinkProbe[0]
-          if (hasRapidBlinkText != blinkProbe[1]) hasRapidBlinkText = blinkProbe[1]
-        }
-
-        // Cursor overlay — drawn in its own Canvas, stacked on top of the text canvas above
-        // (same modifier, so coordinates line up exactly). This is the ONLY place that reads
-        // cursorBlinkVisible, so the ~0.5s blink invalidates just this tiny layer instead of
-        // re-running the full text render. Cursor position is read from the same
-        // composition-scoped snapshots the text canvas uses, so it stays in sync as content
-        // and scroll change. If the cursor intersects an inline image, that cell's alpha masks
-        // the cursor so animated sprite pixels remain above it, matching browser compositing.
-        Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
-          if (size.width < cellWidth || size.height < cellHeight) return@Canvas
-          val customCursorColor = terminal.cursorColor
-          val baseCursorColor = if (customCursorColor != null) {
-            Color(customCursorColor.red, customCursorColor.green, customCursorColor.blue)
-          } else activeTheme.cursorColor
-          with(TerminalCanvasRenderer) {
-            val bufferCursorRow = (cursorY - 1).coerceAtLeast(0)
-            val cursorScreenRow = bufferCursorRow + scrollOffset
-            val cursorImageCell = bufferSnapshot.getLine(bufferCursorRow).getImageCellAt(effectiveCursorX)
-            val cursorImageSlice = cursorImageCell?.let { imageCell ->
-              renderFrame.imagesById[imageCell.imageId]?.let { image ->
-                ImageRenderer.getOrDecodeImage(image)
-              }?.let { bitmap ->
-                imageCellSlice(
-                  imageCell = imageCell,
-                  bitmap = bitmap,
-                  visualColumn = effectiveCursorX,
-                  screenRow = cursorScreenRow,
-                  visibleColumns = (size.width / cellWidth).toInt().coerceAtMost(bufferSnapshot.width),
-                  cellWidth = cellWidth,
-                  cellHeight = cellHeight,
+            // Resolve command blocks to on-screen rows (empty unless the feature is
+            // enabled). Reading the collected `commandBlocks` state here subscribes
+            // the draw to block changes so the gutter repaints as commands run.
+            val resolvedCommandBlocks: List<RenderableBlock> = if (settings.commandBlocksEnabled) {
+              commandBlocks.mapNotNull { block ->
+                val startBuf = selectionTracker.resolveAnchorRow(block.startAnchor, bufferSnapshot)
+                  ?: return@mapNotNull null
+                val endBuf = block.endAnchor?.let { selectionTracker.resolveAnchorRow(it, bufferSnapshot) }
+                val startScreen = startBuf + scrollOffset
+                val endScreen = endBuf?.let { it + scrollOffset } ?: visibleRows
+                if (endScreen < 0 || startScreen > visibleRows) return@mapNotNull null
+                val color = when (block.state) {
+                  BlockState.SUCCESS -> settings.commandBlockSuccessColorValue
+                  BlockState.ERROR -> settings.commandBlockErrorColorValue
+                  BlockState.RUNNING -> settings.commandBlockRunningColorValue
+                }
+                RenderableBlock(
+                  startRow = startScreen.coerceAtLeast(0),
+                  endRow = endScreen.coerceIn(0, visibleRows),
+                  color = color
                 )
               }
+            } else {
+              emptyList()
             }
-            renderCursorOverlay(
-              cursorVisible = cursorVisible,
-              cursorBlinkVisible = cursorBlinkVisible,
-              cursorShape = cursorShape,
-              cursorX = effectiveCursorX,
-              cursorY = cursorY,
-              scrollOffset = scrollOffset,
+
+            // Reset the per-frame blink probe; renderText() sets an entry true if it
+            // draws a SLOW_BLINK / RAPID_BLINK cell in the visible region this frame.
+            blinkProbe[0] = false
+            blinkProbe[1] = false
+
+            // Build rendering context with all state
+            val renderingContext = RenderingContext(
+              bufferSnapshot = bufferSnapshot,
+              blinkProbe = blinkProbe,
               cellWidth = cellWidth,
               cellHeight = cellHeight,
-              isFocused = isFocused,
+              baseCellHeight = baseCellHeight,
+              cellBaseline = cellMetrics.third,
+              scrollOffset = scrollOffset,
+              visibleCols = visibleCols,
+              visibleRows = visibleRows,
+              textMeasurer = textMeasurer,
+              measurementFontFamily = sharedFont,
+              fontSize = effectiveFontSize,
+              settings = settings,
+              ambiguousCharsAreDoubleWidth = display.ambiguousCharsAreDoubleWidth(),
+              selectionStart = effectiveSelectionStart,
+              selectionEnd = effectiveSelectionEnd,
+              selectionMode = effectiveSelectionMode,
+              searchVisible = searchVisible,
+              searchQuery = searchQuery,
+              searchMatches = searchMatches,
+              currentMatchIndex = currentMatchIndex,
+              cursorX = effectiveCursorX,
+              cursorY = cursorY,
+              cursorVisible = cursorVisible,
+              // The text pass no longer draws the cursor (it lives in its own overlay Canvas
+              // below), so pass a constant here. Reading the real cursorBlinkVisible state in
+              // this draw lambda would re-subscribe the whole text canvas to the blink and
+              // defeat the optimization.
+              cursorBlinkVisible = true,
+              cursorShape = cursorShape,
               cursorColor = baseCursorColor,
-              focusedAlpha = settings.cursorFocusedAlpha,
-              unfocusedAlpha = settings.cursorUnfocusedAlpha,
-              imageOcclusion = cursorImageSlice,
+              isFocused = isFocused,
+              hoveredHyperlink = hoveredHyperlink,
+              isModifierPressed = isModifierPressed,
+              slowBlinkVisible = slowBlinkVisible,
+              rapidBlinkVisible = rapidBlinkVisible,
+              imageDataById = renderFrame.imagesById,
+              terminalWidthCells = bufferSnapshot.width,
+              terminalHeightCells = bufferSnapshot.height,
+              precomputedHyperlinks = precomputedHyperlinks,
+              workingDirectory = tab.workingDirectory.value,
+              detectFilePaths = settings.detectFilePaths,
+              hyperlinkRegistry = hyperlinkRegistry,
+              commandBlocks = resolvedCommandBlocks
             )
-          }
-        }
 
-        // IME (Input Method Editor) handler for CJK input
-        // Provides invisible TextField for IME composition (Pinyin, Hiragana, etc.)
-        IMEHandler(
-          enabled = imeState.isEnabled,
-          cursorX = cursorX,
-          cursorY = (cursorY - 1).coerceAtLeast(0), // Adjust for 1-indexed cursor
-          charWidth = cellWidth,
-          charHeight = cellHeight,
-          onTextCommit = { text ->
-            // Forward composed text to terminal
-            scope.launch {
-              tab.writeUserInput(text)
+            // Render terminal using extracted renderer - returns detected hyperlinks
+            with(TerminalCanvasRenderer) {
+              val detectedHyperlinks = renderTerminal(renderingContext)
+              // Update cache for next frame
+              cachedHyperlinks = detectedHyperlinks
+              lastHyperlinkVersionHash = currentVersionHash
             }
-            // Disable IME after successful input and restore focus to terminal
-            imeState.disable()
-            scope.launch {
-              delay(50)
-              focusRequester.requestFocus()
+
+            // Reflect the renderer's blink-presence findings into composition state. Only
+            // an actual change notifies (mutableStateOf uses structural equality), so this
+            // re-arms/parks the blink loops on transitions and is a no-op otherwise — no
+            // per-frame recomposition. Reads here are in the draw phase, not composition.
+            if (hasSlowBlinkText != blinkProbe[0]) hasSlowBlinkText = blinkProbe[0]
+            if (hasRapidBlinkText != blinkProbe[1]) hasRapidBlinkText = blinkProbe[1]
+          }
+
+          // Cursor overlay — drawn in its own Canvas, stacked on top of the text canvas above
+          // (same modifier, so coordinates line up exactly). This is the ONLY place that reads
+          // cursorBlinkVisible, so the ~0.5s blink invalidates just this tiny layer instead of
+          // re-running the full text render. Cursor position is read from the same
+          // composition-scoped snapshots the text canvas uses, so it stays in sync as content
+          // and scroll change. If the cursor intersects an inline image, that cell's alpha masks
+          // the cursor so animated sprite pixels remain above it, matching browser compositing.
+          Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
+            if (size.width < cellWidth || size.height < cellHeight) return@Canvas
+            val customCursorColor = terminal.cursorColor
+            val baseCursorColor = if (customCursorColor != null) {
+              Color(customCursorColor.red, customCursorColor.green, customCursorColor.blue)
+            } else activeTheme.cursorColor
+            with(TerminalCanvasRenderer) {
+              val bufferCursorRow = (cursorY - 1).coerceAtLeast(0)
+              val cursorScreenRow = bufferCursorRow + scrollOffset
+              val cursorImageCell = bufferSnapshot.getLine(bufferCursorRow).getImageCellAt(effectiveCursorX)
+              val cursorImageSlice = cursorImageCell?.let { imageCell ->
+                renderFrame.imagesById[imageCell.imageId]?.let { image ->
+                  ImageRenderer.getOrDecodeImage(image)
+                }?.let { bitmap ->
+                  imageCellSlice(
+                    imageCell = imageCell,
+                    bitmap = bitmap,
+                    visualColumn = effectiveCursorX,
+                    screenRow = cursorScreenRow,
+                    visibleColumns = (size.width / cellWidth).toInt().coerceAtMost(bufferSnapshot.width),
+                    cellWidth = cellWidth,
+                    cellHeight = cellHeight,
+                  )
+                }
+              }
+              renderCursorOverlay(
+                cursorVisible = cursorVisible,
+                cursorBlinkVisible = cursorBlinkVisible,
+                cursorShape = cursorShape,
+                cursorX = effectiveCursorX,
+                cursorY = cursorY,
+                scrollOffset = scrollOffset,
+                cellWidth = cellWidth,
+                cellHeight = cellHeight,
+                isFocused = isFocused,
+                cursorColor = baseCursorColor,
+                focusedAlpha = settings.cursorFocusedAlpha,
+                unfocusedAlpha = settings.cursorUnfocusedAlpha,
+                imageOcclusion = cursorImageSlice,
+              )
             }
           }
-        )
+
+          // IME (Input Method Editor) handler for CJK input
+          // Provides invisible TextField for IME composition (Pinyin, Hiragana, etc.)
+          IMEHandler(
+            enabled = imeState.isEnabled,
+            cursorX = cursorX,
+            cursorY = (cursorY - 1).coerceAtLeast(0), // Adjust for 1-indexed cursor
+            charWidth = cellWidth,
+            charHeight = cellHeight,
+            onTextCommit = { text ->
+              // Forward composed text to terminal
+              scope.launch {
+                tab.writeUserInput(text)
+              }
+              // Disable IME after successful input and restore focus to terminal
+              imeState.disable()
+              scope.launch {
+                delay(50)
+                focusRequester.requestFocus()
+              }
+            }
+          )
+        }
 
         // Search bar UI
         SearchBar(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -134,9 +134,15 @@ private data class StableTerminalRenderFrame(
   val cursorShape: CursorShape?,
 )
 
-private class StableTerminalRenderFrameHolder(
-  var frame: StableTerminalRenderFrame,
-)
+/** UI-thread-confined retention of the last frame accepted by the sync gate. */
+internal class StableRenderFrameHolder<T : Any> {
+  private var frame: T? = null
+
+  fun retain(candidate: T?): T? {
+    if (candidate != null) frame = candidate
+    return frame
+  }
+}
 
 /**
  * Proper terminal implementation using BossTerm's emulator.
@@ -1855,33 +1861,29 @@ fun ProperTerminal(
         // Create snapshot for lock-free rendering with copy-on-write optimization
         // Uses version tracking to reuse unchanged lines (99%+ allocation reduction)
         // Snapshot cached by Compose - recreated when display triggers redraw OR buffer dimensions change
-        // Cursor state is captured atomically to prevent flickering from partial updates
+        // Buffer, images, and cursor state are retained as one accepted render frame.
         val currentTrigger = display.redrawTrigger.value
         val imageDataCache = terminal.getImageDataCache()
         val stableFrameHolder = remember(textBuffer, display) {
-          StableTerminalRenderFrameHolder(
-            StableTerminalRenderFrame(
-              buffer = textBuffer.createIncrementalSnapshot(),
-              imagesById = imageDataCache.snapshotImages(),
-              cursorX = display.cursorXSnapshot,
-              cursorY = display.cursorYSnapshot,
-              cursorVisible = display.cursorVisibleSnapshot,
-              cursorShape = display.cursorShapeSnapshot,
-            )
-          )
+          StableRenderFrameHolder<StableTerminalRenderFrame>()
         }
         val renderFrame = remember(currentTrigger, textBuffer.width, textBuffer.height) {
-          display.captureStableRenderFrame {
-            StableTerminalRenderFrame(
-              buffer = textBuffer.createIncrementalSnapshot(),
-              imagesById = imageDataCache.snapshotImages(),
-              cursorX = display.cursorXSnapshot,
-              cursorY = display.cursorYSnapshot,
-              cursorVisible = display.cursorVisibleSnapshot,
-              cursorShape = display.cursorShapeSnapshot,
-            )
-          }?.also { stableFrameHolder.frame = it } ?: stableFrameHolder.frame
+          stableFrameHolder.retain(
+            display.captureStableRenderFrame {
+              StableTerminalRenderFrame(
+                buffer = textBuffer.createIncrementalSnapshot(),
+                imagesById = imageDataCache.snapshotImages(),
+                cursorX = display.cursorXSnapshot,
+                cursorY = display.cursorYSnapshot,
+                cursorVisible = display.cursorVisibleSnapshot,
+                cursorShape = display.cursorShapeSnapshot,
+              )
+            }
+          )
         }
+        // A first mount during ?2026 has no trusted fallback frame yet. Leave the
+        // terminal canvas empty until the synchronized update publishes its redraw.
+        renderFrame ?: return@Box
         val bufferSnapshot = renderFrame.buffer
         // Cursor and content must come from the same committed ?2026 frame. Kitty
         // image updates temporarily move the real cursor to the placement anchor.

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/SynchronizedRenderFrameTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/SynchronizedRenderFrameTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose
 
+import ai.rever.bossterm.compose.ui.StableRenderFrameHolder
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -32,6 +33,28 @@ class SynchronizedRenderFrameTest {
             assertNull(captured)
             assertEquals("complete", display.captureStableRenderFrame { "complete" })
         } finally {
+            display.dispose()
+        }
+    }
+
+    @Test
+    fun rejectedInitialCaptureDoesNotSeedFallbackFrame() {
+        val display = ComposeTerminalDisplay()
+        val holder = StableRenderFrameHolder<String>()
+        try {
+            display.setSynchronizedUpdate(true)
+            assertNull(holder.retain(display.captureStableRenderFrame { "partial initial" }))
+
+            display.setSynchronizedUpdate(false)
+            assertEquals("complete", holder.retain(display.captureStableRenderFrame { "complete" }))
+
+            display.setSynchronizedUpdate(true)
+            assertEquals(
+                "complete",
+                holder.retain(display.captureStableRenderFrame { "later partial" }),
+            )
+        } finally {
+            display.setSynchronizedUpdate(false)
             display.dispose()
         }
     }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/SynchronizedRenderFrameTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/SynchronizedRenderFrameTest.kt
@@ -3,6 +3,7 @@ package ai.rever.bossterm.compose
 import ai.rever.bossterm.compose.ui.StableRenderFrameHolder
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class SynchronizedRenderFrameTest {
@@ -43,19 +44,32 @@ class SynchronizedRenderFrameTest {
         val holder = StableRenderFrameHolder<String>()
         try {
             display.setSynchronizedUpdate(true)
-            assertNull(holder.retain(display.captureStableRenderFrame { "partial initial" }))
+            assertNull(holder.frameFor(display.captureStableRenderFrame { "partial initial" }))
 
             display.setSynchronizedUpdate(false)
-            assertEquals("complete", holder.retain(display.captureStableRenderFrame { "complete" }))
+            val complete = assertNotNull(display.captureStableRenderFrame { "complete" })
+            assertEquals("complete", holder.frameFor(complete))
+            holder.commit(complete)
 
             display.setSynchronizedUpdate(true)
             assertEquals(
                 "complete",
-                holder.retain(display.captureStableRenderFrame { "later partial" }),
+                holder.frameFor(display.captureStableRenderFrame { "later partial" }),
             )
         } finally {
             display.setSynchronizedUpdate(false)
             display.dispose()
         }
+    }
+
+    @Test
+    fun uncommittedCandidateDoesNotBecomeFallback() {
+        val holder = StableRenderFrameHolder<String>()
+
+        assertEquals("abandoned", holder.frameFor("abandoned"))
+        assertNull(holder.frameFor(null))
+
+        holder.commit("committed")
+        assertEquals("committed", holder.frameFor(null))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/SynchronizedRenderFrameTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/SynchronizedRenderFrameTest.kt
@@ -1,0 +1,38 @@
+package ai.rever.bossterm.compose
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SynchronizedRenderFrameTest {
+
+    @Test
+    fun captureIsRejectedWhileSynchronizedUpdateIsActive() {
+        val display = ComposeTerminalDisplay()
+        try {
+            display.setSynchronizedUpdate(true)
+
+            assertNull(display.captureStableRenderFrame { "partial" })
+        } finally {
+            display.setSynchronizedUpdate(false)
+            display.dispose()
+        }
+    }
+
+    @Test
+    fun captureIsRejectedWhenSynchronizedUpdateOverlapsIt() {
+        val display = ComposeTerminalDisplay()
+        try {
+            val captured = display.captureStableRenderFrame {
+                display.setSynchronizedUpdate(true)
+                display.setSynchronizedUpdate(false)
+                "partial"
+            }
+
+            assertNull(captured)
+            assertEquals("complete", display.captureStableRenderFrame { "complete" })
+        } finally {
+            display.dispose()
+        }
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/rendering/CursorOverlayTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/rendering/CursorOverlayTest.kt
@@ -1,0 +1,134 @@
+package ai.rever.bossterm.compose.rendering
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import ai.rever.bossterm.terminal.CursorShape
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CursorOverlayTest {
+
+    private fun draw(
+        width: Int,
+        height: Int,
+        density: Density = Density(1f),
+        block: DrawScope.() -> Unit,
+    ): ImageBitmap {
+        val bitmap = ImageBitmap(width, height)
+        CanvasDrawScope().draw(
+            density = density,
+            layoutDirection = LayoutDirection.Ltr,
+            canvas = Canvas(bitmap),
+            size = Size(width.toFloat(), height.toFloat()),
+            block = block,
+        )
+        return bitmap
+    }
+
+    @Test
+    fun focusedCursorDefaultsToBrowserLikeOpaqueColor() {
+        val bitmap = draw(width = 10, height = 20) {
+            with(TerminalCanvasRenderer) {
+                renderCursorOverlay(
+                    cursorVisible = true,
+                    cursorBlinkVisible = true,
+                    cursorShape = CursorShape.STEADY_BLOCK,
+                    cursorX = 0,
+                    cursorY = 1,
+                    scrollOffset = 0,
+                    cellWidth = 10f,
+                    cellHeight = 20f,
+                    isFocused = true,
+                    cursorColor = Color.Red,
+                )
+            }
+        }
+
+        val cursorPixel = bitmap.toPixelMap()[5, 10]
+        assertEquals(1f, cursorPixel.alpha, 0.01f)
+        assertTrue(cursorPixel.red > 0.99f)
+    }
+
+    @Test
+    fun underlineUsesOneLogicalPixelAndStaysInsideItsCell() {
+        val bitmap = draw(width = 30, height = 20, density = Density(2f)) {
+            with(TerminalCanvasRenderer) {
+                renderCursorOverlay(
+                    cursorVisible = true,
+                    cursorBlinkVisible = true,
+                    cursorShape = CursorShape.STEADY_UNDERLINE,
+                    cursorX = 1,
+                    cursorY = 1,
+                    scrollOffset = 0,
+                    cellWidth = 7.5f,
+                    cellHeight = 20f,
+                    isFocused = true,
+                    cursorColor = Color.Red,
+                )
+            }
+        }.toPixelMap()
+
+        // 1.dp at 2x density is exactly two device pixels, on floor-aligned cell edges [7, 15).
+        assertEquals(0f, bitmap[10, 17].alpha, 0.01f)
+        assertTrue(bitmap[10, 18].alpha > 0.99f)
+        assertTrue(bitmap[10, 19].alpha > 0.99f)
+        assertEquals(0f, bitmap[6, 19].alpha, 0.01f)
+        assertEquals(0f, bitmap[15, 19].alpha, 0.01f)
+    }
+
+    @Test
+    fun inlineImageAlphaOccludesCursorWithoutErasingTheImage() {
+        val image = draw(width = 10, height = 20) {
+            drawRect(
+                color = Color.Green,
+                topLeft = Offset.Zero,
+                size = Size(5f, 20f),
+            )
+        }
+        val slice = ImageCellSlice(
+            bitmap = image,
+            srcOffset = IntOffset.Zero,
+            srcSize = IntSize(10, 20),
+            dstOffset = IntOffset.Zero,
+            dstSize = IntSize(10, 20),
+        )
+
+        val bitmap = draw(width = 10, height = 20) {
+            drawImage(image)
+            with(TerminalCanvasRenderer) {
+                renderCursorOverlay(
+                    cursorVisible = true,
+                    cursorBlinkVisible = true,
+                    cursorShape = CursorShape.STEADY_BLOCK,
+                    cursorX = 0,
+                    cursorY = 1,
+                    scrollOffset = 0,
+                    cellWidth = 10f,
+                    cellHeight = 20f,
+                    isFocused = true,
+                    cursorColor = Color.Red,
+                    imageOcclusion = slice,
+                )
+            }
+        }.toPixelMap()
+
+        val petPixel = bitmap[2, 10]
+        assertTrue(petPixel.green > 0.99f, "opaque sprite pixels must remain unchanged")
+        assertTrue(petPixel.red < 0.01f, "the cursor must not tint opaque sprite pixels")
+
+        val transparentPixel = bitmap[7, 10]
+        assertTrue(transparentPixel.red > 0.99f, "transparent sprite pixels should reveal the cursor")
+        assertTrue(transparentPixel.green < 0.01f)
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/rendering/CursorOverlayTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/rendering/CursorOverlayTest.kt
@@ -138,6 +138,33 @@ class CursorOverlayTest {
     }
 
     @Test
+    fun verticalBarUsesOneLogicalPixelAndStaysInsideItsCell() {
+        val bitmap = draw(width = 30, height = 20, density = Density(2f)) {
+            with(TerminalCanvasRenderer) {
+                renderCursorOverlay(
+                    cursorVisible = true,
+                    cursorBlinkVisible = true,
+                    cursorShape = CursorShape.STEADY_VERTICAL_BAR,
+                    cursorX = 1,
+                    cursorY = 1,
+                    scrollOffset = 0,
+                    cellWidth = 7.5f,
+                    cellHeight = 20f,
+                    isFocused = true,
+                    cursorColor = Color.Red,
+                )
+            }
+        }.toPixelMap()
+
+        // 1.dp at 2x density is two device pixels at the floor-aligned left edge x=7.
+        assertEquals(0f, bitmap[6, 10].alpha, 0.01f)
+        assertTrue(bitmap[7, 10].alpha > 0.99f)
+        assertTrue(bitmap[8, 10].alpha > 0.99f)
+        assertEquals(0f, bitmap[9, 10].alpha, 0.01f)
+        assertEquals(0f, bitmap[15, 10].alpha, 0.01f)
+    }
+
+    @Test
     fun inlineImageAlphaOccludesCursorWithoutErasingTheImage() {
         val image = draw(width = 10, height = 20) {
             drawRect(

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/rendering/CursorOverlayTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/rendering/CursorOverlayTest.kt
@@ -1,10 +1,12 @@
 package ai.rever.bossterm.compose.rendering
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.toPixelMap
@@ -18,6 +20,15 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class CursorOverlayTest {
+
+    private class LayerCountingCanvas(private val delegate: Canvas) : Canvas by delegate {
+        var savedLayerCount = 0
+
+        override fun saveLayer(bounds: Rect, paint: Paint) {
+            savedLayerCount++
+            delegate.saveLayer(bounds, paint)
+        }
+    }
 
     private fun draw(
         width: Int,
@@ -34,6 +45,23 @@ class CursorOverlayTest {
             block = block,
         )
         return bitmap
+    }
+
+    private fun savedLayerCount(
+        width: Int,
+        height: Int,
+        block: DrawScope.() -> Unit,
+    ): Int {
+        val bitmap = ImageBitmap(width, height)
+        val canvas = LayerCountingCanvas(Canvas(bitmap))
+        CanvasDrawScope().draw(
+            density = Density(1f),
+            layoutDirection = LayoutDirection.Ltr,
+            canvas = canvas,
+            size = Size(width.toFloat(), height.toFloat()),
+            block = block,
+        )
+        return canvas.savedLayerCount
     }
 
     @Test
@@ -58,6 +86,28 @@ class CursorOverlayTest {
         val cursorPixel = bitmap.toPixelMap()[5, 10]
         assertEquals(1f, cursorPixel.alpha, 0.01f)
         assertTrue(cursorPixel.red > 0.99f)
+    }
+
+    @Test
+    fun cursorWithoutImageAvoidsOffscreenLayer() {
+        val layers = savedLayerCount(width = 10, height = 20) {
+            with(TerminalCanvasRenderer) {
+                renderCursorOverlay(
+                    cursorVisible = true,
+                    cursorBlinkVisible = true,
+                    cursorShape = CursorShape.STEADY_BLOCK,
+                    cursorX = 0,
+                    cursorY = 1,
+                    scrollOffset = 0,
+                    cellWidth = 10f,
+                    cellHeight = 20f,
+                    isFocused = true,
+                    cursorColor = Color.Red,
+                )
+            }
+        }
+
+        assertEquals(0, layers)
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/settings/CursorRenderingSettingsMigrationTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/settings/CursorRenderingSettingsMigrationTest.kt
@@ -1,0 +1,39 @@
+package ai.rever.bossterm.compose.settings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CursorRenderingSettingsMigrationTest {
+
+    @Test
+    fun upgradesLegacyFocusedOpacityToBrowserParity() {
+        val migrated = migrateCursorRenderingDefaults(
+            settings = TerminalSettings(cursorFocusedAlpha = 0.7f),
+            hasCursorRenderingVersion = false,
+        )
+
+        assertEquals(1f, migrated.cursorFocusedAlpha)
+        assertEquals(2, migrated.cursorRenderingVersion)
+    }
+
+    @Test
+    fun preservesCustomizedLegacyOpacity() {
+        val migrated = migrateCursorRenderingDefaults(
+            settings = TerminalSettings(cursorFocusedAlpha = 0.5f),
+            hasCursorRenderingVersion = false,
+        )
+
+        assertEquals(0.5f, migrated.cursorFocusedAlpha)
+        assertEquals(2, migrated.cursorRenderingVersion)
+    }
+
+    @Test
+    fun versionedSettingsNeverReapplyMigration() {
+        val migrated = migrateCursorRenderingDefaults(
+            settings = TerminalSettings(cursorFocusedAlpha = 0.7f, cursorRenderingVersion = 2),
+            hasCursorRenderingVersion = true,
+        )
+
+        assertEquals(0.7f, migrated.cursorFocusedAlpha)
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/terminal/TerminalEmulatorDrainTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/terminal/TerminalEmulatorDrainTest.kt
@@ -1,0 +1,61 @@
+package ai.rever.bossterm.compose.terminal
+
+import ai.rever.bossterm.compose.ComposeTerminalDisplay
+import ai.rever.bossterm.terminal.emulator.BossEmulator
+import ai.rever.bossterm.terminal.model.BossTerminal
+import ai.rever.bossterm.terminal.model.StyleState
+import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TerminalEmulatorDrainTest {
+
+    @Test
+    fun eofDuringSynchronizedUpdateRestoresStableCapture() {
+        val display = ComposeTerminalDisplay()
+        val styleState = StyleState()
+        val textBuffer = TerminalTextBuffer(width = 8, height = 2, styleState = styleState)
+        val terminal = BossTerminal(display, textBuffer, styleState)
+        val dataStream = BlockingTerminalDataStream()
+        val emulator = BossEmulator(dataStream, terminal)
+        val synchronizedUpdateConsumed = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+
+        dataStream.onChunkStart = textBuffer::beginBatch
+        dataStream.onChunkEnd = {
+            textBuffer.endBatch()
+            synchronizedUpdateConsumed.countDown()
+        }
+        dataStream.append("\u001B[?2026h")
+
+        val drain = executor.submit {
+            drainTerminalEmulator(
+                emulator = emulator,
+                dataStream = dataStream,
+                terminal = terminal,
+                shouldContinue = { true },
+            )
+        }
+
+        try {
+            assertTrue(synchronizedUpdateConsumed.await(2, TimeUnit.SECONDS))
+            assertNull(display.captureStableRenderFrame { "mid-sync" })
+
+            dataStream.close()
+            drain.get(2, TimeUnit.SECONDS)
+
+            assertEquals("after-disconnect", display.captureStableRenderFrame { "after-disconnect" })
+            assertEquals(false, display.cursorVisibleSnapshot)
+        } finally {
+            dataStream.close()
+            runCatching { drain.get(2, TimeUnit.SECONDS) }
+            executor.shutdownNow()
+            display.dispose()
+        }
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ThemeDefaultsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ThemeDefaultsTest.kt
@@ -57,5 +57,6 @@ class ThemeDefaultsTest {
         assertEquals(t.selection, s.selectionColor)
         assertEquals(t.searchMatch, s.foundPatternColor)
         assertEquals(t.hyperlink, s.hyperlinkColor)
+        assertEquals(1f, s.cursorFocusedAlpha, "focused cursor should match the opaque browser cursor")
     }
 }


### PR DESCRIPTION
## Summary

- match the focused cursor opacity and one-logical-pixel bar/underline geometry used by the browser viewer
- keep opaque inline-image pixels above the cursor while preserving the cursor through transparent image pixels
- retain the last complete buffer, image, and cursor frame while DEC synchronized updates replace Kitty images
- coalesce PTY chunk redraws without holding the snapshot lock, and recover abandoned batch/sync state during emulator teardown
- migrate unversioned legacy 70% focused-opacity values once to the browser-compatible default

## Root cause

The focused cursor was translucent, used percentage-based bar geometry, and was painted directly over inline-image pixels. Codex Pet also hard-deletes and retransmits each Kitty image while temporarily moving the cursor to the placement anchor inside a `?2026h`/`?2026l` synchronized update. A delayed Compose repaint could capture the deleted image state or the temporary placement cursor, producing brief blank pixels or a cursor flash next to the sprite.

The renderer now commits buffer contents, referenced images, and cursor state as one stable frame. Any capture overlapping a synchronized update is rejected, so Compose keeps rendering the previous complete frame until the replacement is ready.

PTY chunk batching remains limited to coalescing model-change notifications, so snapshot capture never waits for a whole output chunk. If emulation exits before the chunk-end callback, terminal teardown clears the abandoned batch and synchronized-update mode and publishes the final model change.

## Upgrade note

Settings files created before cursor-rendering preferences were versioned migrate a focused cursor opacity of exactly 70% to the new browser-compatible 100% default. Because those files do not record whether 70% was the default or an explicit slider choice, deliberately selected legacy 70% values are migrated too; already-versioned opacity choices are preserved.

## Validation

- `./gradlew :compose-ui:desktopTest :bossterm-core-mpp:jvmTest --no-daemon`
- live-tested Codex Pet animation during typing and streamed agent output in BossTerm
