### PR TITLE
fix(updater): survive macOS App Translocation

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/MacOSAppIdentity.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/MacOSAppIdentity.kt
@@ -1,0 +1,7 @@
+package ai.rever.bossterm.compose.update
+
+/** Bundle identifier shared by BossTerm's macOS runtime integrations. */
+internal const val BOSSTERM_MACOS_BUNDLE_ID = "ai.rever.bossterm"
+
+/** Shipping app-bundle name used by the default `/Applications` fallback. */
+internal const val BOSSTERM_MACOS_APP_BUNDLE_NAME = "BossTerm.app"

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateInstaller.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateInstaller.kt
@@ -31,6 +31,24 @@ internal fun macOSAppBundlePathFromLibraryPath(libraryPath: String): String? {
         .firstNotNullOfOrNull(::macOSAppBundlePathIn)
 }
 
+/** Choose a valid Spotlight result deterministically, preferring system-wide installs. */
+internal fun preferredInstalledAppPath(
+    candidates: Sequence<String>,
+    appExists: (String) -> Boolean
+): String? {
+    return candidates
+        .map { it.trim() }
+        .filter { it.endsWith(MACOS_APP_BUNDLE_SUFFIX) }
+        .filterNot { it.contains(APP_TRANSLOCATION_PATH_SEGMENT) }
+        .filterNot { it.contains("/Frameworks/") || it.contains("/Helpers/") }
+        .filter(appExists)
+        .sortedWith(
+            compareBy<String> { !it.startsWith("$MACOS_APPLICATIONS_DIRECTORY/") }
+                .thenBy { it }
+        )
+        .firstOrNull()
+}
+
 /**
  * Resolve a macOS app bundle path without coupling the decision logic to the
  * filesystem or Spotlight.
@@ -471,12 +489,10 @@ object UpdateInstaller {
                 return null
             }
 
-            output.lineSequence()
-                .map { it.trim() }
-                .filter { it.endsWith(MACOS_APP_BUNDLE_SUFFIX) }
-                .filterNot { it.contains(APP_TRANSLOCATION_PATH_SEGMENT) }
-                .filterNot { it.contains("/Frameworks/") || it.contains("/Helpers/") }
-                .firstOrNull { File(it).exists() }
+            preferredInstalledAppPath(
+                candidates = output.lineSequence(),
+                appExists = { File(it).exists() }
+            )
         } catch (e: Exception) {
             println("⚠️ mdfind lookup for installed BossTerm failed: ${e.message}")
             null

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateInstaller.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateInstaller.kt
@@ -4,6 +4,55 @@ import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+private const val APP_TRANSLOCATION_PATH_SEGMENT = "/AppTranslocation/"
+private const val MACOS_APP_BUNDLE_SUFFIX = ".app"
+private const val MACOS_APPLICATIONS_DIRECTORY = "/Applications"
+private const val SPOTLIGHT_LOOKUP_TIMEOUT_SECONDS = 5L
+
+/** Return the outermost complete `.app` path segment in [path]. */
+internal fun macOSAppBundlePathIn(path: String): String? {
+    val pathSegments = path.split('/')
+    val bundleIndex = pathSegments.indexOfFirst {
+        it.length > MACOS_APP_BUNDLE_SUFFIX.length &&
+            it.endsWith(MACOS_APP_BUNDLE_SUFFIX)
+    }
+    if (bundleIndex < 0) return null
+
+    return pathSegments.take(bundleIndex + 1).joinToString("/")
+}
+
+/** Extract the first app bundle represented in `java.library.path`. */
+internal fun macOSAppBundlePathFromLibraryPath(libraryPath: String): String? {
+    return libraryPath
+        .split(File.pathSeparatorChar)
+        .firstNotNullOfOrNull(::macOSAppBundlePathIn)
+}
+
+/**
+ * Resolve a macOS app bundle path without coupling the decision logic to the
+ * filesystem or Spotlight.
+ */
+internal fun realAppPathFor(
+    path: String,
+    appExists: (String) -> Boolean,
+    installedAppLookup: () -> String?
+): String {
+    if (!path.contains(APP_TRANSLOCATION_PATH_SEGMENT)) return path
+
+    val bundleName = macOSAppBundlePathIn(
+        path.substringAfter(APP_TRANSLOCATION_PATH_SEGMENT)
+    )
+        ?.substringAfterLast('/')
+        ?: return path
+
+    val applicationsPath = "$MACOS_APPLICATIONS_DIRECTORY/$bundleName"
+    if (appExists(applicationsPath)) return applicationsPath
+
+    return installedAppLookup()?.takeIf(appExists) ?: path
+}
 
 /**
  * Platform-specific update installation logic.
@@ -346,31 +395,90 @@ object UpdateInstaller {
     fun getCurrentApplicationPath(): String? {
         return try {
             val libraryPath = System.getProperty("java.library.path")
-            val bundlePath = libraryPath
-                ?.split(":")
-                ?.find { it.contains(".app") }
-                ?.let { "${it.substringBefore(".app")}.app" }
+            val bundlePath = libraryPath?.let(::macOSAppBundlePathFromLibraryPath)
 
-            if (bundlePath?.contains(".app") == true && File(bundlePath).exists()) {
-                return bundlePath
+            if (bundlePath != null && File(bundlePath).exists()) {
+                return resolveRealAppPath(bundlePath)
             }
 
             val jarPath = UpdateInstaller::class.java.protectionDomain.codeSource.location.path
             var currentFile = File(jarPath)
             for (i in 0..5) {
                 if (currentFile.name.endsWith(".app")) {
-                    return currentFile.absolutePath
+                    return resolveRealAppPath(currentFile.absolutePath)
                 }
                 currentFile = currentFile.parentFile ?: break
             }
 
-            val applicationsPath = "/Applications/BossTerm.app"
+            val applicationsPath = "$MACOS_APPLICATIONS_DIRECTORY/$BOSSTERM_MACOS_APP_BUNDLE_NAME"
             if (File(applicationsPath).exists()) {
                 return applicationsPath
             }
 
             null
         } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Resolve a Gatekeeper App Translocation path back to the writable installed
+     * bundle before generating the in-place update helper script.
+     */
+    private fun resolveRealAppPath(path: String): String {
+        if (!path.contains(APP_TRANSLOCATION_PATH_SEGMENT)) return path
+
+        println("⚠️ BossTerm is running translocated by Gatekeeper; resolving the installed app path")
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { File(it).exists() },
+            installedAppLookup = ::findInstalledAppViaSpotlight
+        )
+
+        if (resolvedPath != path) {
+            println("✅ Resolved installed BossTerm app path: $resolvedPath")
+            return resolvedPath
+        }
+
+        println("⚠️ Could not resolve the installed app path; keeping translocated path: $path")
+        return path
+    }
+
+    /** Locate the installed BossTerm app via Spotlight without blocking on a full output pipe. */
+    private fun findInstalledAppViaSpotlight(): String? {
+        return try {
+            val process = ProcessBuilder(
+                "mdfind", "kMDItemCFBundleIdentifier == '$BOSSTERM_MACOS_BUNDLE_ID'"
+            )
+                .redirectErrorStream(true)
+                .start()
+
+            val outputFuture = CompletableFuture.supplyAsync {
+                process.inputStream.bufferedReader().use { it.readText() }
+            }
+
+            if (!process.waitFor(SPOTLIGHT_LOOKUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                outputFuture.cancel(true)
+                println("⚠️ mdfind lookup timed out after $SPOTLIGHT_LOOKUP_TIMEOUT_SECONDS seconds")
+                return null
+            }
+
+            val output = outputFuture.get(1, TimeUnit.SECONDS)
+            if (process.exitValue() != 0) {
+                println("⚠️ mdfind lookup failed with exit code ${process.exitValue()}")
+                return null
+            }
+
+            output.lineSequence()
+                .map { it.trim() }
+                .filter { it.endsWith(MACOS_APP_BUNDLE_SUFFIX) }
+                .filterNot { it.contains(APP_TRANSLOCATION_PATH_SEGMENT) }
+                .filterNot { it.contains("/Frameworks/") || it.contains("/Helpers/") }
+                .firstOrNull { File(it).exists() }
+        } catch (e: Exception) {
+            println("⚠️ mdfind lookup for installed BossTerm failed: ${e.message}")
             null
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateScriptGenerator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateScriptGenerator.kt
@@ -130,7 +130,7 @@ object UpdateScriptGenerator {
             if [ -d $escapedTargetAppPath ]; then
                 rm -rf $escapedTargetAppPath
                 if [ ${'$'}? -ne 0 ]; then
-                    echo "Failed to remove old app"
+                    echo "Failed to remove old app at $escapedTargetAppPath (path may be read-only or need admin permissions)"
                     hdiutil detach "${'$'}VOLUME" -quiet
                     exit 1
                 fi
@@ -145,10 +145,25 @@ object UpdateScriptGenerator {
             fi
 
             echo "Installation successful!"
+
+            # Clear quarantine before relaunch so Gatekeeper does not run the newly
+            # installed, notarized app from another read-only App Translocation mount.
+            echo "Clearing quarantine attribute..."
+            if ! xattr -dr com.apple.quarantine $escapedTargetAppPath; then
+                echo "Warning: failed to clear quarantine attribute; future launches may be translocated"
+            fi
+
             hdiutil detach "${'$'}VOLUME" -quiet
 
+            # A successful `open` only means LaunchServices accepted the request;
+            # it does not verify that BossTerm stayed running after launch.
             echo "Launching new BossTerm..."
             open $escapedTargetAppPath
+            if [ ${'$'}? -ne 0 ]; then
+                echo "First relaunch attempt failed - retrying in 2s..."
+                sleep 2
+                open $escapedTargetAppPath || echo "Relaunch failed - please start BossTerm manually"
+            fi
 
             sleep 2
             rm -f "${'$'}0"

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/update/UpdateInstallerPathResolutionTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/update/UpdateInstallerPathResolutionTest.kt
@@ -76,6 +76,43 @@ class UpdateInstallerPathResolutionTest {
     }
 
     @Test
+    fun `Spotlight candidates prefer Applications regardless of result order`() {
+        val applicationsPath = "/Applications/BossTerm Preview.app"
+        val candidates = listOf(
+            "/Users/test/Downloads/BossTerm.app",
+            applicationsPath,
+            "/Users/test/Applications/BossTerm.app"
+        )
+
+        assertEquals(
+            applicationsPath,
+            preferredInstalledAppPath(candidates.asSequence()) { true }
+        )
+        assertEquals(
+            applicationsPath,
+            preferredInstalledAppPath(candidates.reversed().asSequence()) { true }
+        )
+    }
+
+    @Test
+    fun `Spotlight candidates use path order as a deterministic tie breaker`() {
+        val expectedPath = "/Users/alpha/Applications/BossTerm.app"
+        val candidates = listOf(
+            "/Users/zulu/Applications/BossTerm.app",
+            expectedPath
+        )
+
+        assertEquals(
+            expectedPath,
+            preferredInstalledAppPath(candidates.asSequence()) { true }
+        )
+        assertEquals(
+            expectedPath,
+            preferredInstalledAppPath(candidates.reversed().asSequence()) { true }
+        )
+    }
+
+    @Test
     fun `unresolved translocated path is preserved`() {
         val path = "/private/var/folders/xx/T/AppTranslocation/uuid/d/BossTerm.app"
 

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/update/UpdateInstallerPathResolutionTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/update/UpdateInstallerPathResolutionTest.kt
@@ -1,0 +1,90 @@
+package ai.rever.bossterm.compose.update
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class UpdateInstallerPathResolutionTest {
+
+    @Test
+    fun `non-translocated app path is returned without filesystem lookup`() {
+        val path = "/Applications/BossTerm.app"
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { fail("Non-translocated paths must not query the filesystem") },
+            installedAppLookup = { fail("Non-translocated paths must not query Spotlight") }
+        )
+
+        assertEquals(path, resolvedPath)
+    }
+
+    @Test
+    fun `translocated path resolves bundle name in Applications`() {
+        val path = "/private/var/folders/xx/T/AppTranslocation/uuid/d/BossTerm Preview.app/Contents/MacOS/BossTerm"
+        val expectedPath = "/Applications/BossTerm Preview.app"
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { it == expectedPath },
+            installedAppLookup = { fail("Applications path should be preferred over Spotlight") }
+        )
+
+        assertEquals(expectedPath, resolvedPath)
+    }
+
+    @Test
+    fun `bundle suffix is matched at path segment boundary`() {
+        val path = "/private/var/folders/xx/T/AppTranslocation/uuid/d/My.application.app/Contents/MacOS/App"
+        val expectedPath = "/Applications/My.application.app"
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { it == expectedPath },
+            installedAppLookup = { fail("Applications path should be preferred over Spotlight") }
+        )
+
+        assertEquals(expectedPath, resolvedPath)
+    }
+
+    @Test
+    fun `library path preserves app substring inside bundle name`() {
+        val libraryPath = listOf(
+            "/usr/local/lib",
+            "/Applications/My.application.app/Contents/runtime/Contents/Home/lib"
+        ).joinToString(File.pathSeparator)
+
+        assertEquals(
+            "/Applications/My.application.app",
+            macOSAppBundlePathFromLibraryPath(libraryPath)
+        )
+    }
+
+    @Test
+    fun `translocated path falls back to installed app lookup`() {
+        val path = "/private/var/folders/xx/T/AppTranslocation/uuid/d/BossTerm.app"
+        val spotlightPath = "/Users/test/Applications/BossTerm.app"
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { it == spotlightPath },
+            installedAppLookup = { spotlightPath }
+        )
+
+        assertEquals(spotlightPath, resolvedPath)
+    }
+
+    @Test
+    fun `unresolved translocated path is preserved`() {
+        val path = "/private/var/folders/xx/T/AppTranslocation/uuid/d/BossTerm.app"
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { false },
+            installedAppLookup = { null }
+        )
+
+        assertEquals(path, resolvedPath)
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/update/UpdateScriptGeneratorSecurityTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/update/UpdateScriptGeneratorSecurityTest.kt
@@ -1,0 +1,58 @@
+package ai.rever.bossterm.compose.update
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class UpdateScriptGeneratorSecurityTest {
+
+    @Test
+    fun `macOS script strips quarantine and keeps failure visible`() {
+        val scriptFile = UpdateScriptGenerator.generateMacOSUpdateScript(
+            dmgPath = "/tmp/update.dmg",
+            targetAppPath = "/Applications/BossTerm.app",
+            appPid = 12345
+        )
+
+        try {
+            val scriptContent = scriptFile.readText()
+            assertTrue(
+                scriptContent.contains("xattr -dr com.apple.quarantine '/Applications/BossTerm.app'"),
+                "Script should strip quarantine from the installed bundle"
+            )
+            assertTrue(
+                scriptContent.contains("Warning: failed to clear quarantine attribute"),
+                "Quarantine-removal failures should remain visible without aborting the update"
+            )
+        } finally {
+            scriptFile.delete()
+        }
+    }
+
+    @Test
+    fun `macOS script retries a rejected relaunch request`() {
+        val scriptFile = UpdateScriptGenerator.generateMacOSUpdateScript(
+            dmgPath = "/tmp/update.dmg",
+            targetAppPath = "/Applications/BossTerm.app",
+            appPid = 12345
+        )
+
+        try {
+            val scriptContent = scriptFile.readText()
+            val expectedRetryBlock = """
+                open '/Applications/BossTerm.app'
+                if [ ${'$'}? -ne 0 ]; then
+                    echo "First relaunch attempt failed - retrying in 2s..."
+                    sleep 2
+                    open '/Applications/BossTerm.app' || echo "Relaunch failed - please start BossTerm manually"
+                fi
+            """.trimIndent()
+
+            assertTrue(
+                scriptContent.contains(expectedRetryBlock),
+                "Script should retry a rejected LaunchServices request and provide a manual fallback"
+            )
+        } finally {
+            scriptFile.delete()
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On quarantined macOS installs, Gatekeeper can launch BossTerm from a read-only App Translocation mount. The updater then discovers that ephemeral bundle path and embeds it in its helper script, so replacement or relaunch can fail.

This ports the updater hardening from risa-labs-inc/BossConsole#16 to BossTerm.

## Fix

- Resolve translocated bundles to /Applications/<bundle>.app, with a bounded Spotlight fallback using the BossTerm bundle ID.
- Parse app-bundle paths at directory boundaries, including names such as My.application.app.
- Drain mdfind output concurrently and enforce a five-second timeout.
- Clear com.apple.quarantine after copying the notarized app, while keeping failures visible.
- Retry only rejected LaunchServices requests and provide a manual-launch fallback.
- Add focused regression tests for path resolution and generated helper-script behavior.

## Migration note

The installed build generates the update helper, so users already stuck on an older affected build need one manual install of a fixed build. Subsequent in-app updates use this fix.

## Testing

- ./gradlew :compose-ui:desktopTest — passed
- 8 focused updater regression tests — passed
- The app was not launched, per repository workflow.