### PR TITLE
Add worktree action to sidebar context menu

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -599,13 +599,12 @@ fun TabbedTerminal(
             onGitBranch = { gitCmd(GitUtils.Commands.BRANCH) }
             onGitCheckoutPrev = { gitCmd(GitUtils.Commands.CHECKOUT_PREV) }
             onGitCheckoutNew = {
-                // Uses gitCommand but without trailing newline (user types branch name)
-                val cwd = getWorkingDir()
-                if (cwd != null) {
-                    writeToTerminal("git -C \"$cwd\" ${GitUtils.Commands.CHECKOUT_NEW}")
-                } else {
-                    writeToTerminal("git ${GitUtils.Commands.CHECKOUT_NEW}")
-                }
+                // Prefill only: the user still needs to type the new branch name.
+                val command = GitUtils.gitCommand(
+                    GitUtils.Commands.CHECKOUT_NEW,
+                    getWorkingDir()
+                ).removeSuffix("\n")
+                writeToTerminal(command)
             }
             onGitStash = { gitCmd(GitUtils.Commands.STASH) }
             onGitStashPop = { gitCmd(GitUtils.Commands.STASH_POP) }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1513,6 +1513,17 @@ fun TabbedTerminal(
                         tabController.createTab(workingDir = wd)
                     }
                 },
+                onCreateWorktree = { tabIndex, paneId ->
+                    // Target the pane that was right-clicked, even when it is not currently
+                    // focused, then leave the path/branch portion for the user to complete.
+                    val tab = tabController.tabs.getOrNull(tabIndex) ?: return@TabBar
+                    val session = sessionFor(tabIndex, paneId) ?: return@TabBar
+                    tabController.switchToTab(tabIndex)
+                    splitStates[tab.id]?.setFocusedPane(paneId)
+                    val cwd = session.workingDirectory.value
+                    val command = GitUtils.gitCommand("worktree add ", cwd).removeSuffix("\n")
+                    session.writeUserInput(command)
+                },
                 onShareTab = { index ->
                     tabController.tabs.getOrNull(index)?.let { startShare(it.id, ai.rever.bossterm.compose.share.ShareScope.TAB) }
                 },

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1235,17 +1235,20 @@ fun TabbedTerminal(
                 val st = splitStates[tab.id]
                 val panes = if (st != null && !summaryMode) {
                     st.getAllPanes().map { p ->
+                        val terminalPane = p.session as? ai.rever.bossterm.compose.tabs.TerminalTab
                         ai.rever.bossterm.compose.tabs.TabBarPane(
                             p.id, p.session.title.value, colorHexFor(p.session),
                             subtitle = abbreviateCwd(p.session.workingDirectory.value),
-                            branch = (p.session as? ai.rever.bossterm.compose.tabs.TerminalTab)?.gitBranch?.value
+                            branch = terminalPane?.gitBranch?.value,
+                            isGitRepo = terminalPane?.isGitRepo?.value == true
                         )
                     }
                 } else {
                     listOf(ai.rever.bossterm.compose.tabs.TabBarPane(
                         tab.id, tab.title.value, colorHexFor(tab),
                         subtitle = abbreviateCwd(tab.workingDirectory.value),
-                        branch = tab.gitBranch.value
+                        branch = tab.gitBranch.value,
+                        isGitRepo = tab.isGitRepo.value
                     ))
                 }
                 tab to ai.rever.bossterm.compose.tabs.TabBarGroup(index, panes)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1519,6 +1519,8 @@ fun TabbedTerminal(
                 onCreateWorktree = { tabIndex, paneId ->
                     // Target the pane that was right-clicked, even when it is not currently
                     // focused, then leave the path/branch portion for the user to complete.
+                    // Like the existing checkout/clone prefill actions, this appends without
+                    // clearing existing prompt input and does not submit the command.
                     val tab = tabController.tabs.getOrNull(tabIndex) ?: return@TabBar
                     val session = sessionFor(tabIndex, paneId) ?: return@TabBar
                     tabController.switchToTab(tabIndex)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1240,7 +1240,7 @@ fun TabbedTerminal(
                             p.id, p.session.title.value, colorHexFor(p.session),
                             subtitle = abbreviateCwd(p.session.workingDirectory.value),
                             branch = terminalPane?.gitBranch?.value,
-                            isGitRepo = terminalPane?.isGitRepo?.value == true
+                            isGitRepo = if (terminalPane == null) false else terminalPane.isGitRepo.value
                         )
                     }
                 } else {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -121,7 +121,7 @@ internal fun parseTabColor(hex: String?): Color? {
  * (manual or auto). [subtitle] (abbreviated cwd) and [branch] (git branch) are
  * the second and third lines shown on the vertical (left) bar's Warp-style chips;
  * both are ignored by the single-line top bar. [isGitRepo] gates repository-only
- * actions in the local chip menu.
+ * actions in the local chip menu; null means repository detection is pending.
  */
 data class TabBarPane(
     val paneId: String,
@@ -129,8 +129,11 @@ data class TabBarPane(
     val colorHex: String? = null,
     val subtitle: String? = null,
     val branch: String? = null,
-    val isGitRepo: Boolean = false
+    val isGitRepo: Boolean? = false
 )
+
+/** Keep worktree creation optimistic while repository detection is still pending. */
+internal fun canCreateWorktree(isGitRepo: Boolean?): Boolean = isGitRepo != false
 
 /** A tab and its panes, rendered as a visually-grouped cluster of chips. */
 data class TabBarGroup(val tabIndex: Int, val panes: List<TabBarPane>)
@@ -321,7 +324,7 @@ fun TabBar(
             ContextMenuController.MenuItem(
                 id = "create_worktree",
                 label = "Create Worktree for This…",
-                enabled = localGitRepoByPane[tabIndex to paneId] == true,
+                enabled = canCreateWorktree(localGitRepoByPane[tabIndex to paneId]),
                 action = { onCreateWorktree(tabIndex, paneId) }
             ),
             ContextMenuController.MenuSeparator(id = "separator_worktree"),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -107,14 +107,16 @@ internal fun parseTabColor(hex: String?): Color? {
  * One pane shown as a chip in the tab bar. [colorHex] is the resolved accent
  * (manual or auto). [subtitle] (abbreviated cwd) and [branch] (git branch) are
  * the second and third lines shown on the vertical (left) bar's Warp-style chips;
- * both are ignored by the single-line top bar.
+ * both are ignored by the single-line top bar. [isGitRepo] gates repository-only
+ * actions in the local chip menu.
  */
 data class TabBarPane(
     val paneId: String,
     val title: String,
     val colorHex: String? = null,
     val subtitle: String? = null,
-    val branch: String? = null
+    val branch: String? = null,
+    val isGitRepo: Boolean = false
 )
 
 /** A tab and its panes, rendered as a visually-grouped cluster of chips. */
@@ -288,6 +290,10 @@ fun TabBar(
     // "Rename…" menu item; cleared on commit/cancel.
     var editingPaneId by remember { mutableStateOf<String?>(null) }
 
+    val localGitRepoByPane = groups.flatMap { group ->
+        group.panes.map { pane -> (group.tabIndex to pane.paneId) to pane.isGitRepo }
+    }.toMap()
+
     val showChipMenu: (Int, String) -> Unit = { tabIndex, paneId ->
         val colorSubmenu = ContextMenuController.MenuSubmenu(
             id = "tab_color",
@@ -302,7 +308,7 @@ fun TabBar(
             ContextMenuController.MenuItem(
                 id = "create_worktree",
                 label = "Create Worktree for This…",
-                enabled = true,
+                enabled = localGitRepoByPane[tabIndex to paneId] == true,
                 action = { onCreateWorktree(tabIndex, paneId) }
             ),
             ContextMenuController.MenuSeparator(id = "separator_worktree"),
@@ -430,6 +436,12 @@ fun TabBar(
         }
     }
 
+    val showMenuFor: (Int, String) -> Unit = { tabIndex, paneId ->
+        val remote = remoteByTabIndex[tabIndex]
+        if (remote != null) showRemoteChipMenu(remote.first, remote.second, tabIndex, paneId)
+        else showChipMenu(tabIndex, paneId)
+    }
+
     // Tab-bar chrome follows the active terminal theme, so the left panel
     // re-styles live when the theme/palette is switched (collectAsState recomposes).
     val tabBarTheme by ThemeManager.instance.currentTheme.collectAsState()
@@ -446,7 +458,15 @@ fun TabBar(
 
     // A single compact action button for the left bar's top toolbar.
     val barButton: @Composable (ImageVector, String, () -> Unit) -> Unit = { icon, desc, onClick ->
-        IconButton(onClick = onClick, modifier = Modifier.size(30.dp)) {
+        IconButton(
+            onClick = onClick,
+            modifier = Modifier.size(30.dp)
+                .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
+                    if (event.button == PointerButton.Secondary) {
+                        event.changes.forEach { it.consume() }
+                    }
+                }
+        ) {
             Icon(imageVector = icon, contentDescription = desc, tint = barMuted, modifier = Modifier.size(16.dp))
         }
     }
@@ -487,11 +507,7 @@ fun TabBar(
             },
             onCancelRename = { editingPaneId = null },
             onClose = { onPaneClosed(group.tabIndex, pane.paneId) },
-            onContextMenu = {
-                val ctx = remoteByTabIndex[group.tabIndex]
-                if (ctx != null) showRemoteChipMenu(ctx.first, ctx.second, group.tabIndex, pane.paneId)
-                else showChipMenu(group.tabIndex, pane.paneId)
-            },
+            onContextMenu = { showMenuFor(group.tabIndex, pane.paneId) },
             modifier = chipModifier
         )
     }
@@ -503,9 +519,7 @@ fun TabBar(
         val group = allGroups.firstOrNull { it.tabIndex == activeTabIndex }
         val pane = group?.panes?.firstOrNull { it.paneId == focusedPaneId } ?: group?.panes?.firstOrNull()
         if (group != null && pane != null) {
-            val ctx = remoteByTabIndex[group.tabIndex]
-            if (ctx != null) showRemoteChipMenu(ctx.first, ctx.second, group.tabIndex, pane.paneId)
-            else showChipMenu(group.tabIndex, pane.paneId)
+            showMenuFor(group.tabIndex, pane.paneId)
         }
     }
 
@@ -570,12 +584,7 @@ fun TabBar(
                                             .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
                                                 if (event.button == PointerButton.Secondary) {
                                                     event.changes.forEach { it.consume() }
-                                                    val ctx = remoteByTabIndex[group.tabIndex]
-                                                    if (ctx != null) {
-                                                        showRemoteChipMenu(ctx.first, ctx.second, group.tabIndex, pane.paneId)
-                                                    } else {
-                                                        showChipMenu(group.tabIndex, pane.paneId)
-                                                    }
+                                                    showMenuFor(group.tabIndex, pane.paneId)
                                                 }
                                             }
                                             .clickable { onPaneSelected(group.tabIndex, pane.paneId) },
@@ -871,7 +880,13 @@ fun TabBar(
                 ) {
                     Row(
                         modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp))
-                            .clickable(onClick = onAddRemote).padding(vertical = 6.dp, horizontal = 8.dp),
+                            .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
+                                if (event.button == PointerButton.Secondary) {
+                                    event.changes.forEach { it.consume() }
+                                }
+                            }
+                            .clickable(onClick = onAddRemote)
+                            .padding(vertical = 6.dp, horizontal = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
@@ -884,7 +899,15 @@ fun TabBar(
                         Text("Add remote", color = Color(0xFFB0B0B0), fontSize = 12.sp)
                     }
                     onToggleCollapse?.let { toggle ->
-                        IconButton(onClick = toggle, modifier = Modifier.size(28.dp)) {
+                        IconButton(
+                            onClick = toggle,
+                            modifier = Modifier.size(28.dp)
+                                .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
+                                    if (event.button == PointerButton.Secondary) {
+                                        event.changes.forEach { it.consume() }
+                                    }
+                                }
+                        ) {
                             Icon(
                                 imageVector = Icons.Default.ChevronLeft,
                                 contentDescription = "Collapse sidebar",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -84,6 +84,19 @@ private val RemoteAccent: Color = Color(0xFF4FC3F7)
 private val TabChipGap: Dp = 3.dp
 
 /**
+ * Consume secondary presses before click gestures can treat them as primary actions.
+ * An optional callback supports controls that also open a context menu.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+private fun Modifier.consumeSecondaryPress(onSecondaryPress: (() -> Unit)? = null): Modifier =
+    onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
+        if (event.button == PointerButton.Secondary) {
+            event.changes.forEach { it.consume() }
+            onSecondaryPress?.invoke()
+        }
+    }
+
+/**
  * Preset accent colors offered in the chip "Color" submenu (Warp-style).
  * Stored as ARGB hex ("0xAARRGGBB") to match [ai.rever.bossterm.compose.settings.TerminalSettings].
  */
@@ -461,11 +474,7 @@ fun TabBar(
         IconButton(
             onClick = onClick,
             modifier = Modifier.size(30.dp)
-                .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
-                    if (event.button == PointerButton.Secondary) {
-                        event.changes.forEach { it.consume() }
-                    }
-                }
+                .consumeSecondaryPress()
         ) {
             Icon(imageVector = icon, contentDescription = desc, tint = barMuted, modifier = Modifier.size(16.dp))
         }
@@ -581,11 +590,8 @@ fun TabBar(
                                 }) {
                                     Box(
                                         modifier = Modifier.size(24.dp).clip(RoundedCornerShape(6.dp))
-                                            .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
-                                                if (event.button == PointerButton.Secondary) {
-                                                    event.changes.forEach { it.consume() }
-                                                    showMenuFor(group.tabIndex, pane.paneId)
-                                                }
+                                            .consumeSecondaryPress {
+                                                showMenuFor(group.tabIndex, pane.paneId)
                                             }
                                             .clickable { onPaneSelected(group.tabIndex, pane.paneId) },
                                         contentAlignment = Alignment.Center
@@ -641,12 +647,7 @@ fun TabBar(
                         ) {
                             Row(
                                 modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp, vertical = 2.dp)
-                                    .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
-                                        if (event.button == PointerButton.Secondary) {
-                                            event.changes.forEach { it.consume() }
-                                            showRemoteGroupMenu(rg)
-                                        }
-                                    },
+                                    .consumeSecondaryPress { showRemoteGroupMenu(rg) },
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(4.dp)
                             ) {
@@ -880,11 +881,7 @@ fun TabBar(
                 ) {
                     Row(
                         modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp))
-                            .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
-                                if (event.button == PointerButton.Secondary) {
-                                    event.changes.forEach { it.consume() }
-                                }
-                            }
+                            .consumeSecondaryPress()
                             .clickable(onClick = onAddRemote)
                             .padding(vertical = 6.dp, horizontal = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -902,11 +899,7 @@ fun TabBar(
                         IconButton(
                             onClick = toggle,
                             modifier = Modifier.size(28.dp)
-                                .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
-                                    if (event.button == PointerButton.Secondary) {
-                                        event.changes.forEach { it.consume() }
-                                    }
-                                }
+                                .consumeSecondaryPress()
                         ) {
                             Icon(
                                 imageVector = Icons.Default.ChevronLeft,
@@ -985,14 +978,9 @@ private fun TabItem(
             .then(
                 if (isEditing) Modifier
                 else Modifier
-                    .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
-                        // Observe and consume secondary presses before combinedClickable can
-                        // interpret them as a normal selection gesture.
-                        if (event.button == PointerButton.Secondary) {
-                            event.changes.forEach { it.consume() }
-                            onContextMenu()
-                        }
-                    }
+                    // Observe and consume secondary presses before combinedClickable can
+                    // interpret them as a normal selection gesture.
+                    .consumeSecondaryPress(onContextMenu)
                     .combinedClickable(onClick = onSelected, onDoubleClick = onStartRename)
             ),
         shape = RoundedCornerShape(6.dp),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.text.TextStyle
@@ -235,8 +236,8 @@ private val REMOTE_AI_ASSISTANTS = listOf(
  * - Close button per chip (X)
  * - New tab button (+)
  * - Active/focused pane highlighting
- * - Right-click context menu: Rename…, Color ▸, Duplicate, Close, Close Others,
- *   Close Tabs Below, Move Tab to New Window
+ * - Right-click context menu: Create Worktree for This…, Rename…, Color ▸,
+ *   Duplicate, Close, Close Others, Close Tabs Below, Move Tab to New Window
  * - Double-click a chip to rename inline
  *
  * Styling matches the Material 3 design of the search bar for visual consistency.
@@ -256,6 +257,7 @@ fun TabBar(
     onCloseOthers: (Int) -> Unit = {},
     onCloseBelow: (Int) -> Unit = {},
     onDuplicate: (Int) -> Unit = {},
+    onCreateWorktree: (tabIndex: Int, paneId: String) -> Unit = { _, _ -> },
     onShareTab: (Int) -> Unit = {},
     onShareWindow: (Int) -> Unit = {},
     onShareAll: (Int) -> Unit = {},
@@ -297,6 +299,13 @@ fun TabBar(
         )
         val items = listOf(
             ContextMenuController.MenuItem(id = "new_tab", label = "New Tab", enabled = true, action = { onNewTab() }),
+            ContextMenuController.MenuItem(
+                id = "create_worktree",
+                label = "Create Worktree for This…",
+                enabled = true,
+                action = { onCreateWorktree(tabIndex, paneId) }
+            ),
+            ContextMenuController.MenuSeparator(id = "separator_worktree"),
             ContextMenuController.MenuItem(id = "rename_tab", label = "Rename…", enabled = true, action = { editingPaneId = paneId }),
             colorSubmenu,
             ContextMenuController.MenuSeparator(id = "separator_tab_ops"),
@@ -487,11 +496,37 @@ fun TabBar(
         )
     }
 
+    // Right-clicking empty sidebar chrome targets the active pane. Child controls consume
+    // their own secondary presses, so the Final-pass handler below only handles background.
+    val showActivePaneMenu: () -> Unit = {
+        val allGroups = groups + remoteGroups.flatMap { it.groups + it.nested.flatMap { n -> n.groups } }
+        val group = allGroups.firstOrNull { it.tabIndex == activeTabIndex }
+        val pane = group?.panes?.firstOrNull { it.paneId == focusedPaneId } ?: group?.panes?.firstOrNull()
+        if (group != null && pane != null) {
+            val ctx = remoteByTabIndex[group.tabIndex]
+            if (ctx != null) showRemoteChipMenu(ctx.first, ctx.second, group.tabIndex, pane.paneId)
+            else showChipMenu(group.tabIndex, pane.paneId)
+        }
+    }
+
     Surface(
-        modifier = modifier.then(
-            if (vertical) Modifier.fillMaxHeight().width(if (collapsed) TabBarRailWidth else verticalWidth)
-            else Modifier.fillMaxWidth().height(TabBarHeight)
-        ),
+        modifier = modifier
+            .then(
+                if (vertical) Modifier.fillMaxHeight().width(if (collapsed) TabBarRailWidth else verticalWidth)
+                else Modifier.fillMaxWidth().height(TabBarHeight)
+            )
+            .then(
+                if (vertical) {
+                    Modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Final) { event ->
+                        if (event.button == PointerButton.Secondary && event.changes.none { it.isConsumed }) {
+                            event.changes.forEach { it.consume() }
+                            showActivePaneMenu()
+                        }
+                    }
+                } else {
+                    Modifier
+                }
+            ),
         color = barBg,
         shadowElevation = 2.dp
     ) {
@@ -532,6 +567,17 @@ fun TabBar(
                                 }) {
                                     Box(
                                         modifier = Modifier.size(24.dp).clip(RoundedCornerShape(6.dp))
+                                            .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
+                                                if (event.button == PointerButton.Secondary) {
+                                                    event.changes.forEach { it.consume() }
+                                                    val ctx = remoteByTabIndex[group.tabIndex]
+                                                    if (ctx != null) {
+                                                        showRemoteChipMenu(ctx.first, ctx.second, group.tabIndex, pane.paneId)
+                                                    } else {
+                                                        showChipMenu(group.tabIndex, pane.paneId)
+                                                    }
+                                                }
+                                            }
                                             .clickable { onPaneSelected(group.tabIndex, pane.paneId) },
                                         contentAlignment = Alignment.Center
                                     ) {
@@ -586,8 +632,11 @@ fun TabBar(
                         ) {
                             Row(
                                 modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp, vertical = 2.dp)
-                                    .onPointerEvent(PointerEventType.Press) { event ->
-                                        if (event.button == PointerButton.Secondary) showRemoteGroupMenu(rg)
+                                    .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
+                                        if (event.button == PointerButton.Secondary) {
+                                            event.changes.forEach { it.consume() }
+                                            showRemoteGroupMenu(rg)
+                                        }
                                     },
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(4.dp)
@@ -913,13 +962,15 @@ private fun TabItem(
             .then(
                 if (isEditing) Modifier
                 else Modifier
-                    .combinedClickable(onClick = onSelected, onDoubleClick = onStartRename)
-                    .onPointerEvent(PointerEventType.Press) { event ->
-                        // Handle right-click for context menu
+                    .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
+                        // Observe and consume secondary presses before combinedClickable can
+                        // interpret them as a normal selection gesture.
                         if (event.button == PointerButton.Secondary) {
+                            event.changes.forEach { it.consume() }
                             onContextMenu()
                         }
                     }
+                    .combinedClickable(onClick = onSelected, onDoubleClick = onStartRename)
             ),
         shape = RoundedCornerShape(6.dp),
         color = if (isActive) itemRaised else itemBg,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -129,7 +129,7 @@ data class TabBarPane(
     val colorHex: String? = null,
     val subtitle: String? = null,
     val branch: String? = null,
-    val isGitRepo: Boolean? = false
+    val isGitRepo: Boolean? = null
 )
 
 /** Keep worktree creation optimistic while repository detection is still pending. */
@@ -306,9 +306,11 @@ fun TabBar(
     // "Rename…" menu item; cleared on commit/cancel.
     var editingPaneId by remember { mutableStateOf<String?>(null) }
 
-    val localGitRepoByPane = groups.flatMap { group ->
-        group.panes.map { pane -> (group.tabIndex to pane.paneId) to pane.isGitRepo }
-    }.toMap()
+    val localGitRepoByPane = remember(groups) {
+        groups.flatMap { group ->
+            group.panes.map { pane -> (group.tabIndex to pane.paneId) to pane.isGitRepo }
+        }.toMap()
+    }
 
     val showChipMenu: (Int, String) -> Unit = { tabIndex, paneId ->
         val colorSubmenu = ContextMenuController.MenuSubmenu(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -136,15 +136,20 @@ class TabController(
             }
         }
 
-        // Track the git branch of the working directory for the left tab-bar's
-        // third chip line (Warp-style title / cwd / branch). Debounced + collectLatest
-        // so a rapid `cd` cancels the stale lookup; null outside a repository.
+        // Track repository membership and the git branch of the working directory for
+        // repository-only actions and the left tab-bar's third chip line. Debounced +
+        // collectLatest so a rapid `cd` cancels the stale lookup.
         session.coroutineScope.launch {
             snapshotFlow { session.workingDirectory.value }
                 .distinctUntilChanged()
                 .collectLatest { cwd ->
                     delay(350)
-                    session.gitBranch.value = withContext(Dispatchers.IO) { GitUtils.getCurrentBranch(cwd) }
+                    val (branch, isRepo) = withContext(Dispatchers.IO) {
+                        val currentBranch = GitUtils.getCurrentBranch(cwd)
+                        currentBranch to (currentBranch != null || GitUtils.isGitRepo(cwd))
+                    }
+                    session.gitBranch.value = branch
+                    session.isGitRepo.value = isRepo
                 }
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -143,6 +143,7 @@ class TabController(
             snapshotFlow { session.workingDirectory.value }
                 .distinctUntilChanged()
                 .collectLatest { cwd ->
+                    session.isGitRepo.value = null
                     delay(350)
                     val (branch, isRepo) = withContext(Dispatchers.IO) {
                         val currentBranch = GitUtils.getCurrentBranch(cwd)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -145,12 +145,11 @@ class TabController(
                 .collectLatest { cwd ->
                     session.isGitRepo.value = null
                     delay(350)
-                    val (branch, isRepo) = withContext(Dispatchers.IO) {
-                        val currentBranch = GitUtils.getCurrentBranch(cwd)
-                        currentBranch to (currentBranch != null || GitUtils.isGitRepo(cwd))
+                    val repository = withContext(Dispatchers.IO) {
+                        GitUtils.getRepositoryState(cwd)
                     }
-                    session.gitBranch.value = branch
-                    session.isGitRepo.value = isRepo
+                    session.gitBranch.value = repository.branch
+                    session.isGitRepo.value = repository.isRepository
                 }
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -350,6 +350,12 @@ data class TerminalTab(
      */
     val gitBranch: MutableState<String?> = mutableStateOf(null)
 
+    /**
+     * Whether [workingDirectory] is inside a git repository. Tracked alongside
+     * [gitBranch]; unlike a nullable branch, this remains true for detached HEAD.
+     */
+    val isGitRepo: MutableState<Boolean> = mutableStateOf(false)
+
     // === Content-Anchored Selection ===
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -353,6 +353,8 @@ data class TerminalTab(
     /**
      * Whether [workingDirectory] is inside a git repository. Tracked alongside
      * [gitBranch]; unlike a nullable branch, this remains true for detached HEAD.
+     * Starts false, so repository-only actions stay disabled until the debounced
+     * background probe for a newly opened tab or changed directory completes.
      */
     val isGitRepo: MutableState<Boolean> = mutableStateOf(false)
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -351,12 +351,11 @@ data class TerminalTab(
     val gitBranch: MutableState<String?> = mutableStateOf(null)
 
     /**
-     * Whether [workingDirectory] is inside a git repository. Tracked alongside
-     * [gitBranch]; unlike a nullable branch, this remains true for detached HEAD.
-     * Starts false, so repository-only actions stay disabled until the debounced
-     * background probe for a newly opened tab or changed directory completes.
+     * Whether [workingDirectory] is inside a git repository. Null means the
+     * debounced background probe is still pending; true remains distinct from a
+     * nullable [gitBranch] for detached HEAD.
      */
-    val isGitRepo: MutableState<Boolean> = mutableStateOf(false)
+    val isGitRepo: MutableState<Boolean?> = mutableStateOf(null)
 
     // === Content-Anchored Selection ===
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/vcs/GitUtils.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/vcs/GitUtils.kt
@@ -10,6 +10,11 @@ import java.util.concurrent.TimeUnit
  */
 object GitUtils {
 
+    internal data class RepositoryState(
+        val branch: String?,
+        val isRepository: Boolean
+    )
+
     /**
      * Quote one path as a single shell argument. POSIX single quotes prevent interpolation
      * and are escaped by ending and reopening the quoted segment. On Windows, where filenames
@@ -80,31 +85,46 @@ object GitUtils {
     }
 
     /**
-     * Get the current branch name.
+     * Resolve repository membership and the current branch with one git process.
+     * symbolic-ref exits 1 for detached HEAD, which still means the cwd is a repo.
      */
-    fun getCurrentBranch(cwd: String?): String? {
-        if (cwd == null) return null
+    internal fun getRepositoryState(cwd: String?): RepositoryState {
+        if (cwd == null) return RepositoryState(branch = null, isRepository = false)
         var process: Process? = null
         return try {
-            process = ProcessBuilder("git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD")
+            process = ProcessBuilder("git", "-C", cwd, "symbolic-ref", "--quiet", "--short", "HEAD")
                 .redirectErrorStream(true)
                 .start()
-            val output = process.inputStream.bufferedReader().use { it.readText().trim() }
             val completed = process.waitFor(2, TimeUnit.SECONDS)
             if (!completed) {
                 process.destroyForcibly()
-                null
-            } else if (process.exitValue() == 0 && output.isNotEmpty() && output != "HEAD") {
-                output
-            } else null
+                RepositoryState(branch = null, isRepository = false)
+            } else {
+                val output = process.inputStream.bufferedReader().use { it.readText() }
+                parseRepositoryState(process.exitValue(), output)
+            }
         } catch (e: Exception) {
-            null
+            RepositoryState(branch = null, isRepository = false)
         } finally {
             process?.inputStream?.close()
             process?.errorStream?.close()
             process?.outputStream?.close()
         }
     }
+
+    internal fun parseRepositoryState(exitCode: Int, output: String): RepositoryState {
+        return when (exitCode) {
+            0 -> RepositoryState(
+                branch = output.trim().takeIf { it.isNotEmpty() },
+                isRepository = true
+            )
+            1 -> RepositoryState(branch = null, isRepository = true)
+            else -> RepositoryState(branch = null, isRepository = false)
+        }
+    }
+
+    /** Get the current branch name, or null for detached HEAD and non-repositories. */
+    fun getCurrentBranch(cwd: String?): String? = getRepositoryState(cwd).branch
 
     /**
      * Get list of local branches.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/vcs/GitUtils.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/vcs/GitUtils.kt
@@ -11,9 +11,10 @@ import java.util.concurrent.TimeUnit
 object GitUtils {
 
     /**
-     * Quote one shell argument without allowing interpolation. Windows filenames cannot
-     * contain a double quote; POSIX single quotes are escaped by ending and reopening the
-     * quoted segment.
+     * Quote one path as a single shell argument. POSIX single quotes prevent interpolation
+     * and are escaped by ending and reopening the quoted segment. On Windows, where filenames
+     * cannot contain a double quote, wrapping prevents argument break-out but cmd.exe and
+     * PowerShell may still expand their own interpolation sigils inside the quoted value.
      */
     internal fun shellQuote(value: String, isWindows: Boolean = ShellCustomizationUtils.isWindows()): String {
         return if (isWindows) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/vcs/GitUtils.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/vcs/GitUtils.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.vcs
 
+import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -8,6 +9,19 @@ import java.util.concurrent.TimeUnit
  * Used by both context menu (VersionControlMenuProvider) and window menu (MenuActions).
  */
 object GitUtils {
+
+    /**
+     * Quote one shell argument without allowing interpolation. Windows filenames cannot
+     * contain a double quote; POSIX single quotes are escaped by ending and reopening the
+     * quoted segment.
+     */
+    internal fun shellQuote(value: String, isWindows: Boolean = ShellCustomizationUtils.isWindows()): String {
+        return if (isWindows) {
+            "\"$value\""
+        } else {
+            "'" + value.replace("'", "'\"'\"'") + "'"
+        }
+    }
 
     /**
      * Check if a directory is inside a git repository.
@@ -130,7 +144,7 @@ object GitUtils {
      */
     fun gitCommand(cmd: String, cwd: String?): String {
         return if (cwd != null) {
-            "git -C \"$cwd\" $cmd\n"
+            "git -C ${shellQuote(cwd)} $cmd\n"
         } else {
             "git $cmd\n"
         }
@@ -144,7 +158,7 @@ object GitUtils {
      */
     fun ghCommand(cmd: String, cwd: String?): String {
         return if (cwd != null) {
-            "cd \"$cwd\" && gh $cmd\n"
+            "cd ${shellQuote(cwd)} && gh $cmd\n"
         } else {
             "gh $cmd\n"
         }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabBarWorktreeActionTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabBarWorktreeActionTest.kt
@@ -1,0 +1,19 @@
+package ai.rever.bossterm.compose.tabs
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TabBarWorktreeActionTest {
+
+    @Test
+    fun `worktree action remains enabled while repository detection is pending`() {
+        assertTrue(canCreateWorktree(null))
+    }
+
+    @Test
+    fun `worktree action disables only for a confirmed non-repository`() {
+        assertTrue(canCreateWorktree(true))
+        assertFalse(canCreateWorktree(false))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/vcs/GitUtilsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/vcs/GitUtilsTest.kt
@@ -1,0 +1,23 @@
+package ai.rever.bossterm.compose.vcs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GitUtilsTest {
+
+    @Test
+    fun `POSIX shell quote preserves spaces quotes and interpolation characters`() {
+        assertEquals(
+            "'/tmp/a b/'\"'\"'c\"/\$HOME/`cmd`'",
+            GitUtils.shellQuote("/tmp/a b/'c\"/\$HOME/`cmd`", isWindows = false)
+        )
+    }
+
+    @Test
+    fun `Windows shell quote preserves a valid Windows path`() {
+        assertEquals(
+            "\"C:\\Users\\Boss User\\repo\"",
+            GitUtils.shellQuote("C:\\Users\\Boss User\\repo", isWindows = true)
+        )
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/vcs/GitUtilsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/vcs/GitUtilsTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.vcs
 
+import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -19,5 +20,15 @@ class GitUtilsTest {
             "\"C:\\Users\\Boss User\\repo\"",
             GitUtils.shellQuote("C:\\Users\\Boss User\\repo", isWindows = true)
         )
+    }
+
+    @Test
+    fun `git command quotes cwd before worktree command`() {
+        val expected = if (ShellCustomizationUtils.isWindows()) {
+            "git -C \"/tmp/a b\" worktree add \n"
+        } else {
+            "git -C '/tmp/a b' worktree add \n"
+        }
+        assertEquals(expected, GitUtils.gitCommand("worktree add ", "/tmp/a b"))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/vcs/GitUtilsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/vcs/GitUtilsTest.kt
@@ -31,4 +31,28 @@ class GitUtilsTest {
         }
         assertEquals(expected, GitUtils.gitCommand("worktree add ", "/tmp/a b"))
     }
+
+    @Test
+    fun `repository state includes a symbolic branch`() {
+        assertEquals(
+            GitUtils.RepositoryState(branch = "feature/worktrees", isRepository = true),
+            GitUtils.parseRepositoryState(exitCode = 0, output = "feature/worktrees\n")
+        )
+    }
+
+    @Test
+    fun `repository state keeps detached HEAD inside the repository`() {
+        assertEquals(
+            GitUtils.RepositoryState(branch = null, isRepository = true),
+            GitUtils.parseRepositoryState(exitCode = 1, output = "")
+        )
+    }
+
+    @Test
+    fun `repository state rejects non-repository failures`() {
+        assertEquals(
+            GitUtils.RepositoryState(branch = null, isRepository = false),
+            GitUtils.parseRepositoryState(exitCode = 128, output = "fatal: not a git repository")
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- make BossTerm sidebar context menus respond reliably to secondary clicks
- expose the same menu from expanded tab chips, collapsed rail icons, and empty sidebar chrome
- add **Create Worktree for This…**, targeting the clicked pane and prefilling a path-aware `git worktree add` command
- consume secondary presses before normal click handling so right-click does not also select or open duplicate menus

## Why

The sidebar's normal click gesture could consume secondary presses, while the collapsed rail and empty sidebar background had no context-menu handling. As a result, right-clicking the sidebar could appear to do nothing and there was no direct worktree entry point for a terminal pane.

## Impact

Users can now right-click anywhere relevant in the BossTerm sidebar and start a worktree command for the intended local pane. Remote pane menus keep their existing host-routed behavior.

## Validation

- `./gradlew :compose-ui:compileKotlinDesktop :compose-ui:desktopTest --no-daemon`
- `git diff --check`
