### PR TITLE
Add sidebar tab drag reordering

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1445,6 +1445,9 @@ fun TabbedTerminal(
                     tabController.switchToTab(tabIndex)
                     tabController.tabs.getOrNull(tabIndex)?.let { t -> splitStates[t.id]?.setFocusedPane(paneId) }
                 },
+                onTabReordered = { fromIndex, toIndex ->
+                    tabController.moveTab(fromIndex, toIndex)
+                },
                 onPaneClosed = { tabIndex, paneId ->
                     val t = tabController.tabs.getOrNull(tabIndex)
                     if (t != null) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -746,10 +746,11 @@ fun TabbedTerminal(
         }
     }
 
-    // Phase 6: persist session structure on structural change (tab add/close/switch,
+    // Phase 6: persist session structure on structural change (tab add/close/reorder/switch,
     // and split/ratio changes in the active tab via its rootNode identity).
+    val persistedTabOrder = tabController.tabs.map { it.id }
     LaunchedEffect(
-        tabController.tabs.size,
+        persistedTabOrder,
         tabController.activeTabIndex,
         settings.restoreSessionOnLaunch,
         tabController.activeTab?.let { splitStates[it.id]?.rootNode }
@@ -1446,7 +1447,11 @@ fun TabbedTerminal(
                     tabController.tabs.getOrNull(tabIndex)?.let { t -> splitStates[t.id]?.setFocusedPane(paneId) }
                 },
                 onTabReordered = { fromIndex, toIndex ->
-                    tabController.moveTab(fromIndex, toIndex)
+                    tabController.moveTabWithinIndices(
+                        fromIndex = fromIndex,
+                        toIndex = toIndex,
+                        movableIndices = tabGroups.map { it.tabIndex }
+                    )
                 },
                 onPaneClosed = { tabIndex, paneId ->
                     val t = tabController.tabs.getOrNull(tabIndex)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
@@ -36,6 +36,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.lerp
@@ -49,12 +50,17 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInParent
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import kotlin.math.abs
 
 /** Fixed height of the [TabBar] surface; referenced by overlays that must clear it. */
 val TabBarHeight: Dp = 48.dp
@@ -134,6 +140,10 @@ data class TabBarPane(
 
 /** Keep worktree creation optimistic while repository detection is still pending. */
 internal fun canCreateWorktree(isGitRepo: Boolean?): Boolean = isGitRepo != false
+
+internal fun nearestTabIndex(pointerY: Float, tabCenters: List<Pair<Int, Float>>): Int? {
+    return tabCenters.minByOrNull { (_, centerY) -> abs(centerY - pointerY) }?.first
+}
 
 /** A tab and its panes, rendered as a visually-grouped cluster of chips. */
 data class TabBarGroup(val tabIndex: Int, val panes: List<TabBarPane>)
@@ -256,7 +266,7 @@ private val REMOTE_AI_ASSISTANTS = listOf(
  * - Active/focused pane highlighting
  * - Right-click context menu: Create Worktree for This…, Rename…, Color ▸,
  *   Duplicate, Close, Close Others, Close Tabs Below, Move Tab to New Window
- * - Double-click a chip to rename inline
+ * - Drag a local tab group in the expanded left sidebar to reorder tabs
  *
  * Styling matches the Material 3 design of the search bar for visual consistency.
  */
@@ -269,6 +279,7 @@ fun TabBar(
     onPaneSelected: (tabIndex: Int, paneId: String) -> Unit,
     onPaneClosed: (tabIndex: Int, paneId: String) -> Unit,
     onNewTab: () -> Unit,
+    onTabReordered: (fromIndex: Int, toIndex: Int) -> Unit = { _, _ -> },
     onTabMoveToNewWindow: (Int) -> Unit = {},
     onRename: (tabIndex: Int, paneId: String, newTitle: String) -> Unit = { _, _, _ -> },
     onSetColor: (tabIndex: Int, paneId: String, hex: String?) -> Unit = { _, _, _ -> },
@@ -302,9 +313,15 @@ fun TabBar(
     val contextMenuController = remember { ContextMenuController() }
     val vertical = orientation == TabBarOrientation.LEFT
 
-    // Pane currently being renamed inline (null = none). Set by double-click or the
-    // "Rename…" menu item; cleared on commit/cancel.
+    // Pane currently being renamed inline (null = none). Set by the "Rename…"
+    // context-menu item and cleared on commit/cancel.
     var editingPaneId by remember { mutableStateOf<String?>(null) }
+    var draggedTabIndex by remember { mutableStateOf<Int?>(null) }
+    var draggedTabOffsetY by remember { mutableStateOf(0f) }
+    var primaryPressedTabIndex by remember { mutableStateOf<Int?>(null) }
+    val localTabBounds = remember { mutableMapOf<Int, androidx.compose.ui.geometry.Rect>() }
+    val localTabOrder = groups.map { it.tabIndex }
+    val latestOnTabReordered by rememberUpdatedState(onTabReordered)
 
     val localGitRepoByPane = remember(groups) {
         groups.flatMap { group ->
@@ -514,7 +531,6 @@ fun TabBar(
             colorHex = pane.colorHex,
             isEditing = pane.paneId == editingPaneId,
             onSelected = { onPaneSelected(group.tabIndex, pane.paneId) },
-            onStartRename = { editingPaneId = pane.paneId },
             onCommitRename = { newTitle ->
                 editingPaneId = null
                 onRename(group.tabIndex, pane.paneId, newTitle)
@@ -630,7 +646,83 @@ fun TabBar(
                     verticalArrangement = Arrangement.spacedBy(TabGroupGap)
                 ) {
                     groups.forEach { group ->
-                        Column(verticalArrangement = Arrangement.spacedBy(TabChipGap)) {
+                        Column(
+                            modifier = Modifier.fillMaxWidth()
+                                .onGloballyPositioned { coordinates ->
+                                    localTabBounds[group.tabIndex] = coordinates.boundsInParent()
+                                }
+                                .zIndex(if (draggedTabIndex == group.tabIndex) 1f else 0f)
+                                .graphicsLayer {
+                                    val isDragged = draggedTabIndex == group.tabIndex
+                                    alpha = if (isDragged) 0.88f else 1f
+                                    if (isDragged) {
+                                        translationY = draggedTabOffsetY
+                                    }
+                                }
+                                .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
+                                    if (event.button == PointerButton.Primary) {
+                                        primaryPressedTabIndex = group.tabIndex
+                                    }
+                                }
+                                .onPointerEvent(PointerEventType.Release, PointerEventPass.Initial) { event ->
+                                    if (
+                                        event.button == PointerButton.Primary &&
+                                        primaryPressedTabIndex == group.tabIndex
+                                    ) {
+                                        primaryPressedTabIndex = null
+                                    }
+                                }
+                                .pointerInput(group.tabIndex, localTabOrder) {
+                                    var totalDragY = 0f
+                                    var acceptsDrag = false
+                                    detectDragGestures(
+                                        onDragStart = {
+                                            acceptsDrag = primaryPressedTabIndex == group.tabIndex
+                                            if (acceptsDrag) {
+                                                totalDragY = 0f
+                                                draggedTabIndex = group.tabIndex
+                                                draggedTabOffsetY = 0f
+                                            }
+                                        },
+                                        onDragCancel = {
+                                            if (acceptsDrag) {
+                                                primaryPressedTabIndex = null
+                                                draggedTabIndex = null
+                                                draggedTabOffsetY = 0f
+                                            }
+                                        },
+                                        onDragEnd = {
+                                            if (acceptsDrag) {
+                                                val sourceBounds = localTabBounds[group.tabIndex]
+                                                val targetIndex = sourceBounds?.let { bounds ->
+                                                    nearestTabIndex(
+                                                        pointerY = bounds.center.y + totalDragY,
+                                                        tabCenters = groups.mapNotNull { candidate ->
+                                                            localTabBounds[candidate.tabIndex]?.center?.y?.let { centerY ->
+                                                                candidate.tabIndex to centerY
+                                                            }
+                                                        }
+                                                    )
+                                                }
+                                                primaryPressedTabIndex = null
+                                                draggedTabIndex = null
+                                                draggedTabOffsetY = 0f
+                                                if (targetIndex != null && targetIndex != group.tabIndex) {
+                                                    latestOnTabReordered(group.tabIndex, targetIndex)
+                                                }
+                                            }
+                                        },
+                                        onDrag = { change, dragAmount ->
+                                            if (acceptsDrag) {
+                                                change.consume()
+                                                totalDragY += dragAmount.y
+                                                draggedTabOffsetY = totalDragY
+                                            }
+                                        }
+                                    )
+                                },
+                            verticalArrangement = Arrangement.spacedBy(TabChipGap)
+                        ) {
                             group.panes.forEach { pane -> chip(group, pane, Modifier.fillMaxWidth()) }
                         }
                     }
@@ -956,7 +1048,6 @@ private fun TabItem(
     colorHex: String?,
     isEditing: Boolean,
     onSelected: () -> Unit,
-    onStartRename: () -> Unit,
     onCommitRename: (String) -> Unit,
     onCancelRename: () -> Unit,
     onClose: () -> Unit,
@@ -983,10 +1074,10 @@ private fun TabItem(
             .then(
                 if (isEditing) Modifier
                 else Modifier
-                    // Observe and consume secondary presses before combinedClickable can
-                    // interpret them as a normal selection gesture.
+                    // Consume secondary presses before clickable can interpret them as a
+                    // normal selection gesture.
                     .consumeSecondaryPress(onContextMenu)
-                    .combinedClickable(onClick = onSelected, onDoubleClick = onStartRename)
+                    .clickable(onClick = onSelected)
             ),
         shape = RoundedCornerShape(6.dp),
         color = if (isActive) itemRaised else itemBg,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -746,6 +746,9 @@ fun TabBar(
                                         }
                                     }
                                 }
+                                // Desktop contract: the parent keeps wheel/trackpad scrolling,
+                                // while a primary drag begun on a chip owns reordering. Revisit
+                                // this gesture split if the component gains touch support.
                                 .pointerInput(group.tabIndex, localTabOrder) {
                                     var acceptsDrag = false
                                     try {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -142,6 +142,7 @@ data class TabBarPane(
 /** Keep worktree creation optimistic while repository detection is still pending. */
 internal fun canCreateWorktree(isGitRepo: Boolean?): Boolean = isGitRepo != false
 
+/** Return the nearest resting tab center; exact midpoint ties favor the first visual group. */
 internal fun nearestTabIndex(pointerY: Float, tabCenters: List<Pair<Int, Float>>): Int? {
     return tabCenters.minByOrNull { (_, centerY) -> abs(centerY - pointerY) }?.first
 }
@@ -336,6 +337,8 @@ fun TabBar(
     val finishTabDrag: (Int) -> Unit = { sourceIndex ->
         val targetIndex = if (draggedTabIndex == sourceIndex) {
             localTabBounds[sourceIndex]?.let { bounds ->
+                // graphicsLayer translation is draw-only, so resting centers intentionally
+                // provide a simple static snap target without a live insertion preview.
                 nearestTabIndex(
                     pointerY = bounds.center.y + draggedTabOffsetY,
                     tabCenters = groups.mapNotNull { candidate ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -320,8 +320,12 @@ fun TabBar(
     var draggedTabIndex by remember { mutableStateOf<Int?>(null) }
     var draggedTabOffsetY by remember { mutableStateOf(0f) }
     var primaryPressedTabIndex by remember { mutableStateOf<Int?>(null) }
-    val localTabBounds = remember { mutableMapOf<Int, androidx.compose.ui.geometry.Rect>() }
     val localTabOrder = groups.map { it.tabIndex }
+    // Full-list indices are reassigned after closes and remote-layout updates, so replace
+    // the measurement map whenever the set of local slots changes.
+    val localTabBounds = remember(localTabOrder) {
+        mutableMapOf<Int, androidx.compose.ui.geometry.Rect>()
+    }
     val latestOnTabReordered by rememberUpdatedState(onTabReordered)
     val isWindowFocused = LocalWindowInfo.current.isWindowFocused
     val resetTabDrag: () -> Unit = {
@@ -604,13 +608,12 @@ fun TabBar(
             )
             .then(
                 if (vertical) {
-                    Modifier
-                        .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) {
-                            if (draggedTabIndex != null) resetTabDrag()
-                        }
-                        .onPointerEvent(PointerEventType.Exit, PointerEventPass.Initial) {
-                            resetTabDrag()
-                        }
+                    Modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) {
+                        // A fresh press is the fallback cleanup for a release that was lost
+                        // without a focus change. Leaving the narrow sidebar must not cancel
+                        // an otherwise valid in-flight drag.
+                        if (draggedTabIndex != null) resetTabDrag()
+                    }
                 } else {
                     Modifier
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -147,6 +147,12 @@ internal fun nearestTabIndex(pointerY: Float, tabCenters: List<Pair<Int, Float>>
     return tabCenters.minByOrNull { (_, centerY) -> abs(centerY - pointerY) }?.first
 }
 
+/** Return a neighboring tab in visual order; [delta] is normally -1 or 1. */
+internal fun tabReorderNeighbor(tabIndex: Int, tabOrder: List<Int>, delta: Int): Int? {
+    val position = tabOrder.indexOf(tabIndex)
+    return if (position == -1) null else tabOrder.getOrNull(position + delta)
+}
+
 /** A tab and its panes, rendered as a visually-grouped cluster of chips. */
 data class TabBarGroup(val tabIndex: Int, val panes: List<TabBarPane>)
 
@@ -267,7 +273,8 @@ private val REMOTE_AI_ASSISTANTS = listOf(
  * - New tab button (+)
  * - Active/focused pane highlighting
  * - Right-click context menu: Create Worktree for This…, Rename…, Color ▸,
- *   Duplicate, Close, Close Others, Close Tabs Below, Move Tab to New Window
+ *   Duplicate, Move Up/Down (or Left/Right), Close, Close Others, Close Tabs Below,
+ *   Move Tab to New Window
  * - Drag a local tab group in the expanded left sidebar to reorder tabs
  *
  * Styling matches the Material 3 design of the search bar for visual consistency.
@@ -376,6 +383,10 @@ fun TabBar(
             } + ContextMenuController.MenuSeparator(id = "separator_color") +
                 ContextMenuController.MenuItem(id = "color_clear", label = "Clear", enabled = true, action = { onSetColor(tabIndex, paneId, null) })
         )
+        val previousTabIndex = tabReorderNeighbor(tabIndex, localTabOrder, -1)
+        val nextTabIndex = tabReorderNeighbor(tabIndex, localTabOrder, 1)
+        val movePreviousLabel = if (vertical) "Move Tab Up" else "Move Tab Left"
+        val moveNextLabel = if (vertical) "Move Tab Down" else "Move Tab Right"
         val items = listOf(
             ContextMenuController.MenuItem(id = "new_tab", label = "New Tab", enabled = true, action = { onNewTab() }),
             ContextMenuController.MenuItem(
@@ -389,6 +400,18 @@ fun TabBar(
             colorSubmenu,
             ContextMenuController.MenuSeparator(id = "separator_tab_ops"),
             ContextMenuController.MenuItem(id = "duplicate_tab", label = "Duplicate Tab", enabled = true, action = { onDuplicate(tabIndex) }),
+            ContextMenuController.MenuItem(
+                id = "move_tab_previous",
+                label = movePreviousLabel,
+                enabled = previousTabIndex != null,
+                action = { previousTabIndex?.let { latestOnTabReordered(tabIndex, it) } }
+            ),
+            ContextMenuController.MenuItem(
+                id = "move_tab_next",
+                label = moveNextLabel,
+                enabled = nextTabIndex != null,
+                action = { nextTabIndex?.let { latestOnTabReordered(tabIndex, it) } }
+            ),
             ContextMenuController.MenuItem(id = "close_pane", label = "Close", enabled = true, action = { onPaneClosed(tabIndex, paneId) }),
             ContextMenuController.MenuItem(id = "close_others", label = "Close Other Tabs", enabled = true, action = { onCloseOthers(tabIndex) }),
             ContextMenuController.MenuItem(id = "close_below", label = "Close Tabs Below", enabled = true, action = { onCloseBelow(tabIndex) }),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
@@ -322,6 +323,36 @@ fun TabBar(
     val localTabBounds = remember { mutableMapOf<Int, androidx.compose.ui.geometry.Rect>() }
     val localTabOrder = groups.map { it.tabIndex }
     val latestOnTabReordered by rememberUpdatedState(onTabReordered)
+    val isWindowFocused = LocalWindowInfo.current.isWindowFocused
+    val resetTabDrag: () -> Unit = {
+        primaryPressedTabIndex = null
+        draggedTabIndex = null
+        draggedTabOffsetY = 0f
+    }
+    val finishTabDrag: (Int) -> Unit = { sourceIndex ->
+        val targetIndex = if (draggedTabIndex == sourceIndex) {
+            localTabBounds[sourceIndex]?.let { bounds ->
+                nearestTabIndex(
+                    pointerY = bounds.center.y + draggedTabOffsetY,
+                    tabCenters = groups.mapNotNull { candidate ->
+                        localTabBounds[candidate.tabIndex]?.center?.y?.let { centerY ->
+                            candidate.tabIndex to centerY
+                        }
+                    }
+                )
+            }
+        } else {
+            null
+        }
+        resetTabDrag()
+        if (targetIndex != null && targetIndex != sourceIndex) {
+            latestOnTabReordered(sourceIndex, targetIndex)
+        }
+    }
+
+    LaunchedEffect(isWindowFocused) {
+        if (!isWindowFocused) resetTabDrag()
+    }
 
     val localGitRepoByPane = remember(groups) {
         groups.flatMap { group ->
@@ -570,6 +601,19 @@ fun TabBar(
                 } else {
                     Modifier
                 }
+            )
+            .then(
+                if (vertical) {
+                    Modifier
+                        .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) {
+                            if (draggedTabIndex != null) resetTabDrag()
+                        }
+                        .onPointerEvent(PointerEventType.Exit, PointerEventPass.Initial) {
+                            resetTabDrag()
+                        }
+                } else {
+                    Modifier
+                }
             ),
         color = barBg,
         shadowElevation = 2.dp
@@ -665,61 +709,53 @@ fun TabBar(
                                     }
                                 }
                                 .onPointerEvent(PointerEventType.Release, PointerEventPass.Initial) { event ->
-                                    if (
-                                        event.button == PointerButton.Primary &&
-                                        primaryPressedTabIndex == group.tabIndex
-                                    ) {
-                                        primaryPressedTabIndex = null
+                                    if (event.button == PointerButton.Primary) {
+                                        if (draggedTabIndex == group.tabIndex) {
+                                            finishTabDrag(group.tabIndex)
+                                        } else {
+                                            primaryPressedTabIndex = null
+                                        }
                                     }
                                 }
                                 .pointerInput(group.tabIndex, localTabOrder) {
-                                    var totalDragY = 0f
                                     var acceptsDrag = false
-                                    detectDragGestures(
-                                        onDragStart = {
-                                            acceptsDrag = primaryPressedTabIndex == group.tabIndex
-                                            if (acceptsDrag) {
-                                                totalDragY = 0f
-                                                draggedTabIndex = group.tabIndex
-                                                draggedTabOffsetY = 0f
-                                            }
-                                        },
-                                        onDragCancel = {
-                                            if (acceptsDrag) {
-                                                primaryPressedTabIndex = null
-                                                draggedTabIndex = null
-                                                draggedTabOffsetY = 0f
-                                            }
-                                        },
-                                        onDragEnd = {
-                                            if (acceptsDrag) {
-                                                val sourceBounds = localTabBounds[group.tabIndex]
-                                                val targetIndex = sourceBounds?.let { bounds ->
-                                                    nearestTabIndex(
-                                                        pointerY = bounds.center.y + totalDragY,
-                                                        tabCenters = groups.mapNotNull { candidate ->
-                                                            localTabBounds[candidate.tabIndex]?.center?.y?.let { centerY ->
-                                                                candidate.tabIndex to centerY
-                                                            }
-                                                        }
-                                                    )
+                                    try {
+                                        detectDragGestures(
+                                            onDragStart = {
+                                                acceptsDrag = primaryPressedTabIndex == group.tabIndex
+                                                if (acceptsDrag) {
+                                                    draggedTabIndex = group.tabIndex
+                                                    draggedTabOffsetY = 0f
                                                 }
-                                                primaryPressedTabIndex = null
-                                                draggedTabIndex = null
-                                                draggedTabOffsetY = 0f
-                                                if (targetIndex != null && targetIndex != group.tabIndex) {
-                                                    latestOnTabReordered(group.tabIndex, targetIndex)
+                                            },
+                                            onDragCancel = {
+                                                if (acceptsDrag) {
+                                                    resetTabDrag()
+                                                    acceptsDrag = false
+                                                }
+                                            },
+                                            onDragEnd = {
+                                                if (acceptsDrag) {
+                                                    finishTabDrag(group.tabIndex)
+                                                    acceptsDrag = false
+                                                }
+                                            },
+                                            onDrag = { change, dragAmount ->
+                                                if (
+                                                    acceptsDrag &&
+                                                    draggedTabIndex == group.tabIndex
+                                                ) {
+                                                    change.consume()
+                                                    draggedTabOffsetY += dragAmount.y
                                                 }
                                             }
-                                        },
-                                        onDrag = { change, dragAmount ->
-                                            if (acceptsDrag) {
-                                                change.consume()
-                                                totalDragY += dragAmount.y
-                                                draggedTabOffsetY = totalDragY
-                                            }
+                                        )
+                                    } finally {
+                                        if (acceptsDrag) {
+                                            resetTabDrag()
+                                            acceptsDrag = false
                                         }
-                                    )
+                                    }
                                 },
                             verticalArrangement = Arrangement.spacedBy(TabChipGap)
                         ) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -54,6 +54,8 @@ internal fun tabOrderAfterMoveWithin(
 ): List<Int>? {
     if (tabCount <= 0 || fromIndex == toIndex) return null
 
+    // TabbedTerminal derives the visible local groups by filtering a mapIndexed list, so
+    // visual order is the ascending order of their full-list slots.
     val slots = movableIndices.distinct().sorted()
     if (slots.any { it !in 0 until tabCount }) return null
 
@@ -1946,6 +1948,8 @@ class TabController(
 
         val previousTabs = tabs.toList()
         val newActiveTabIndex = newOrder.indexOf(activeTabIndex)
+        // Keep the SnapshotStateList instance stable and write only changed local slots;
+        // non-movable remote slots retain their entries without emitting snapshot writes.
         newOrder.forEachIndexed { newIndex, previousIndex ->
             if (newIndex != previousIndex) {
                 tabs[newIndex] = previousTabs[previousIndex]

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -1938,13 +1938,13 @@ class TabController(
         fromIndex: Int,
         toIndex: Int,
         movableIndices: List<Int>
-    ): Boolean {
+    ) {
         val newOrder = tabOrderAfterMoveWithin(
             tabCount = tabs.size,
             fromIndex = fromIndex,
             toIndex = toIndex,
             movableIndices = movableIndices
-        ) ?: return false
+        ) ?: return
 
         val previousTabs = tabs.toList()
         val newActiveTabIndex = newOrder.indexOf(activeTabIndex)
@@ -1956,7 +1956,6 @@ class TabController(
             }
         }
         activeTabIndex = newActiveTabIndex
-        return true
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -42,15 +42,6 @@ import ai.rever.bossterm.core.typeahead.TerminalTypeAheadManager
 import ai.rever.bossterm.core.typeahead.TypeAheadTerminalModel
 import ai.rever.bossterm.terminal.util.GraphemeBoundaryUtils
 
-internal fun indexAfterTabMove(index: Int, fromIndex: Int, toIndex: Int): Int {
-    return when {
-        index == fromIndex -> toIndex
-        fromIndex < index && index <= toIndex -> index - 1
-        toIndex <= index && index < fromIndex -> index + 1
-        else -> index
-    }
-}
-
 /**
  * Return the full index permutation for moving a tab only among [movableIndices].
  * Indices outside that subset retain both their item and their position.
@@ -1935,23 +1926,6 @@ class TabController(
 
         // Notify listeners
         notifyAllSessionsClosed()
-    }
-
-    /**
-     * Move one tab to a new index without changing which tab is active.
-     *
-     * @return true when the tab order changed, false for invalid or identical indices.
-     */
-    fun moveTab(fromIndex: Int, toIndex: Int): Boolean {
-        if (fromIndex !in tabs.indices || toIndex !in tabs.indices || fromIndex == toIndex) {
-            return false
-        }
-
-        val newActiveTabIndex = indexAfterTabMove(activeTabIndex, fromIndex, toIndex)
-        val tab = tabs.removeAt(fromIndex)
-        tabs.add(toIndex, tab)
-        activeTabIndex = newActiveTabIndex
-        return true
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -42,6 +42,15 @@ import ai.rever.bossterm.core.typeahead.TerminalTypeAheadManager
 import ai.rever.bossterm.core.typeahead.TypeAheadTerminalModel
 import ai.rever.bossterm.terminal.util.GraphemeBoundaryUtils
 
+internal fun indexAfterTabMove(index: Int, fromIndex: Int, toIndex: Int): Int {
+    return when {
+        index == fromIndex -> toIndex
+        fromIndex < index && index <= toIndex -> index - 1
+        toIndex <= index && index < fromIndex -> index + 1
+        else -> index
+    }
+}
+
 /**
  * Controller for managing multiple terminal tabs.
  *
@@ -1896,6 +1905,23 @@ class TabController(
 
         // Notify listeners
         notifyAllSessionsClosed()
+    }
+
+    /**
+     * Move one tab to a new index without changing which tab is active.
+     *
+     * @return true when the tab order changed, false for invalid or identical indices.
+     */
+    fun moveTab(fromIndex: Int, toIndex: Int): Boolean {
+        if (fromIndex !in tabs.indices || toIndex !in tabs.indices || fromIndex == toIndex) {
+            return false
+        }
+
+        val newActiveTabIndex = indexAfterTabMove(activeTabIndex, fromIndex, toIndex)
+        val tab = tabs.removeAt(fromIndex)
+        tabs.add(toIndex, tab)
+        activeTabIndex = newActiveTabIndex
+        return true
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -52,6 +52,36 @@ internal fun indexAfterTabMove(index: Int, fromIndex: Int, toIndex: Int): Int {
 }
 
 /**
+ * Return the full index permutation for moving a tab only among [movableIndices].
+ * Indices outside that subset retain both their item and their position.
+ */
+internal fun tabOrderAfterMoveWithin(
+    tabCount: Int,
+    fromIndex: Int,
+    toIndex: Int,
+    movableIndices: List<Int>
+): List<Int>? {
+    if (tabCount <= 0 || fromIndex == toIndex) return null
+
+    val slots = movableIndices.distinct().sorted()
+    if (slots.any { it !in 0 until tabCount }) return null
+
+    val fromSlot = slots.indexOf(fromIndex)
+    val toSlot = slots.indexOf(toIndex)
+    if (fromSlot == -1 || toSlot == -1) return null
+
+    val reorderedItems = slots.toMutableList()
+    val movedItem = reorderedItems.removeAt(fromSlot)
+    reorderedItems.add(toSlot, movedItem)
+
+    return (0 until tabCount).toMutableList().also { order ->
+        slots.forEachIndexed { slotIndex, fullIndex ->
+            order[fullIndex] = reorderedItems[slotIndex]
+        }
+    }
+}
+
+/**
  * Controller for managing multiple terminal tabs.
  *
  * This class is responsible for the lifecycle of terminal tabs, including:
@@ -1920,6 +1950,33 @@ class TabController(
         val newActiveTabIndex = indexAfterTabMove(activeTabIndex, fromIndex, toIndex)
         val tab = tabs.removeAt(fromIndex)
         tabs.add(toIndex, tab)
+        activeTabIndex = newActiveTabIndex
+        return true
+    }
+
+    /**
+     * Move a tab among a subset of full-list indices while leaving all other slots untouched.
+     * Used by the sidebar so local tabs can reorder without shifting mirrored remote tabs.
+     */
+    fun moveTabWithinIndices(
+        fromIndex: Int,
+        toIndex: Int,
+        movableIndices: List<Int>
+    ): Boolean {
+        val newOrder = tabOrderAfterMoveWithin(
+            tabCount = tabs.size,
+            fromIndex = fromIndex,
+            toIndex = toIndex,
+            movableIndices = movableIndices
+        ) ?: return false
+
+        val previousTabs = tabs.toList()
+        val newActiveTabIndex = newOrder.indexOf(activeTabIndex)
+        newOrder.forEachIndexed { newIndex, previousIndex ->
+            if (newIndex != previousIndex) {
+                tabs[newIndex] = previousTabs[previousIndex]
+            }
+        }
         activeTabIndex = newActiveTabIndex
         return true
     }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabReorderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabReorderTest.kt
@@ -14,8 +14,20 @@ class TabReorderTest {
         assertEquals(null, nearestTabIndex(pointerY = 20f, tabCenters = emptyList()))
         assertEquals(0, nearestTabIndex(pointerY = -10f, tabCenters = centers))
         assertEquals(0, nearestTabIndex(pointerY = 40f, tabCenters = centers))
+        assertEquals(1, nearestTabIndex(pointerY = 40.01f, tabCenters = centers))
         assertEquals(1, nearestTabIndex(pointerY = 72f, tabCenters = centers))
         assertEquals(2, nearestTabIndex(pointerY = 130f, tabCenters = centers))
+    }
+
+    @Test
+    fun `context menu reorder follows sparse local visual order`() {
+        val localOrder = listOf(0, 2, 4)
+
+        assertEquals(null, tabReorderNeighbor(0, localOrder, -1))
+        assertEquals(2, tabReorderNeighbor(0, localOrder, 1))
+        assertEquals(0, tabReorderNeighbor(2, localOrder, -1))
+        assertEquals(4, tabReorderNeighbor(2, localOrder, 1))
+        assertEquals(null, tabReorderNeighbor(4, localOrder, 1))
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabReorderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabReorderTest.kt
@@ -3,7 +3,6 @@ package ai.rever.bossterm.compose.tabs
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class TabReorderTest {
 
@@ -72,7 +71,7 @@ class TabReorderTest {
             val activeRemoteId = controller.tabs[1].id
             controller.switchToTab(1)
 
-            assertTrue(controller.moveTabWithinIndices(0, 4, LOCAL_TAB_INDICES))
+            controller.moveTabWithinIndices(0, 4, LOCAL_TAB_INDICES)
             assertEquals(
                 listOf("local-b", "remote-a", "local-c", "remote-b", "local-a"),
                 controller.tabs.map { it.title.value }
@@ -90,7 +89,7 @@ class TabReorderTest {
         try {
             val activeLocalId = controller.tabs.first().id
 
-            assertTrue(controller.moveTabWithinIndices(0, 4, LOCAL_TAB_INDICES))
+            controller.moveTabWithinIndices(0, 4, LOCAL_TAB_INDICES)
             assertEquals(4, controller.activeTabIndex)
             assertEquals(activeLocalId, controller.activeTabId)
         } finally {
@@ -118,6 +117,8 @@ class TabReorderTest {
     }
 
     private companion object {
+        // Models the sparse slots produced by TabbedTerminal's RemoteSessionManager filter.
+        // The manager-to-UI partition itself remains integration coverage, not a unit fixture here.
         val LOCAL_TAB_INDICES = listOf(0, 2, 4)
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabReorderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabReorderTest.kt
@@ -1,0 +1,30 @@
+package ai.rever.bossterm.compose.tabs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TabReorderTest {
+
+    @Test
+    fun `active tab follows itself when moved`() {
+        assertEquals(3, indexAfterTabMove(index = 1, fromIndex = 1, toIndex = 3))
+        assertEquals(0, indexAfterTabMove(index = 3, fromIndex = 3, toIndex = 0))
+    }
+
+    @Test
+    fun `active index shifts around a moved neighboring tab`() {
+        assertEquals(1, indexAfterTabMove(index = 2, fromIndex = 0, toIndex = 3))
+        assertEquals(2, indexAfterTabMove(index = 1, fromIndex = 3, toIndex = 0))
+        assertEquals(2, indexAfterTabMove(index = 2, fromIndex = 0, toIndex = 1))
+    }
+
+    @Test
+    fun `drop target is nearest tab center`() {
+        val centers = listOf(0 to 20f, 1 to 60f, 2 to 100f)
+
+        assertEquals(null, nearestTabIndex(pointerY = 20f, tabCenters = emptyList()))
+        assertEquals(0, nearestTabIndex(pointerY = -10f, tabCenters = centers))
+        assertEquals(1, nearestTabIndex(pointerY = 72f, tabCenters = centers))
+        assertEquals(2, nearestTabIndex(pointerY = 130f, tabCenters = centers))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabReorderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabReorderTest.kt
@@ -1,22 +1,11 @@
 package ai.rever.bossterm.compose.tabs
 
+import ai.rever.bossterm.compose.settings.TerminalSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class TabReorderTest {
-
-    @Test
-    fun `active tab follows itself when moved`() {
-        assertEquals(3, indexAfterTabMove(index = 1, fromIndex = 1, toIndex = 3))
-        assertEquals(0, indexAfterTabMove(index = 3, fromIndex = 3, toIndex = 0))
-    }
-
-    @Test
-    fun `active index shifts around a moved neighboring tab`() {
-        assertEquals(1, indexAfterTabMove(index = 2, fromIndex = 0, toIndex = 3))
-        assertEquals(2, indexAfterTabMove(index = 1, fromIndex = 3, toIndex = 0))
-        assertEquals(2, indexAfterTabMove(index = 2, fromIndex = 0, toIndex = 1))
-    }
 
     @Test
     fun `drop target is nearest tab center`() {
@@ -24,6 +13,7 @@ class TabReorderTest {
 
         assertEquals(null, nearestTabIndex(pointerY = 20f, tabCenters = emptyList()))
         assertEquals(0, nearestTabIndex(pointerY = -10f, tabCenters = centers))
+        assertEquals(0, nearestTabIndex(pointerY = 40f, tabCenters = centers))
         assertEquals(1, nearestTabIndex(pointerY = 72f, tabCenters = centers))
         assertEquals(2, nearestTabIndex(pointerY = 130f, tabCenters = centers))
     }
@@ -61,5 +51,61 @@ class TabReorderTest {
                 movableIndices = listOf(0, 2, 4)
             )
         )
+    }
+
+    @Test
+    fun `controller moves local tab while active remote keeps its slot`() {
+        val controller = controllerWithInterspersedTabs()
+        try {
+            val activeRemoteId = controller.tabs[1].id
+            controller.switchToTab(1)
+
+            assertTrue(controller.moveTabWithinIndices(0, 4, LOCAL_TAB_INDICES))
+            assertEquals(
+                listOf("local-b", "remote-a", "local-c", "remote-b", "local-a"),
+                controller.tabs.map { it.title.value }
+            )
+            assertEquals(1, controller.activeTabIndex)
+            assertEquals(activeRemoteId, controller.activeTabId)
+        } finally {
+            controller.disposeAll()
+        }
+    }
+
+    @Test
+    fun `controller active local tab follows its identity after reorder`() {
+        val controller = controllerWithInterspersedTabs()
+        try {
+            val activeLocalId = controller.tabs.first().id
+
+            assertTrue(controller.moveTabWithinIndices(0, 4, LOCAL_TAB_INDICES))
+            assertEquals(4, controller.activeTabIndex)
+            assertEquals(activeLocalId, controller.activeTabId)
+        } finally {
+            controller.disposeAll()
+        }
+    }
+
+    private fun controllerWithInterspersedTabs(): TabController {
+        val controller = TabController(
+            settings = TerminalSettings(),
+            onLastTabClosed = {}
+        )
+        listOf(
+            "local-a" to false,
+            "remote-a" to true,
+            "local-b" to false,
+            "remote-b" to true,
+            "local-c" to false
+        ).forEach { (title, isRemote) ->
+            val tab = controller.createRemoteSession(title = title, feedsStream = false)
+            tab.isRemote = isRemote
+            controller.tabs.add(tab)
+        }
+        return controller
+    }
+
+    private companion object {
+        val LOCAL_TAB_INDICES = listOf(0, 2, 4)
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabReorderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabReorderTest.kt
@@ -27,4 +27,39 @@ class TabReorderTest {
         assertEquals(1, nearestTabIndex(pointerY = 72f, tabCenters = centers))
         assertEquals(2, nearestTabIndex(pointerY = 130f, tabCenters = centers))
     }
+
+    @Test
+    fun `local reorder leaves interspersed remote slots untouched`() {
+        assertEquals(
+            listOf(2, 1, 4, 3, 0),
+            tabOrderAfterMoveWithin(
+                tabCount = 5,
+                fromIndex = 0,
+                toIndex = 4,
+                movableIndices = listOf(0, 2, 4)
+            )
+        )
+        assertEquals(
+            listOf(4, 1, 0, 3, 2),
+            tabOrderAfterMoveWithin(
+                tabCount = 5,
+                fromIndex = 4,
+                toIndex = 0,
+                movableIndices = listOf(0, 2, 4)
+            )
+        )
+    }
+
+    @Test
+    fun `subset reorder rejects non-local source or target`() {
+        assertEquals(
+            null,
+            tabOrderAfterMoveWithin(
+                tabCount = 5,
+                fromIndex = 0,
+                toIndex = 3,
+                movableIndices = listOf(0, 2, 4)
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- remove double-click-to-rename from tab chips while keeping Rename… in the context menu
- add primary-button drag-and-drop reordering for local tab groups in the expanded left sidebar
- add local-tab context-menu actions for non-drag reordering: Up/Down in the sidebar and Left/Right in the top bar
- move split-pane groups together and preserve the active tab by identity during reordering
- reset interrupted drags on focus loss, gesture cancellation, pointer-input disposal, or a subsequent press without cancelling a drag that crosses the sidebar edge
- reorder local tabs only within local slots so interspersed mirrored remote tabs remain stationary
- persist the ordered tab IDs when session restore is enabled and discard stale sidebar measurements when local slots change
- keep remote mirrored tabs host-controlled and protect right-click context-menu behavior
- use resting tab centers as intentional static snap targets; exact midpoint ties favor the first visual group and the target changes immediately after that midpoint
- test the shipped controller path with real lightweight tabs, including active local identity and stationary active remote slots

## Why

Double-click rename was being triggered accidentally during normal tab interaction, and the sidebar had no direct way to reorder tabs.

A drag could also retain its visual offset when pointer release was lost during a focus or pointer-ownership change. Cleanup is now independent of the normal release path, and delayed drag events cannot reorder a cancelled tab. Crossing the narrow sidebar boundary does not cancel an otherwise active drag.

Local tab indices can be sparse when remote mirrors are interspersed in the controller list. Reordering now permutes only local slots, keeping remote slots stable, and session persistence observes ordered tab IDs so the new local order survives restart when restore is enabled.

The first iteration intentionally uses static resting centers for drop resolution rather than shifting non-dragged tabs into a live insertion preview. Context-menu actions provide a non-drag alternative and skip over remote slots.

## Validation

- `./gradlew :compose-ui:compileKotlinDesktop :compose-ui:desktopTest --no-daemon`
- focused real-controller `TabReorderTest` run
- launched `:bossterm-app:run` from the feature worktree in a bottom split
