### PR TITLE
Add resilient reconnects and terminal graphics to the web viewer

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -662,28 +662,34 @@ class BossTerminal(
         // Store image data in cache
         val imageId = myImageDataCache.storeImage(image)
 
-        // Strategy: Write image cells row by row, scrolling as needed
-        // This ensures ALL image rows get ImageCell data, even those that scroll into history
+        // Strategy: Write image cells row by row, scrolling as needed. Batch the per-row
+        // notifications so native rendering and web-share observers see one complete placement.
         var currentBufferRow = bufferRow
-        for (cellY in 0 until dimensions.cellHeight) {
-            // If we're at or past the bottom of the screen, scroll first
-            if (currentBufferRow >= myTerminalHeight) {
-                scrollArea(myScrollRegionTop, scrollingRegionSize(), -1)
-                currentBufferRow = myTerminalHeight - 1  // Write to last row after scroll
-                bufferRow--  // Anchor moves up in buffer coordinates
+        terminalTextBuffer.beginBatch()
+        try {
+            for (cellY in 0 until dimensions.cellHeight) {
+                // If we're at or past the bottom of the screen, scroll first
+                if (currentBufferRow >= myTerminalHeight) {
+                    scrollArea(myScrollRegionTop, scrollingRegionSize(), -1)
+                    currentBufferRow = myTerminalHeight - 1  // Write to last row after scroll
+                    bufferRow--  // Anchor moves up in buffer coordinates
+                }
+
+                // Write this row of image cells
+                terminalTextBuffer.writeImageCellRow(
+                    row = currentBufferRow,
+                    startCol = anchorCol,
+                    imageId = imageId,
+                    cellY = cellY,
+                    cellWidth = dimensions.cellWidth,
+                    cellHeight = dimensions.cellHeight
+                )
+
+                currentBufferRow++
             }
-
-            // Write this row of image cells
-            terminalTextBuffer.writeImageCellRow(
-                row = currentBufferRow,
-                startCol = anchorCol,
-                imageId = imageId,
-                cellY = cellY,
-                cellWidth = dimensions.cellWidth,
-                cellHeight = dimensions.cellHeight
-            )
-
-            currentBufferRow++
+            terminalTextBuffer.imageCellRowsChanged(bufferRow)
+        } finally {
+            terminalTextBuffer.endBatch()
         }
 
         if (moveCursor) {

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -687,7 +687,9 @@ class BossTerminal(
 
                 currentBufferRow++
             }
-            terminalTextBuffer.imageCellRowsChanged(bufferRow)
+            // Change listeners use screen-row coordinates; a tall image can scroll its anchor
+            // into history while it is being placed, but must never publish a negative fromRow.
+            terminalTextBuffer.imageCellRowsChanged(bufferRow.coerceAtLeast(0))
         } finally {
             terminalTextBuffer.endBatch()
         }

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -662,8 +662,8 @@ class BossTerminal(
         // Store image data in cache
         val imageId = myImageDataCache.storeImage(image)
 
-        // Strategy: Write image cells row by row, scrolling as needed. Batch the per-row
-        // notifications so native rendering and web-share observers see one complete placement.
+        // Strategy: Write image cells row by row, scrolling as needed. Batch TerminalModelListener
+        // notifications so web-share and snapshot consumers see one complete placement.
         var currentBufferRow = bufferRow
         terminalTextBuffer.beginBatch()
         try {

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/CyclicBufferLinesStorage.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/CyclicBufferLinesStorage.kt
@@ -3,7 +3,10 @@ package ai.rever.bossterm.terminal.model
 /**
  * @param maxCapacity maximum number of stored lines; -1 means no restriction
  */
-internal class CyclicBufferLinesStorage(private val maxCapacity: Int) : LinesStorage {
+internal class CyclicBufferLinesStorage(
+  private val maxCapacity: Int,
+  private val onImageCellsChanged: (() -> Unit)? = null,
+) : LinesStorage {
 
   private val lines: ArrayDeque<TerminalLine> = ArrayDeque()
 
@@ -38,6 +41,7 @@ internal class CyclicBufferLinesStorage(private val maxCapacity: Int) : LinesSto
     if (isCapacityLimited && lines.size == maxCapacity) {
       return
     }
+    line.setImageCellsChangedListener(onImageCellsChanged)
     lines.addFirst(line)
   }
 
@@ -46,6 +50,7 @@ internal class CyclicBufferLinesStorage(private val maxCapacity: Int) : LinesSto
    * The worst case is when we need to extend the internal storage of the array deque.
    */
   override fun addToBottom(line: TerminalLine) {
+    line.setImageCellsChangedListener(onImageCellsChanged)
     lines.addLast(line)
     if (isCapacityLimited && lines.size > maxCapacity) {
       lines.removeFirst()
@@ -76,6 +81,7 @@ internal class CyclicBufferLinesStorage(private val maxCapacity: Int) : LinesSto
     if (index < 0 || index > lines.size) {
       throw IndexOutOfBoundsException("Index: $index, Size: ${lines.size}")
     }
+    line.setImageCellsChangedListener(onImageCellsChanged)
     // ArrayDeque implements MutableList, so add(index, element) is available
     (lines as MutableList<TerminalLine>).add(index, line)
   }

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/CyclicBufferLinesStorage.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/CyclicBufferLinesStorage.kt
@@ -53,22 +53,25 @@ internal class CyclicBufferLinesStorage(
     line.setImageCellsChangedListener(onImageCellsChanged)
     lines.addLast(line)
     if (isCapacityLimited && lines.size > maxCapacity) {
-      lines.removeFirst()
+      lines.removeFirst().setImageCellsChangedListener(null)
     }
   }
 
   /** O(1) */
   override fun removeFromTop(): TerminalLine {
-    return lines.removeFirst()
+    return lines.removeFirst().also { it.setImageCellsChangedListener(null) }
   }
 
   /** O(1) */
   override fun removeFromBottom(): TerminalLine {
-    return lines.removeLast()
+    return lines.removeLast().also { it.setImageCellsChangedListener(null) }
   }
 
   /** O(size) */
-  override fun clear() = lines.clear()
+  override fun clear() {
+    lines.forEach { it.setImageCellsChangedListener(null) }
+    lines.clear()
+  }
 
   /**
    * O(min(index, size-index)) using ArrayDeque's efficient index operations.
@@ -94,6 +97,7 @@ internal class CyclicBufferLinesStorage(
       throw IndexOutOfBoundsException("Index: $index, Size: ${lines.size}")
     }
     return (lines as MutableList<TerminalLine>).removeAt(index)
+      .also { it.setImageCellsChangedListener(null) }
   }
 
   override fun iterator(): Iterator<TerminalLine> = lines.iterator()

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalLine.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalLine.kt
@@ -54,6 +54,19 @@ class TerminalLine {
      * Each cell stores which portion of image it renders - cells reflow like text.
      */
     private var myImageCells: MutableMap<Int, ImageCell>? = null
+    private var imageCellsChangedListener: (() -> Unit)? = null
+
+    /**
+     * Installed by [TerminalTextBuffer]'s line storage. Keeping the callback on the line makes
+     * text overwrites observable without rescanning the whole scrollback for image-cell changes.
+     */
+    internal fun setImageCellsChangedListener(listener: (() -> Unit)?) {
+        imageCellsChangedListener = listener
+    }
+
+    private fun imageCellsChanged() {
+        imageCellsChangedListener?.invoke()
+    }
 
     /**
      * Get the current snapshot version for copy-on-write optimization.
@@ -93,8 +106,9 @@ class TerminalLine {
      */
     fun setImageCell(col: Int, cell: ImageCell) {
         if (myImageCells == null) myImageCells = mutableMapOf()
-        myImageCells!![col] = cell
+        if (myImageCells!!.put(col, cell) == cell) return
         incrementSnapshotVersion()
+        imageCellsChanged()
     }
 
     /**
@@ -103,11 +117,14 @@ class TerminalLine {
      */
     fun clearImageCellsInRange(startCol: Int, endCol: Int) {
         val cells = myImageCells ?: return
+        var changed = false
         for (col in startCol until endCol) {
-            cells.remove(col)
+            if (cells.remove(col) != null) changed = true
         }
+        if (!changed) return
         if (cells.isEmpty()) myImageCells = null
         incrementSnapshotVersion()
+        imageCellsChanged()
     }
 
     /**
@@ -117,6 +134,7 @@ class TerminalLine {
         if (myImageCells == null) return false
         myImageCells = null
         incrementSnapshotVersion()
+        imageCellsChanged()
         return true
     }
 
@@ -126,6 +144,7 @@ class TerminalLine {
         if (!cells.entries.removeIf { it.value.imageId == imageId }) return false
         if (cells.isEmpty()) myImageCells = null
         incrementSnapshotVersion()
+        imageCellsChanged()
         return true
     }
 
@@ -135,6 +154,7 @@ class TerminalLine {
         if (!cells.entries.removeIf { it.value.imageId !in retainedImageIds }) return false
         if (cells.isEmpty()) myImageCells = null
         incrementSnapshotVersion()
+        imageCellsChanged()
         return true
     }
 
@@ -199,11 +219,13 @@ class TerminalLine {
     }
 
     fun clear(filler: TextEntry) {
+        val clearedImageCells = myImageCells != null
         myTextEntries.clear()
         myTextEntries.add(filler)
         myRequiresVisualColumnMapping = filler.text.requiresVisualColumnMapping()
         myImageCells = null  // Clear all image cells
         incrementSnapshotVersion()
+        if (clearedImageCells) imageCellsChanged()
     }
 
     fun writeString(x: Int, str: CharBuffer, style: TextStyle) {

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
@@ -14,6 +14,7 @@ import ai.rever.bossterm.terminal.util.CharUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.math.max
@@ -40,6 +41,17 @@ class TerminalTextBuffer internal constructor(
     private set
   var height: Int = initialHeight
     private set
+
+  private val imageCellRevisionCounter = AtomicLong()
+  private val imageCellHistoryTrimCounter = AtomicLong()
+
+  /** O(1) token changed whenever image-cell contents or non-trivial layout changes. */
+  val imageCellRevision: Long
+    get() = imageCellRevisionCounter.get()
+
+  /** Number of oldest rows discarded after scrollback reached its capacity. */
+  val imageCellHistoryTrimCount: Long
+    get() = imageCellHistoryTrimCounter.get()
 
   var historyLinesStorage: LinesStorage = createHistoryLinesStorage()
     private set
@@ -117,11 +129,11 @@ class TerminalTextBuffer internal constructor(
   )
 
   private fun createScreenLinesStorage(): LinesStorage {
-    return CyclicBufferLinesStorage(-1)
+    return CyclicBufferLinesStorage(-1, imageCellRevisionCounter::incrementAndGet)
   }
 
   private fun createHistoryLinesStorage(): LinesStorage {
-    return CyclicBufferLinesStorage(maxHistoryLinesCount)
+    return CyclicBufferLinesStorage(maxHistoryLinesCount, imageCellRevisionCounter::incrementAndGet)
   }
 
 
@@ -258,6 +270,8 @@ class TerminalTextBuffer internal constructor(
     width = newWidth
     height = newHeight
 
+    // Reflow and height changes can move image-bearing line objects without mutating the cells.
+    imageCellRevisionCounter.incrementAndGet()
     fireModelChangeEvent()
     // Return result with both cursor positions
     val newSavedCursorPos = if (newSavedCursorX != null && newSavedCursorY != null) {
@@ -450,6 +464,7 @@ class TerminalTextBuffer internal constructor(
 
   fun addLine(line: TerminalLine) {
     screenLinesStorage.addToBottom(line)
+    if (line.hasImageCells()) imageCellRevisionCounter.incrementAndGet()
     fireModelChangeEvent()
     changesMulticaster.linesChanged(fromIndex = screenLinesStorage.size - 1)
   }
@@ -668,7 +683,15 @@ class TerminalTextBuffer internal constructor(
       insertLines(scrollRegionTop - 1, dy, scrollRegionBottom)
     }
     else {
-      val deletedLines = deleteLines(scrollRegionTop - 1, -dy, scrollRegionBottom)
+      // A top-of-screen upward scroll preserves absolute buffer indices until history trims.
+      // Avoid a general layout revision on that hot path; [addLinesToHistory] publishes the
+      // cheaper trim count once capped history starts discarding its oldest rows.
+      val deletedLines = deleteLines(
+        scrollRegionTop - 1,
+        -dy,
+        scrollRegionBottom,
+        publishImageLayoutChange = scrollRegionTop != 1 || scrollRegionBottom != height,
+      )
       if (scrollRegionTop == 1) {
         addLinesToHistory(deletedLines)
       }
@@ -822,18 +845,30 @@ class TerminalTextBuffer internal constructor(
         }
       }
     }
+    imageCellRevisionCounter.incrementAndGet()
     fireModelChangeEvent()
   }
 
   fun insertLines(y: Int, count: Int, scrollRegionBottom: Int) {
     screenLinesStorage.insertLines(y, count, scrollRegionBottom - 1, createFillerEntry())
+    imageCellRevisionCounter.incrementAndGet()
     fireModelChangeEvent()
     changesMulticaster.linesChanged(fromIndex = y)
   }
 
   // returns deleted lines
   fun deleteLines(y: Int, count: Int, scrollRegionBottom: Int): List<TerminalLine> {
+    return deleteLines(y, count, scrollRegionBottom, publishImageLayoutChange = true)
+  }
+
+  private fun deleteLines(
+    y: Int,
+    count: Int,
+    scrollRegionBottom: Int,
+    publishImageLayoutChange: Boolean,
+  ): List<TerminalLine> {
     val deletedLines = screenLinesStorage.deleteLines(y, count, scrollRegionBottom - 1, createFillerEntry())
+    if (publishImageLayoutChange) imageCellRevisionCounter.incrementAndGet()
     fireModelChangeEvent()
     changesMulticaster.linesChanged(fromIndex = y)
     return deletedLines
@@ -888,6 +923,7 @@ class TerminalTextBuffer internal constructor(
   fun clearScreenAndHistoryBuffers() {
     screenLinesStorage.clear()
     historyLinesStorage.clear()
+    imageCellRevisionCounter.incrementAndGet()
     fireModelChangeEvent()
     changesMulticaster.historyCleared()
     changesMulticaster.linesChanged(fromIndex = 0)
@@ -895,6 +931,7 @@ class TerminalTextBuffer internal constructor(
 
   fun clearScreenBuffer() {
     screenLinesStorage.clear()
+    imageCellRevisionCounter.incrementAndGet()
     fireModelChangeEvent()
     changesMulticaster.linesChanged(fromIndex = 0)
   }
@@ -927,6 +964,7 @@ class TerminalTextBuffer internal constructor(
     modify {
       val lineCount = historyLinesStorage.size
       historyLinesStorage.clear()
+      imageCellRevisionCounter.incrementAndGet()
       if (lineCount > 0) {
         fireHistoryBufferLineCountChanged()
       }
@@ -986,6 +1024,7 @@ class TerminalTextBuffer internal constructor(
     }
 
     historyLinesStorage.addAllToBottom(linesToAdd)
+    imageCellHistoryTrimCounter.addAndGet(discardedLinesCount.toLong())
 
     if (linesToDiscard.isNotEmpty()) {
       changesMulticaster.linesDiscardedFromHistory(linesToDiscard)

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
@@ -32,7 +32,7 @@ class TerminalTextBuffer internal constructor(
   initialWidth: Int,
   initialHeight: Int,
   private val styleState: StyleState,
-  private val maxHistoryLinesCount: Int,
+  val maxHistoryLinesCount: Int,
   internal val textProcessing: TextProcessing?
 ) {
   // Public accessor for Java interop

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
@@ -560,6 +560,17 @@ class TerminalTextBuffer internal constructor(
     }
   }
 
+  /** Publish one complete row-by-row image placement after its caller finishes writing it. */
+  internal fun imageCellRowsChanged(fromRow: Int) {
+    myLock.lock()
+    try {
+      fireModelChangeEvent()
+      changesMulticaster.linesChanged(fromIndex = fromRow)
+    } finally {
+      myLock.unlock()
+    }
+  }
+
   /**
    * Replace one text cell with one slice of a virtual image. Writing the blank
    * first gives transparent pixels the placeholder's current background and

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
@@ -575,7 +575,13 @@ class TerminalTextBuffer internal constructor(
     }
   }
 
-  /** Publish one complete row-by-row image placement after its caller finishes writing it. */
+  /**
+   * Publish one complete row-by-row image placement after its caller finishes writing it.
+   *
+   * Must remain inside the caller's beginBatch/endBatch scope: model notifications are deferred
+   * by the batch and delivered outside [myLock]. The lower-level linesChanged callback is
+   * synchronous under this lock, matching the existing text-buffer mutation contract.
+   */
   internal fun imageCellRowsChanged(fromRow: Int) {
     myLock.lock()
     try {
@@ -850,8 +856,9 @@ class TerminalTextBuffer internal constructor(
   }
 
   fun insertLines(y: Int, count: Int, scrollRegionBottom: Int) {
+    val movesImageCells = screenRangeHasImageCells(y, scrollRegionBottom - 1)
     screenLinesStorage.insertLines(y, count, scrollRegionBottom - 1, createFillerEntry())
-    imageCellRevisionCounter.incrementAndGet()
+    if (movesImageCells) imageCellRevisionCounter.incrementAndGet()
     fireModelChangeEvent()
     changesMulticaster.linesChanged(fromIndex = y)
   }
@@ -867,11 +874,20 @@ class TerminalTextBuffer internal constructor(
     scrollRegionBottom: Int,
     publishImageLayoutChange: Boolean,
   ): List<TerminalLine> {
+    val movesImageCells = publishImageLayoutChange &&
+      screenRangeHasImageCells(y, scrollRegionBottom - 1)
     val deletedLines = screenLinesStorage.deleteLines(y, count, scrollRegionBottom - 1, createFillerEntry())
-    if (publishImageLayoutChange) imageCellRevisionCounter.incrementAndGet()
+    if (movesImageCells) imageCellRevisionCounter.incrementAndGet()
     fireModelChangeEvent()
     changesMulticaster.linesChanged(fromIndex = y)
     return deletedLines
+  }
+
+  private fun screenRangeHasImageCells(fromRow: Int, toRow: Int): Boolean {
+    val start = fromRow.coerceAtLeast(0)
+    val end = toRow.coerceAtMost(screenLinesStorage.size - 1)
+    if (start > end) return false
+    return (start..end).any { screenLinesStorage[it].hasImageCells() }
   }
 
   fun clearLines(startRow: Int, endRow: Int) {

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/image/ImageDataCache.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/image/ImageDataCache.kt
@@ -25,8 +25,13 @@ class ImageDataCache(
     private val images = ConcurrentHashMap<Long, TerminalImage>()
     private val accessOrder = ConcurrentHashMap<Long, Long>() // id -> access timestamp
     private val accessCounter = AtomicLong(0)
+    private val contentRevisionCounter = AtomicLong(0)
     @Volatile
     private var totalBytes: Long = 0
+
+    /** O(1) token changed whenever browser-visible raster objects may have changed. */
+    val contentRevision: Long
+        get() = contentRevisionCounter.get()
 
     /**
      * Store image data. Returns imageId for reference from ImageAnchorCell.
@@ -44,6 +49,7 @@ class ImageDataCache(
         images[image.id] = image
         accessOrder[image.id] = accessCounter.incrementAndGet()
         totalBytes += image.data.size
+        contentRevisionCounter.incrementAndGet()
         LOG.debug("Stored image id={}, size={} bytes, total images={}",
             image.id, image.data.size, images.size)
         return image.id
@@ -83,6 +89,7 @@ class ImageDataCache(
         totalBytes -= image.data.size
         accessOrder.remove(imageId)
         onImageRemoved(imageId)
+        contentRevisionCounter.incrementAndGet()
         LOG.debug("Removed image id={}, remaining images={}", imageId, images.size)
         return true
     }
@@ -97,6 +104,7 @@ class ImageDataCache(
         accessOrder.clear()
         totalBytes = 0
         removedImageIds.forEach(onImageRemoved)
+        if (removedImageIds.isNotEmpty()) contentRevisionCounter.incrementAndGet()
         LOG.debug("Cleared all images")
     }
 

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/BossTerminalImageSizingTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/BossTerminalImageSizingTest.kt
@@ -51,6 +51,21 @@ class BossTerminalImageSizingTest {
     }
 
     @Test
+    fun inlineImagePublishesOneCompleteModelChange() {
+        val terminal = createTerminal()
+        var modelChanges = 0
+        terminal.terminalTextBuffer.addModelListener(object : TerminalModelListener {
+            override fun modelChanged() {
+                modelChanges++
+            }
+        })
+
+        terminal.processInlineImage(autoImage())
+
+        assertEquals(1, modelChanges)
+    }
+
+    @Test
     fun unicodePlaceholderWritesOneMovableImageCell() {
         val terminal = createTerminal()
         val image = autoImage(width = 40, height = 100).copy(

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
@@ -15,6 +15,23 @@ import kotlin.test.assertTrue
 class TerminalTextBufferBatchTest {
 
     @Test
+    fun imageCellRevisionChangesOnlyForImageContentOrLayout() {
+        val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = StyleState())
+        buffer.getLine(1)
+        val initial = buffer.imageCellRevision
+
+        buffer.writeImagePlaceholderCell(0, 0, 42, 0, 0, 1, 1)
+        val afterImage = buffer.imageCellRevision
+        assertTrue(afterImage > initial)
+
+        buffer.eraseCharacters(0, 1, 1)
+        assertEquals(afterImage, buffer.imageCellRevision, "ordinary text on another row stays O(1)")
+
+        buffer.eraseCharacters(0, 1, 0)
+        assertTrue(buffer.imageCellRevision > afterImage, "overwriting an image cell publishes a revision")
+    }
+
+    @Test
     fun modelListenerRunsOutsideBatchStateLock() {
         val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = StyleState())
         buffer.getLine(0)

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
@@ -29,6 +29,24 @@ class TerminalTextBufferBatchTest {
     }
 
     @Test
+    fun screenLineKeepsImageRevisionListenerWhenMovedToHistory() {
+        val buffer = TerminalTextBuffer(
+            width = 8,
+            height = 2,
+            styleState = StyleState(),
+            maxHistoryLinesCount = 10,
+        )
+        buffer.getLine(1)
+        buffer.writeImagePlaceholderCell(0, 0, 42, 0, 0, 1, 1)
+        buffer.scrollArea(scrollRegionTop = 1, dy = -1, scrollRegionBottom = 2)
+        val afterMove = buffer.imageCellRevision
+
+        assertTrue(buffer.getLine(-1).clearAllImageCells())
+
+        assertTrue(buffer.imageCellRevision > afterMove)
+    }
+
+    @Test
     fun imageCellRevisionChangesOnlyForImageContentOrLayout() {
         val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = StyleState())
         buffer.getLine(1)
@@ -43,6 +61,21 @@ class TerminalTextBufferBatchTest {
 
         buffer.eraseCharacters(0, 1, 0)
         assertTrue(buffer.imageCellRevision > afterImage, "overwriting an image cell publishes a revision")
+    }
+
+    @Test
+    fun lineInsertionOnlyRevisesGraphicsWhenItMovesImageCells() {
+        val buffer = TerminalTextBuffer(width = 8, height = 3, styleState = StyleState())
+        buffer.getLine(2)
+        val initial = buffer.imageCellRevision
+
+        buffer.insertLines(y = 0, count = 1, scrollRegionBottom = 3)
+        assertEquals(initial, buffer.imageCellRevision)
+
+        buffer.writeImagePlaceholderCell(1, 0, 42, 0, 0, 1, 1)
+        val afterImage = buffer.imageCellRevision
+        buffer.insertLines(y = 0, count = 1, scrollRegionBottom = 3)
+        assertTrue(buffer.imageCellRevision > afterImage)
     }
 
     @Test

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
@@ -4,6 +4,7 @@ import ai.rever.bossterm.terminal.CursorShape
 import ai.rever.bossterm.terminal.TerminalDisplay
 import ai.rever.bossterm.terminal.emulator.mouse.MouseFormat
 import ai.rever.bossterm.terminal.emulator.mouse.MouseMode
+import ai.rever.bossterm.terminal.model.image.ImageCell
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -13,6 +14,19 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class TerminalTextBufferBatchTest {
+
+    @Test
+    fun removedLinesNoLongerPublishImageRevisionsToTheirFormerStorage() {
+        var changes = 0
+        val storage = CyclicBufferLinesStorage(maxCapacity = -1) { changes++ }
+        val line = TerminalLine()
+        storage.addToBottom(line)
+        storage.removeFromTop()
+
+        line.setImageCell(0, ImageCell(1, 0, 0, 1, 1))
+
+        assertEquals(0, changes)
+    }
 
     @Test
     fun imageCellRevisionChangesOnlyForImageContentOrLayout() {

--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -143,6 +143,7 @@ kotlin {
                 implementation("io.ktor:ktor-server-content-negotiation:3.2.3")
                 // Session sharing (issue #276): WebSocket endpoint for the web viewer.
                 implementation("io.ktor:ktor-server-websockets:3.2.3")
+                implementation("io.ktor:ktor-server-default-headers:3.2.3")
                 // QR code for the share dialog (pure-Java, no Android deps).
                 implementation("com.google.zxing:core:3.5.3")
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareConnection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareConnection.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.daemon
 
+import ai.rever.bossterm.compose.share.GraphicsResyncLimiter
 import kotlinx.coroutines.CompletableDeferred
 
 /**
@@ -25,6 +26,7 @@ internal class DaemonShareConnection(
     // Tighter budget than the attach outbox: browser viewers ride real (possibly remote) links, and
     // a healing re-snapshot replaces a big stale backlog more cheaply than delivering it.
     val outbox = FrameOutbox(outputCapacityChars = 2 * 1024 * 1024)
+    internal val graphicsResyncLimiter = GraphicsResyncLimiter()
 }
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareConnection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareConnection.kt
@@ -19,6 +19,8 @@ internal class DaemonShareConnection(
     @Volatile var canControl: Boolean,
     /** Device label from the viewer's Hello — shown to attached GUIs in the approval list. */
     val name: String,
+    /** True for the bundled web viewer; native peers decode raw graphics themselves. */
+    val supportsPaneGraphics: Boolean = false,
 ) {
     // Tighter budget than the attach outbox: browser viewers ride real (possibly remote) links, and
     // a healing re-snapshot replaces a big stale backlog more cheaply than delivering it.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -6,7 +6,8 @@ import ai.rever.bossterm.compose.settings.theme.ColorPaletteManager
 import ai.rever.bossterm.compose.settings.theme.ThemeManager
 import ai.rever.bossterm.compose.share.ClientMessage
 import ai.rever.bossterm.compose.share.CloudflaredExposer
-import ai.rever.bossterm.compose.share.GraphicsSequenceDetector
+import ai.rever.bossterm.compose.share.GraphicsOutputFilter
+import ai.rever.bossterm.compose.share.GraphicsResyncLimiter
 import ai.rever.bossterm.compose.share.Kex
 import ai.rever.bossterm.compose.share.PANE_GRAPHICS_CAPABILITY
 import ai.rever.bossterm.compose.share.PaneGraphicsTracker
@@ -17,10 +18,10 @@ import ai.rever.bossterm.compose.share.ShareProtocol
 import ai.rever.bossterm.compose.share.TabNode
 import ai.rever.bossterm.compose.share.TailscaleExposer
 import ai.rever.bossterm.compose.share.TerminalSnapshotEncoder
+import ai.rever.bossterm.compose.share.installShareViewerFontRoutes
 import ai.rever.bossterm.compose.share.webTerminalFontFamily
 import ai.rever.bossterm.terminal.model.TerminalModelListener
 import io.ktor.http.CacheControl
-import io.ktor.http.HttpHeaders
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.cio.CIOApplicationEngine
@@ -28,8 +29,6 @@ import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.http.content.staticResources
 import io.ktor.server.plugins.origin
-import io.ktor.server.response.respondResource
-import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.websocket.WebSockets
 import io.ktor.server.websocket.webSocket
@@ -464,14 +463,7 @@ class DaemonShareServer(
                     install(WebSockets)
                     routing {
                         webSocket("/ws/{token}") { serveViewer(this) }
-                        get("/fonts/MesloLGSNF-Regular.ttf") {
-                            call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
-                            call.respondResource("fonts/MesloLGSNF-Regular.ttf")
-                        }
-                        get("/fonts/NotoSansSymbols2-Regular.ttf") {
-                            call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
-                            call.respondResource("fonts/NotoSansSymbols2-Regular.ttf")
-                        }
+                        installShareViewerFontRoutes()
                         // Static web viewer (index.html + viewer.js + css). Share URL:
                         // http://<host>:<port>/?t=<token>. no-cache so a phone re-validates the
                         // viewer assets (filenames aren't content-hashed) — unchanged ones 304.
@@ -697,23 +689,19 @@ class DaemonShareServer(
                     val update = attachment.graphics.pollUpdate()
                     if (update != null) {
                         val core = attachment.core
-                        if (update.requiresTextSnapshot) {
-                            val currentSize = core.display.termSizeFlow.value
-                            // Control frames outrank queued raw output. Keep that output instead of
-                            // purging it: replaying a small overlap is preferable to dropping bytes
-                            // the emulator had not interpreted when this snapshot was captured.
-                            vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(
-                                ServerMessage.PaneSnapshot(
-                                    core.id,
-                                    TerminalSnapshotEncoder.encode(
-                                        core.textBuffer.createSnapshot(),
-                                        core.terminal.cursorX,
-                                        core.terminal.cursorY,
-                                    ),
-                                    currentSize.columns,
-                                    currentSize.rows,
-                                )
-                            )))
+                        if (update.requiresTextSnapshot &&
+                            attachment.textSnapshotLimiter.tryAcquire(core.id)
+                        ) {
+                            // Keep the re-anchor in the pane-output lane: older output drains first,
+                            // then RIS clears it and the authoritative snapshot repaints. Sending
+                            // this on the priority control lane would replay queued output below the
+                            // snapshot and visibly duplicate it.
+                            val repaint = "\u001bc" + TerminalSnapshotEncoder.encode(
+                                core.textBuffer.createSnapshot(),
+                                core.terminal.cursorX,
+                                core.terminal.cursorY,
+                            )
+                            vc.outbox.sendOutput(core.id, repaint)
                         }
                         vc.outbox.sendControl(
                             FrameOutbox.Frame.Text(ShareProtocol.encodeServer(update.message))
@@ -742,36 +730,43 @@ class DaemonShareServer(
             val preludeLock = Any()
             var prelude: ArrayList<String>? = ArrayList()
             var preludeChars = 0
-            val detector = GraphicsSequenceDetector()
+            val graphicsOutputFilter = GraphicsOutputFilter()
             val graphics = PaneGraphicsTracker(core.id, core.textBuffer, core.terminal.getImageDataCache())
             lateinit var attachment: Attachment
             val tap: (String) -> Unit = { d ->
-                if (detector.inspect(d)) {
-                    attachment.monitoringGraphics.set(true)
-                    scheduleGraphicsSync(attachment)
+                val output = if (vc.supportsPaneGraphics) {
+                    val filtered = graphicsOutputFilter.filter(d)
+                    if (filtered.detectedGraphics) {
+                        attachment.monitoringGraphics.set(true)
+                        scheduleGraphicsSync(attachment)
+                    }
+                    filtered.output
+                } else {
+                    d
                 }
                 val held = synchronized(preludeLock) {
                     val p = prelude
                     when {
                         p == null -> false // snapshot already enqueued → send live
+                        output.isEmpty() -> true // filtered graphics payload: retain no empty chunks
                         // Cap the buffer (bounds heap if a session floods output during a slow
                         // large-scrollback encode — the one path that bypasses outbox backpressure).
                         // Past the cap, drop; a small gap heals on the next resync.
-                        preludeChars + d.length > MAX_PRELUDE_CHARS -> true
-                        else -> { p.add(d); preludeChars += d.length; true }
+                        preludeChars + output.length > MAX_PRELUDE_CHARS -> true
+                        else -> { p.add(output); preludeChars += output.length; true }
                     }
                 }
                 // Raw chunk, not a pre-encoded PaneOutput: the writer encodes at drain time, so the
                 // outbox can coalesce queued same-pane chunks into ONE PaneOutput (concatenated pane
                 // bytes are protocol-equivalent, and a backlog collapses into few frames).
-                if (!held) vc.outbox.sendOutput(core.id, d)
+                if (!held) vc.outbox.sendOutput(core.id, output)
             }
             val modelListener = object : TerminalModelListener {
                 override fun modelChanged() {
                     if (attachment.monitoringGraphics.get()) scheduleGraphicsSync(attachment)
                 }
             }
-            attachment = Attachment(core, tap, modelListener, graphics, detector)
+            attachment = Attachment(core, tap, modelListener, graphics, graphicsOutputFilter)
             attachments[core.id] = attachment
             core.addRawOutputListener(tap)
             core.textBuffer.addModelListener(modelListener)
@@ -807,6 +802,7 @@ class DaemonShareServer(
                 a.core.textBuffer.removeModelListener(a.modelListener)
                 a.graphicsSyncJob?.cancel()
                 a.sizeJob?.cancel()
+                vc.graphicsResyncLimiter.remove(id)
             }
         }
 
@@ -908,7 +904,11 @@ class DaemonShareServer(
                 if (msg is ClientMessage.GraphicsResync) {
                     if (vc.supportsPaneGraphics) {
                         val tracker = synchronized(attachLock) { attachments[msg.paneId]?.graphics }
-                        if (tracker != null && vc.graphicsResyncLimiter.tryAcquire(msg.paneId)) {
+                        if (tracker != null && vc.graphicsResyncLimiter.tryAcquire(
+                                msg.paneId,
+                                tracker.estimatedRasterBytes(),
+                            )
+                        ) {
                             val full = tracker.fullMessage()
                             vc.outbox.sendControl(
                                 FrameOutbox.Frame.Text(ShareProtocol.encodeServer(full))
@@ -942,13 +942,14 @@ class DaemonShareServer(
         val tap: (String) -> Unit,
         val modelListener: TerminalModelListener,
         val graphics: PaneGraphicsTracker,
-        /** Retains detector state across fragmented PTY chunks for this attachment's lifetime. */
-        val detector: GraphicsSequenceDetector,
+        /** Retains graphics-filter state across fragmented PTY chunks for this attachment. */
+        val graphicsOutputFilter: GraphicsOutputFilter,
     ) {
         val ready = AtomicBoolean(false)
         val monitoringGraphics = AtomicBoolean(false)
         val graphicsSyncPending = AtomicBoolean(false)
         val graphicsSyncAgain = AtomicBoolean(false)
+        val textSnapshotLimiter = GraphicsResyncLimiter(1_000_000_000L)
         @Volatile var graphicsSyncJob: Job? = null
         @Volatile var sizeJob: Job? = null
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -700,12 +700,13 @@ class DaemonShareServer(
                         if (update.requiresTextSnapshot) {
                             // Keep the screen-only re-anchor in the pane-output lane so it remains
                             // ordered with PTY output without rebuilding retained browser history.
-                            val repaint = TerminalSnapshotEncoder.encodeScreenRepaint(
-                                core.textBuffer.createSnapshot(),
-                                core.terminal.cursorX,
-                                core.terminal.cursorY,
-                            )
-                            attachment.repaintSender.offer(repaint)
+                            attachment.repaintSender.offer {
+                                TerminalSnapshotEncoder.encodeScreenRepaint(
+                                    core.textBuffer.createSnapshot(),
+                                    core.terminal.cursorX,
+                                    core.terminal.cursorY,
+                                )
+                            }
                         }
                         enqueueGraphics(vc.outbox, update.message)
                     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -19,6 +19,7 @@ import ai.rever.bossterm.compose.share.TabNode
 import ai.rever.bossterm.compose.share.TailscaleExposer
 import ai.rever.bossterm.compose.share.TerminalSnapshotEncoder
 import ai.rever.bossterm.compose.share.installShareViewerFontRoutes
+import ai.rever.bossterm.compose.share.webViewerScrollbackLines
 import ai.rever.bossterm.compose.share.webTerminalFontFamily
 import ai.rever.bossterm.terminal.model.TerminalModelListener
 import io.ktor.http.CacheControl
@@ -700,6 +701,7 @@ class DaemonShareServer(
                                 core.textBuffer.createSnapshot(),
                                 core.terminal.cursorX,
                                 core.terminal.cursorY,
+                                webViewerScrollbackLines(core.textBuffer),
                             )
                             vc.outbox.sendOutput(core.id, repaint)
                         }
@@ -773,9 +775,14 @@ class DaemonShareServer(
             // One-time styled initial paint (identical encoder to the attach server / MirrorShare).
             vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(ServerMessage.PaneSnapshot(
                 core.id,
-                TerminalSnapshotEncoder.encode(core.textBuffer.createSnapshot(), core.terminal.cursorX, core.terminal.cursorY),
+                TerminalSnapshotEncoder.encode(
+                    core.textBuffer.createSnapshot(),
+                    core.terminal.cursorX,
+                    core.terminal.cursorY,
+                    webViewerScrollbackLines(core.textBuffer),
+                ),
                 sz.columns, sz.rows,
-                core.textBuffer.maxHistoryLinesCount,
+                webViewerScrollbackLines(core.textBuffer),
             ))))
             if (vc.supportsPaneGraphics) {
                 val initialGraphics = graphics.fullMessage()
@@ -907,7 +914,7 @@ class DaemonShareServer(
                         val tracker = synchronized(attachLock) { attachments[msg.paneId]?.graphics }
                         if (tracker != null && vc.graphicsResyncLimiter.tryAcquire(
                                 msg.paneId,
-                                tracker.estimatedRasterBytes(),
+                                tracker.estimatedWireBytes(),
                             )
                         ) {
                             val full = tracker.fullMessage()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -20,6 +20,8 @@ import ai.rever.bossterm.compose.share.TabNode
 import ai.rever.bossterm.compose.share.TailscaleExposer
 import ai.rever.bossterm.compose.share.TerminalSnapshotEncoder
 import ai.rever.bossterm.compose.share.installShareViewerFontRoutes
+import ai.rever.bossterm.compose.share.installShareViewerIndexRoute
+import ai.rever.bossterm.compose.share.isShareViewerIndexResource
 import ai.rever.bossterm.compose.share.resyncSentinel
 import ai.rever.bossterm.compose.share.webViewerScrollbackLines
 import ai.rever.bossterm.compose.share.webTerminalFontFamily
@@ -472,11 +474,15 @@ class DaemonShareServer(
                     routing {
                         webSocket("/ws/{token}") { serveViewer(this) }
                         installShareViewerFontRoutes()
-                        // Static web viewer (index.html + viewer.js + css). Share URL:
+                        // The shell is templated per request (its CSP names this request's own
+                        // WebSocket origin), so it owns "/" and "/index.html" outright.
+                        installShareViewerIndexRoute()
+                        // Static web viewer (viewer.js + css + vendor). Share URL:
                         // http://<host>:<port>/?t=<token>. no-cache so a phone re-validates the
                         // viewer assets (filenames aren't content-hashed) — unchanged ones 304.
-                        staticResources("/", "share-viewer", index = "index.html") {
+                        staticResources("/", "share-viewer", index = null) {
                             cacheControl { listOf(CacheControl.NoCache(null)) }
+                            exclude { isShareViewerIndexResource(it.path) }
                         }
                     }
                 }
@@ -792,7 +798,10 @@ class DaemonShareServer(
             core.addRawOutputListener(tap)
             core.textBuffer.addModelListener(modelListener)
             // One-time styled initial paint (identical encoder to the attach server / MirrorShare).
-            vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(ServerMessage.PaneSnapshot(
+            // sendSnapshot, not sendControl: beginning every pane of a window/global share at once
+            // can outrun a slow writer, and that backlog must defer into the re-snapshot heal rather
+            // than close the connection (which would also burn one auto-reconnect attempt).
+            vc.outbox.sendSnapshot(core.id, FrameOutbox.Frame.Text(ShareProtocol.encodeServer(ServerMessage.PaneSnapshot(
                 core.id,
                 TerminalSnapshotEncoder.encode(
                     core.textBuffer.createSnapshot(),
@@ -849,11 +858,10 @@ class DaemonShareServer(
             vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(layoutFor(def))))
         }
 
-        val onChange: () -> Unit = { resync() }
-        host.addChangeListener(onChange)
-
-        // Heal a viewer whose incremental output was evicted under back-pressure (slow remote link):
-        // re-snapshot the affected pane after a quiet delay — same pattern as the attach server.
+        // Heal a viewer whose incremental output was evicted under back-pressure (slow remote link),
+        // or whose snapshot found the control backlog at its ceiling: re-snapshot the affected pane
+        // after a quiet delay — same pattern as the attach server. Wired BEFORE the change listener,
+        // since [beginLocked] can already defer a snapshot into this heal on the very first paint.
         val resnapshotPending = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
         vc.outbox.onOutputDropped = { pid ->
             if (resnapshotPending.add(pid)) {
@@ -872,6 +880,9 @@ class DaemonShareServer(
                 }
             }
         }
+
+        val onChange: () -> Unit = { resync() }
+        host.addChangeListener(onChange)
 
         // Register the viewer UNDER [mutex] and verify the share is still live + under the viewer cap.
         // stopShare clears def.viewers under the lock, so adding outside it could orphan a viewer that

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -6,7 +6,10 @@ import ai.rever.bossterm.compose.settings.theme.ColorPaletteManager
 import ai.rever.bossterm.compose.settings.theme.ThemeManager
 import ai.rever.bossterm.compose.share.ClientMessage
 import ai.rever.bossterm.compose.share.CloudflaredExposer
+import ai.rever.bossterm.compose.share.GraphicsSequenceDetector
 import ai.rever.bossterm.compose.share.Kex
+import ai.rever.bossterm.compose.share.PANE_GRAPHICS_CAPABILITY
+import ai.rever.bossterm.compose.share.PaneGraphicsTracker
 import ai.rever.bossterm.compose.share.PaneTreeNode
 import ai.rever.bossterm.compose.share.ServerMessage
 import ai.rever.bossterm.compose.share.SessionCrypto
@@ -14,6 +17,7 @@ import ai.rever.bossterm.compose.share.ShareProtocol
 import ai.rever.bossterm.compose.share.TabNode
 import ai.rever.bossterm.compose.share.TailscaleExposer
 import ai.rever.bossterm.compose.share.TerminalSnapshotEncoder
+import ai.rever.bossterm.terminal.model.TerminalModelListener
 import io.ktor.http.CacheControl
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
@@ -51,6 +55,7 @@ import java.net.ServerSocket
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -142,6 +147,8 @@ class DaemonShareServer(
         /** Delay before re-snapshotting a pane whose output was dropped under back-pressure —
          *  long enough to coalesce a burst of drops into one heal, short enough to feel instant. */
         const val RESNAPSHOT_DELAY_MS = 500L
+        /** One animation frame: coalesces multipart image transfers and row-by-row placements. */
+        const val GRAPHICS_SYNC_DEBOUNCE_MS = 16L
     }
 
     /** A granted device key: which share, its role, the client it was issued to, and its windows. */
@@ -653,13 +660,56 @@ class DaemonShareServer(
         send(mcpStatusMessage())
         send(layoutFor(def))
 
-        val vc = DaemonShareConnection(def.viewerSeq.incrementAndGet(), canControl,
-            hello?.name?.takeIf { it.isNotBlank() } ?: "Viewer (${clientId.take(6)})")
+        val vc = DaemonShareConnection(
+            def.viewerSeq.incrementAndGet(),
+            canControl,
+            hello?.name?.takeIf { it.isNotBlank() } ?: "Viewer (${clientId.take(6)})",
+            hello?.capabilities?.contains(PANE_GRAPHICS_CAPABILITY) == true,
+        )
 
         // Per-session attachment: the output tap + its size collector. Mutated from BOTH the change
         // listener (any thread) and this coroutine, so guarded by [attachLock].
         val attachments = HashMap<String, Attachment>()
         val attachLock = Any()
+
+        fun scheduleGraphicsSync(attachment: Attachment) {
+            if (!vc.supportsPaneGraphics || !attachment.ready.get()) return
+            if (!attachment.graphicsSyncPending.compareAndSet(false, true)) {
+                attachment.graphicsSyncAgain.set(true)
+                return
+            }
+            attachment.graphicsSyncJob = ws.launch {
+                delay(GRAPHICS_SYNC_DEBOUNCE_MS)
+                attachment.graphicsSyncPending.set(false)
+                if (synchronized(attachLock) { attachments[attachment.core.id] } !== attachment) return@launch
+                val update = attachment.graphics.pollUpdate()
+                if (update != null) {
+                    val core = attachment.core
+                    val currentSize = core.display.termSizeFlow.value
+                    // Control frames drain before raw output. Purge chunks already represented by
+                    // this authoritative paint so a Sixel/Kitty sequence cannot replay after it.
+                    vc.outbox.dropQueuedOutput(core.id)
+                    vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(
+                        ServerMessage.PaneSnapshot(
+                            core.id,
+                            TerminalSnapshotEncoder.encode(
+                                core.textBuffer.createSnapshot(),
+                                core.terminal.cursorX,
+                                core.terminal.cursorY,
+                            ),
+                            currentSize.columns,
+                            currentSize.rows,
+                        )
+                    )))
+                    vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(update)))
+                }
+                attachment.monitoringGraphics.set(attachment.graphics.hasVisibleGraphics())
+                if (attachment.graphicsSyncAgain.getAndSet(false)) {
+                    attachment.monitoringGraphics.set(true)
+                    scheduleGraphicsSync(attachment)
+                }
+            }
+        }
 
         fun beginLocked(core: TerminalSessionCore) {
             if (attachments.containsKey(core.id)) return
@@ -671,7 +721,14 @@ class DaemonShareServer(
             val preludeLock = Any()
             var prelude: ArrayList<String>? = ArrayList()
             var preludeChars = 0
+            val detector = GraphicsSequenceDetector()
+            val graphics = PaneGraphicsTracker(core.id, core.textBuffer, core.terminal.getImageDataCache())
+            lateinit var attachment: Attachment
             val tap: (String) -> Unit = { d ->
+                if (detector.inspect(d)) {
+                    attachment.monitoringGraphics.set(true)
+                    scheduleGraphicsSync(attachment)
+                }
                 val held = synchronized(preludeLock) {
                     val p = prelude
                     when {
@@ -688,13 +745,26 @@ class DaemonShareServer(
                 // bytes are protocol-equivalent, and a backlog collapses into few frames).
                 if (!held) vc.outbox.sendOutput(core.id, d)
             }
+            val modelListener = object : TerminalModelListener {
+                override fun modelChanged() {
+                    if (attachment.monitoringGraphics.get()) scheduleGraphicsSync(attachment)
+                }
+            }
+            attachment = Attachment(core, tap, modelListener, graphics, detector)
+            attachments[core.id] = attachment
             core.addRawOutputListener(tap)
+            core.textBuffer.addModelListener(modelListener)
             // One-time styled initial paint (identical encoder to the attach server / MirrorShare).
             vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(ServerMessage.PaneSnapshot(
                 core.id,
                 TerminalSnapshotEncoder.encode(core.textBuffer.createSnapshot(), core.terminal.cursorX, core.terminal.cursorY),
                 sz.columns, sz.rows,
             ))))
+            if (vc.supportsPaneGraphics) {
+                val initialGraphics = graphics.fullMessage()
+                vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(initialGraphics)))
+                if (initialGraphics.requiredImageIds.isNotEmpty()) attachment.monitoringGraphics.set(true)
+            }
             synchronized(preludeLock) {
                 prelude?.forEach { vc.outbox.sendOutput(core.id, it) }
                 prelude = null
@@ -705,13 +775,17 @@ class DaemonShareServer(
                     vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(ServerMessage.PaneResize(core.id, it.columns, it.rows))))
                 }
             }
-            attachments[core.id] = Attachment(core, tap, sizeJob)
+            attachment.sizeJob = sizeJob
+            attachment.ready.set(true)
+            if (attachment.monitoringGraphics.get()) scheduleGraphicsSync(attachment)
         }
         fun endLocked(id: String) {
             attachments.remove(id)?.let { a ->
                 // Remove the tap from the core directly — host.get(id) is null once a session exited.
                 a.core.removeRawOutputListener(a.tap)
-                a.sizeJob.cancel()
+                a.core.textBuffer.removeModelListener(a.modelListener)
+                a.graphicsSyncJob?.cancel()
+                a.sizeJob?.cancel()
             }
         }
 
@@ -810,7 +884,14 @@ class DaemonShareServer(
             synchronized(attachLock) { inScopeCores(def).forEach { beginLocked(it) } } // initial paint
             for (frame in ws.incoming) {
                 val msg = decodeIncoming(frame) ?: continue
-                handleClient(def, vc, msg)
+                if (msg is ClientMessage.GraphicsResync) {
+                    if (vc.supportsPaneGraphics) {
+                        synchronized(attachLock) { attachments[msg.paneId]?.graphics?.fullMessage() }
+                            ?.let { vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(it))) }
+                    }
+                } else {
+                    handleClient(def, vc, msg)
+                }
             }
         } catch (_: Throwable) {
             // client gone
@@ -829,8 +910,21 @@ class DaemonShareServer(
         }
     }
 
-    /** Per-connection, per-session attachment: the core, its raw-output tap + size-collector job. */
-    private class Attachment(val core: TerminalSessionCore, val tap: (String) -> Unit, val sizeJob: Job)
+    /** Per-connection, per-session output, sizing, and authoritative web-graphics state. */
+    private class Attachment(
+        val core: TerminalSessionCore,
+        val tap: (String) -> Unit,
+        val modelListener: TerminalModelListener,
+        val graphics: PaneGraphicsTracker,
+        @Suppress("unused") val detector: GraphicsSequenceDetector,
+    ) {
+        val ready = AtomicBoolean(false)
+        val monitoringGraphics = AtomicBoolean(false)
+        val graphicsSyncPending = AtomicBoolean(false)
+        val graphicsSyncAgain = AtomicBoolean(false)
+        @Volatile var graphicsSyncJob: Job? = null
+        @Volatile var sizeJob: Job? = null
+    }
 
     /**
      * Route a viewer message to the daemon (controller role only for mutating actions). A daemon

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -692,15 +692,12 @@ class DaemonShareServer(
                     if (update != null) {
                         val core = attachment.core
                         if (update.requiresTextSnapshot) {
-                            // Keep the re-anchor in the pane-output lane: older output drains first,
-                            // then RIS clears it and the authoritative snapshot repaints. Sending
-                            // this on the priority control lane would replay queued output below the
-                            // snapshot and visibly duplicate it.
-                            val repaint = "\u001bc" + TerminalSnapshotEncoder.encode(
+                            // Keep the screen-only re-anchor in the pane-output lane so it remains
+                            // ordered with PTY output without rebuilding retained browser history.
+                            val repaint = TerminalSnapshotEncoder.encodeScreenRepaint(
                                 core.textBuffer.createSnapshot(),
                                 core.terminal.cursorX,
                                 core.terminal.cursorY,
-                                webViewerScrollbackLines(core.textBuffer),
                             )
                             if (attachment.textSnapshotLimiter.tryAcquire(
                                     core.id,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -17,6 +17,7 @@ import ai.rever.bossterm.compose.share.ShareProtocol
 import ai.rever.bossterm.compose.share.TabNode
 import ai.rever.bossterm.compose.share.TailscaleExposer
 import ai.rever.bossterm.compose.share.TerminalSnapshotEncoder
+import ai.rever.bossterm.compose.share.webTerminalFontFamily
 import ai.rever.bossterm.terminal.model.TerminalModelListener
 import io.ktor.http.CacheControl
 import io.ktor.server.application.install
@@ -460,6 +461,9 @@ class DaemonShareServer(
                     install(WebSockets)
                     routing {
                         webSocket("/ws/{token}") { serveViewer(this) }
+                        staticResources("/fonts", "fonts") {
+                            cacheControl { listOf(CacheControl.NoCache(null)) }
+                        }
                         // Static web viewer (index.html + viewer.js + css). Share URL:
                         // http://<host>:<port>/?t=<token>. no-cache so a phone re-validates the
                         // viewer assets (filenames aren't content-hashed) — unchanged ones 304.
@@ -1002,10 +1006,6 @@ class DaemonShareServer(
         val theme = ThemeManager.instance.currentTheme.value
         val palette = ColorPaletteManager.instance.currentPalette.value ?: ColorPalette.fromTheme(theme)
         val s = settings()
-        val font = s.fontName
-            ?.takeIf { it.isNotBlank() }
-            ?.let { "\"$it\", Menlo, Monaco, monospace" }
-            ?: "Menlo, Monaco, \"Courier New\", monospace"
         return ServerMessage.Theme(
             background = hexToCss(theme.background),
             foreground = hexToCss(theme.foreground),
@@ -1013,7 +1013,7 @@ class DaemonShareServer(
             cursorAccent = hexToCss(theme.cursorText),
             selectionBackground = hexToCss(theme.selection),
             ansi = (0..15).map { hexToCss(palette.getAnsiColorHex(it)) },
-            fontFamily = font,
+            fontFamily = webTerminalFontFamily(s.fontName),
             fontSize = s.fontSize.toInt(),
         )
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -38,6 +38,7 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -683,16 +684,14 @@ class DaemonShareServer(
                 attachment.graphicsSyncAgain.set(true)
                 return
             }
-            attachment.graphicsSyncJob = ws.launch {
+            val job = ws.launch(start = CoroutineStart.LAZY) {
                 try {
                     delay(GRAPHICS_SYNC_DEBOUNCE_MS)
                     if (synchronized(attachLock) { attachments[attachment.core.id] } !== attachment) return@launch
                     val update = attachment.graphics.pollUpdate()
                     if (update != null) {
                         val core = attachment.core
-                        if (update.requiresTextSnapshot &&
-                            attachment.textSnapshotLimiter.tryAcquire(core.id)
-                        ) {
+                        if (update.requiresTextSnapshot) {
                             // Keep the re-anchor in the pane-output lane: older output drains first,
                             // then RIS clears it and the authoritative snapshot repaints. Sending
                             // this on the priority control lane would replay queued output below the
@@ -703,11 +702,15 @@ class DaemonShareServer(
                                 core.terminal.cursorY,
                                 webViewerScrollbackLines(core.textBuffer),
                             )
-                            vc.outbox.sendOutput(core.id, repaint)
+                            if (attachment.textSnapshotLimiter.tryAcquire(
+                                    core.id,
+                                    estimatedBytes = repaint.length.toLong() * 2,
+                                )
+                            ) {
+                                vc.outbox.sendOutput(core.id, repaint)
+                            }
                         }
-                        vc.outbox.sendControl(
-                            FrameOutbox.Frame.Text(ShareProtocol.encodeServer(update.message))
-                        )
+                        enqueueGraphics(vc.outbox, update.message)
                     }
                     attachment.monitoringGraphics.set(attachment.graphics.hasVisibleGraphics())
                 } finally {
@@ -720,6 +723,8 @@ class DaemonShareServer(
                     }
                 }
             }
+            attachment.graphicsSyncJob = job
+            job.start()
         }
 
         fun beginLocked(core: TerminalSessionCore) {
@@ -768,7 +773,7 @@ class DaemonShareServer(
                     if (attachment.monitoringGraphics.get()) scheduleGraphicsSync(attachment)
                 }
             }
-            attachment = Attachment(core, tap, modelListener, graphics, graphicsOutputFilter)
+            attachment = Attachment(core, tap, modelListener, graphics)
             attachments[core.id] = attachment
             core.addRawOutputListener(tap)
             core.textBuffer.addModelListener(modelListener)
@@ -786,7 +791,7 @@ class DaemonShareServer(
             ))))
             if (vc.supportsPaneGraphics) {
                 val initialGraphics = graphics.fullMessage()
-                vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(initialGraphics)))
+                enqueueGraphics(vc.outbox, initialGraphics)
                 if (initialGraphics.requiredImageIds.isNotEmpty()) attachment.monitoringGraphics.set(true)
             }
             synchronized(preludeLock) {
@@ -918,9 +923,7 @@ class DaemonShareServer(
                             )
                         ) {
                             val full = tracker.fullMessage()
-                            vc.outbox.sendControl(
-                                FrameOutbox.Frame.Text(ShareProtocol.encodeServer(full))
-                            )
+                            enqueueGraphics(vc.outbox, full)
                         }
                     }
                 } else {
@@ -944,14 +947,29 @@ class DaemonShareServer(
         }
     }
 
+    private fun enqueueGraphics(
+        outbox: FrameOutbox,
+        message: ServerMessage.PaneGraphics,
+    ) {
+        val fullFrame = FrameOutbox.Frame.Text(ShareProtocol.encodeServer(message))
+        val recovery = message.copy(
+            revision = message.revision + 1,
+            full = false,
+            images = emptyList(),
+            removedImageIds = emptyList(),
+        )
+        outbox.sendRecoverableControl(
+            fullFrame,
+            FrameOutbox.Frame.Text(ShareProtocol.encodeServer(recovery)),
+        )
+    }
+
     /** Per-connection, per-session output, sizing, and authoritative web-graphics state. */
     private class Attachment(
         val core: TerminalSessionCore,
         val tap: (String) -> Unit,
         val modelListener: TerminalModelListener,
         val graphics: PaneGraphicsTracker,
-        /** Retains graphics-filter state across fragmented PTY chunks for this attachment. */
-        val graphicsOutputFilter: GraphicsOutputFilter,
     ) {
         val ready = AtomicBoolean(false)
         val monitoringGraphics = AtomicBoolean(false)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -6,6 +6,7 @@ import ai.rever.bossterm.compose.settings.theme.ColorPaletteManager
 import ai.rever.bossterm.compose.settings.theme.ThemeManager
 import ai.rever.bossterm.compose.share.ClientMessage
 import ai.rever.bossterm.compose.share.CloudflaredExposer
+import ai.rever.bossterm.compose.share.DeferredPaneRepaint
 import ai.rever.bossterm.compose.share.GraphicsOutputFilter
 import ai.rever.bossterm.compose.share.GraphicsResyncLimiter
 import ai.rever.bossterm.compose.share.Kex
@@ -19,6 +20,7 @@ import ai.rever.bossterm.compose.share.TabNode
 import ai.rever.bossterm.compose.share.TailscaleExposer
 import ai.rever.bossterm.compose.share.TerminalSnapshotEncoder
 import ai.rever.bossterm.compose.share.installShareViewerFontRoutes
+import ai.rever.bossterm.compose.share.resyncSentinel
 import ai.rever.bossterm.compose.share.webViewerScrollbackLines
 import ai.rever.bossterm.compose.share.webTerminalFontFamily
 import ai.rever.bossterm.terminal.model.TerminalModelListener
@@ -703,13 +705,7 @@ class DaemonShareServer(
                                 core.terminal.cursorX,
                                 core.terminal.cursorY,
                             )
-                            if (attachment.textSnapshotLimiter.tryAcquire(
-                                    core.id,
-                                    estimatedBytes = repaint.length.toLong() * 2,
-                                )
-                            ) {
-                                vc.outbox.sendRepaint(core.id, repaint)
-                            }
+                            attachment.repaintSender.offer(repaint)
                         }
                         enqueueGraphics(vc.outbox, update.message)
                     }
@@ -775,6 +771,22 @@ class DaemonShareServer(
                 }
             }
             attachment = Attachment(core, tap, modelListener, graphics)
+            attachment.repaintSender = DeferredPaneRepaint(
+                scope = ws,
+                admit = { repaint ->
+                    val estimatedBytes = repaint.length.toLong() * 2
+                    if (attachment.textSnapshotLimiter.tryAcquire(core.id, estimatedBytes)) {
+                        null
+                    } else {
+                        attachment.textSnapshotLimiter.retryAfterMillis(core.id, estimatedBytes)
+                    }
+                },
+                send = { repaint ->
+                    if (synchronized(attachLock) { attachments[core.id] } === attachment) {
+                        vc.outbox.sendRepaint(core.id, repaint)
+                    }
+                },
+            )
             attachments[core.id] = attachment
             core.addRawOutputListener(tap)
             core.textBuffer.addModelListener(modelListener)
@@ -815,6 +827,7 @@ class DaemonShareServer(
                 a.core.removeRawOutputListener(a.tap)
                 a.core.textBuffer.removeModelListener(a.modelListener)
                 a.graphicsSyncJob?.cancel()
+                a.repaintSender.cancel()
                 a.sizeJob?.cancel()
                 vc.graphicsResyncLimiter.remove(id)
             }
@@ -963,14 +976,7 @@ class DaemonShareServer(
         message: ServerMessage.PaneGraphics,
     ) {
         val fullFrame = FrameOutbox.Frame.Text(ShareProtocol.encodeServer(message))
-        val recovery = message.copy(
-            full = false,
-            images = emptyList(),
-            removedImageIds = emptyList(),
-            requiredImageIds = emptyList(),
-            cells = emptyList(),
-            resyncRequired = true,
-        )
+        val recovery = message.resyncSentinel()
         outbox.sendRecoverableControl(
             fullFrame,
             FrameOutbox.Frame.Text(ShareProtocol.encodeServer(recovery)),
@@ -991,6 +997,7 @@ class DaemonShareServer(
         val textSnapshotLimiter = GraphicsResyncLimiter(1_000_000_000L)
         @Volatile var graphicsSyncJob: Job? = null
         @Volatile var sizeJob: Job? = null
+        lateinit var repaintSender: DeferredPaneRepaint
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -20,6 +20,7 @@ import ai.rever.bossterm.compose.share.TerminalSnapshotEncoder
 import ai.rever.bossterm.compose.share.webTerminalFontFamily
 import ai.rever.bossterm.terminal.model.TerminalModelListener
 import io.ktor.http.CacheControl
+import io.ktor.http.HttpHeaders
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.cio.CIOApplicationEngine
@@ -27,6 +28,8 @@ import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.http.content.staticResources
 import io.ktor.server.plugins.origin
+import io.ktor.server.response.respondResource
+import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.websocket.WebSockets
 import io.ktor.server.websocket.webSocket
@@ -148,8 +151,8 @@ class DaemonShareServer(
         /** Delay before re-snapshotting a pane whose output was dropped under back-pressure —
          *  long enough to coalesce a burst of drops into one heal, short enough to feel instant. */
         const val RESNAPSHOT_DELAY_MS = 500L
-        /** One animation frame: coalesces multipart image transfers and row-by-row placements. */
-        const val GRAPHICS_SYNC_DEBOUNCE_MS = 16L
+        /** Caps full-buffer graphics scans at 10 Hz while coalescing multipart transfers. */
+        const val GRAPHICS_SYNC_DEBOUNCE_MS = 100L
     }
 
     /** A granted device key: which share, its role, the client it was issued to, and its windows. */
@@ -461,8 +464,13 @@ class DaemonShareServer(
                     install(WebSockets)
                     routing {
                         webSocket("/ws/{token}") { serveViewer(this) }
-                        staticResources("/fonts", "fonts") {
-                            cacheControl { listOf(CacheControl.NoCache(null)) }
+                        get("/fonts/MesloLGSNF-Regular.ttf") {
+                            call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
+                            call.respondResource("fonts/MesloLGSNF-Regular.ttf")
+                        }
+                        get("/fonts/NotoSansSymbols2-Regular.ttf") {
+                            call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
+                            call.respondResource("fonts/NotoSansSymbols2-Regular.ttf")
                         }
                         // Static web viewer (index.html + viewer.js + css). Share URL:
                         // http://<host>:<port>/?t=<token>. no-cache so a phone re-validates the
@@ -683,34 +691,43 @@ class DaemonShareServer(
                 return
             }
             attachment.graphicsSyncJob = ws.launch {
-                delay(GRAPHICS_SYNC_DEBOUNCE_MS)
-                attachment.graphicsSyncPending.set(false)
-                if (synchronized(attachLock) { attachments[attachment.core.id] } !== attachment) return@launch
-                val update = attachment.graphics.pollUpdate()
-                if (update != null) {
-                    val core = attachment.core
-                    val currentSize = core.display.termSizeFlow.value
-                    // Control frames drain before raw output. Purge chunks already represented by
-                    // this authoritative paint so a Sixel/Kitty sequence cannot replay after it.
-                    vc.outbox.dropQueuedOutput(core.id)
-                    vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(
-                        ServerMessage.PaneSnapshot(
-                            core.id,
-                            TerminalSnapshotEncoder.encode(
-                                core.textBuffer.createSnapshot(),
-                                core.terminal.cursorX,
-                                core.terminal.cursorY,
-                            ),
-                            currentSize.columns,
-                            currentSize.rows,
+                try {
+                    delay(GRAPHICS_SYNC_DEBOUNCE_MS)
+                    if (synchronized(attachLock) { attachments[attachment.core.id] } !== attachment) return@launch
+                    val update = attachment.graphics.pollUpdate()
+                    if (update != null) {
+                        val core = attachment.core
+                        if (update.requiresTextSnapshot) {
+                            val currentSize = core.display.termSizeFlow.value
+                            // Control frames outrank queued raw output. Keep that output instead of
+                            // purging it: replaying a small overlap is preferable to dropping bytes
+                            // the emulator had not interpreted when this snapshot was captured.
+                            vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(
+                                ServerMessage.PaneSnapshot(
+                                    core.id,
+                                    TerminalSnapshotEncoder.encode(
+                                        core.textBuffer.createSnapshot(),
+                                        core.terminal.cursorX,
+                                        core.terminal.cursorY,
+                                    ),
+                                    currentSize.columns,
+                                    currentSize.rows,
+                                )
+                            )))
+                        }
+                        vc.outbox.sendControl(
+                            FrameOutbox.Frame.Text(ShareProtocol.encodeServer(update.message))
                         )
-                    )))
-                    vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(update)))
-                }
-                attachment.monitoringGraphics.set(attachment.graphics.hasVisibleGraphics())
-                if (attachment.graphicsSyncAgain.getAndSet(false)) {
-                    attachment.monitoringGraphics.set(true)
-                    scheduleGraphicsSync(attachment)
+                    }
+                    attachment.monitoringGraphics.set(attachment.graphics.hasVisibleGraphics())
+                } finally {
+                    attachment.graphicsSyncPending.set(false)
+                    if (attachment.graphicsSyncAgain.getAndSet(false) &&
+                        synchronized(attachLock) { attachments[attachment.core.id] } === attachment
+                    ) {
+                        attachment.monitoringGraphics.set(true)
+                        scheduleGraphicsSync(attachment)
+                    }
                 }
             }
         }
@@ -890,8 +907,13 @@ class DaemonShareServer(
                 val msg = decodeIncoming(frame) ?: continue
                 if (msg is ClientMessage.GraphicsResync) {
                     if (vc.supportsPaneGraphics) {
-                        synchronized(attachLock) { attachments[msg.paneId]?.graphics?.fullMessage() }
-                            ?.let { vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(it))) }
+                        val tracker = synchronized(attachLock) { attachments[msg.paneId]?.graphics }
+                        if (tracker != null && vc.graphicsResyncLimiter.tryAcquire(msg.paneId)) {
+                            val full = tracker.fullMessage()
+                            vc.outbox.sendControl(
+                                FrameOutbox.Frame.Text(ShareProtocol.encodeServer(full))
+                            )
+                        }
                     }
                 } else {
                     handleClient(def, vc, msg)
@@ -920,7 +942,8 @@ class DaemonShareServer(
         val tap: (String) -> Unit,
         val modelListener: TerminalModelListener,
         val graphics: PaneGraphicsTracker,
-        @Suppress("unused") val detector: GraphicsSequenceDetector,
+        /** Retains detector state across fragmented PTY chunks for this attachment's lifetime. */
+        val detector: GraphicsSequenceDetector,
     ) {
         val ready = AtomicBoolean(false)
         val monitoringGraphics = AtomicBoolean(false)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -29,6 +29,7 @@ import io.ktor.server.cio.CIOApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.http.content.staticResources
+import io.ktor.server.plugins.defaultheaders.DefaultHeaders
 import io.ktor.server.plugins.origin
 import io.ktor.server.routing.routing
 import io.ktor.server.websocket.WebSockets
@@ -463,6 +464,9 @@ class DaemonShareServer(
             try {
                 val started = embeddedServer(CIO, host = host, port = port) {
                     install(WebSockets)
+                    install(DefaultHeaders) {
+                        header("X-Frame-Options", "DENY")
+                    }
                     routing {
                         webSocket("/ws/{token}") { serveViewer(this) }
                         installShareViewerFontRoutes()
@@ -704,7 +708,7 @@ class DaemonShareServer(
                                     estimatedBytes = repaint.length.toLong() * 2,
                                 )
                             ) {
-                                vc.outbox.sendOutput(core.id, repaint)
+                                vc.outbox.sendRepaint(core.id, repaint)
                             }
                         }
                         enqueueGraphics(vc.outbox, update.message)
@@ -889,8 +893,12 @@ class DaemonShareServer(
                 vc.outbox.drainTo { f ->
                     val text = when (f) {
                         is FrameOutbox.Frame.Text -> f.text
-                        // Coalesced pane bytes → one PaneOutput, encoded here at drain time.
-                        is FrameOutbox.Frame.Output -> ShareProtocol.encodeServer(ServerMessage.PaneOutput(f.sessionId, f.data))
+                        // Ordered pane bytes are encoded here at drain time; repaint barriers stay
+                        // distinct so the browser can preserve its scroll position.
+                        is FrameOutbox.Frame.Output -> ShareProtocol.encodeServer(
+                            if (f.repaint) ServerMessage.PaneRepaint(f.sessionId, f.data)
+                            else ServerMessage.PaneOutput(f.sessionId, f.data)
+                        )
                         is FrameOutbox.Frame.Binary -> {
                             // Never enqueued on the share path — loud skip so a future mis-wiring
                             // surfaces instead of silently dropping a frame.
@@ -914,13 +922,19 @@ class DaemonShareServer(
                 if (msg is ClientMessage.GraphicsResync) {
                     if (vc.supportsPaneGraphics) {
                         val tracker = synchronized(attachLock) { attachments[msg.paneId]?.graphics }
-                        if (tracker != null && vc.graphicsResyncLimiter.tryAcquire(
-                                msg.paneId,
-                                tracker.estimatedWireBytes(),
-                            )
-                        ) {
-                            val full = tracker.fullMessage()
-                            enqueueGraphics(vc.outbox, full)
+                        if (tracker != null) {
+                            val estimatedBytes = tracker.estimatedWireBytes()
+                            if (vc.graphicsResyncLimiter.tryAcquire(msg.paneId, estimatedBytes)) {
+                                val full = tracker.fullMessage()
+                                enqueueGraphics(vc.outbox, full)
+                            } else {
+                                vc.outbox.sendControl(FrameOutbox.Frame.Text(ShareProtocol.encodeServer(
+                                    ServerMessage.GraphicsResyncDenied(
+                                        msg.paneId,
+                                        vc.graphicsResyncLimiter.retryAfterMillis(msg.paneId, estimatedBytes),
+                                    )
+                                )))
+                            }
                         }
                     }
                 } else {
@@ -950,10 +964,12 @@ class DaemonShareServer(
     ) {
         val fullFrame = FrameOutbox.Frame.Text(ShareProtocol.encodeServer(message))
         val recovery = message.copy(
-            revision = message.revision + 1,
             full = false,
             images = emptyList(),
             removedImageIds = emptyList(),
+            requiredImageIds = emptyList(),
+            cells = emptyList(),
+            resyncRequired = true,
         )
         outbox.sendRecoverableControl(
             fullFrame,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -775,6 +775,7 @@ class DaemonShareServer(
                 core.id,
                 TerminalSnapshotEncoder.encode(core.textBuffer.createSnapshot(), core.terminal.cursorX, core.terminal.cursorY),
                 sz.columns, sz.rows,
+                core.textBuffer.maxHistoryLinesCount,
             ))))
             if (vc.supportsPaneGraphics) {
                 val initialGraphics = graphics.fullMessage()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
@@ -2,6 +2,7 @@ package ai.rever.bossterm.compose.daemon
 
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.selects.select
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * A per-connection send queue with TWO lanes, drained by ONE writer coroutine:
@@ -27,6 +28,7 @@ import kotlinx.coroutines.selects.select
 internal class FrameOutbox(
     outputCapacityChars: Int = DEFAULT_OUTPUT_CAPACITY_CHARS,
     controlCapacity: Int = 1024,
+    private val controlCapacityBytes: Long = DEFAULT_CONTROL_CAPACITY_BYTES,
 ) {
     /** What [drainTo] hands the socket writer. */
     sealed interface Frame {
@@ -47,6 +49,7 @@ internal class FrameOutbox(
     // the GUI reconnects to a fresh snapshot. (Reconnects are paced by DaemonSessionBridge's
     // exponential backoff, so a persistently-wedged client settles into slow retries.)
     private val control = Channel<Frame>(capacity = controlCapacity)
+    private val controlBytes = AtomicLong()
 
     // Output lane: a plain deque under a lock (not a Channel) so eviction can report WHICH session
     // lost data ([onOutputDropped]) and so [takeCoalesced] can peek/merge same-session runs.
@@ -76,6 +79,9 @@ internal class FrameOutbox(
          *  client, and dropped output is healed by [onOutputDropped]'s re-snapshot. */
         const val DEFAULT_OUTPUT_CAPACITY_CHARS = 4 * 1024 * 1024
 
+        /** Heap-oriented bound for large snapshots/graphics frames, independent of frame count. */
+        const val DEFAULT_CONTROL_CAPACITY_BYTES = 128L * 1024 * 1024
+
         /** Secondary bound on queued output FRAMES: the char budget bounds payload heap, but each
          *  queued chunk also costs an object + deque slot, so a pathological stream of tiny chunks
          *  could hold millions of objects while staying under the char budget. Evicts oldest-first
@@ -89,7 +95,26 @@ internal class FrameOutbox(
     /** Enqueue a frame that must not be dropped (snapshot / list / lifecycle / resize). */
     fun sendControl(frame: Frame) {
         if (closed) return
-        if (control.trySend(frame).isFailure) close() // saturated → unrecoverable client; drop it
+        val bytes = estimatedBytes(frame)
+        if (bytes > controlCapacityBytes || controlBytes.addAndGet(bytes) > controlCapacityBytes) {
+            controlBytes.addAndGet(-bytes)
+            close()
+            return
+        }
+        if (control.trySend(frame).isFailure) {
+            controlBytes.addAndGet(-bytes)
+            close() // saturated → unrecoverable client; drop it
+        }
+    }
+
+    private fun estimatedBytes(frame: Frame): Long = when (frame) {
+        is Frame.Text -> frame.text.length.toLong() * 2
+        is Frame.Binary -> frame.bytes.size.toLong()
+        is Frame.Output -> frame.data.length.toLong() * 2
+    }
+
+    private fun releaseControl(frame: Frame) {
+        controlBytes.addAndGet(-estimatedBytes(frame))
     }
 
     /** Enqueue incremental output that may be dropped under back-pressure. */
@@ -163,7 +188,13 @@ internal class FrameOutbox(
             while (burst < CONTROL_BURST) {
                 val r = control.tryReceive()
                 when {
-                    r.isSuccess -> { emit(r.getOrThrow()); drainedControl = true; burst++ }
+                    r.isSuccess -> {
+                        val frame = r.getOrThrow()
+                        releaseControl(frame)
+                        emit(frame)
+                        drainedControl = true
+                        burst++
+                    }
                     r.isClosed -> { controlClosed = true; break }
                     else -> break // control lane empty
                 }
@@ -177,7 +208,16 @@ internal class FrameOutbox(
             if (controlClosed || closed) return
             // 5) Suspend until a control frame or an output wake (or close).
             val ended = select<Boolean> {
-                control.onReceiveCatching { r -> if (r.isClosed) true else { emit(r.getOrThrow()); false } }
+                control.onReceiveCatching { r ->
+                    if (r.isClosed) {
+                        true
+                    } else {
+                        val frame = r.getOrThrow()
+                        releaseControl(frame)
+                        emit(frame)
+                        false
+                    }
+                }
                 // A wake signal (or wake-close) just re-runs the loop, which sweeps both lanes.
                 wake.onReceiveCatching { false }
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
@@ -84,11 +84,11 @@ internal class FrameOutbox(
 
         /**
          * Heap-oriented bound for large snapshots/graphics frames, independent of frame count.
-         * A pane may own 50 MiB of encoded rasters; base64 expands that by 4/3 and the queued JVM
-         * String uses two bytes per char (~134 MiB before JSON), so 192 MiB admits every legal
-         * single full-graphics frame while still bounding a stalled connection.
+         * The web-share path forwards at most 16 MiB of rasters per pane; base64 expands that by
+         * 4/3 and the queued JVM String uses two bytes per char (~43 MiB before JSON). 64 MiB
+         * admits one legal full-graphics frame while bounding a stalled connection.
          */
-        const val DEFAULT_CONTROL_CAPACITY_BYTES = 192L * 1024 * 1024
+        const val DEFAULT_CONTROL_CAPACITY_BYTES = 64L * 1024 * 1024
 
         /** Secondary bound on queued output FRAMES: the char budget bounds payload heap, but each
          *  queued chunk also costs an object + deque slot, so a pathological stream of tiny chunks
@@ -262,5 +262,4 @@ internal class FrameOutbox(
         runCatching { control.close() }
         runCatching { wake.close() }
     }
-
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
@@ -102,30 +102,36 @@ internal class FrameOutbox(
 
     /** Enqueue a frame that must not be dropped (snapshot / list / lifecycle / resize). */
     fun sendControl(frame: Frame) {
-        if (closed) return
+        if (closed || trySendControlFrame(frame)) return
         val bytes = estimatedBytes(frame)
-        if (bytes > controlCapacityBytes) {
-            log.warn(
-                "Closing stalled outbox: one control frame needs {} bytes (capacity {})",
-                bytes,
-                controlCapacityBytes,
-            )
-            close()
-            return
-        }
-        if (!reserveControl(bytes)) {
-            log.warn(
-                "Closing stalled outbox: control backlog exceeds {} bytes",
-                controlCapacityBytes,
-            )
-            close()
-            return
-        }
-        if (control.trySend(frame).isFailure) {
-            controlBytes.addAndGet(-bytes)
-            log.warn("Closing stalled outbox: control frame capacity is saturated")
-            close() // saturated → unrecoverable client; drop it
-        }
+        log.warn(
+            "Closing stalled outbox: control frame/backlog needs {} bytes (capacity {})",
+            bytes,
+            controlCapacityBytes,
+        )
+        close()
+    }
+
+    /**
+     * Try a large but recoverable graphics frame. If it cannot fit, enqueue [recoveryFrame]
+     * instead; the lightweight revision gap/missing-image metadata makes the viewer request a full
+     * resync after the writer drains, without sacrificing the connection or its retry budget.
+     */
+    fun sendRecoverableControl(frame: Frame, recoveryFrame: Frame) {
+        if (closed || trySendControlFrame(frame)) return
+        log.warn(
+            "Dropping recoverable graphics frame ({} bytes); enqueueing resync metadata",
+            estimatedBytes(frame),
+        )
+        sendControl(recoveryFrame)
+    }
+
+    private fun trySendControlFrame(frame: Frame): Boolean {
+        val bytes = estimatedBytes(frame)
+        if (bytes > controlCapacityBytes || !reserveControl(bytes)) return false
+        if (control.trySend(frame).isSuccess) return true
+        controlBytes.addAndGet(-bytes)
+        return false
     }
 
     private fun reserveControl(bytes: Long): Boolean {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
@@ -8,9 +8,10 @@ import java.util.concurrent.atomic.AtomicLong
 /**
  * A per-connection send queue with TWO lanes, drained by ONE writer coroutine:
  *
- *  - [sendControl] — **guaranteed delivery** (bounded channel). Full-paint snapshots, session/layout
- *    lists, lifecycle (closed), and resizes go here: dropping one corrupts the mirror until the next
- *    resync, so they must never be evicted.
+ *  - [sendControl] — **guaranteed delivery** (bounded channel). Session/layout lists, lifecycle
+ *    (closed), and resizes go here: dropping one corrupts the mirror until the next resync, so they
+ *    must never be evicted. [sendSnapshot] and [sendRecoverableControl] share the lane but trade a
+ *    momentarily-full backlog for a deferred heal / resync sentinel instead of the connection.
  *  - [sendOutput] — **best-effort** (char-bounded deque, drop-oldest). Incremental PTY output goes
  *    here: a stalled client must never back-pressure the PTY, so the oldest output is dropped under
  *    load. Each drop reports the affected session via [onOutputDropped], so the connection can
@@ -107,7 +108,7 @@ internal class FrameOutbox(
         const val MAX_COALESCED_CHARS = 256 * 1024
     }
 
-    /** Enqueue a frame that must not be dropped (snapshot / list / lifecycle / resize). */
+    /** Enqueue a frame that must not be dropped (list / lifecycle / resize). */
     fun sendControl(frame: Frame) {
         if (closed || trySendControlFrame(frame)) return
         val bytes = estimatedBytes(frame)
@@ -117,6 +118,37 @@ internal class FrameOutbox(
             controlCapacityBytes,
         )
         close()
+    }
+
+    /**
+     * Enqueue a full-paint snapshot for [sessionId] — guaranteed while the lane has room, but a
+     * merely-BACKLOGGED lane must not cost the connection.
+     *
+     * [controlCapacityBytes] bounds the whole queued control backlog, and a window/global share
+     * beginning every pane at once (each with a full styled scrollback) can queue snapshot bytes
+     * faster than a slow link drains them. That backlog is transient, so report the session as
+     * dropped instead of closing: the connection's [onOutputDropped] heal re-snapshots it once the
+     * writer has caught up. Only a single frame too large to EVER fit the ceiling is unrecoverable.
+     */
+    fun sendSnapshot(sessionId: String, frame: Frame) {
+        if (closed || trySendControlFrame(frame)) return
+        val bytes = estimatedBytes(frame)
+        if (bytes > controlCapacityBytes) {
+            log.warn(
+                "Closing stalled outbox: snapshot frame needs {} bytes (capacity {})",
+                bytes,
+                controlCapacityBytes,
+            )
+            close()
+            return
+        }
+        log.warn(
+            "Deferring {} snapshot ({} bytes): control backlog is at the {}-byte ceiling",
+            sessionId,
+            bytes,
+            controlCapacityBytes,
+        )
+        onOutputDropped?.invoke(sessionId)
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
@@ -39,8 +39,15 @@ internal class FrameOutbox(
         /** A pre-encoded binary control frame (snapshot). */
         class Binary(val bytes: ByteArray) : Frame
 
-        /** Coalesced incremental output for one session; encoded to a binary frame at send time. */
-        data class Output(val sessionId: String, val data: String) : Frame
+        /**
+         * Ordered pane bytes encoded at send time. Repaints are queue barriers and remain distinct
+         * from surrounding incremental output so the viewer can preserve its scroll position.
+         */
+        data class Output(
+            val sessionId: String,
+            val data: String,
+            val repaint: Boolean = false,
+        ) : Frame
     }
 
     // Control frames must not be DROPPED, but the lane is still BOUNDED: a wedged client (socket
@@ -114,8 +121,8 @@ internal class FrameOutbox(
 
     /**
      * Try a large but recoverable graphics frame. If it cannot fit, enqueue [recoveryFrame]
-     * instead; the lightweight revision gap/missing-image metadata makes the viewer request a full
-     * resync after the writer drains, without sacrificing the connection or its retry budget.
+     * instead; the lightweight resync-required sentinel makes the viewer request a full frame
+     * after the writer drains, without inventing a revision or sacrificing the connection.
      */
     fun sendRecoverableControl(frame: Frame, recoveryFrame: Frame) {
         if (closed || trySendControlFrame(frame)) return
@@ -154,10 +161,19 @@ internal class FrameOutbox(
 
     /** Enqueue incremental output that may be dropped under back-pressure. */
     fun sendOutput(sessionId: String, data: String) {
+        enqueueOutput(sessionId, data, repaint = false)
+    }
+
+    /** Enqueue an authoritative screen repaint in the same ordered lane as pane output. */
+    fun sendRepaint(sessionId: String, data: String) {
+        enqueueOutput(sessionId, data, repaint = true)
+    }
+
+    private fun enqueueOutput(sessionId: String, data: String, repaint: Boolean) {
         if (closed || data.isEmpty()) return
         var dropped: MutableSet<String>? = null
         synchronized(outputLock) {
-            outputQueue.addLast(Frame.Output(sessionId, data))
+            outputQueue.addLast(Frame.Output(sessionId, data, repaint))
             outputChars += data.length
             // Evict oldest-first past either bound (chars for payload heap, frames for object
             // count), but always keep the newest chunk — a single over-budget chunk must still go
@@ -196,11 +212,13 @@ internal class FrameOutbox(
     private fun takeCoalesced(): Frame.Output? = synchronized(outputLock) {
         val first = outputQueue.removeFirstOrNull() ?: return null
         outputChars -= first.data.length
-        if (outputQueue.firstOrNull()?.sessionId != first.sessionId) return first
+        if (first.repaint) return first
+        val queuedNext = outputQueue.firstOrNull()
+        if (queuedNext?.sessionId != first.sessionId || queuedNext.repaint) return first
         val sb = StringBuilder(first.data)
         while (sb.length < MAX_COALESCED_CHARS) {
             val next = outputQueue.firstOrNull() ?: break
-            if (next.sessionId != first.sessionId) break
+            if (next.sessionId != first.sessionId || next.repaint) break
             outputQueue.removeFirst()
             outputChars -= next.data.length
             sb.append(next.data)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/FrameOutbox.kt
@@ -2,6 +2,7 @@ package ai.rever.bossterm.compose.daemon
 
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.selects.select
+import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -72,6 +73,8 @@ internal class FrameOutbox(
     @Volatile var onOutputDropped: ((sessionId: String) -> Unit)? = null
 
     internal companion object {
+        private val log = LoggerFactory.getLogger(FrameOutbox::class.java)
+
         /** Max control frames drained before yielding to one output emission (fairness; see [drainTo]). */
         const val CONTROL_BURST = 64
 
@@ -79,8 +82,13 @@ internal class FrameOutbox(
          *  client, and dropped output is healed by [onOutputDropped]'s re-snapshot. */
         const val DEFAULT_OUTPUT_CAPACITY_CHARS = 4 * 1024 * 1024
 
-        /** Heap-oriented bound for large snapshots/graphics frames, independent of frame count. */
-        const val DEFAULT_CONTROL_CAPACITY_BYTES = 128L * 1024 * 1024
+        /**
+         * Heap-oriented bound for large snapshots/graphics frames, independent of frame count.
+         * A pane may own 50 MiB of encoded rasters; base64 expands that by 4/3 and the queued JVM
+         * String uses two bytes per char (~134 MiB before JSON), so 192 MiB admits every legal
+         * single full-graphics frame while still bounding a stalled connection.
+         */
+        const val DEFAULT_CONTROL_CAPACITY_BYTES = 192L * 1024 * 1024
 
         /** Secondary bound on queued output FRAMES: the char budget bounds payload heap, but each
          *  queued chunk also costs an object + deque slot, so a pathological stream of tiny chunks
@@ -96,14 +104,35 @@ internal class FrameOutbox(
     fun sendControl(frame: Frame) {
         if (closed) return
         val bytes = estimatedBytes(frame)
-        if (bytes > controlCapacityBytes || controlBytes.addAndGet(bytes) > controlCapacityBytes) {
-            controlBytes.addAndGet(-bytes)
+        if (bytes > controlCapacityBytes) {
+            log.warn(
+                "Closing stalled outbox: one control frame needs {} bytes (capacity {})",
+                bytes,
+                controlCapacityBytes,
+            )
+            close()
+            return
+        }
+        if (!reserveControl(bytes)) {
+            log.warn(
+                "Closing stalled outbox: control backlog exceeds {} bytes",
+                controlCapacityBytes,
+            )
             close()
             return
         }
         if (control.trySend(frame).isFailure) {
             controlBytes.addAndGet(-bytes)
+            log.warn("Closing stalled outbox: control frame capacity is saturated")
             close() // saturated → unrecoverable client; drop it
+        }
+    }
+
+    private fun reserveControl(bytes: Long): Boolean {
+        while (true) {
+            val current = controlBytes.get()
+            if (bytes > controlCapacityBytes - current) return false
+            if (controlBytes.compareAndSet(current, current + bytes)) return true
         }
     }
 
@@ -233,4 +262,5 @@ internal class FrameOutbox(
         runCatching { control.close() }
         runCatching { wake.close() }
     }
+
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/remote/RemoteSessionManager.kt
@@ -513,6 +513,7 @@ class RemoteSession internal constructor(
                 s.dataStream.append("[3J[2J[H" + msg.data)
             }
             is ServerMessage.PaneOutput -> sessionByPane[msg.paneId]?.dataStream?.append(msg.data)
+            is ServerMessage.PaneRepaint -> sessionByPane[msg.paneId]?.dataStream?.append(msg.data)
             is ServerMessage.PaneResize -> {
                 val s = sessionByPane[msg.paneId] ?: return
                 if (msg.cols >= 2 && msg.rows >= 2) s.terminal.resize(TermSize(msg.cols, msg.rows), RequestOrigin.User)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/DeferredPaneRepaint.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/DeferredPaneRepaint.kt
@@ -1,0 +1,79 @@
+package ai.rever.bossterm.compose.share
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Coalesces authoritative pane repaints while their byte/rate limiter is closed.
+ *
+ * [admit] returns null when [data] may be sent now, or the delay before it should be retried.
+ * Newer repaint data replaces older pending data, so a busy image TUI eventually receives the
+ * latest text re-anchor without building an unbounded queue of obsolete screen paints.
+ */
+internal class DeferredPaneRepaint(
+    private val scope: CoroutineScope,
+    private val admit: (data: String) -> Long?,
+    private val send: (data: String) -> Unit,
+) {
+    private val lock = Any()
+    private var pending: String? = null
+    private var worker: Job? = null
+
+    fun offer(data: String) {
+        if (data.isEmpty()) return
+        synchronized(lock) {
+            pending = data
+            startWorkerLocked()
+        }
+    }
+
+    fun cancel() {
+        synchronized(lock) {
+            pending = null
+            worker?.cancel()
+        }
+    }
+
+    private fun startWorkerLocked() {
+        if (worker?.isActive == true) return
+        worker = scope.launch {
+            try {
+                drain()
+            } finally {
+                val completedWorker = currentCoroutineContext()[Job]
+                synchronized(lock) {
+                    if (worker === completedWorker) {
+                        worker = null
+                        if (pending != null && scope.isActive) startWorkerLocked()
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun drain() {
+        while (scope.isActive) {
+            var sendNow: String? = null
+            var retryAfterMs = 0L
+            synchronized(lock) {
+                val latest = pending ?: return
+                val retry = admit(latest)
+                if (retry == null) {
+                    pending = null
+                    sendNow = latest
+                } else {
+                    retryAfterMs = retry.coerceAtLeast(1L)
+                }
+            }
+            if (sendNow != null) {
+                send(sendNow!!)
+            } else {
+                delay(retryAfterMs)
+            }
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/DeferredPaneRepaint.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/DeferredPaneRepaint.kt
@@ -10,9 +10,9 @@ import kotlinx.coroutines.launch
 /**
  * Coalesces authoritative pane repaints while their byte/rate limiter is closed.
  *
- * [admit] returns null when [data] may be sent now, or the delay before it should be retried.
- * Newer repaint data replaces older pending data, so a busy image TUI eventually receives the
- * latest text re-anchor without building an unbounded queue of obsolete screen paints.
+ * [admit] returns null when the captured data may be sent now, or the delay before it should be
+ * retried. The pending value is a capture function, not an encoded screen: every retry captures
+ * the latest terminal state so ordinary output cannot overtake a stale deferred repaint.
  */
 internal class DeferredPaneRepaint(
     private val scope: CoroutineScope,
@@ -20,13 +20,12 @@ internal class DeferredPaneRepaint(
     private val send: (data: String) -> Unit,
 ) {
     private val lock = Any()
-    private var pending: String? = null
+    private var pending: (() -> String)? = null
     private var worker: Job? = null
 
-    fun offer(data: String) {
-        if (data.isEmpty()) return
+    fun offer(capture: () -> String) {
         synchronized(lock) {
-            pending = data
+            pending = capture
             startWorkerLocked()
         }
     }
@@ -57,22 +56,26 @@ internal class DeferredPaneRepaint(
 
     private suspend fun drain() {
         while (scope.isActive) {
-            var sendNow: String? = null
-            var retryAfterMs = 0L
+            val capture = synchronized(lock) { pending } ?: return
+            val latestScreen = capture()
+            var sendNow = false
+            var retryAfterMs: Long? = null
             synchronized(lock) {
-                val latest = pending ?: return
-                val retry = admit(latest)
-                if (retry == null) {
-                    pending = null
-                    sendNow = latest
-                } else {
-                    retryAfterMs = retry.coerceAtLeast(1L)
+                // A newer placement arrived while this screen was being encoded. Discard the
+                // obsolete capture and immediately recapture through the latest supplier.
+                if (pending === capture) {
+                    val retry = admit(latestScreen)
+                    if (retry == null) {
+                        pending = null
+                        sendNow = true
+                    } else {
+                        retryAfterMs = retry.coerceAtLeast(1L)
+                    }
                 }
             }
-            if (sendNow != null) {
-                send(sendNow!!)
-            } else {
-                delay(retryAfterMs)
+            when {
+                sendNow -> send(latestScreen)
+                retryAfterMs != null -> delay(retryAfterMs!!)
             }
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -11,9 +11,6 @@ import ai.rever.bossterm.compose.settings.theme.ThemeManager
 import ai.rever.bossterm.compose.splits.SplitNode
 import ai.rever.bossterm.compose.tabs.TerminalTab
 import ai.rever.bossterm.compose.window.WindowManager
-import ai.rever.bossterm.terminal.TerminalColor
-import ai.rever.bossterm.terminal.TextStyle
-import ai.rever.bossterm.terminal.model.TerminalLine
 import ai.rever.bossterm.terminal.model.TerminalModelListener
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -205,7 +202,7 @@ class MirrorShare(
         for ((id, tab) in paneTabMap()) {
             val sz = sig.sizes[id] ?: listOf(80, 24)
             out.add(ServerMessage.PaneSnapshot(
-                id, snapshotText(tab), sz[0], sz[1], tab.textBuffer.maxHistoryLinesCount
+                id, snapshotText(tab), sz[0], sz[1], webViewerScrollbackLines(tab.textBuffer)
             ))
             if (includePaneGraphics) {
                 val entry = synchronized(taps) { taps[id] }
@@ -263,7 +260,7 @@ class MirrorShare(
                 val tracker = synchronized(taps) { taps[msg.paneId]?.graphics }
                 if (tracker != null && vc.graphicsResyncLimiter.tryAcquire(
                         msg.paneId,
-                        tracker.estimatedRasterBytes(),
+                        tracker.estimatedWireBytes(),
                     )
                 ) {
                     vc.outbox.trySend(ShareProtocol.encodeServer(tracker.fullMessage(commit = false)))
@@ -552,8 +549,10 @@ class MirrorShare(
                     val graphicsOutputFilter = GraphicsOutputFilter()
                     lateinit var entry: TapEntry
                     val listener: (String) -> Unit = { d ->
+                        // Keep parser state coherent even with zero graphics viewers, so a viewer
+                        // joining mid-payload never receives raw raster bytes as terminal text.
+                        val filtered = graphicsOutputFilter.filter(d)
                         if (viewers.any { it.supportsPaneGraphics }) {
-                            val filtered = graphicsOutputFilter.filter(d)
                             if (filtered.detectedGraphics) {
                                 entry.monitoringGraphics.set(true)
                                 scheduleGraphicsSync(id, entry)
@@ -574,7 +573,7 @@ class MirrorShare(
                     tab.textBuffer.addModelListener(modelListener)
                     val sz = sig.sizes[id] ?: listOf(80, 24)
                     broadcast(ServerMessage.PaneSnapshot(
-                        id, snapshotText(tab), sz[0], sz[1], tab.textBuffer.maxHistoryLinesCount
+                        id, snapshotText(tab), sz[0], sz[1], webViewerScrollbackLines(tab.textBuffer)
                     ))
                     if (hasGraphicsViewer) {
                         val initialGraphics = graphics.fullMessage()
@@ -787,60 +786,12 @@ class MirrorShare(
      */
     private fun snapshotText(tab: TerminalTab): String {
         val snap = tab.textBuffer.createSnapshot()
-        val sb = StringBuilder()
-        var row = -snap.historyLinesCount
-        while (row < snap.height) {
-            appendStyledLine(sb, snap.getLine(row))
-            if (row < snap.height - 1) sb.append("\r\n")
-            row++
-        }
-        sb.append("[0m") // reset trailing style
-        // Park the cursor at its real screen position (1-based row;col) — otherwise xterm.js
-        // leaves it on the bottom row after we write the full-height blob (scrollback + screen).
-        val cy = tab.terminal.cursorY.coerceIn(1, snap.height)
-        val cx = tab.terminal.cursorX.coerceAtLeast(1)
-        sb.append("[$cy;${cx}H")
-        return sb.toString()
-    }
-
-    /** Append one buffer line as SGR-prefixed styled runs, trimming invisible trailing padding. */
-    private fun appendStyledLine(sb: StringBuilder, line: TerminalLine) {
-        // Collect runs, stopping at the first NUL entry (trailing unfilled cells), like TerminalLine.text.
-        val runs = ArrayList<TerminalLine.TextEntry>()
-        for (e in line.entries) {
-            if (e == null) continue
-            if (e.isNul) break
-            runs.add(e)
-        }
-        // Drop trailing runs that are blank with no background — invisible padding (old .trimEnd()).
-        var end = runs.size
-        while (end > 0 && runs[end - 1].let { it.text.toString().isBlank() && it.style.background == null }) end--
-        for (i in 0 until end) {
-            sb.append(ansiForStyle(runs[i].style)).append(runs[i].text.toString())
-        }
-    }
-
-    /** SGR escape that resets then applies [style]'s colors + attributes (256-color / truecolor). */
-    private fun ansiForStyle(style: TextStyle): String {
-        val codes = ArrayList<String>()
-        codes.add("0") // reset first so each run is self-contained
-        if (style.hasOption(TextStyle.Option.BOLD)) codes.add("1")
-        if (style.hasOption(TextStyle.Option.DIM)) codes.add("2")
-        if (style.hasOption(TextStyle.Option.ITALIC)) codes.add("3")
-        if (style.hasOption(TextStyle.Option.UNDERLINED)) codes.add("4")
-        if (style.hasOption(TextStyle.Option.SLOW_BLINK)) codes.add("5")
-        if (style.hasOption(TextStyle.Option.RAPID_BLINK)) codes.add("6")
-        if (style.hasOption(TextStyle.Option.INVERSE)) codes.add("7")
-        if (style.hasOption(TextStyle.Option.HIDDEN)) codes.add("8")
-        style.foreground?.let { codes.add(sgrColor(it, fg = true)) }
-        style.background?.let { codes.add(sgrColor(it, fg = false)) }
-        return "[" + codes.joinToString(";") + "m"
-    }
-
-    private fun sgrColor(c: TerminalColor, fg: Boolean): String {
-        val base = if (fg) "38" else "48"
-        return if (c.isIndexed) "$base;5;${c.colorIndex}"
-        else c.toColor().let { "$base;2;${it.red};${it.green};${it.blue}" }
+        return TerminalSnapshotEncoder.encode(
+            snap,
+            tab.terminal.cursorX,
+            tab.terminal.cursorY,
+            webViewerScrollbackLines(tab.textBuffer),
+        )
     }
 
     // ---- theme (host palette → CSS) ----
@@ -908,8 +859,8 @@ class ViewerConnection(
 /**
  * Desktop-hosted counterpart to the daemon's heap-bounded [FrameOutbox]. Frames are best effort,
  * matching the old `DROP_OLDEST` channel semantics, but the real bound is characters rather than
- * 2048 arbitrarily-sized Strings. A legal 50 MiB raster snapshot expands to ~70M base64 chars, so
- * the default admits one such frame while bounding the aggregate queue to ~192 MiB of UTF-16.
+ * 2048 arbitrarily-sized Strings. A legal 16 MiB web-raster snapshot expands to ~22M base64 chars,
+ * so the default admits one such frame while bounding the aggregate queue to ~64 MiB of UTF-16.
  */
 internal class BoundedViewerOutbox(
     private val capacityChars: Int = DEFAULT_CAPACITY_CHARS,
@@ -955,7 +906,7 @@ internal class BoundedViewerOutbox(
     }
 
     private companion object {
-        const val DEFAULT_CAPACITY_CHARS = 96 * 1024 * 1024
+        const val DEFAULT_CAPACITY_CHARS = 32 * 1024 * 1024
         const val DEFAULT_CAPACITY_FRAMES = 2048
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
@@ -205,7 +204,9 @@ class MirrorShare(
         out.add(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft, sig.summaryMode, sig.sessionName))
         for ((id, tab) in paneTabMap()) {
             val sz = sig.sizes[id] ?: listOf(80, 24)
-            out.add(ServerMessage.PaneSnapshot(id, snapshotText(tab), sz[0], sz[1]))
+            out.add(ServerMessage.PaneSnapshot(
+                id, snapshotText(tab), sz[0], sz[1], tab.textBuffer.maxHistoryLinesCount
+            ))
             if (includePaneGraphics) {
                 val entry = synchronized(taps) { taps[id] }
                 val tracker = entry?.graphics
@@ -572,7 +573,9 @@ class MirrorShare(
                     tab.dataStream.addRawOutputListener(listener)
                     tab.textBuffer.addModelListener(modelListener)
                     val sz = sig.sizes[id] ?: listOf(80, 24)
-                    broadcast(ServerMessage.PaneSnapshot(id, snapshotText(tab), sz[0], sz[1]))
+                    broadcast(ServerMessage.PaneSnapshot(
+                        id, snapshotText(tab), sz[0], sz[1], tab.textBuffer.maxHistoryLinesCount
+                    ))
                     if (hasGraphicsViewer) {
                         val initialGraphics = graphics.fullMessage()
                         if (initialGraphics.requiredImageIds.isNotEmpty()) entry.monitoringGraphics.set(true)
@@ -876,8 +879,8 @@ class MirrorShare(
 
 /**
  * A connected browser viewer. The host pushes pre-encoded JSON frames into [outbox];
- * the Ktor route drains it. Bounded + DROP_OLDEST so a slow viewer never stalls the
- * terminal — it just misses intermediate frames (the next snapshot heals it).
+ * the Ktor route drains it. The queue is bounded by both UTF-16 payload size and frame count, so a
+ * slow viewer never stalls the terminal or retains gigabytes of large graphics frames.
  */
 class ViewerConnection(
     val id: Int,
@@ -888,7 +891,7 @@ class ViewerConnection(
     /** True only for peers that render the host's normalized image-cell protocol. */
     val supportsPaneGraphics: Boolean = false,
 ) {
-    val outbox: Channel<String> = Channel(capacity = 2048, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    internal val outbox = BoundedViewerOutbox()
     internal val graphicsResyncLimiter = GraphicsResyncLimiter()
 
     /** A mid-session control request is awaiting the host's decision (dedupes re-requests). */
@@ -900,4 +903,59 @@ class ViewerConnection(
      * the same view link + key; without this each blip demoted it to view-only).
      */
     @Volatile var grantKey: String? = null
+}
+
+/**
+ * Desktop-hosted counterpart to the daemon's heap-bounded [FrameOutbox]. Frames are best effort,
+ * matching the old `DROP_OLDEST` channel semantics, but the real bound is characters rather than
+ * 2048 arbitrarily-sized Strings. A legal 50 MiB raster snapshot expands to ~70M base64 chars, so
+ * the default admits one such frame while bounding the aggregate queue to ~192 MiB of UTF-16.
+ */
+internal class BoundedViewerOutbox(
+    private val capacityChars: Int = DEFAULT_CAPACITY_CHARS,
+    private val capacityFrames: Int = DEFAULT_CAPACITY_FRAMES,
+) {
+    private val lock = Any()
+    private val frames = ArrayDeque<String>()
+    private var queuedChars = 0
+    private val wake = Channel<Unit>(Channel.CONFLATED)
+    @Volatile private var closed = false
+
+    fun trySend(text: String): Boolean {
+        if (closed || text.isEmpty() || text.length > capacityChars) return false
+        synchronized(lock) {
+            if (closed) return false
+            frames.addLast(text)
+            queuedChars += text.length
+            while ((queuedChars > capacityChars || frames.size > capacityFrames) && frames.size > 1) {
+                queuedChars -= frames.removeFirst().length
+            }
+        }
+        wake.trySend(Unit)
+        return true
+    }
+
+    suspend fun drainTo(emit: suspend (String) -> Unit) {
+        while (true) {
+            val next = synchronized(lock) {
+                frames.removeFirstOrNull()?.also { queuedChars -= it.length }
+            }
+            if (next != null) {
+                emit(next)
+                continue
+            }
+            if (closed) return
+            wake.receiveCatching()
+        }
+    }
+
+    fun close() {
+        closed = true
+        wake.close()
+    }
+
+    private companion object {
+        const val DEFAULT_CAPACITY_CHARS = 96 * 1024 * 1024
+        const val DEFAULT_CAPACITY_FRAMES = 2048
+    }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -786,10 +786,6 @@ class MirrorShare(
         val theme = ThemeManager.instance.currentTheme.value
         val palette = ColorPaletteManager.instance.currentPalette.value ?: ColorPalette.fromTheme(theme)
         val settings = SettingsManager.instance.settings.value
-        val font = settings.fontName
-            ?.takeIf { it.isNotBlank() }
-            ?.let { "\"$it\", Menlo, Monaco, monospace" }
-            ?: "Menlo, Monaco, \"Courier New\", monospace"
         return ServerMessage.Theme(
             background = hexToCss(theme.background),
             foreground = hexToCss(theme.foreground),
@@ -797,7 +793,7 @@ class MirrorShare(
             cursorAccent = hexToCss(theme.cursorText),
             selectionBackground = hexToCss(theme.selection),
             ansi = (0..15).map { hexToCss(palette.getAnsiColorHex(it)) },
-            fontFamily = font,
+            fontFamily = webTerminalFontFamily(settings.fontName),
             fontSize = settings.fontSize.toInt(),
         )
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -206,15 +206,13 @@ class MirrorShare(
                 id, snapshotText(tab), sz[0], sz[1], webViewerScrollbackLines(tab.textBuffer)
             ))
             if (includePaneGraphics) {
-                val entry = synchronized(taps) { taps[id] }
-                val tracker = entry?.graphics
-                    ?: PaneGraphicsTracker(id, tab.textBuffer, tab.terminal.getImageDataCache())
+                val entry = synchronized(taps) { taps[id] } ?: continue
                 // The first graphics-capable viewer establishes the shared baseline. A later
                 // viewer gets a private full frame without advancing revisions for existing peers.
-                val full = tracker.fullMessage(
-                    commit = viewers.none { it.supportsPaneGraphics }
+                val full = entry.graphics.fullMessage(
+                    commit = viewers.count { it.supportsPaneGraphics } <= 1
                 )
-                if (full.requiredImageIds.isNotEmpty()) entry?.monitoringGraphics?.set(true)
+                if (full.requiredImageIds.isNotEmpty()) entry.monitoringGraphics.set(true)
                 out.add(full)
             }
         }
@@ -604,9 +602,13 @@ class MirrorShare(
                     if (update.requiresTextSnapshot) {
                         // xterm.js does not emulate image-protocol cursor movement. Re-anchor text
                         // only for a real placement change, never for scrolling/raster animation.
-                        // RIS + snapshot stays in the same FIFO lane as PaneOutput, so queued bytes
-                        // are cleared by the repaint instead of replaying below it.
-                        val repaint = "\u001bc" + snapshotText(entry.tab)
+                        // Repaint only the visible screen: retained browser scrollback stays intact
+                        // and the payload remains bounded by the pane dimensions.
+                        val repaint = TerminalSnapshotEncoder.encodeScreenRepaint(
+                            entry.tab.textBuffer.createSnapshot(),
+                            entry.tab.terminal.cursorX,
+                            entry.tab.terminal.cursorY,
+                        )
                         if (entry.textSnapshotLimiter.tryAcquire(
                                 id,
                                 estimatedBytes = repaint.length.toLong() * 2,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -26,6 +27,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
 import java.security.SecureRandom
 import java.util.Base64
 import java.util.concurrent.CopyOnWriteArrayList
@@ -89,7 +91,6 @@ class MirrorShare(
         val listener: (String) -> Unit,
         val modelListener: TerminalModelListener,
         val graphics: PaneGraphicsTracker,
-        val graphicsOutputFilter: GraphicsOutputFilter,
         val monitoringGraphics: AtomicBoolean = AtomicBoolean(false),
         val graphicsSyncPending: AtomicBoolean = AtomicBoolean(false),
         val graphicsSyncAgain: AtomicBoolean = AtomicBoolean(false),
@@ -567,7 +568,7 @@ class MirrorShare(
                             if (entry.monitoringGraphics.get()) scheduleGraphicsSync(id, entry)
                         }
                     }
-                    entry = TapEntry(tab, listener, modelListener, graphics, graphicsOutputFilter)
+                    entry = TapEntry(tab, listener, modelListener, graphics)
                     taps[id] = entry
                     tab.dataStream.addRawOutputListener(listener)
                     tab.textBuffer.addModelListener(modelListener)
@@ -593,22 +594,26 @@ class MirrorShare(
             entry.graphicsSyncAgain.set(true)
             return
         }
-        entry.graphicsSyncJob = coro.launch {
+        val job = coro.launch(start = CoroutineStart.LAZY) {
             try {
                 // Cap full-buffer graphics scans at 10 Hz while coalescing multipart transfers.
                 delay(GRAPHICS_SYNC_DEBOUNCE_MS)
                 if (synchronized(taps) { taps[id] } !== entry) return@launch
                 val update = entry.graphics.pollUpdate()
                 if (update != null) {
-                    if (update.requiresTextSnapshot && entry.textSnapshotLimiter.tryAcquire(id)) {
+                    if (update.requiresTextSnapshot) {
                         // xterm.js does not emulate image-protocol cursor movement. Re-anchor text
                         // only for a real placement change, never for scrolling/raster animation.
                         // RIS + snapshot stays in the same FIFO lane as PaneOutput, so queued bytes
                         // are cleared by the repaint instead of replaying below it.
-                        broadcastGraphics(ServerMessage.PaneOutput(
-                            id,
-                            "\u001bc" + snapshotText(entry.tab),
-                        ))
+                        val repaint = "\u001bc" + snapshotText(entry.tab)
+                        if (entry.textSnapshotLimiter.tryAcquire(
+                                id,
+                                estimatedBytes = repaint.length.toLong() * 2,
+                            )
+                        ) {
+                            broadcastGraphics(ServerMessage.PaneOutput(id, repaint))
+                        }
                     }
                     broadcastGraphics(update.message)
                 }
@@ -625,6 +630,8 @@ class MirrorShare(
                 }
             }
         }
+        entry.graphicsSyncJob = job
+        job.start()
     }
 
     private fun disposeTap(entry: TapEntry) {
@@ -873,14 +880,27 @@ internal class BoundedViewerOutbox(
     @Volatile private var closed = false
 
     fun trySend(text: String): Boolean {
-        if (closed || text.isEmpty() || text.length > capacityChars) return false
+        if (closed || text.isEmpty()) return false
+        if (text.length > capacityChars) {
+            log.warn(
+                "Dropping viewer frame of {} chars above the {}-char queue capacity",
+                text.length,
+                capacityChars,
+            )
+            return false
+        }
+        var droppedFrames = 0
         synchronized(lock) {
             if (closed) return false
             frames.addLast(text)
             queuedChars += text.length
             while ((queuedChars > capacityChars || frames.size > capacityFrames) && frames.size > 1) {
                 queuedChars -= frames.removeFirst().length
+                droppedFrames++
             }
+        }
+        if (droppedFrames > 0) {
+            log.warn("Dropped {} stale viewer frame(s) under back-pressure", droppedFrames)
         }
         wake.trySend(Unit)
         return true
@@ -906,6 +926,7 @@ internal class BoundedViewerOutbox(
     }
 
     private companion object {
+        val log = LoggerFactory.getLogger(BoundedViewerOutbox::class.java)
         const val DEFAULT_CAPACITY_CHARS = 32 * 1024 * 1024
         const val DEFAULT_CAPACITY_FRAMES = 2048
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -97,6 +97,7 @@ class MirrorShare(
         val textSnapshotLimiter: GraphicsResyncLimiter = GraphicsResyncLimiter(1_000_000_000L),
     ) {
         @Volatile var graphicsSyncJob: Job? = null
+        lateinit var repaintSender: DeferredPaneRepaint
     }
     private val taps = HashMap<String, TapEntry>()
 
@@ -163,7 +164,12 @@ class MirrorShare(
             vc.outbox.close()
             broadcast(ServerMessage.Presence(viewers.size))
             if (viewers.none { it.supportsPaneGraphics }) {
-                synchronized(taps) { taps.values.forEach { it.monitoringGraphics.set(false) } }
+                synchronized(taps) {
+                    taps.values.forEach {
+                        it.monitoringGraphics.set(false)
+                        it.repaintSender.cancel()
+                    }
+                }
             }
             // Last viewer gone → undo any "fit host to my screen" resize.
             if (viewers.isEmpty()) SessionShareManager.releaseEmbeddedFit(tabId)
@@ -178,8 +184,25 @@ class MirrorShare(
     }
 
     private fun broadcastGraphics(msg: ServerMessage) {
-        val text = ShareProtocol.encodeServer(msg)
-        for (v in viewers) if (v.supportsPaneGraphics) v.outbox.trySend(text)
+        if (msg is ServerMessage.PaneGraphics) {
+            for (viewer in viewers) {
+                if (viewer.supportsPaneGraphics) enqueueGraphics(viewer, msg)
+            }
+        } else {
+            val text = ShareProtocol.encodeServer(msg)
+            for (viewer in viewers) {
+                if (viewer.supportsPaneGraphics) viewer.outbox.trySend(text)
+            }
+        }
+    }
+
+    private fun enqueueGraphics(
+        viewer: ViewerConnection,
+        message: ServerMessage.PaneGraphics,
+    ) {
+        if (!viewer.outbox.trySend(ShareProtocol.encodeServer(message))) {
+            viewer.outbox.trySend(ShareProtocol.encodeServer(message.resyncSentinel()))
+        }
     }
 
     private fun broadcastPaneOutput(
@@ -270,7 +293,7 @@ class MirrorShare(
                 if (tracker != null) {
                     val estimatedBytes = tracker.estimatedWireBytes()
                     if (vc.graphicsResyncLimiter.tryAcquire(msg.paneId, estimatedBytes)) {
-                        vc.outbox.trySend(ShareProtocol.encodeServer(tracker.fullMessage(commit = false)))
+                        enqueueGraphics(vc, tracker.fullMessage(commit = false))
                     } else {
                         vc.outbox.trySend(ShareProtocol.encodeServer(ServerMessage.GraphicsResyncDenied(
                             msg.paneId,
@@ -581,6 +604,22 @@ class MirrorShare(
                         }
                     }
                     entry = TapEntry(tab, listener, modelListener, graphics)
+                    entry.repaintSender = DeferredPaneRepaint(
+                        scope = coro,
+                        admit = { repaint ->
+                            val estimatedBytes = repaint.length.toLong() * 2
+                            if (entry.textSnapshotLimiter.tryAcquire(id, estimatedBytes)) {
+                                null
+                            } else {
+                                entry.textSnapshotLimiter.retryAfterMillis(id, estimatedBytes)
+                            }
+                        },
+                        send = { repaint ->
+                            if (synchronized(taps) { taps[id] } === entry) {
+                                broadcastGraphics(ServerMessage.PaneRepaint(id, repaint))
+                            }
+                        },
+                    )
                     taps[id] = entry
                     tab.dataStream.addRawOutputListener(listener)
                     tab.textBuffer.addModelListener(modelListener)
@@ -623,13 +662,7 @@ class MirrorShare(
                             entry.tab.terminal.cursorX,
                             entry.tab.terminal.cursorY,
                         )
-                        if (entry.textSnapshotLimiter.tryAcquire(
-                                id,
-                                estimatedBytes = repaint.length.toLong() * 2,
-                            )
-                        ) {
-                            broadcastGraphics(ServerMessage.PaneRepaint(id, repaint))
-                        }
+                        entry.repaintSender.offer(repaint)
                     }
                     broadcastGraphics(update.message)
                 }
@@ -652,6 +685,7 @@ class MirrorShare(
 
     private fun disposeTap(entry: TapEntry) {
         entry.graphicsSyncJob?.cancel()
+        entry.repaintSender.cancel()
         runCatching { entry.tab.dataStream.removeRawOutputListener(entry.listener) }
         runCatching { entry.tab.textBuffer.removeModelListener(entry.modelListener) }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -286,6 +286,9 @@ class MirrorShare(
             ?: McpTerminalRegistry.findState(tabId)
             ?: inScopeStates().firstOrNull()
 
+    /** The tapped tab behind a pane id — [taps] is a plain HashMap, so never read it unlocked. */
+    private fun tappedTab(paneId: String): TerminalTab? = synchronized(taps) { taps[paneId]?.tab }
+
     fun handleClient(vc: ViewerConnection, msg: ClientMessage) {
         if (msg is ClientMessage.GraphicsResync) {
             if (vc.supportsPaneGraphics) {
@@ -337,7 +340,7 @@ class MirrorShare(
         // (our RemoteSession methods no-op silently if we're view-only on it).
         when (msg) {
             is ClientMessage.Input ->
-                (taps[msg.paneId]?.tab ?: paneTabMap()[msg.paneId])?.writeUserInput(msg.data)
+                (tappedTab(msg.paneId) ?: paneTabMap()[msg.paneId])?.writeUserInput(msg.data)
             is ClientMessage.CloseTab ->
                 upstreamSession(msg.tabId)?.closeFromChip(msg.tabId, msg.tabId)
                     ?: stateFor(msg.tabId)?.closeTab(msg.tabId)
@@ -385,7 +388,7 @@ class MirrorShare(
                 }
                 // Run the same launch command the host's AI menu would (honoring the
                 // user's per-assistant YOLO/auto-mode config), in the clicked pane.
-                val target = taps[msg.paneId]?.tab ?: paneTabMap()[msg.paneId]
+                val target = tappedTab(msg.paneId) ?: paneTabMap()[msg.paneId]
                 val assistant = AIAssistants.findById(msg.assistantId)
                 if (target != null && assistant != null) {
                     val cfg = SettingsManager.instance.settings.value.aiAssistantConfigs[msg.assistantId]
@@ -573,8 +576,12 @@ class MirrorShare(
     private fun reconcile(sig: WindowSig) {
         val paneMap = paneTabMap()
         if (paneMap.isEmpty()) { onEnded(); return }
-        val hasGraphicsViewer = viewers.any { it.supportsPaneGraphics }
         synchronized(taps) {
+            // Read INSIDE the lock: [addViewer] snapshots taps under the same lock, so either we
+            // already see its viewer (and send the initial frame) or it sees this new tap (and
+            // schedules its own sync). Reading outside would let a joining graphics viewer miss a
+            // pane created in the same instant.
+            val hasGraphicsViewer = viewers.any { it.supportsPaneGraphics }
             (taps.keys - paneMap.keys).toList().forEach { id ->
                 taps.remove(id)?.let(::disposeTap)
                 viewers.forEach { it.graphicsResyncLimiter.remove(id) }
@@ -585,18 +592,21 @@ class MirrorShare(
                     val graphicsOutputFilter = GraphicsOutputFilter()
                     lateinit var entry: TapEntry
                     val listener: (String) -> Unit = { d ->
-                        // Keep parser state coherent even with zero graphics viewers, so a viewer
-                        // joining mid-payload never receives raw raster bytes as terminal text.
+                        // Filter unconditionally: parser state must stay coherent even with zero
+                        // graphics viewers, so a viewer joining mid-payload never receives raw
+                        // raster bytes as terminal text. Broadcast through broadcastPaneOutput for
+                        // the same reason — it picks raw/filtered PER VIEWER off the live list, so a
+                        // viewer [addViewer] registers between here and the send still gets the
+                        // stream it can render. Branching on a `viewers.any { }` snapshot instead
+                        // would hand that viewer the whole unfiltered payload as terminal text.
+                        // (broadcastPaneOutput also encodes lazily per kind, so with no graphics
+                        // viewer it costs exactly one encodeServer call, same as `broadcast`.)
                         val filtered = graphicsOutputFilter.filter(d)
-                        if (viewers.any { it.supportsPaneGraphics }) {
-                            if (filtered.detectedGraphics) {
-                                entry.monitoringGraphics.set(true)
-                                scheduleGraphicsSync(id, entry)
-                            }
-                            broadcastPaneOutput(id, d, filtered.output)
-                        } else {
-                            broadcast(ServerMessage.PaneOutput(id, d))
+                        if (filtered.detectedGraphics) {
+                            entry.monitoringGraphics.set(true)
+                            scheduleGraphicsSync(id, entry) // no-ops while no viewer wants graphics
                         }
+                        broadcastPaneOutput(id, d, filtered.output)
                     }
                     val modelListener = object : TerminalModelListener {
                         override fun modelChanged() {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -14,6 +14,7 @@ import ai.rever.bossterm.compose.window.WindowManager
 import ai.rever.bossterm.terminal.TerminalColor
 import ai.rever.bossterm.terminal.TextStyle
 import ai.rever.bossterm.terminal.model.TerminalLine
+import ai.rever.bossterm.terminal.model.TerminalModelListener
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -25,12 +26,14 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import java.security.SecureRandom
 import java.util.Base64
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 /** Whether a share covers one tab (incl. its splits), the whole window (all tabs), or every window. */
@@ -85,7 +88,18 @@ class MirrorShare(
     private var observerJob: Job? = null
     private var mcpJob: Job? = null
 
-    private class TapEntry(val tab: TerminalTab, val listener: (String) -> Unit)
+    private class TapEntry(
+        val tab: TerminalTab,
+        val listener: (String) -> Unit,
+        val modelListener: TerminalModelListener,
+        val graphics: PaneGraphicsTracker,
+        val detector: GraphicsSequenceDetector,
+        val monitoringGraphics: AtomicBoolean = AtomicBoolean(false),
+        val graphicsSyncPending: AtomicBoolean = AtomicBoolean(false),
+        val graphicsSyncAgain: AtomicBoolean = AtomicBoolean(false),
+    ) {
+        @Volatile var graphicsSyncJob: Job? = null
+    }
     private val taps = HashMap<String, TapEntry>()
 
     fun start() {
@@ -116,7 +130,7 @@ class MirrorShare(
         observerJob?.cancel()
         mcpJob?.cancel()
         synchronized(taps) {
-            taps.values.forEach { e -> runCatching { e.tab.dataStream.removeRawOutputListener(e.listener) } }
+            taps.values.forEach(::disposeTap)
             taps.clear()
         }
         viewers.forEach { it.outbox.close() }
@@ -125,8 +139,12 @@ class MirrorShare(
     }
 
     // ---- viewers ----
-    fun addViewer(canControl: Boolean, name: String = "Viewer"): ViewerConnection {
-        val vc = ViewerConnection(viewerSeq.incrementAndGet(), canControl, name)
+    fun addViewer(
+        canControl: Boolean,
+        name: String = "Viewer",
+        supportsPaneGraphics: Boolean = false,
+    ): ViewerConnection {
+        val vc = ViewerConnection(viewerSeq.incrementAndGet(), canControl, name, supportsPaneGraphics)
         viewers.add(vc)
         broadcast(ServerMessage.Presence(viewers.size))
         return vc
@@ -148,8 +166,13 @@ class MirrorShare(
         for (v in viewers) v.outbox.trySend(text)
     }
 
+    private fun broadcastGraphics(msg: ServerMessage) {
+        val text = ShareProtocol.encodeServer(msg)
+        for (v in viewers) if (v.supportsPaneGraphics) v.outbox.trySend(text)
+    }
+
     /** Theme + Layout + a PaneSnapshot per pane, for a newly-connected viewer. */
-    fun initialMessages(): List<ServerMessage> {
+    fun initialMessages(includePaneGraphics: Boolean = false): List<ServerMessage> {
         val sig = computeSignature()
         val out = ArrayList<ServerMessage>()
         out.add(themeMessage())
@@ -158,6 +181,11 @@ class MirrorShare(
         for ((id, tab) in paneTabMap()) {
             val sz = sig.sizes[id] ?: listOf(80, 24)
             out.add(ServerMessage.PaneSnapshot(id, snapshotText(tab), sz[0], sz[1]))
+            if (includePaneGraphics) {
+                val tracker = synchronized(taps) { taps[id]?.graphics }
+                    ?: PaneGraphicsTracker(id, tab.textBuffer, tab.terminal.getImageDataCache())
+                out.add(tracker.fullMessage())
+            }
         }
         return out
     }
@@ -197,6 +225,13 @@ class MirrorShare(
             ?: inScopeStates().firstOrNull()
 
     fun handleClient(vc: ViewerConnection, msg: ClientMessage) {
+        if (msg is ClientMessage.GraphicsResync) {
+            if (vc.supportsPaneGraphics) {
+                synchronized(taps) { taps[msg.paneId]?.graphics?.fullMessage() }
+                    ?.let { vc.outbox.trySend(ShareProtocol.encodeServer(it)) }
+            }
+            return
+        }
         if (msg is ClientMessage.RequestControl) {
             val upstream = upstreamSession(msg.tabId)
             if (upstream != null) {
@@ -416,6 +451,8 @@ class MirrorShare(
     }
 
     companion object {
+        private const val GRAPHICS_SYNC_DEBOUNCE_MS = 16L
+
         // MCP server name/label as the CLI attachers register it / as broadcast to viewers.
         // The embedder's BossTermMcpConfig is a Compose CompositionLocal (unavailable in this
         // non-Composable class), so BossTermMcpManager publishes the resolved values to the
@@ -466,20 +503,73 @@ class MirrorShare(
         if (paneMap.isEmpty()) { onEnded(); return }
         synchronized(taps) {
             (taps.keys - paneMap.keys).toList().forEach { id ->
-                taps.remove(id)?.let { e -> runCatching { e.tab.dataStream.removeRawOutputListener(e.listener) } }
+                taps.remove(id)?.let(::disposeTap)
             }
             for ((id, tab) in paneMap) {
                 if (id !in taps) {
-                    val listener: (String) -> Unit = { d -> broadcast(ServerMessage.PaneOutput(id, d)) }
-                    taps[id] = TapEntry(tab, listener)
+                    val graphics = PaneGraphicsTracker(id, tab.textBuffer, tab.terminal.getImageDataCache())
+                    val detector = GraphicsSequenceDetector()
+                    lateinit var entry: TapEntry
+                    val listener: (String) -> Unit = { d ->
+                        if (detector.inspect(d)) {
+                            entry.monitoringGraphics.set(true)
+                            scheduleGraphicsSync(id, entry)
+                        }
+                        broadcast(ServerMessage.PaneOutput(id, d))
+                    }
+                    val modelListener = object : TerminalModelListener {
+                        override fun modelChanged() {
+                            if (entry.monitoringGraphics.get()) scheduleGraphicsSync(id, entry)
+                        }
+                    }
+                    entry = TapEntry(tab, listener, modelListener, graphics, detector)
+                    taps[id] = entry
                     tab.dataStream.addRawOutputListener(listener)
+                    tab.textBuffer.addModelListener(modelListener)
                     val sz = sig.sizes[id] ?: listOf(80, 24)
                     broadcast(ServerMessage.PaneSnapshot(id, snapshotText(tab), sz[0], sz[1]))
+                    val initialGraphics = graphics.fullMessage()
+                    if (initialGraphics.requiredImageIds.isNotEmpty()) entry.monitoringGraphics.set(true)
+                    broadcastGraphics(initialGraphics)
                 }
             }
         }
         broadcast(ServerMessage.Layout(sig.tabs, sig.activeTabId, sig.tabBarOnLeft, sig.summaryMode, sig.sessionName))
         sig.sizes.forEach { (id, sz) -> broadcast(ServerMessage.PaneResize(id, sz[0], sz[1])) }
+    }
+
+    private fun scheduleGraphicsSync(id: String, entry: TapEntry) {
+        if (!entry.graphicsSyncPending.compareAndSet(false, true)) {
+            entry.graphicsSyncAgain.set(true)
+            return
+        }
+        entry.graphicsSyncJob = coro.launch {
+            // Coalesce multipart transfers and multiple ImageCell row writes into one browser paint.
+            delay(GRAPHICS_SYNC_DEBOUNCE_MS)
+            entry.graphicsSyncPending.set(false)
+            if (synchronized(taps) { taps[id] } !== entry) return@launch
+            val update = entry.graphics.pollUpdate()
+            if (update != null) {
+                val size = entry.tab.display.termSize.value
+                // xterm.js 5 does not emulate Sixel/Kitty cursor movement. Re-anchor its text and
+                // cursor before applying the authoritative image-cell overlay.
+                broadcastGraphics(ServerMessage.PaneSnapshot(
+                    id, snapshotText(entry.tab), size.columns, size.rows
+                ))
+                broadcastGraphics(update)
+            }
+            entry.monitoringGraphics.set(entry.graphics.hasVisibleGraphics())
+            if (entry.graphicsSyncAgain.getAndSet(false)) {
+                entry.monitoringGraphics.set(true)
+                scheduleGraphicsSync(id, entry)
+            }
+        }
+    }
+
+    private fun disposeTap(entry: TapEntry) {
+        entry.graphicsSyncJob?.cancel()
+        runCatching { entry.tab.dataStream.removeRawOutputListener(entry.listener) }
+        runCatching { entry.tab.textBuffer.removeModelListener(entry.modelListener) }
     }
 
     // ---- window-state signature (pure-serializable; drives distinctUntilChanged) ----
@@ -740,6 +830,8 @@ class ViewerConnection(
     @Volatile var canControl: Boolean,
     /** Device name from the viewer's Hello — shown in the control-request approval prompt. */
     val name: String = "Viewer",
+    /** True only for peers that render the host's normalized image-cell protocol. */
+    val supportsPaneGraphics: Boolean = false,
 ) {
     val outbox: Channel<String> = Channel(capacity = 2048, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -144,6 +144,16 @@ class MirrorShare(
     ): ViewerConnection {
         val vc = ViewerConnection(viewerSeq.incrementAndGet(), canControl, name, supportsPaneGraphics)
         viewers.add(vc)
+        if (supportsPaneGraphics) {
+            // A graphics mutation may have landed after this viewer's initial full frames were
+            // captured but before admission. Poll every pane once after registration so even a
+            // quiet pane closes that window without registering early and replaying text twice.
+            val entries = synchronized(taps) { taps.toList() }
+            entries.forEach { (id, entry) ->
+                entry.monitoringGraphics.set(true)
+                scheduleGraphicsSync(id, entry)
+            }
+        }
         broadcast(ServerMessage.Presence(viewers.size))
         return vc
     }
@@ -210,7 +220,7 @@ class MirrorShare(
                 // The first graphics-capable viewer establishes the shared baseline. A later
                 // viewer gets a private full frame without advancing revisions for existing peers.
                 val full = entry.graphics.fullMessage(
-                    commit = viewers.count { it.supportsPaneGraphics } <= 1
+                    commit = viewers.none { it.supportsPaneGraphics }
                 )
                 if (full.requiredImageIds.isNotEmpty()) entry.monitoringGraphics.set(true)
                 out.add(full)
@@ -257,12 +267,16 @@ class MirrorShare(
         if (msg is ClientMessage.GraphicsResync) {
             if (vc.supportsPaneGraphics) {
                 val tracker = synchronized(taps) { taps[msg.paneId]?.graphics }
-                if (tracker != null && vc.graphicsResyncLimiter.tryAcquire(
-                        msg.paneId,
-                        tracker.estimatedWireBytes(),
-                    )
-                ) {
-                    vc.outbox.trySend(ShareProtocol.encodeServer(tracker.fullMessage(commit = false)))
+                if (tracker != null) {
+                    val estimatedBytes = tracker.estimatedWireBytes()
+                    if (vc.graphicsResyncLimiter.tryAcquire(msg.paneId, estimatedBytes)) {
+                        vc.outbox.trySend(ShareProtocol.encodeServer(tracker.fullMessage(commit = false)))
+                    } else {
+                        vc.outbox.trySend(ShareProtocol.encodeServer(ServerMessage.GraphicsResyncDenied(
+                            msg.paneId,
+                            vc.graphicsResyncLimiter.retryAfterMillis(msg.paneId, estimatedBytes),
+                        )))
+                    }
                 }
             }
             return
@@ -614,7 +628,7 @@ class MirrorShare(
                                 estimatedBytes = repaint.length.toLong() * 2,
                             )
                         ) {
-                            broadcastGraphics(ServerMessage.PaneOutput(id, repaint))
+                            broadcastGraphics(ServerMessage.PaneRepaint(id, repaint))
                         }
                     }
                     broadcastGraphics(update.message)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -93,10 +93,11 @@ class MirrorShare(
         val listener: (String) -> Unit,
         val modelListener: TerminalModelListener,
         val graphics: PaneGraphicsTracker,
-        val detector: GraphicsSequenceDetector,
+        val graphicsOutputFilter: GraphicsOutputFilter,
         val monitoringGraphics: AtomicBoolean = AtomicBoolean(false),
         val graphicsSyncPending: AtomicBoolean = AtomicBoolean(false),
         val graphicsSyncAgain: AtomicBoolean = AtomicBoolean(false),
+        val textSnapshotLimiter: GraphicsResyncLimiter = GraphicsResyncLimiter(1_000_000_000L),
     ) {
         @Volatile var graphicsSyncJob: Job? = null
     }
@@ -174,6 +175,27 @@ class MirrorShare(
         for (v in viewers) if (v.supportsPaneGraphics) v.outbox.trySend(text)
     }
 
+    private fun broadcastPaneOutput(
+        paneId: String,
+        raw: String,
+        filtered: String,
+    ) {
+        var rawFrame: String? = null
+        var filteredFrame: String? = null
+        for (viewer in viewers) {
+            val data = if (viewer.supportsPaneGraphics) filtered else raw
+            if (data.isEmpty()) continue
+            val frame = if (viewer.supportsPaneGraphics) {
+                filteredFrame ?: ShareProtocol.encodeServer(ServerMessage.PaneOutput(paneId, data))
+                    .also { filteredFrame = it }
+            } else {
+                rawFrame ?: ShareProtocol.encodeServer(ServerMessage.PaneOutput(paneId, data))
+                    .also { rawFrame = it }
+            }
+            viewer.outbox.trySend(frame)
+        }
+    }
+
     /** Theme + Layout + a PaneSnapshot per pane, for a newly-connected viewer. */
     fun initialMessages(includePaneGraphics: Boolean = false): List<ServerMessage> {
         val sig = computeSignature()
@@ -238,7 +260,11 @@ class MirrorShare(
         if (msg is ClientMessage.GraphicsResync) {
             if (vc.supportsPaneGraphics) {
                 val tracker = synchronized(taps) { taps[msg.paneId]?.graphics }
-                if (tracker != null && vc.graphicsResyncLimiter.tryAcquire(msg.paneId)) {
+                if (tracker != null && vc.graphicsResyncLimiter.tryAcquire(
+                        msg.paneId,
+                        tracker.estimatedRasterBytes(),
+                    )
+                ) {
                     vc.outbox.trySend(ShareProtocol.encodeServer(tracker.fullMessage(commit = false)))
                 }
             }
@@ -517,25 +543,31 @@ class MirrorShare(
         synchronized(taps) {
             (taps.keys - paneMap.keys).toList().forEach { id ->
                 taps.remove(id)?.let(::disposeTap)
+                viewers.forEach { it.graphicsResyncLimiter.remove(id) }
             }
             for ((id, tab) in paneMap) {
                 if (id !in taps) {
                     val graphics = PaneGraphicsTracker(id, tab.textBuffer, tab.terminal.getImageDataCache())
-                    val detector = GraphicsSequenceDetector()
+                    val graphicsOutputFilter = GraphicsOutputFilter()
                     lateinit var entry: TapEntry
                     val listener: (String) -> Unit = { d ->
-                        if (detector.inspect(d) && viewers.any { it.supportsPaneGraphics }) {
-                            entry.monitoringGraphics.set(true)
-                            scheduleGraphicsSync(id, entry)
+                        if (viewers.any { it.supportsPaneGraphics }) {
+                            val filtered = graphicsOutputFilter.filter(d)
+                            if (filtered.detectedGraphics) {
+                                entry.monitoringGraphics.set(true)
+                                scheduleGraphicsSync(id, entry)
+                            }
+                            broadcastPaneOutput(id, d, filtered.output)
+                        } else {
+                            broadcast(ServerMessage.PaneOutput(id, d))
                         }
-                        broadcast(ServerMessage.PaneOutput(id, d))
                     }
                     val modelListener = object : TerminalModelListener {
                         override fun modelChanged() {
                             if (entry.monitoringGraphics.get()) scheduleGraphicsSync(id, entry)
                         }
                     }
-                    entry = TapEntry(tab, listener, modelListener, graphics, detector)
+                    entry = TapEntry(tab, listener, modelListener, graphics, graphicsOutputFilter)
                     taps[id] = entry
                     tab.dataStream.addRawOutputListener(listener)
                     tab.textBuffer.addModelListener(modelListener)
@@ -566,12 +598,14 @@ class MirrorShare(
                 if (synchronized(taps) { taps[id] } !== entry) return@launch
                 val update = entry.graphics.pollUpdate()
                 if (update != null) {
-                    if (update.requiresTextSnapshot) {
-                        val size = entry.tab.display.termSize.value
+                    if (update.requiresTextSnapshot && entry.textSnapshotLimiter.tryAcquire(id)) {
                         // xterm.js does not emulate image-protocol cursor movement. Re-anchor text
-                        // only for a real placement/raster change, never for ordinary scrolling.
-                        broadcastGraphics(ServerMessage.PaneSnapshot(
-                            id, snapshotText(entry.tab), size.columns, size.rows
+                        // only for a real placement change, never for scrolling/raster animation.
+                        // RIS + snapshot stays in the same FIFO lane as PaneOutput, so queued bytes
+                        // are cleared by the repaint instead of replaying below it.
+                        broadcastGraphics(ServerMessage.PaneOutput(
+                            id,
+                            "\u001bc" + snapshotText(entry.tab),
                         ))
                     }
                     broadcastGraphics(update.message)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -154,6 +154,9 @@ class MirrorShare(
         if (viewers.remove(vc)) {
             vc.outbox.close()
             broadcast(ServerMessage.Presence(viewers.size))
+            if (viewers.none { it.supportsPaneGraphics }) {
+                synchronized(taps) { taps.values.forEach { it.monitoringGraphics.set(false) } }
+            }
             // Last viewer gone → undo any "fit host to my screen" resize.
             if (viewers.isEmpty()) SessionShareManager.releaseEmbeddedFit(tabId)
         }
@@ -182,9 +185,16 @@ class MirrorShare(
             val sz = sig.sizes[id] ?: listOf(80, 24)
             out.add(ServerMessage.PaneSnapshot(id, snapshotText(tab), sz[0], sz[1]))
             if (includePaneGraphics) {
-                val tracker = synchronized(taps) { taps[id]?.graphics }
+                val entry = synchronized(taps) { taps[id] }
+                val tracker = entry?.graphics
                     ?: PaneGraphicsTracker(id, tab.textBuffer, tab.terminal.getImageDataCache())
-                out.add(tracker.fullMessage())
+                // The first graphics-capable viewer establishes the shared baseline. A later
+                // viewer gets a private full frame without advancing revisions for existing peers.
+                val full = tracker.fullMessage(
+                    commit = viewers.none { it.supportsPaneGraphics }
+                )
+                if (full.requiredImageIds.isNotEmpty()) entry?.monitoringGraphics?.set(true)
+                out.add(full)
             }
         }
         return out
@@ -227,8 +237,10 @@ class MirrorShare(
     fun handleClient(vc: ViewerConnection, msg: ClientMessage) {
         if (msg is ClientMessage.GraphicsResync) {
             if (vc.supportsPaneGraphics) {
-                synchronized(taps) { taps[msg.paneId]?.graphics?.fullMessage() }
-                    ?.let { vc.outbox.trySend(ShareProtocol.encodeServer(it)) }
+                val tracker = synchronized(taps) { taps[msg.paneId]?.graphics }
+                if (tracker != null && vc.graphicsResyncLimiter.tryAcquire(msg.paneId)) {
+                    vc.outbox.trySend(ShareProtocol.encodeServer(tracker.fullMessage(commit = false)))
+                }
             }
             return
         }
@@ -451,7 +463,7 @@ class MirrorShare(
     }
 
     companion object {
-        private const val GRAPHICS_SYNC_DEBOUNCE_MS = 16L
+        private const val GRAPHICS_SYNC_DEBOUNCE_MS = 100L
 
         // MCP server name/label as the CLI attachers register it / as broadcast to viewers.
         // The embedder's BossTermMcpConfig is a Compose CompositionLocal (unavailable in this
@@ -501,6 +513,7 @@ class MirrorShare(
     private fun reconcile(sig: WindowSig) {
         val paneMap = paneTabMap()
         if (paneMap.isEmpty()) { onEnded(); return }
+        val hasGraphicsViewer = viewers.any { it.supportsPaneGraphics }
         synchronized(taps) {
             (taps.keys - paneMap.keys).toList().forEach { id ->
                 taps.remove(id)?.let(::disposeTap)
@@ -511,7 +524,7 @@ class MirrorShare(
                     val detector = GraphicsSequenceDetector()
                     lateinit var entry: TapEntry
                     val listener: (String) -> Unit = { d ->
-                        if (detector.inspect(d)) {
+                        if (detector.inspect(d) && viewers.any { it.supportsPaneGraphics }) {
                             entry.monitoringGraphics.set(true)
                             scheduleGraphicsSync(id, entry)
                         }
@@ -528,9 +541,11 @@ class MirrorShare(
                     tab.textBuffer.addModelListener(modelListener)
                     val sz = sig.sizes[id] ?: listOf(80, 24)
                     broadcast(ServerMessage.PaneSnapshot(id, snapshotText(tab), sz[0], sz[1]))
-                    val initialGraphics = graphics.fullMessage()
-                    if (initialGraphics.requiredImageIds.isNotEmpty()) entry.monitoringGraphics.set(true)
-                    broadcastGraphics(initialGraphics)
+                    if (hasGraphicsViewer) {
+                        val initialGraphics = graphics.fullMessage()
+                        if (initialGraphics.requiredImageIds.isNotEmpty()) entry.monitoringGraphics.set(true)
+                        broadcastGraphics(initialGraphics)
+                    }
                 }
             }
         }
@@ -539,29 +554,39 @@ class MirrorShare(
     }
 
     private fun scheduleGraphicsSync(id: String, entry: TapEntry) {
+        if (viewers.none { it.supportsPaneGraphics }) return
         if (!entry.graphicsSyncPending.compareAndSet(false, true)) {
             entry.graphicsSyncAgain.set(true)
             return
         }
         entry.graphicsSyncJob = coro.launch {
-            // Coalesce multipart transfers and multiple ImageCell row writes into one browser paint.
-            delay(GRAPHICS_SYNC_DEBOUNCE_MS)
-            entry.graphicsSyncPending.set(false)
-            if (synchronized(taps) { taps[id] } !== entry) return@launch
-            val update = entry.graphics.pollUpdate()
-            if (update != null) {
-                val size = entry.tab.display.termSize.value
-                // xterm.js 5 does not emulate Sixel/Kitty cursor movement. Re-anchor its text and
-                // cursor before applying the authoritative image-cell overlay.
-                broadcastGraphics(ServerMessage.PaneSnapshot(
-                    id, snapshotText(entry.tab), size.columns, size.rows
-                ))
-                broadcastGraphics(update)
-            }
-            entry.monitoringGraphics.set(entry.graphics.hasVisibleGraphics())
-            if (entry.graphicsSyncAgain.getAndSet(false)) {
-                entry.monitoringGraphics.set(true)
-                scheduleGraphicsSync(id, entry)
+            try {
+                // Cap full-buffer graphics scans at 10 Hz while coalescing multipart transfers.
+                delay(GRAPHICS_SYNC_DEBOUNCE_MS)
+                if (synchronized(taps) { taps[id] } !== entry) return@launch
+                val update = entry.graphics.pollUpdate()
+                if (update != null) {
+                    if (update.requiresTextSnapshot) {
+                        val size = entry.tab.display.termSize.value
+                        // xterm.js does not emulate image-protocol cursor movement. Re-anchor text
+                        // only for a real placement/raster change, never for ordinary scrolling.
+                        broadcastGraphics(ServerMessage.PaneSnapshot(
+                            id, snapshotText(entry.tab), size.columns, size.rows
+                        ))
+                    }
+                    broadcastGraphics(update.message)
+                }
+                entry.monitoringGraphics.set(entry.graphics.hasVisibleGraphics())
+            } finally {
+                // Keep the pending flag set through capture + sends. A concurrent model change is
+                // represented by graphicsSyncAgain and cannot launch an overlapping poll.
+                entry.graphicsSyncPending.set(false)
+                if (entry.graphicsSyncAgain.getAndSet(false) &&
+                    synchronized(taps) { taps[id] } === entry
+                ) {
+                    entry.monitoringGraphics.set(true)
+                    scheduleGraphicsSync(id, entry)
+                }
             }
         }
     }
@@ -830,6 +855,7 @@ class ViewerConnection(
     val supportsPaneGraphics: Boolean = false,
 ) {
     val outbox: Channel<String> = Channel(capacity = 2048, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    internal val graphicsResyncLimiter = GraphicsResyncLimiter()
 
     /** A mid-session control request is awaiting the host's decision (dedupes re-requests). */
     @Volatile var controlRequestPending = false

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -200,7 +200,7 @@ class MirrorShare(
         viewer: ViewerConnection,
         message: ServerMessage.PaneGraphics,
     ) {
-        if (!viewer.outbox.trySend(ShareProtocol.encodeServer(message))) {
+        if (!viewer.outbox.trySendWithoutEviction(ShareProtocol.encodeServer(message))) {
             viewer.outbox.trySend(ShareProtocol.encodeServer(message.resyncSentinel()))
         }
     }
@@ -657,12 +657,13 @@ class MirrorShare(
                         // only for a real placement change, never for scrolling/raster animation.
                         // Repaint only the visible screen: retained browser scrollback stays intact
                         // and the payload remains bounded by the pane dimensions.
-                        val repaint = TerminalSnapshotEncoder.encodeScreenRepaint(
-                            entry.tab.textBuffer.createSnapshot(),
-                            entry.tab.terminal.cursorX,
-                            entry.tab.terminal.cursorY,
-                        )
-                        entry.repaintSender.offer(repaint)
+                        entry.repaintSender.offer {
+                            TerminalSnapshotEncoder.encodeScreenRepaint(
+                                entry.tab.textBuffer.createSnapshot(),
+                                entry.tab.terminal.cursorX,
+                                entry.tab.terminal.cursorY,
+                            )
+                        }
                     }
                     broadcastGraphics(update.message)
                 }
@@ -951,6 +952,26 @@ internal class BoundedViewerOutbox(
         }
         if (droppedFrames > 0) {
             log.warn("Dropped {} stale viewer frame(s) under back-pressure", droppedFrames)
+        }
+        wake.trySend(Unit)
+        return true
+    }
+
+    /**
+     * Enqueue a large recoverable frame only when it fits behind all existing output. Graphics
+     * must never evict pane text; callers fall back to a small resync sentinel on false.
+     */
+    fun trySendWithoutEviction(text: String): Boolean {
+        if (closed || text.isEmpty() || text.length > capacityChars) return false
+        synchronized(lock) {
+            if (closed ||
+                queuedChars + text.length > capacityChars ||
+                frames.size + 1 > capacityFrames
+            ) {
+                return false
+            }
+            frames.addLast(text)
+            queuedChars += text.length
         }
         wake.trySend(Unit)
         return true

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -5,6 +5,7 @@ import ai.rever.bossterm.terminal.model.image.ImageDataCache
 import ai.rever.bossterm.terminal.model.image.ImageFormat
 import ai.rever.bossterm.terminal.model.image.TerminalImage
 import ai.rever.bossterm.terminal.model.pool.VersionedBufferSnapshot
+import org.slf4j.LoggerFactory
 import java.lang.ref.WeakReference
 import java.util.Base64
 
@@ -41,6 +42,7 @@ internal class PaneGraphicsTracker(
     private var previousImageCellRevision = textBuffer.imageCellRevision
     private var previousImageCacheRevision = imageDataCache.contentRevision
     private var previousViewerTrimCount = viewerTrimCount()
+    private var previousSkippedRasterIds: Set<Long> = emptySet()
 
     /** Capture and return a delta only when visible image data or placement changed. */
     @Synchronized
@@ -92,6 +94,11 @@ internal class PaneGraphicsTracker(
      */
     @Synchronized
     fun fullMessage(commit: Boolean = true): ServerMessage.PaneGraphics {
+        // Read tokens first. If a mutation races capture, committing these older tokens guarantees
+        // the next poll observes it and re-captures instead of marking stale content as current.
+        val cellRevision = textBuffer.imageCellRevision
+        val cacheRevision = imageDataCache.contentRevision
+        val trimCount = viewerTrimCount()
         val captured = capture()
         if (commit) {
             if (captured.cells != previousCells || captured.fingerprints != previousImages) {
@@ -99,9 +106,9 @@ internal class PaneGraphicsTracker(
             }
             previousCells = captured.cells
             previousImages = captured.fingerprints
-            previousImageCellRevision = textBuffer.imageCellRevision
-            previousImageCacheRevision = imageDataCache.contentRevision
-            previousViewerTrimCount = viewerTrimCount()
+            previousImageCellRevision = cellRevision
+            previousImageCacheRevision = cacheRevision
+            previousViewerTrimCount = trimCount
         }
         return message(captured, full = true, images = captured.images.values.toList(), removed = emptyList())
     }
@@ -120,7 +127,8 @@ internal class PaneGraphicsTracker(
         val snapshot = textBuffer.createIncrementalSnapshot()
         // Browsers cannot decode UNKNOWN/application-octet-stream rasters. Excluding them here
         // prevents shipping bytes that can only become a permanent missing-image placeholder.
-        val cachedImages = imageDataCache.snapshotImages().filterValues {
+        val allCachedImages = imageDataCache.snapshotImages()
+        val cachedImages = allCachedImages.filterValues {
             it.format != ImageFormat.UNKNOWN && it.data.size <= MAX_WEB_IMAGE_RASTER_BYTES
         }
         val allCells = cellRuns(snapshot, cachedImages.keys, scrollbackLines)
@@ -136,6 +144,18 @@ internal class PaneGraphicsTracker(
         }
         val cells = allCells.filter { it.imageId.toLong() in selectedIds }
         val images = cachedImages.filterKeys { it in selectedIds }
+        val skippedIds = (allCachedImages.keys - cachedImages.keys) +
+            (allCells.asSequence().map { it.imageId.toLong() }.toSet() - selectedIds)
+        if (skippedIds != previousSkippedRasterIds) {
+            if (skippedIds.isNotEmpty()) {
+                log.warn(
+                    "Pane {}: omitting {} browser raster(s) due to format/size budgets",
+                    paneId,
+                    skippedIds.size,
+                )
+            }
+            previousSkippedRasterIds = skippedIds
+        }
         val fingerprints = images.mapValues { (_, image) -> fingerprint(image) }
         fingerprintCache.keys.retainAll(images.keys)
         return Captured(
@@ -268,6 +288,7 @@ internal class PaneGraphicsTracker(
     )
 
     internal companion object {
+        private val log = LoggerFactory.getLogger(PaneGraphicsTracker::class.java)
         private const val FNV64_OFFSET = -3750763034362895579L
         private const val FNV64_PRIME = 1099511628211L
         private const val GRAPHICS_JSON_OVERHEAD_BYTES = 64L * 1024

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -1,0 +1,176 @@
+package ai.rever.bossterm.compose.share
+
+import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import ai.rever.bossterm.terminal.model.image.ImageDataCache
+import ai.rever.bossterm.terminal.model.image.ImageFormat
+import ai.rever.bossterm.terminal.model.image.TerminalImage
+import ai.rever.bossterm.terminal.model.pool.VersionedBufferSnapshot
+import java.security.MessageDigest
+import java.util.Base64
+import java.util.IdentityHashMap
+
+internal const val PANE_GRAPHICS_CAPABILITY = "paneGraphicsV1"
+
+/**
+ * Converts BossTerm's authoritative image cache + ImageCell grid into revisioned browser frames.
+ *
+ * Placements are complete on every update, while raster bytes are delta-compressed against the
+ * preceding revision. A new/recovering viewer uses [fullMessage] to receive every referenced image.
+ */
+internal class PaneGraphicsTracker(
+    private val paneId: String,
+    private val textBuffer: TerminalTextBuffer,
+    private val imageDataCache: ImageDataCache,
+) {
+    private var revision = 0L
+    private var previousCells: List<SharedImageCellRun> = emptyList()
+    private var previousImages: Map<Long, TerminalImage> = emptyMap()
+    private val hashes = IdentityHashMap<TerminalImage, String>()
+
+    /** Capture and return a delta only when visible image data or placement changed. */
+    @Synchronized
+    fun pollUpdate(): ServerMessage.PaneGraphics? {
+        val captured = capture()
+        if (captured.cells == previousCells && sameImageObjects(captured.images, previousImages)) return null
+
+        val changed = captured.images.filter { (id, image) -> previousImages[id] !== image }
+        val removed = previousImages.keys.filter { it !in captured.images }.map(Long::toString)
+        previousCells = captured.cells
+        previousImages = captured.images
+        revision++
+        return message(captured, full = false, images = changed.values.toList(), removed = removed)
+    }
+
+    /** Full current state for initial paint or an explicit browser resync. */
+    @Synchronized
+    fun fullMessage(): ServerMessage.PaneGraphics {
+        val captured = capture()
+        return message(captured, full = true, images = captured.images.values.toList(), removed = emptyList())
+    }
+
+    @Synchronized
+    fun hasVisibleGraphics(): Boolean = previousCells.isNotEmpty()
+
+    private fun capture(): Captured {
+        val snapshot = textBuffer.createIncrementalSnapshot()
+        val cachedImages = imageDataCache.snapshotImages()
+        val cells = cellRuns(snapshot, cachedImages.keys)
+        val referenced = cells.asSequence().map { it.imageId.toLong() }.toSet()
+        return Captured(
+            cells = cells,
+            images = cachedImages.filterKeys { it in referenced },
+        )
+    }
+
+    private fun message(
+        captured: Captured,
+        full: Boolean,
+        images: List<TerminalImage>,
+        removed: List<String>,
+    ): ServerMessage.PaneGraphics = ServerMessage.PaneGraphics(
+        paneId = paneId,
+        revision = revision,
+        full = full,
+        images = images.map(::sharedImage),
+        removedImageIds = removed,
+        requiredImageIds = captured.images.keys.map(Long::toString),
+        cells = captured.cells,
+    )
+
+    private fun sharedImage(image: TerminalImage): SharedTerminalImage = SharedTerminalImage(
+        id = image.id.toString(),
+        mimeType = when (image.format) {
+            ImageFormat.PNG -> "image/png"
+            ImageFormat.JPEG -> "image/jpeg"
+            ImageFormat.GIF -> "image/gif"
+            ImageFormat.BMP -> "image/bmp"
+            ImageFormat.WEBP -> "image/webp"
+            ImageFormat.UNKNOWN -> "application/octet-stream"
+        },
+        data = Base64.getEncoder().encodeToString(image.data),
+        contentHash = hashes.getOrPut(image) {
+            MessageDigest.getInstance("SHA-256").digest(image.data)
+                .joinToString("") { "%02x".format(it) }
+        },
+    )
+
+    private fun sameImageObjects(a: Map<Long, TerminalImage>, b: Map<Long, TerminalImage>): Boolean =
+        a.size == b.size && a.all { (id, image) -> b[id] === image }
+
+    private data class Captured(
+        val cells: List<SharedImageCellRun>,
+        val images: Map<Long, TerminalImage>,
+    )
+
+    internal companion object {
+        /**
+         * Compress adjacent cells from the same image row. Missing/evicted image ids are omitted:
+         * a browser must never retain a placement whose raster bytes the host no longer owns.
+         */
+        fun cellRuns(
+            snapshot: VersionedBufferSnapshot,
+            availableImageIds: Set<Long>,
+        ): List<SharedImageCellRun> {
+            val result = ArrayList<SharedImageCellRun>()
+            for (row in -snapshot.historyLinesCount until snapshot.height) {
+                val cells = snapshot.getLine(row).getAllImageCells().toSortedMap()
+                var run: SharedImageCellRun? = null
+                var previousCol = -2
+                for ((col, cell) in cells) {
+                    if (cell.imageId !in availableImageIds) continue
+                    val canExtend = run != null &&
+                        run.imageId == cell.imageId.toString() &&
+                        run.cellY == cell.cellY &&
+                        run.totalCellsX == cell.totalCellsX &&
+                        run.totalCellsY == cell.totalCellsY &&
+                        col == previousCol + 1 &&
+                        cell.cellX == run.cellX + run.length
+                    if (canExtend) {
+                        run = run!!.copy(length = run.length + 1)
+                        result[result.lastIndex] = run
+                    } else {
+                        run = SharedImageCellRun(
+                            imageId = cell.imageId.toString(),
+                            row = row,
+                            col = col,
+                            cellX = cell.cellX,
+                            cellY = cell.cellY,
+                            length = 1,
+                            totalCellsX = cell.totalCellsX,
+                            totalCellsY = cell.totalCellsY,
+                        )
+                        result.add(run)
+                    }
+                    previousCol = col
+                }
+            }
+            return result
+        }
+    }
+}
+
+/**
+ * Stateful prefix detector because PTY reads may split `ESC P` / `ESC _ G` across chunks.
+ * It only arms expensive graphics snapshots for Sixel, Kitty, iTerm2 images, or Kitty's
+ * Unicode placeholder — ordinary ANSI output does not trigger a full-buffer scan.
+ */
+internal class GraphicsSequenceDetector {
+    private var tail = ""
+
+    @Synchronized
+    fun inspect(chunk: String): Boolean {
+        val candidate = tail + chunk
+        tail = candidate.takeLast(96)
+        return SIXEL.containsMatchIn(candidate) ||
+            candidate.contains("\u001b_G") ||
+            candidate.contains("\u009fG") ||
+            candidate.contains("\u001b]1337;File") ||
+            candidate.contains("\u001b]1337;MultipartFile") ||
+            candidate.contains(KITTY_PLACEHOLDER)
+    }
+
+    private companion object {
+        val SIXEL = Regex("(?:\\u001bP|\\u0090)[^q]{0,64}q")
+        val KITTY_PLACEHOLDER = String(Character.toChars(0x10EEEE))
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -11,6 +11,12 @@ import java.util.IdentityHashMap
 
 internal const val PANE_GRAPHICS_CAPABILITY = "paneGraphicsV1"
 
+/** A graphics delta plus whether xterm's text/cursor state needs an authoritative re-anchor. */
+internal data class PaneGraphicsUpdate(
+    val message: ServerMessage.PaneGraphics,
+    val requiresTextSnapshot: Boolean,
+)
+
 /**
  * Converts BossTerm's authoritative image cache + ImageCell grid into revisioned browser frames.
  *
@@ -29,22 +35,39 @@ internal class PaneGraphicsTracker(
 
     /** Capture and return a delta only when visible image data or placement changed. */
     @Synchronized
-    fun pollUpdate(): ServerMessage.PaneGraphics? {
+    fun pollUpdate(): PaneGraphicsUpdate? {
         val captured = capture()
         if (captured.cells == previousCells && sameImageObjects(captured.images, previousImages)) return null
 
         val changed = captured.images.filter { (id, image) -> previousImages[id] !== image }
         val removed = previousImages.keys.filter { it !in captured.images }.map(Long::toString)
+        val requiresTextSnapshot = changed.isNotEmpty() ||
+            (captured.cells.isNotEmpty() && !isUniformRowShift(previousCells, captured.cells))
         previousCells = captured.cells
         previousImages = captured.images
         revision++
-        return message(captured, full = false, images = changed.values.toList(), removed = removed)
+        return PaneGraphicsUpdate(
+            message = message(captured, full = false, images = changed.values.toList(), removed = removed),
+            requiresTextSnapshot = requiresTextSnapshot,
+        )
     }
 
-    /** Full current state for initial paint or an explicit browser resync. */
+    /**
+     * Full current state for initial paint or an explicit browser resync.
+     *
+     * [commit] advances the shared delta baseline. MirrorShare uses `false` for a full frame sent
+     * to only one viewer, so other viewers do not observe an artificial revision gap.
+     */
     @Synchronized
-    fun fullMessage(): ServerMessage.PaneGraphics {
+    fun fullMessage(commit: Boolean = true): ServerMessage.PaneGraphics {
         val captured = capture()
+        if (commit) {
+            if (captured.cells != previousCells || !sameImageObjects(captured.images, previousImages)) {
+                revision++
+            }
+            previousCells = captured.cells
+            previousImages = captured.images
+        }
         return message(captured, full = true, images = captured.images.values.toList(), removed = emptyList())
     }
 
@@ -53,12 +76,18 @@ internal class PaneGraphicsTracker(
 
     private fun capture(): Captured {
         val snapshot = textBuffer.createIncrementalSnapshot()
-        val cachedImages = imageDataCache.snapshotImages()
+        // Browsers cannot decode UNKNOWN/application-octet-stream rasters. Excluding them here
+        // prevents shipping bytes that can only become a permanent missing-image placeholder.
+        val cachedImages = imageDataCache.snapshotImages().filterValues { it.format != ImageFormat.UNKNOWN }
         val cells = cellRuns(snapshot, cachedImages.keys)
         val referenced = cells.asSequence().map { it.imageId.toLong() }.toSet()
+        val images = cachedImages.filterKeys { it in referenced }
+        // IdentityHashMap is intentional (a replaced image may reuse an id), but it must not pin
+        // evicted TerminalImage objects and their ByteArrays for the lifetime of the share.
+        hashes.keys.removeIf { cached -> images.values.none { it === cached } }
         return Captured(
             cells = cells,
-            images = cachedImages.filterKeys { it in referenced },
+            images = images,
         )
     }
 
@@ -85,7 +114,7 @@ internal class PaneGraphicsTracker(
             ImageFormat.GIF -> "image/gif"
             ImageFormat.BMP -> "image/bmp"
             ImageFormat.WEBP -> "image/webp"
-            ImageFormat.UNKNOWN -> "application/octet-stream"
+            ImageFormat.UNKNOWN -> error("unknown image formats are filtered before browser sharing")
         },
         data = Base64.getEncoder().encodeToString(image.data),
         contentHash = hashes.getOrPut(image) {
@@ -96,6 +125,26 @@ internal class PaneGraphicsTracker(
 
     private fun sameImageObjects(a: Map<Long, TerminalImage>, b: Map<Long, TerminalImage>): Boolean =
         a.size == b.size && a.all { (id, image) -> b[id] === image }
+
+    private fun isUniformRowShift(
+        before: List<SharedImageCellRun>,
+        after: List<SharedImageCellRun>,
+    ): Boolean {
+        if (before.isEmpty() || before.size != after.size) return false
+        val delta = after.first().row - before.first().row
+        return before.indices.all { index ->
+            val a = before[index]
+            val b = after[index]
+            b.row - a.row == delta &&
+                a.imageId == b.imageId &&
+                a.col == b.col &&
+                a.cellX == b.cellX &&
+                a.cellY == b.cellY &&
+                a.length == b.length &&
+                a.totalCellsX == b.totalCellsX &&
+                a.totalCellsY == b.totalCellsY
+        }
+    }
 
     private data class Captured(
         val cells: List<SharedImageCellRun>,
@@ -113,36 +162,58 @@ internal class PaneGraphicsTracker(
         ): List<SharedImageCellRun> {
             val result = ArrayList<SharedImageCellRun>()
             for (row in -snapshot.historyLinesCount until snapshot.height) {
-                val cells = snapshot.getLine(row).getAllImageCells().toSortedMap()
-                var run: SharedImageCellRun? = null
+                val cells = snapshot.getLine(row).getAllImageCells()
+                if (cells.isEmpty()) continue
+                val orderedCells = if (cells.size > 1) cells.toSortedMap() else cells
+                var runImageId: Long? = null
+                var runCol = 0
+                var runCellX = 0
+                var runCellY = 0
+                var runLength = 0
+                var runTotalCellsX = 0
+                var runTotalCellsY = 0
                 var previousCol = -2
-                for ((col, cell) in cells) {
-                    if (cell.imageId !in availableImageIds) continue
-                    val canExtend = run != null &&
-                        run.imageId == cell.imageId.toString() &&
-                        run.cellY == cell.cellY &&
-                        run.totalCellsX == cell.totalCellsX &&
-                        run.totalCellsY == cell.totalCellsY &&
-                        col == previousCol + 1 &&
-                        cell.cellX == run.cellX + run.length
-                    if (canExtend) {
-                        run = run!!.copy(length = run.length + 1)
-                        result[result.lastIndex] = run
-                    } else {
-                        run = SharedImageCellRun(
-                            imageId = cell.imageId.toString(),
-                            row = row,
-                            col = col,
-                            cellX = cell.cellX,
-                            cellY = cell.cellY,
-                            length = 1,
-                            totalCellsX = cell.totalCellsX,
-                            totalCellsY = cell.totalCellsY,
+                fun flushRun() {
+                    val imageId = runImageId ?: return
+                    result.add(
+                        SharedImageCellRun(
+                            imageId = imageId.toString(),
+                            // Absolute buffer index is stable when a screen line first scrolls into
+                            // history: historyCount grows while the line's relative row drops.
+                            row = snapshot.historyLinesCount + row,
+                            col = runCol,
+                            cellX = runCellX,
+                            cellY = runCellY,
+                            length = runLength,
+                            totalCellsX = runTotalCellsX,
+                            totalCellsY = runTotalCellsY,
                         )
-                        result.add(run)
+                    )
+                }
+                for ((col, cell) in orderedCells) {
+                    if (cell.imageId !in availableImageIds) continue
+                    val canExtend = runImageId != null &&
+                        runImageId == cell.imageId &&
+                        runCellY == cell.cellY &&
+                        runTotalCellsX == cell.totalCellsX &&
+                        runTotalCellsY == cell.totalCellsY &&
+                        col == previousCol + 1 &&
+                        cell.cellX == runCellX + runLength
+                    if (canExtend) {
+                        runLength++
+                    } else {
+                        flushRun()
+                        runImageId = cell.imageId
+                        runCol = col
+                        runCellX = cell.cellX
+                        runCellY = cell.cellY
+                        runLength = 1
+                        runTotalCellsX = cell.totalCellsX
+                        runTotalCellsY = cell.totalCellsY
                     }
                     previousCol = col
                 }
+                flushRun()
             }
             return result
         }
@@ -160,17 +231,39 @@ internal class GraphicsSequenceDetector {
     @Synchronized
     fun inspect(chunk: String): Boolean {
         val candidate = tail + chunk
-        tail = candidate.takeLast(96)
-        return SIXEL.containsMatchIn(candidate) ||
+        val detected = SIXEL.containsMatchIn(candidate) ||
             candidate.contains("\u001b_G") ||
             candidate.contains("\u009fG") ||
             candidate.contains("\u001b]1337;File") ||
             candidate.contains("\u001b]1337;MultipartFile") ||
             candidate.contains(KITTY_PLACEHOLDER)
+        tail = if (detected) {
+            ""
+        } else {
+            candidate.takeLast(96).let { suffix ->
+                if (suffix.firstOrNull()?.isLowSurrogate() == true) suffix.drop(1) else suffix
+            }
+        }
+        return detected
     }
 
     private companion object {
-        val SIXEL = Regex("(?:\\u001bP|\\u0090)[^q]{0,64}q")
+        val SIXEL = Regex("(?:\\u001bP|\\u0090)[0-9;]{0,64}q")
         val KITTY_PLACEHOLDER = String(Character.toChars(0x10EEEE))
+    }
+}
+
+/** Per-connection, per-pane throttle for expensive full graphics resyncs. */
+internal class GraphicsResyncLimiter(
+    private val minimumIntervalNanos: Long = 500_000_000L,
+) {
+    private val lastByPane = HashMap<String, Long>()
+
+    @Synchronized
+    fun tryAcquire(paneId: String, nowNanos: Long = System.nanoTime()): Boolean {
+        val previous = lastByPane[paneId]
+        if (previous != null && nowNanos - previous < minimumIntervalNanos) return false
+        lastByPane[paneId] = nowNanos
+        return true
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -5,7 +5,6 @@ import ai.rever.bossterm.terminal.model.image.ImageDataCache
 import ai.rever.bossterm.terminal.model.image.ImageFormat
 import ai.rever.bossterm.terminal.model.image.TerminalImage
 import ai.rever.bossterm.terminal.model.pool.VersionedBufferSnapshot
-import java.security.MessageDigest
 import java.util.Base64
 import java.util.IdentityHashMap
 
@@ -32,19 +31,42 @@ internal class PaneGraphicsTracker(
     private var previousCells: List<SharedImageCellRun> = emptyList()
     private var previousImages: Map<Long, TerminalImage> = emptyMap()
     private val hashes = IdentityHashMap<TerminalImage, String>()
+    private var nextContentToken = 0L
+    private var previousImageCellRevision = textBuffer.imageCellRevision
+    private var previousImageCacheRevision = imageDataCache.contentRevision
+    private var previousHistoryTrimCount = textBuffer.imageCellHistoryTrimCount
 
     /** Capture and return a delta only when visible image data or placement changed. */
     @Synchronized
     fun pollUpdate(): PaneGraphicsUpdate? {
+        val cellRevision = textBuffer.imageCellRevision
+        val cacheRevision = imageDataCache.contentRevision
+        val historyTrimCount = textBuffer.imageCellHistoryTrimCount
+        if (cellRevision == previousImageCellRevision && cacheRevision == previousImageCacheRevision) {
+            val trimmedRows = (historyTrimCount - previousHistoryTrimCount).coerceAtLeast(0L)
+            if (trimmedRows == 0L) return null
+            previousHistoryTrimCount = historyTrimCount
+            return shiftForHistoryTrim(trimmedRows)
+        }
+
         val captured = capture()
-        if (captured.cells == previousCells && sameImageObjects(captured.images, previousImages)) return null
+        if (captured.cells == previousCells && sameImageObjects(captured.images, previousImages)) {
+            previousImageCellRevision = cellRevision
+            previousImageCacheRevision = cacheRevision
+            previousHistoryTrimCount = historyTrimCount
+            return null
+        }
 
         val changed = captured.images.filter { (id, image) -> previousImages[id] !== image }
         val removed = previousImages.keys.filter { it !in captured.images }.map(Long::toString)
-        val requiresTextSnapshot = changed.isNotEmpty() ||
-            (captured.cells.isNotEmpty() && !isUniformRowShift(previousCells, captured.cells))
+        val requiresTextSnapshot = captured.cells != previousCells &&
+            captured.cells.isNotEmpty() &&
+            !isUniformRowShift(previousCells, captured.cells)
         previousCells = captured.cells
         previousImages = captured.images
+        previousImageCellRevision = cellRevision
+        previousImageCacheRevision = cacheRevision
+        previousHistoryTrimCount = historyTrimCount
         revision++
         return PaneGraphicsUpdate(
             message = message(captured, full = false, images = changed.values.toList(), removed = removed),
@@ -67,12 +89,19 @@ internal class PaneGraphicsTracker(
             }
             previousCells = captured.cells
             previousImages = captured.images
+            previousImageCellRevision = textBuffer.imageCellRevision
+            previousImageCacheRevision = imageDataCache.contentRevision
+            previousHistoryTrimCount = textBuffer.imageCellHistoryTrimCount
         }
         return message(captured, full = true, images = captured.images.values.toList(), removed = emptyList())
     }
 
     @Synchronized
     fun hasVisibleGraphics(): Boolean = previousCells.isNotEmpty()
+
+    /** Cheap upper bound used before accepting an explicit full-payload resync. */
+    @Synchronized
+    fun estimatedRasterBytes(): Long = previousImages.values.sumOf { it.data.size.toLong() }
 
     private fun capture(): Captured {
         val snapshot = textBuffer.createIncrementalSnapshot()
@@ -100,28 +129,50 @@ internal class PaneGraphicsTracker(
         paneId = paneId,
         revision = revision,
         full = full,
-        images = images.map(::sharedImage),
+        images = images.mapNotNull(::sharedImage),
         removedImageIds = removed,
         requiredImageIds = captured.images.keys.map(Long::toString),
         cells = captured.cells,
     )
 
-    private fun sharedImage(image: TerminalImage): SharedTerminalImage = SharedTerminalImage(
-        id = image.id.toString(),
-        mimeType = when (image.format) {
+    private fun sharedImage(image: TerminalImage): SharedTerminalImage? {
+        val mimeType = when (image.format) {
             ImageFormat.PNG -> "image/png"
             ImageFormat.JPEG -> "image/jpeg"
             ImageFormat.GIF -> "image/gif"
             ImageFormat.BMP -> "image/bmp"
             ImageFormat.WEBP -> "image/webp"
-            ImageFormat.UNKNOWN -> error("unknown image formats are filtered before browser sharing")
-        },
-        data = Base64.getEncoder().encodeToString(image.data),
-        contentHash = hashes.getOrPut(image) {
-            MessageDigest.getInstance("SHA-256").digest(image.data)
-                .joinToString("") { "%02x".format(it) }
-        },
-    )
+            ImageFormat.UNKNOWN -> return null
+        }
+        return SharedTerminalImage(
+            id = image.id.toString(),
+            mimeType = mimeType,
+            data = Base64.getEncoder().encodeToString(image.data),
+            contentHash = hashes.getOrPut(image) {
+                (++nextContentToken).toString(36)
+            },
+        )
+    }
+
+    private fun shiftForHistoryTrim(trimmedRows: Long): PaneGraphicsUpdate {
+        val delta = trimmedRows.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+        val shiftedCells = previousCells.asSequence()
+            .filter { it.row >= delta }
+            .map { it.copy(row = it.row - delta) }
+            .toList()
+        val retainedIds = shiftedCells.asSequence().map { it.imageId.toLong() }.toSet()
+        val shiftedImages = previousImages.filterKeys { it in retainedIds }
+        val removed = previousImages.keys.filter { it !in shiftedImages }.map(Long::toString)
+        previousCells = shiftedCells
+        previousImages = shiftedImages
+        hashes.keys.removeIf { cached -> shiftedImages.values.none { it === cached } }
+        revision++
+        val captured = Captured(shiftedCells, shiftedImages)
+        return PaneGraphicsUpdate(
+            message = message(captured, full = false, images = emptyList(), removed = removed),
+            requiresTextSnapshot = false,
+        )
+    }
 
     private fun sameImageObjects(a: Map<Long, TerminalImage>, b: Map<Long, TerminalImage>): Boolean =
         a.size == b.size && a.all { (id, image) -> b[id] === image }
@@ -220,35 +271,149 @@ internal class PaneGraphicsTracker(
     }
 }
 
+internal data class FilteredGraphicsOutput(
+    val output: String,
+    val detectedGraphics: Boolean,
+)
+
 /**
- * Stateful prefix detector because PTY reads may split `ESC P` / `ESC _ G` across chunks.
- * It only arms expensive graphics snapshots for Sixel, Kitty, iTerm2 images, or Kitty's
- * Unicode placeholder — ordinary ANSI output does not trigger a full-buffer scan.
+ * Streaming filter for image-protocol payloads that xterm.js cannot render.
+ *
+ * Non-graphics viewers still receive the original PTY stream. Graphics-capable browsers receive
+ * ordinary text/ANSI verbatim while Sixel DCS, Kitty APC, and iTerm2 image OSC payloads are
+ * discarded as they arrive, so a multi-megabyte raster is not sent twice. Prefix state crosses PTY
+ * chunk boundaries without retaining the discarded payload.
  */
-internal class GraphicsSequenceDetector {
-    private var tail = ""
+internal class GraphicsOutputFilter {
+    private enum class Mode { TEXT, ESCAPE, SIXEL_PREFIX, KITTY_PREFIX, ITERM_PREFIX, DISCARD_ST, DISCARD_OSC }
+
+    private var mode = Mode.TEXT
+    private val prefix = StringBuilder()
+    private var discardEscape = false
 
     @Synchronized
-    fun inspect(chunk: String): Boolean {
-        val candidate = tail + chunk
-        val detected = SIXEL.containsMatchIn(candidate) ||
-            candidate.contains("\u001b_G") ||
-            candidate.contains("\u009fG") ||
-            candidate.contains("\u001b]1337;File") ||
-            candidate.contains("\u001b]1337;MultipartFile") ||
-            candidate.contains(KITTY_PLACEHOLDER)
-        tail = if (detected) {
-            ""
-        } else {
-            candidate.takeLast(96).let { suffix ->
-                if (suffix.firstOrNull()?.isLowSurrogate() == true) suffix.drop(1) else suffix
+    fun filter(chunk: String): FilteredGraphicsOutput {
+        var detected = chunk.contains(KITTY_PLACEHOLDER)
+        val input = if (detected) chunk.replace(KITTY_PLACEHOLDER, " ") else chunk
+        val output = StringBuilder(input.length)
+
+        for (char in input) {
+            when (mode) {
+                Mode.TEXT -> when (char) {
+                    ESC -> {
+                        prefix.clear()
+                        prefix.append(char)
+                        mode = Mode.ESCAPE
+                    }
+                    DCS -> beginPrefix(char, Mode.SIXEL_PREFIX)
+                    APC -> beginPrefix(char, Mode.KITTY_PREFIX)
+                    OSC -> beginPrefix(char, Mode.ITERM_PREFIX)
+                    else -> output.append(char)
+                }
+
+                Mode.ESCAPE -> when (char) {
+                    'P' -> {
+                        prefix.append(char)
+                        mode = Mode.SIXEL_PREFIX
+                    }
+                    '_' -> {
+                        prefix.append(char)
+                        mode = Mode.KITTY_PREFIX
+                    }
+                    ']' -> {
+                        prefix.append(char)
+                        mode = Mode.ITERM_PREFIX
+                    }
+                    else -> {
+                        output.append(prefix).append(char)
+                        prefix.clear()
+                        mode = Mode.TEXT
+                    }
+                }
+
+                Mode.SIXEL_PREFIX -> {
+                    prefix.append(char)
+                    val parameters = prefix.substring(if (prefix[0] == ESC) 2 else 1)
+                    when {
+                        char == 'q' && parameters.dropLast(1).all { it.isDigit() || it == ';' } -> {
+                            detected = true
+                            beginDiscard(Mode.DISCARD_ST)
+                        }
+                        parameters.length > MAX_SIXEL_PARAMETERS ||
+                            parameters.any { it != 'q' && !it.isDigit() && it != ';' } -> flushPrefix(output)
+                    }
+                }
+
+                Mode.KITTY_PREFIX -> {
+                    prefix.append(char)
+                    if (char == 'G') {
+                        detected = true
+                        beginDiscard(Mode.DISCARD_ST)
+                    } else {
+                        flushPrefix(output)
+                    }
+                }
+
+                Mode.ITERM_PREFIX -> {
+                    prefix.append(char)
+                    val value = prefix.substring(if (prefix[0] == ESC) 2 else 1)
+                    when {
+                        ITERM_IMAGE_PREFIXES.any { it == value } -> {
+                            detected = true
+                            beginDiscard(Mode.DISCARD_OSC)
+                        }
+                        ITERM_IMAGE_PREFIXES.none { it.startsWith(value) } -> flushPrefix(output)
+                    }
+                }
+
+                Mode.DISCARD_ST -> discard(char, acceptsBell = false)
+                Mode.DISCARD_OSC -> discard(char, acceptsBell = true)
             }
         }
-        return detected
+        return FilteredGraphicsOutput(output.toString(), detected)
+    }
+
+    private fun beginPrefix(char: Char, nextMode: Mode) {
+        prefix.clear()
+        prefix.append(char)
+        mode = nextMode
+    }
+
+    private fun beginDiscard(nextMode: Mode) {
+        prefix.clear()
+        discardEscape = false
+        mode = nextMode
+    }
+
+    private fun flushPrefix(output: StringBuilder) {
+        output.append(prefix)
+        prefix.clear()
+        mode = Mode.TEXT
+    }
+
+    private fun discard(char: Char, acceptsBell: Boolean) {
+        if (char == ST || (acceptsBell && char == BEL)) {
+            discardEscape = false
+            mode = Mode.TEXT
+            return
+        }
+        if (discardEscape && char == '\\') {
+            discardEscape = false
+            mode = Mode.TEXT
+            return
+        }
+        discardEscape = char == ESC
     }
 
     private companion object {
-        val SIXEL = Regex("(?:\\u001bP|\\u0090)[0-9;]{0,64}q")
+        const val ESC = '\u001b'
+        const val BEL = '\u0007'
+        const val DCS = '\u0090'
+        const val OSC = '\u009d'
+        const val APC = '\u009f'
+        const val ST = '\u009c'
+        const val MAX_SIXEL_PARAMETERS = 65
+        val ITERM_IMAGE_PREFIXES = listOf("1337;File=", "1337;MultipartFile=")
         val KITTY_PLACEHOLDER = String(Character.toChars(0x10EEEE))
     }
 }
@@ -256,14 +421,39 @@ internal class GraphicsSequenceDetector {
 /** Per-connection, per-pane throttle for expensive full graphics resyncs. */
 internal class GraphicsResyncLimiter(
     private val minimumIntervalNanos: Long = 500_000_000L,
+    private val maximumBytesPerWindow: Long = 64L * 1024 * 1024,
+    private val windowNanos: Long = 60_000_000_000L,
 ) {
-    private val lastByPane = HashMap<String, Long>()
+    private data class Entry(
+        var lastNanos: Long,
+        var windowStartNanos: Long,
+        var bytesInWindow: Long,
+    )
+
+    private val entries = HashMap<String, Entry>()
 
     @Synchronized
-    fun tryAcquire(paneId: String, nowNanos: Long = System.nanoTime()): Boolean {
-        val previous = lastByPane[paneId]
-        if (previous != null && nowNanos - previous < minimumIntervalNanos) return false
-        lastByPane[paneId] = nowNanos
+    fun tryAcquire(
+        paneId: String,
+        estimatedBytes: Long = 0,
+        nowNanos: Long = System.nanoTime(),
+    ): Boolean {
+        val entry = entries[paneId]
+        if (entry != null && nowNanos - entry.lastNanos < minimumIntervalNanos) return false
+        val active = entry ?: Entry(nowNanos, nowNanos, 0)
+        if (nowNanos - active.windowStartNanos >= windowNanos) {
+            active.windowStartNanos = nowNanos
+            active.bytesInWindow = 0
+        }
+        if (estimatedBytes > maximumBytesPerWindow - active.bytesInWindow) return false
+        active.lastNanos = nowNanos
+        active.bytesInWindow += estimatedBytes
+        entries[paneId] = active
         return true
+    }
+
+    @Synchronized
+    fun remove(paneId: String) {
+        entries.remove(paneId)
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -403,8 +403,8 @@ private object SharedRasterBase64Cache {
         }
         val encoded = Base64.getEncoder().encodeToString(data)
         if (encoded.length > MAX_CACHED_CHARS) return encoded
+        val iterator = values.entries.iterator()
         while (cachedChars + encoded.length > MAX_CACHED_CHARS && values.isNotEmpty()) {
-            val iterator = values.entries.iterator()
             val oldest = iterator.next()
             cachedChars -= oldest.value.chars
             iterator.remove()
@@ -453,9 +453,10 @@ internal class GraphicsOutputFilter(
 
     @Synchronized
     fun filter(chunk: String): FilteredGraphicsOutput {
+        val startedInPlainText = mode == Mode.TEXT && !stripLeadingKittyMarks
         // Ordinary PTY output overwhelmingly contains no graphics introducer. Avoid the
         // per-character state machine (and its allocation) on that hot path.
-        if (mode == Mode.TEXT && !stripLeadingKittyMarks && !requiresFiltering(chunk)) {
+        if (startedInPlainText && !requiresFiltering(chunk)) {
             return FilteredGraphicsOutput(chunk, detectedGraphics = false)
         }
         val stripped = stripKittyUnicodePlacements(chunk)
@@ -544,14 +545,24 @@ internal class GraphicsOutputFilter(
                 Mode.DISCARD_OSC -> discard(char, acceptsBell = true)
             }
         }
-        return FilteredGraphicsOutput(output.toString(), detected)
+        val rendered = if (startedInPlainText && !detected && mode == Mode.TEXT) input else output.toString()
+        return FilteredGraphicsOutput(rendered, detected)
     }
 
     private fun requiresFiltering(chunk: String): Boolean {
         var index = 0
         while (index < chunk.length) {
             when (chunk[index]) {
-                ESC, DCS, OSC, APC -> return true
+                ESC -> {
+                    // Colored/TUI output contains ESC constantly. Enter the state machine only for
+                    // an actual graphics control introducer, or a trailing ESC whose next byte is
+                    // fragmented into the following PTY chunk.
+                    val next = chunk.getOrNull(index + 1)
+                    if (next == null || next == 'P' || next == '_' || next == ']') {
+                        return true
+                    }
+                }
+                DCS, OSC, APC -> return true
                 KITTY_PLACEHOLDER[0] -> {
                     if (chunk.startsWith(KITTY_PLACEHOLDER, index)) return true
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -140,7 +140,10 @@ internal class PaneGraphicsTracker(
         val allCells = cellRuns(snapshot, cachedImages.keys, scrollbackLines)
         val selectedIds = LinkedHashSet<Long>()
         var selectedBytes = 0L
-        for (run in allCells) {
+        // Prefer the newest/screen-most images when the pane budget cannot retain everything.
+        // [allCells] is oldest-history-first, so select in reverse and preserve its original order
+        // only when emitting the filtered cell list below.
+        for (run in allCells.asReversed()) {
             val id = run.imageId.toLong()
             if (id in selectedIds) continue
             val image = cachedImages[id] ?: continue
@@ -409,6 +412,7 @@ private object SharedRasterBase64Cache {
             cachedChars -= oldest.value.chars
             iterator.remove()
         }
+        if (values.isEmpty()) cachedChars = 0
         values[contentHash] = CachedBase64(contentHash, encoded, encoded.length, clearedValues)
         cachedChars += encoded.length
         return encoded

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -17,8 +17,14 @@ internal const val MAX_WEB_VIEWER_SCROLLBACK_LINES = 20_000
 internal const val MAX_WEB_IMAGE_RASTER_BYTES = 8 * 1024 * 1024
 internal const val MAX_WEB_PANE_RASTER_BYTES = 16L * 1024 * 1024
 
-internal fun webViewerScrollbackLines(textBuffer: TerminalTextBuffer): Int =
-    textBuffer.maxHistoryLinesCount.coerceIn(0, MAX_WEB_VIEWER_SCROLLBACK_LINES)
+internal fun webViewerScrollbackLines(textBuffer: TerminalTextBuffer): Int {
+    // LinesStorage treats a negative maxHistoryLinesCount as UNLIMITED. Clamping it as a number
+    // would hand the viewer zero scrollback (and drop every history-row image placement), so an
+    // unlimited host history maps to the browser cap instead.
+    val hostHistory = textBuffer.maxHistoryLinesCount
+    if (hostHistory < 0) return MAX_WEB_VIEWER_SCROLLBACK_LINES
+    return hostHistory.coerceAtMost(MAX_WEB_VIEWER_SCROLLBACK_LINES)
+}
 
 /** A graphics delta plus whether xterm's text/cursor state needs an authoritative re-anchor. */
 internal data class PaneGraphicsUpdate(
@@ -64,6 +70,7 @@ internal class PaneGraphicsTracker(
         }
 
         val captured = capture()
+        noteSkippedRasters(captured.skippedRasterIds)
         if (captured.cells == previousCells && captured.fingerprints == previousImages) {
             previousImageCellRevision = cellRevision
             previousImageCacheRevision = cacheRevision
@@ -107,6 +114,7 @@ internal class PaneGraphicsTracker(
         val trimCount = viewerTrimCount()
         val captured = capture()
         if (commit) {
+            noteSkippedRasters(captured.skippedRasterIds)
             if (captured.cells != previousCells || captured.fingerprints != previousImages) {
                 revision++
             }
@@ -143,6 +151,13 @@ internal class PaneGraphicsTracker(
         // Prefer the newest/screen-most images when the pane budget cannot retain everything.
         // [allCells] is oldest-history-first, so select in reverse and preserve its original order
         // only when emitting the filtered cell list below.
+        //
+        // The newest image can never LOSE this contest: MAX_WEB_IMAGE_RASTER_BYTES is half
+        // MAX_WEB_PANE_RASTER_BYTES, so the first candidate is always weighed against an empty
+        // budget (anything larger was already dropped by the per-image filter above). Past that,
+        // skipping — rather than stopping at — an image that doesn't fit lets a smaller, older
+        // raster use the space instead of wasting it, so more of the pane's history stays visible.
+        // Keep the two caps in that ratio, or the newest-wins property has to be re-established.
         for (run in allCells.asReversed()) {
             val id = run.imageId.toLong()
             if (id in selectedIds) continue
@@ -153,18 +168,6 @@ internal class PaneGraphicsTracker(
         }
         val cells = allCells.filter { it.imageId.toLong() in selectedIds }
         val images = cachedImages.filterKeys { it in selectedIds }
-        val skippedIds = (allCachedImages.keys - cachedImages.keys) +
-            (allCells.asSequence().map { it.imageId.toLong() }.toSet() - selectedIds)
-        if (skippedIds != previousSkippedRasterIds) {
-            if (skippedIds.isNotEmpty()) {
-                log.warn(
-                    "Pane {}: omitting {} browser raster(s) due to format/size budgets",
-                    paneId,
-                    skippedIds.size,
-                )
-            }
-            previousSkippedRasterIds = skippedIds
-        }
         val fingerprints = images.mapValues { (_, image) -> fingerprint(image) }
         fingerprintCache.keys.retainAll(images.keys)
         return Captured(
@@ -172,7 +175,26 @@ internal class PaneGraphicsTracker(
             images = images,
             fingerprints = fingerprints,
             historyLines = snapshot.historyLinesCount.coerceAtMost(scrollbackLines),
+            skippedRasterIds = (allCachedImages.keys - cachedImages.keys) +
+                (allCells.asSequence().map { it.imageId.toLong() }.toSet() - selectedIds),
         )
+    }
+
+    /**
+     * Log a change in the omitted-raster set ONCE. Called only from the paths that advance the
+     * shared baseline: a private, non-committing [fullMessage] must not consume the transition, or
+     * one viewer's resync would suppress the warning a later committing poll would have logged.
+     */
+    private fun noteSkippedRasters(skippedIds: Set<Long>) {
+        if (skippedIds == previousSkippedRasterIds) return
+        if (skippedIds.isNotEmpty()) {
+            log.warn(
+                "Pane {}: omitting {} browser raster(s) due to format/size budgets",
+                paneId,
+                skippedIds.size,
+            )
+        }
+        previousSkippedRasterIds = skippedIds
     }
 
     private fun message(
@@ -293,6 +315,7 @@ internal class PaneGraphicsTracker(
         val images: Map<Long, TerminalImage>,
         val fingerprints: Map<Long, ImageFingerprint>,
         val historyLines: Int,
+        val skippedRasterIds: Set<Long> = emptySet(),
     )
 
     private data class ImageFingerprint(
@@ -561,12 +584,14 @@ internal class GraphicsOutputFilter(
                     // Colored/TUI output contains ESC constantly. Enter the state machine only for
                     // an actual graphics control introducer, or a trailing ESC whose next byte is
                     // fragmented into the following PTY chunk.
-                    val next = chunk.getOrNull(index + 1)
-                    if (next == null || next == 'P' || next == '_' || next == ']') {
-                        return true
+                    when (chunk.getOrNull(index + 1)) {
+                        null, 'P', '_' -> return true
+                        ']' -> if (mayIntroduceImageOsc(chunk, index + 2)) return true
+                        else -> {}
                     }
                 }
-                DCS, OSC, APC -> return true
+                DCS, APC -> return true
+                OSC -> if (mayIntroduceImageOsc(chunk, index + 1)) return true
                 KITTY_PLACEHOLDER[0] -> {
                     if (chunk.startsWith(KITTY_PLACEHOLDER, index)) return true
                 }
@@ -575,6 +600,22 @@ internal class GraphicsOutputFilter(
         }
         return false
     }
+
+    /**
+     * Whether an OSC starting at [start] could still be an iTerm2 image sequence.
+     *
+     * Only iTerm2 image OSCs are filtered, and every one of [ITERM_IMAGE_PREFIXES] begins with
+     * [ITERM_IMAGE_OSC_PREFIX] — so a few characters rule out the shell-integration OSCs this
+     * repo tells users to emit on EVERY prompt (OSC 7 cwd, OSC 133 marks). Without this the
+     * per-character state machine would run on most prompt-bearing chunks. An OSC truncated
+     * before the decision still enters the machine, so prefix state crosses the chunk boundary.
+     */
+    private fun mayIntroduceImageOsc(chunk: String, start: Int): Boolean =
+        if (chunk.length - start < ITERM_IMAGE_OSC_PREFIX.length) {
+            ITERM_IMAGE_OSC_PREFIX.startsWith(chunk.substring(start)) // undecided at the boundary
+        } else {
+            chunk.startsWith(ITERM_IMAGE_OSC_PREFIX, start)
+        }
 
     /**
      * Kitty's Unicode placement placeholder is followed by combining marks that encode row/column.
@@ -653,12 +694,9 @@ internal class GraphicsOutputFilter(
             endDiscard()
             return
         }
-        if (discardEscape && char == '\\') {
-            endDiscard()
-            return
-        }
         if (discardEscape) {
-            // BossEmulator consumes the byte after a stray ESC and aborts the control string.
+            // Ends the string on `ESC \` (ST) and, for any other byte, matches BossEmulator —
+            // it consumes the byte after a stray ESC and aborts the control string either way.
             endDiscard()
             return
         }
@@ -695,11 +733,13 @@ internal class GraphicsOutputFilter(
         const val MAX_GRAPHICS_CONTROL_CHARS = 70 * 1024 * 1024 + 64 * 1024
         // Mirrors SystemCommandSequence's OSC bound.
         const val MAX_OSC_CONTROL_CHARS = 50 * 1024 * 1024
+        /** Shared discriminator of every entry in [ITERM_IMAGE_PREFIXES]; see [mayIntroduceImageOsc]. */
+        const val ITERM_IMAGE_OSC_PREFIX = "1337;"
         val ITERM_IMAGE_PREFIXES = listOf(
-            "1337;File=",
-            "1337;MultipartFile=",
-            "1337;FilePart=",
-            "1337;FileEnd",
+            "${ITERM_IMAGE_OSC_PREFIX}File=",
+            "${ITERM_IMAGE_OSC_PREFIX}MultipartFile=",
+            "${ITERM_IMAGE_OSC_PREFIX}FilePart=",
+            "${ITERM_IMAGE_OSC_PREFIX}FileEnd",
         )
         val KITTY_PLACEHOLDER = String(Character.toChars(0x10EEEE))
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -9,6 +9,12 @@ import java.lang.ref.WeakReference
 import java.util.Base64
 
 internal const val PANE_GRAPHICS_CAPABILITY = "paneGraphicsV1"
+internal const val MAX_WEB_VIEWER_SCROLLBACK_LINES = 100_000
+internal const val MAX_WEB_IMAGE_RASTER_BYTES = 8 * 1024 * 1024
+internal const val MAX_WEB_PANE_RASTER_BYTES = 16L * 1024 * 1024
+
+internal fun webViewerScrollbackLines(textBuffer: TerminalTextBuffer): Int =
+    textBuffer.maxHistoryLinesCount.coerceIn(0, MAX_WEB_VIEWER_SCROLLBACK_LINES)
 
 /** A graphics delta plus whether xterm's text/cursor state needs an authoritative re-anchor. */
 internal data class PaneGraphicsUpdate(
@@ -26,6 +32,7 @@ internal class PaneGraphicsTracker(
     private val paneId: String,
     private val textBuffer: TerminalTextBuffer,
     private val imageDataCache: ImageDataCache,
+    private val scrollbackLines: Int = webViewerScrollbackLines(textBuffer),
 ) {
     private var revision = 0L
     private var previousCells: List<SharedImageCellRun> = emptyList()
@@ -33,18 +40,18 @@ internal class PaneGraphicsTracker(
     private val fingerprintCache = HashMap<Long, CachedFingerprint>()
     private var previousImageCellRevision = textBuffer.imageCellRevision
     private var previousImageCacheRevision = imageDataCache.contentRevision
-    private var previousHistoryTrimCount = textBuffer.imageCellHistoryTrimCount
+    private var previousViewerTrimCount = viewerTrimCount()
 
     /** Capture and return a delta only when visible image data or placement changed. */
     @Synchronized
     fun pollUpdate(): PaneGraphicsUpdate? {
         val cellRevision = textBuffer.imageCellRevision
         val cacheRevision = imageDataCache.contentRevision
-        val historyTrimCount = textBuffer.imageCellHistoryTrimCount
+        val viewerTrimCount = viewerTrimCount()
         if (cellRevision == previousImageCellRevision && cacheRevision == previousImageCacheRevision) {
-            val trimmedRows = (historyTrimCount - previousHistoryTrimCount).coerceAtLeast(0L)
+            val trimmedRows = (viewerTrimCount - previousViewerTrimCount).coerceAtLeast(0L)
             if (trimmedRows == 0L) return null
-            previousHistoryTrimCount = historyTrimCount
+            previousViewerTrimCount = viewerTrimCount
             return shiftForHistoryTrim(trimmedRows)
         }
 
@@ -52,7 +59,7 @@ internal class PaneGraphicsTracker(
         if (captured.cells == previousCells && captured.fingerprints == previousImages) {
             previousImageCellRevision = cellRevision
             previousImageCacheRevision = cacheRevision
-            previousHistoryTrimCount = historyTrimCount
+            previousViewerTrimCount = viewerTrimCount
             return null
         }
 
@@ -67,7 +74,7 @@ internal class PaneGraphicsTracker(
         previousImages = captured.fingerprints
         previousImageCellRevision = cellRevision
         previousImageCacheRevision = cacheRevision
-        previousHistoryTrimCount = historyTrimCount
+        previousViewerTrimCount = viewerTrimCount
         revision++
         return PaneGraphicsUpdate(
             message = message(captured, full = false, images = changed.values.toList(), removed = removed),
@@ -80,6 +87,8 @@ internal class PaneGraphicsTracker(
      *
      * [commit] advances the shared delta baseline. MirrorShare uses `false` for a full frame sent
      * to only one viewer, so other viewers do not observe an artificial revision gap.
+     * Consequently, a private full frame's revision may describe the shared baseline rather than
+     * its newer complete placements; `full=true` makes those placements authoritative regardless.
      */
     @Synchronized
     fun fullMessage(commit: Boolean = true): ServerMessage.PaneGraphics {
@@ -92,7 +101,7 @@ internal class PaneGraphicsTracker(
             previousImages = captured.fingerprints
             previousImageCellRevision = textBuffer.imageCellRevision
             previousImageCacheRevision = imageDataCache.contentRevision
-            previousHistoryTrimCount = textBuffer.imageCellHistoryTrimCount
+            previousViewerTrimCount = viewerTrimCount()
         }
         return message(captured, full = true, images = captured.images.values.toList(), removed = emptyList())
     }
@@ -100,18 +109,33 @@ internal class PaneGraphicsTracker(
     @Synchronized
     fun hasVisibleGraphics(): Boolean = previousCells.isNotEmpty()
 
-    /** Cheap upper bound used before accepting an explicit full-payload resync. */
+    /** Heap-oriented wire estimate used before accepting an explicit full-payload resync. */
     @Synchronized
-    fun estimatedRasterBytes(): Long = previousImages.values.sumOf { it.rasterBytes }
+    fun estimatedWireBytes(): Long =
+        previousImages.values.sumOf { fingerprint ->
+            ((fingerprint.rasterBytes + 2) / 3 * 4) * 2
+        } + GRAPHICS_JSON_OVERHEAD_BYTES
 
     private fun capture(): Captured {
         val snapshot = textBuffer.createIncrementalSnapshot()
         // Browsers cannot decode UNKNOWN/application-octet-stream rasters. Excluding them here
         // prevents shipping bytes that can only become a permanent missing-image placeholder.
-        val cachedImages = imageDataCache.snapshotImages().filterValues { it.format != ImageFormat.UNKNOWN }
-        val cells = cellRuns(snapshot, cachedImages.keys)
-        val referenced = cells.asSequence().map { it.imageId.toLong() }.toSet()
-        val images = cachedImages.filterKeys { it in referenced }
+        val cachedImages = imageDataCache.snapshotImages().filterValues {
+            it.format != ImageFormat.UNKNOWN && it.data.size <= MAX_WEB_IMAGE_RASTER_BYTES
+        }
+        val allCells = cellRuns(snapshot, cachedImages.keys, scrollbackLines)
+        val selectedIds = LinkedHashSet<Long>()
+        var selectedBytes = 0L
+        for (run in allCells) {
+            val id = run.imageId.toLong()
+            if (id in selectedIds) continue
+            val image = cachedImages[id] ?: continue
+            if (selectedBytes + image.data.size > MAX_WEB_PANE_RASTER_BYTES) continue
+            selectedIds.add(id)
+            selectedBytes += image.data.size
+        }
+        val cells = allCells.filter { it.imageId.toLong() in selectedIds }
+        val images = cachedImages.filterKeys { it in selectedIds }
         val fingerprints = images.mapValues { (_, image) -> fingerprint(image) }
         fingerprintCache.keys.retainAll(images.keys)
         return Captured(
@@ -136,6 +160,7 @@ internal class PaneGraphicsTracker(
         removedImageIds = removed,
         requiredImageIds = captured.fingerprints.keys.map(Long::toString),
         cells = captured.cells,
+        historyLines = textBuffer.historyLinesCount.coerceAtMost(scrollbackLines),
     )
 
     private fun sharedImage(
@@ -153,7 +178,7 @@ internal class PaneGraphicsTracker(
         return SharedTerminalImage(
             id = image.id.toString(),
             mimeType = mimeType,
-            data = Base64.getEncoder().encodeToString(image.data),
+            data = SharedRasterBase64Cache.encode(fingerprint.contentHash, image.data),
             contentHash = fingerprint.contentHash,
         )
     }
@@ -198,6 +223,14 @@ internal class PaneGraphicsTracker(
         )
     }
 
+    /**
+     * Counts both real host evictions and rows hidden by the stricter browser history cap. Their
+     * sum advances once for every oldest row xterm trims, even while the larger host history grows.
+     */
+    private fun viewerTrimCount(): Long =
+        textBuffer.imageCellHistoryTrimCount +
+            (textBuffer.historyLinesCount - scrollbackLines).coerceAtLeast(0).toLong()
+
     private fun isUniformRowShift(
         before: List<SharedImageCellRun>,
         after: List<SharedImageCellRun>,
@@ -237,6 +270,7 @@ internal class PaneGraphicsTracker(
     internal companion object {
         private const val FNV64_OFFSET = -3750763034362895579L
         private const val FNV64_PRIME = 1099511628211L
+        private const val GRAPHICS_JSON_OVERHEAD_BYTES = 64L * 1024
 
         /**
          * Compress adjacent cells from the same image row. Missing/evicted image ids are omitted:
@@ -245,9 +279,11 @@ internal class PaneGraphicsTracker(
         fun cellRuns(
             snapshot: VersionedBufferSnapshot,
             availableImageIds: Set<Long>,
+            historyLimit: Int = Int.MAX_VALUE,
         ): List<SharedImageCellRun> {
             val result = ArrayList<SharedImageCellRun>()
-            for (row in -snapshot.historyLinesCount until snapshot.height) {
+            val retainedHistoryLines = snapshot.historyLinesCount.coerceAtMost(historyLimit)
+            for (row in -retainedHistoryLines until snapshot.height) {
                 val cells = snapshot.getLine(row).getAllImageCells()
                 if (cells.isEmpty()) continue
                 val orderedCells = if (cells.size > 1) cells.toSortedMap() else cells
@@ -266,7 +302,7 @@ internal class PaneGraphicsTracker(
                             imageId = imageId.toString(),
                             // Absolute buffer index is stable when a screen line first scrolls into
                             // history: historyCount grows while the line's relative row drops.
-                            row = snapshot.historyLinesCount + row,
+                            row = retainedHistoryLines + row,
                             col = runCol,
                             cellX = runCellX,
                             cellY = runCellY,
@@ -306,6 +342,32 @@ internal class PaneGraphicsTracker(
     }
 }
 
+/**
+ * Reuses the expensive base64 String across viewers and resyncs. The access-ordered cache is
+ * globally char-bounded (~64 MiB UTF-16) and keyed by the stable content fingerprint.
+ */
+private object SharedRasterBase64Cache {
+    private const val MAX_CACHED_CHARS = 32 * 1024 * 1024
+    private val values = object : LinkedHashMap<String, String>(16, 0.75f, true) {}
+    private var cachedChars = 0
+
+    @Synchronized
+    fun encode(contentHash: String, data: ByteArray): String {
+        values[contentHash]?.let { return it }
+        val encoded = Base64.getEncoder().encodeToString(data)
+        if (encoded.length > MAX_CACHED_CHARS) return encoded
+        while (cachedChars + encoded.length > MAX_CACHED_CHARS && values.isNotEmpty()) {
+            val iterator = values.entries.iterator()
+            val oldest = iterator.next()
+            cachedChars -= oldest.value.length
+            iterator.remove()
+        }
+        values[contentHash] = encoded
+        cachedChars += encoded.length
+        return encoded
+    }
+}
+
 internal data class FilteredGraphicsOutput(
     val output: String,
     val detectedGraphics: Boolean,
@@ -328,22 +390,18 @@ internal class GraphicsOutputFilter(
     private val prefix = StringBuilder()
     private var discardEscape = false
     private var discardChars = 0
+    private var stripLeadingKittyMarks = false
 
     @Synchronized
     fun filter(chunk: String): FilteredGraphicsOutput {
         // Ordinary PTY output overwhelmingly contains no graphics introducer. Avoid the
         // per-character state machine (and its allocation) on that hot path.
-        if (mode == Mode.TEXT &&
-            chunk.indexOf(ESC) < 0 &&
-            chunk.indexOf(DCS) < 0 &&
-            chunk.indexOf(OSC) < 0 &&
-            chunk.indexOf(APC) < 0 &&
-            !chunk.contains(KITTY_PLACEHOLDER)
-        ) {
+        if (mode == Mode.TEXT && !stripLeadingKittyMarks && !requiresFiltering(chunk)) {
             return FilteredGraphicsOutput(chunk, detectedGraphics = false)
         }
-        var detected = chunk.contains(KITTY_PLACEHOLDER)
-        val input = if (detected) chunk.replace(KITTY_PLACEHOLDER, " ") else chunk
+        val stripped = stripKittyUnicodePlacements(chunk)
+        var detected = stripped.second
+        val input = stripped.first
         val output = StringBuilder(input.length)
 
         for (char in input) {
@@ -361,6 +419,13 @@ internal class GraphicsOutputFilter(
                 }
 
                 Mode.ESCAPE -> when (char) {
+                    ESC -> {
+                        // Preserve the first unrelated ESC while keeping the second as a possible
+                        // fragmented graphics introducer (`ESC ESC P q ...`).
+                        output.append(prefix)
+                        prefix.clear()
+                        prefix.append(char)
+                    }
                     'P' -> {
                         prefix.append(char)
                         mode = Mode.SIXEL_PREFIX
@@ -421,6 +486,68 @@ internal class GraphicsOutputFilter(
             }
         }
         return FilteredGraphicsOutput(output.toString(), detected)
+    }
+
+    private fun requiresFiltering(chunk: String): Boolean {
+        var index = 0
+        while (index < chunk.length) {
+            when (chunk[index]) {
+                ESC, DCS, OSC, APC -> return true
+                KITTY_PLACEHOLDER[0] -> {
+                    if (chunk.startsWith(KITTY_PLACEHOLDER, index)) return true
+                }
+            }
+            index++
+        }
+        return false
+    }
+
+    /**
+     * Kitty's Unicode placement placeholder is followed by combining marks that encode row/column.
+     * xterm cannot render that protocol, so remove the marks with the placeholder, including when
+     * the placeholder and its marks are split across PTY chunks.
+     */
+    private fun stripKittyUnicodePlacements(chunk: String): Pair<String, Boolean> {
+        var index = 0
+        var modified = false
+        var detected = false
+        val output = StringBuilder(chunk.length)
+        if (stripLeadingKittyMarks) {
+            if (chunk.isEmpty()) return chunk to false
+            while (index < chunk.length) {
+                val codePoint = chunk.codePointAt(index)
+                if (!isCombiningMark(codePoint)) break
+                index += Character.charCount(codePoint)
+                modified = true
+            }
+            stripLeadingKittyMarks = false
+            if (index == chunk.length) stripLeadingKittyMarks = true
+        }
+        while (index < chunk.length) {
+            val placeholder = chunk.indexOf(KITTY_PLACEHOLDER, index)
+            if (placeholder < 0) {
+                output.append(chunk, index, chunk.length)
+                break
+            }
+            modified = true
+            detected = true
+            output.append(chunk, index, placeholder).append(' ')
+            index = placeholder + KITTY_PLACEHOLDER.length
+            while (index < chunk.length) {
+                val codePoint = chunk.codePointAt(index)
+                if (!isCombiningMark(codePoint)) break
+                index += Character.charCount(codePoint)
+            }
+            if (index == chunk.length) stripLeadingKittyMarks = true
+        }
+        return (if (modified) output.toString() else chunk) to detected
+    }
+
+    private fun isCombiningMark(codePoint: Int): Boolean = when (Character.getType(codePoint)) {
+        Character.NON_SPACING_MARK.toInt(),
+        Character.COMBINING_SPACING_MARK.toInt(),
+        Character.ENCLOSING_MARK.toInt() -> true
+        else -> false
     }
 
     private fun beginPrefix(char: Char, nextMode: Mode) {
@@ -514,13 +641,12 @@ internal class GraphicsResyncLimiter(
         val entry = entries[paneId]
         if (entry != null && nowNanos - entry.lastNanos < minimumIntervalNanos) return false
         val active = entry ?: Entry(nowNanos, nowNanos, 0)
-        if (nowNanos - active.windowStartNanos >= windowNanos) {
-            active.windowStartNanos = nowNanos
-            active.bytesInWindow = 0
-        }
-        if (estimatedBytes > maximumBytesPerWindow - active.bytesInWindow) return false
+        val startsNewWindow = nowNanos - active.windowStartNanos >= windowNanos
+        val admittedWindowBytes = if (startsNewWindow) 0 else active.bytesInWindow
+        if (estimatedBytes > maximumBytesPerWindow - admittedWindowBytes) return false
+        if (startsNewWindow) active.windowStartNanos = nowNanos
         active.lastNanos = nowNanos
-        active.bytesInWindow += estimatedBytes
+        active.bytesInWindow = admittedWindowBytes + estimatedBytes
         entries[paneId] = active
         return true
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -6,11 +6,13 @@ import ai.rever.bossterm.terminal.model.image.ImageFormat
 import ai.rever.bossterm.terminal.model.image.TerminalImage
 import ai.rever.bossterm.terminal.model.pool.VersionedBufferSnapshot
 import org.slf4j.LoggerFactory
+import java.lang.ref.SoftReference
 import java.lang.ref.WeakReference
+import java.security.MessageDigest
 import java.util.Base64
 
 internal const val PANE_GRAPHICS_CAPABILITY = "paneGraphicsV1"
-internal const val MAX_WEB_VIEWER_SCROLLBACK_LINES = 100_000
+internal const val MAX_WEB_VIEWER_SCROLLBACK_LINES = 20_000
 internal const val MAX_WEB_IMAGE_RASTER_BYTES = 8 * 1024 * 1024
 internal const val MAX_WEB_PANE_RASTER_BYTES = 16L * 1024 * 1024
 
@@ -54,7 +56,10 @@ internal class PaneGraphicsTracker(
             val trimmedRows = (viewerTrimCount - previousViewerTrimCount).coerceAtLeast(0L)
             if (trimmedRows == 0L) return null
             previousViewerTrimCount = viewerTrimCount
-            return shiftForHistoryTrim(trimmedRows)
+            val historyLines = textBuffer.createIncrementalSnapshot()
+                .historyLinesCount
+                .coerceAtMost(scrollbackLines)
+            return shiftForHistoryTrim(trimmedRows, historyLines)
         }
 
         val captured = capture()
@@ -162,6 +167,7 @@ internal class PaneGraphicsTracker(
             cells = cells,
             images = images,
             fingerprints = fingerprints,
+            historyLines = snapshot.historyLinesCount.coerceAtMost(scrollbackLines),
         )
     }
 
@@ -180,7 +186,7 @@ internal class PaneGraphicsTracker(
         removedImageIds = removed,
         requiredImageIds = captured.fingerprints.keys.map(Long::toString),
         cells = captured.cells,
-        historyLines = textBuffer.historyLinesCount.coerceAtMost(scrollbackLines),
+        historyLines = captured.historyLines,
     )
 
     private fun sharedImage(
@@ -211,19 +217,21 @@ internal class PaneGraphicsTracker(
         fingerprintCache[image.id]?.let { cached ->
             if (cached.image.get() === image) return cached.fingerprint
         }
-        var hash = FNV64_OFFSET xor image.format.ordinal.toLong()
-        for (byte in image.data) {
-            hash = (hash xor (byte.toLong() and 0xffL)) * FNV64_PRIME
-        }
+        val digest = MessageDigest.getInstance("SHA-256")
+        digest.update(image.format.ordinal.toByte())
+        val hash = Base64.getUrlEncoder().withoutPadding().encodeToString(digest.digest(image.data))
         val fingerprint = ImageFingerprint(
-            contentHash = "${image.data.size.toString(36)}-${java.lang.Long.toUnsignedString(hash, 36)}",
+            contentHash = "${image.data.size.toString(36)}-$hash",
             rasterBytes = image.data.size.toLong(),
         )
         fingerprintCache[image.id] = CachedFingerprint(WeakReference(image), fingerprint)
         return fingerprint
     }
 
-    private fun shiftForHistoryTrim(trimmedRows: Long): PaneGraphicsUpdate {
+    private fun shiftForHistoryTrim(
+        trimmedRows: Long,
+        historyLines: Int,
+    ): PaneGraphicsUpdate {
         val delta = trimmedRows.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
         val shiftedCells = previousCells.asSequence()
             .filter { it.row >= delta }
@@ -236,7 +244,12 @@ internal class PaneGraphicsTracker(
         previousImages = shiftedImages
         fingerprintCache.keys.retainAll(retainedIds)
         revision++
-        val captured = Captured(shiftedCells, emptyMap(), shiftedImages)
+        val captured = Captured(
+            cells = shiftedCells,
+            images = emptyMap(),
+            fingerprints = shiftedImages,
+            historyLines = historyLines,
+        )
         return PaneGraphicsUpdate(
             message = message(captured, full = false, images = emptyList(), removed = removed),
             requiresTextSnapshot = false,
@@ -275,6 +288,7 @@ internal class PaneGraphicsTracker(
         val cells: List<SharedImageCellRun>,
         val images: Map<Long, TerminalImage>,
         val fingerprints: Map<Long, ImageFingerprint>,
+        val historyLines: Int,
     )
 
     private data class ImageFingerprint(
@@ -289,8 +303,6 @@ internal class PaneGraphicsTracker(
 
     internal companion object {
         private val log = LoggerFactory.getLogger(PaneGraphicsTracker::class.java)
-        private const val FNV64_OFFSET = -3750763034362895579L
-        private const val FNV64_PRIME = 1099511628211L
         private const val GRAPHICS_JSON_OVERHEAD_BYTES = 64L * 1024
 
         /**
@@ -369,21 +381,30 @@ internal class PaneGraphicsTracker(
  */
 private object SharedRasterBase64Cache {
     private const val MAX_CACHED_CHARS = 32 * 1024 * 1024
-    private val values = object : LinkedHashMap<String, String>(16, 0.75f, true) {}
+    private data class CachedBase64(
+        val value: SoftReference<String>,
+        val chars: Int,
+    )
+
+    private val values = object : LinkedHashMap<String, CachedBase64>(16, 0.75f, true) {}
     private var cachedChars = 0
 
     @Synchronized
     fun encode(contentHash: String, data: ByteArray): String {
-        values[contentHash]?.let { return it }
+        values[contentHash]?.let { cached ->
+            cached.value.get()?.let { return it }
+            values.remove(contentHash)
+            cachedChars -= cached.chars
+        }
         val encoded = Base64.getEncoder().encodeToString(data)
         if (encoded.length > MAX_CACHED_CHARS) return encoded
         while (cachedChars + encoded.length > MAX_CACHED_CHARS && values.isNotEmpty()) {
             val iterator = values.entries.iterator()
             val oldest = iterator.next()
-            cachedChars -= oldest.value.length
+            cachedChars -= oldest.value.chars
             iterator.remove()
         }
-        values[contentHash] = encoded
+        values[contentHash] = CachedBase64(SoftReference(encoded), encoded.length)
         cachedChars += encoded.length
         return encoded
     }
@@ -404,6 +425,7 @@ internal data class FilteredGraphicsOutput(
  */
 internal class GraphicsOutputFilter(
     private val maxDiscardChars: Int = MAX_GRAPHICS_CONTROL_CHARS,
+    private val maxOscDiscardChars: Int = MAX_OSC_CONTROL_CHARS,
 ) {
     private enum class Mode { TEXT, ESCAPE, SIXEL_PREFIX, KITTY_PREFIX, ITERM_PREFIX, DISCARD_ST, DISCARD_OSC }
 
@@ -411,6 +433,7 @@ internal class GraphicsOutputFilter(
     private val prefix = StringBuilder()
     private var discardEscape = false
     private var discardChars = 0
+    private var discardLimit = maxDiscardChars
     private var stripLeadingKittyMarks = false
 
     @Synchronized
@@ -581,6 +604,7 @@ internal class GraphicsOutputFilter(
         prefix.clear()
         discardEscape = false
         discardChars = alreadyConsumedChars
+        discardLimit = if (nextMode == Mode.DISCARD_OSC) maxOscDiscardChars else maxDiscardChars
         mode = nextMode
     }
 
@@ -591,6 +615,10 @@ internal class GraphicsOutputFilter(
     }
 
     private fun discard(char: Char, acceptsBell: Boolean) {
+        if (mode == Mode.DISCARD_OSC && char == NUL) {
+            endDiscard()
+            return
+        }
         if (char == ST || (acceptsBell && char == BEL)) {
             endDiscard()
             return
@@ -613,7 +641,7 @@ internal class GraphicsOutputFilter(
             return
         }
         discardChars++
-        if (discardChars >= maxDiscardChars) endDiscard()
+        if (discardChars >= discardLimit) endDiscard()
     }
 
     private fun endDiscard() {
@@ -624,6 +652,7 @@ internal class GraphicsOutputFilter(
 
     private companion object {
         const val ESC = '\u001b'
+        const val NUL = '\u0000'
         const val BEL = '\u0007'
         const val CAN = '\u0018'
         const val SUB = '\u001a'
@@ -634,7 +663,14 @@ internal class GraphicsOutputFilter(
         const val MAX_SIXEL_PARAMETERS = 65
         // Mirrors RasterCodec.MAX_CONTROL_STRING_CHARS without exposing the decoder's internal API.
         const val MAX_GRAPHICS_CONTROL_CHARS = 70 * 1024 * 1024 + 64 * 1024
-        val ITERM_IMAGE_PREFIXES = listOf("1337;File=", "1337;MultipartFile=")
+        // Mirrors SystemCommandSequence's OSC bound.
+        const val MAX_OSC_CONTROL_CHARS = 50 * 1024 * 1024
+        val ITERM_IMAGE_PREFIXES = listOf(
+            "1337;File=",
+            "1337;MultipartFile=",
+            "1337;FilePart=",
+            "1337;FileEnd",
+        )
         val KITTY_PLACEHOLDER = String(Character.toChars(0x10EEEE))
     }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -5,8 +5,8 @@ import ai.rever.bossterm.terminal.model.image.ImageDataCache
 import ai.rever.bossterm.terminal.model.image.ImageFormat
 import ai.rever.bossterm.terminal.model.image.TerminalImage
 import ai.rever.bossterm.terminal.model.pool.VersionedBufferSnapshot
+import java.lang.ref.WeakReference
 import java.util.Base64
-import java.util.IdentityHashMap
 
 internal const val PANE_GRAPHICS_CAPABILITY = "paneGraphicsV1"
 
@@ -29,9 +29,8 @@ internal class PaneGraphicsTracker(
 ) {
     private var revision = 0L
     private var previousCells: List<SharedImageCellRun> = emptyList()
-    private var previousImages: Map<Long, TerminalImage> = emptyMap()
-    private val hashes = IdentityHashMap<TerminalImage, String>()
-    private var nextContentToken = 0L
+    private var previousImages: Map<Long, ImageFingerprint> = emptyMap()
+    private val fingerprintCache = HashMap<Long, CachedFingerprint>()
     private var previousImageCellRevision = textBuffer.imageCellRevision
     private var previousImageCacheRevision = imageDataCache.contentRevision
     private var previousHistoryTrimCount = textBuffer.imageCellHistoryTrimCount
@@ -50,20 +49,22 @@ internal class PaneGraphicsTracker(
         }
 
         val captured = capture()
-        if (captured.cells == previousCells && sameImageObjects(captured.images, previousImages)) {
+        if (captured.cells == previousCells && captured.fingerprints == previousImages) {
             previousImageCellRevision = cellRevision
             previousImageCacheRevision = cacheRevision
             previousHistoryTrimCount = historyTrimCount
             return null
         }
 
-        val changed = captured.images.filter { (id, image) -> previousImages[id] !== image }
+        val changed = captured.images.filter { (id, _) ->
+            captured.fingerprints[id] != previousImages[id]
+        }
         val removed = previousImages.keys.filter { it !in captured.images }.map(Long::toString)
         val requiresTextSnapshot = captured.cells != previousCells &&
             captured.cells.isNotEmpty() &&
             !isUniformRowShift(previousCells, captured.cells)
         previousCells = captured.cells
-        previousImages = captured.images
+        previousImages = captured.fingerprints
         previousImageCellRevision = cellRevision
         previousImageCacheRevision = cacheRevision
         previousHistoryTrimCount = historyTrimCount
@@ -84,11 +85,11 @@ internal class PaneGraphicsTracker(
     fun fullMessage(commit: Boolean = true): ServerMessage.PaneGraphics {
         val captured = capture()
         if (commit) {
-            if (captured.cells != previousCells || !sameImageObjects(captured.images, previousImages)) {
+            if (captured.cells != previousCells || captured.fingerprints != previousImages) {
                 revision++
             }
             previousCells = captured.cells
-            previousImages = captured.images
+            previousImages = captured.fingerprints
             previousImageCellRevision = textBuffer.imageCellRevision
             previousImageCacheRevision = imageDataCache.contentRevision
             previousHistoryTrimCount = textBuffer.imageCellHistoryTrimCount
@@ -101,7 +102,7 @@ internal class PaneGraphicsTracker(
 
     /** Cheap upper bound used before accepting an explicit full-payload resync. */
     @Synchronized
-    fun estimatedRasterBytes(): Long = previousImages.values.sumOf { it.data.size.toLong() }
+    fun estimatedRasterBytes(): Long = previousImages.values.sumOf { it.rasterBytes }
 
     private fun capture(): Captured {
         val snapshot = textBuffer.createIncrementalSnapshot()
@@ -111,12 +112,12 @@ internal class PaneGraphicsTracker(
         val cells = cellRuns(snapshot, cachedImages.keys)
         val referenced = cells.asSequence().map { it.imageId.toLong() }.toSet()
         val images = cachedImages.filterKeys { it in referenced }
-        // IdentityHashMap is intentional (a replaced image may reuse an id), but it must not pin
-        // evicted TerminalImage objects and their ByteArrays for the lifetime of the share.
-        hashes.keys.removeIf { cached -> images.values.none { it === cached } }
+        val fingerprints = images.mapValues { (_, image) -> fingerprint(image) }
+        fingerprintCache.keys.retainAll(images.keys)
         return Captured(
             cells = cells,
             images = images,
+            fingerprints = fingerprints,
         )
     }
 
@@ -129,13 +130,18 @@ internal class PaneGraphicsTracker(
         paneId = paneId,
         revision = revision,
         full = full,
-        images = images.mapNotNull(::sharedImage),
+        images = images.mapNotNull { image ->
+            sharedImage(image, captured.fingerprints.getValue(image.id))
+        },
         removedImageIds = removed,
-        requiredImageIds = captured.images.keys.map(Long::toString),
+        requiredImageIds = captured.fingerprints.keys.map(Long::toString),
         cells = captured.cells,
     )
 
-    private fun sharedImage(image: TerminalImage): SharedTerminalImage? {
+    private fun sharedImage(
+        image: TerminalImage,
+        fingerprint: ImageFingerprint,
+    ): SharedTerminalImage? {
         val mimeType = when (image.format) {
             ImageFormat.PNG -> "image/png"
             ImageFormat.JPEG -> "image/jpeg"
@@ -148,10 +154,28 @@ internal class PaneGraphicsTracker(
             id = image.id.toString(),
             mimeType = mimeType,
             data = Base64.getEncoder().encodeToString(image.data),
-            contentHash = hashes.getOrPut(image) {
-                (++nextContentToken).toString(36)
-            },
+            contentHash = fingerprint.contentHash,
         )
+    }
+
+    /**
+     * Stable across tracker/connection lifetimes, unlike a local sequence number. The weak cache
+     * avoids hashing an unchanged raster on every capture without retaining evicted byte arrays.
+     */
+    private fun fingerprint(image: TerminalImage): ImageFingerprint {
+        fingerprintCache[image.id]?.let { cached ->
+            if (cached.image.get() === image) return cached.fingerprint
+        }
+        var hash = FNV64_OFFSET xor image.format.ordinal.toLong()
+        for (byte in image.data) {
+            hash = (hash xor (byte.toLong() and 0xffL)) * FNV64_PRIME
+        }
+        val fingerprint = ImageFingerprint(
+            contentHash = "${image.data.size.toString(36)}-${java.lang.Long.toUnsignedString(hash, 36)}",
+            rasterBytes = image.data.size.toLong(),
+        )
+        fingerprintCache[image.id] = CachedFingerprint(WeakReference(image), fingerprint)
+        return fingerprint
     }
 
     private fun shiftForHistoryTrim(trimmedRows: Long): PaneGraphicsUpdate {
@@ -165,17 +189,14 @@ internal class PaneGraphicsTracker(
         val removed = previousImages.keys.filter { it !in shiftedImages }.map(Long::toString)
         previousCells = shiftedCells
         previousImages = shiftedImages
-        hashes.keys.removeIf { cached -> shiftedImages.values.none { it === cached } }
+        fingerprintCache.keys.retainAll(retainedIds)
         revision++
-        val captured = Captured(shiftedCells, shiftedImages)
+        val captured = Captured(shiftedCells, emptyMap(), shiftedImages)
         return PaneGraphicsUpdate(
             message = message(captured, full = false, images = emptyList(), removed = removed),
             requiresTextSnapshot = false,
         )
     }
-
-    private fun sameImageObjects(a: Map<Long, TerminalImage>, b: Map<Long, TerminalImage>): Boolean =
-        a.size == b.size && a.all { (id, image) -> b[id] === image }
 
     private fun isUniformRowShift(
         before: List<SharedImageCellRun>,
@@ -200,9 +221,23 @@ internal class PaneGraphicsTracker(
     private data class Captured(
         val cells: List<SharedImageCellRun>,
         val images: Map<Long, TerminalImage>,
+        val fingerprints: Map<Long, ImageFingerprint>,
+    )
+
+    private data class ImageFingerprint(
+        val contentHash: String,
+        val rasterBytes: Long,
+    )
+
+    private data class CachedFingerprint(
+        val image: WeakReference<TerminalImage>,
+        val fingerprint: ImageFingerprint,
     )
 
     internal companion object {
+        private const val FNV64_OFFSET = -3750763034362895579L
+        private const val FNV64_PRIME = 1099511628211L
+
         /**
          * Compress adjacent cells from the same image row. Missing/evicted image ids are omitted:
          * a browser must never retain a placement whose raster bytes the host no longer owns.
@@ -284,15 +319,29 @@ internal data class FilteredGraphicsOutput(
  * discarded as they arrive, so a multi-megabyte raster is not sent twice. Prefix state crosses PTY
  * chunk boundaries without retaining the discarded payload.
  */
-internal class GraphicsOutputFilter {
+internal class GraphicsOutputFilter(
+    private val maxDiscardChars: Int = MAX_GRAPHICS_CONTROL_CHARS,
+) {
     private enum class Mode { TEXT, ESCAPE, SIXEL_PREFIX, KITTY_PREFIX, ITERM_PREFIX, DISCARD_ST, DISCARD_OSC }
 
     private var mode = Mode.TEXT
     private val prefix = StringBuilder()
     private var discardEscape = false
+    private var discardChars = 0
 
     @Synchronized
     fun filter(chunk: String): FilteredGraphicsOutput {
+        // Ordinary PTY output overwhelmingly contains no graphics introducer. Avoid the
+        // per-character state machine (and its allocation) on that hot path.
+        if (mode == Mode.TEXT &&
+            chunk.indexOf(ESC) < 0 &&
+            chunk.indexOf(DCS) < 0 &&
+            chunk.indexOf(OSC) < 0 &&
+            chunk.indexOf(APC) < 0 &&
+            !chunk.contains(KITTY_PLACEHOLDER)
+        ) {
+            return FilteredGraphicsOutput(chunk, detectedGraphics = false)
+        }
         var detected = chunk.contains(KITTY_PLACEHOLDER)
         val input = if (detected) chunk.replace(KITTY_PLACEHOLDER, " ") else chunk
         val output = StringBuilder(input.length)
@@ -348,7 +397,8 @@ internal class GraphicsOutputFilter {
                     prefix.append(char)
                     if (char == 'G') {
                         detected = true
-                        beginDiscard(Mode.DISCARD_ST)
+                        // BossEmulator's APC reader counts the Kitty `G` as the first body char.
+                        beginDiscard(Mode.DISCARD_ST, alreadyConsumedChars = 1)
                     } else {
                         flushPrefix(output)
                     }
@@ -379,9 +429,10 @@ internal class GraphicsOutputFilter {
         mode = nextMode
     }
 
-    private fun beginDiscard(nextMode: Mode) {
+    private fun beginDiscard(nextMode: Mode, alreadyConsumedChars: Int = 0) {
         prefix.clear()
         discardEscape = false
+        discardChars = alreadyConsumedChars
         mode = nextMode
     }
 
@@ -393,26 +444,48 @@ internal class GraphicsOutputFilter {
 
     private fun discard(char: Char, acceptsBell: Boolean) {
         if (char == ST || (acceptsBell && char == BEL)) {
-            discardEscape = false
-            mode = Mode.TEXT
+            endDiscard()
             return
         }
         if (discardEscape && char == '\\') {
-            discardEscape = false
-            mode = Mode.TEXT
+            endDiscard()
             return
         }
-        discardEscape = char == ESC
+        if (discardEscape) {
+            // BossEmulator consumes the byte after a stray ESC and aborts the control string.
+            endDiscard()
+            return
+        }
+        if (char == CAN || char == SUB) {
+            endDiscard()
+            return
+        }
+        if (char == ESC) {
+            discardEscape = true
+            return
+        }
+        discardChars++
+        if (discardChars >= maxDiscardChars) endDiscard()
+    }
+
+    private fun endDiscard() {
+        discardEscape = false
+        discardChars = 0
+        mode = Mode.TEXT
     }
 
     private companion object {
         const val ESC = '\u001b'
         const val BEL = '\u0007'
+        const val CAN = '\u0018'
+        const val SUB = '\u001a'
         const val DCS = '\u0090'
         const val OSC = '\u009d'
         const val APC = '\u009f'
         const val ST = '\u009c'
         const val MAX_SIXEL_PARAMETERS = 65
+        // Mirrors RasterCodec.MAX_CONTROL_STRING_CHARS without exposing the decoder's internal API.
+        const val MAX_GRAPHICS_CONTROL_CHARS = 70 * 1024 * 1024 + 64 * 1024
         val ITERM_IMAGE_PREFIXES = listOf("1337;File=", "1337;MultipartFile=")
         val KITTY_PLACEHOLDER = String(Character.toChars(0x10EEEE))
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTracker.kt
@@ -6,6 +6,7 @@ import ai.rever.bossterm.terminal.model.image.ImageFormat
 import ai.rever.bossterm.terminal.model.image.TerminalImage
 import ai.rever.bossterm.terminal.model.pool.VersionedBufferSnapshot
 import org.slf4j.LoggerFactory
+import java.lang.ref.ReferenceQueue
 import java.lang.ref.SoftReference
 import java.lang.ref.WeakReference
 import java.security.MessageDigest
@@ -381,18 +382,22 @@ internal class PaneGraphicsTracker(
  */
 private object SharedRasterBase64Cache {
     private const val MAX_CACHED_CHARS = 32 * 1024 * 1024
-    private data class CachedBase64(
-        val value: SoftReference<String>,
+    private class CachedBase64(
+        val key: String,
+        value: String,
         val chars: Int,
-    )
+        queue: ReferenceQueue<String>,
+    ) : SoftReference<String>(value, queue)
 
     private val values = object : LinkedHashMap<String, CachedBase64>(16, 0.75f, true) {}
+    private val clearedValues = ReferenceQueue<String>()
     private var cachedChars = 0
 
     @Synchronized
     fun encode(contentHash: String, data: ByteArray): String {
+        drainClearedValues()
         values[contentHash]?.let { cached ->
-            cached.value.get()?.let { return it }
+            cached.get()?.let { return it }
             values.remove(contentHash)
             cachedChars -= cached.chars
         }
@@ -404,9 +409,19 @@ private object SharedRasterBase64Cache {
             cachedChars -= oldest.value.chars
             iterator.remove()
         }
-        values[contentHash] = CachedBase64(SoftReference(encoded), encoded.length)
+        values[contentHash] = CachedBase64(contentHash, encoded, encoded.length, clearedValues)
         cachedChars += encoded.length
         return encoded
+    }
+
+    private fun drainClearedValues() {
+        while (true) {
+            val cleared = clearedValues.poll() as? CachedBase64 ?: return
+            if (values[cleared.key] === cleared) {
+                values.remove(cleared.key)
+                cachedChars -= cleared.chars
+            }
+        }
     }
 }
 
@@ -706,6 +721,30 @@ internal class GraphicsResyncLimiter(
         active.bytesInWindow = admittedWindowBytes + estimatedBytes
         entries[paneId] = active
         return true
+    }
+
+    /**
+     * Delay until the same request can pass both the per-pane interval and rolling byte budget.
+     * Intended for an explicit denial response, so clients can retry without spending a timeout.
+     */
+    @Synchronized
+    fun retryAfterMillis(
+        paneId: String,
+        estimatedBytes: Long = 0,
+        nowNanos: Long = System.nanoTime(),
+    ): Long {
+        val entry = entries[paneId]
+        val intervalRemaining = entry?.let {
+            (minimumIntervalNanos - (nowNanos - it.lastNanos)).coerceAtLeast(0)
+        } ?: 0
+        val windowRemaining = when {
+            estimatedBytes > maximumBytesPerWindow -> windowNanos
+            entry == null || nowNanos - entry.windowStartNanos >= windowNanos -> 0
+            estimatedBytes <= maximumBytesPerWindow - entry.bytesInWindow -> 0
+            else -> (windowNanos - (nowNanos - entry.windowStartNanos)).coerceAtLeast(0)
+        }
+        val remaining = maxOf(intervalRemaining, windowRemaining)
+        return ((remaining + 999_999L) / 1_000_000L).coerceAtLeast(1L)
     }
 
     @Synchronized

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -4,15 +4,12 @@ import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import io.ktor.http.CacheControl
-import io.ktor.http.HttpHeaders
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.cio.CIOApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.http.content.staticResources
-import io.ktor.server.response.respondResource
-import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.websocket.WebSockets
 import io.ktor.server.websocket.webSocket
@@ -774,14 +771,7 @@ object SessionShareManager {
                     install(WebSockets)
                     routing {
                         webSocket("/ws/{token}") { serveViewer(this) }
-                        get("/fonts/MesloLGSNF-Regular.ttf") {
-                            call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
-                            call.respondResource("fonts/MesloLGSNF-Regular.ttf")
-                        }
-                        get("/fonts/NotoSansSymbols2-Regular.ttf") {
-                            call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
-                            call.respondResource("fonts/NotoSansSymbols2-Regular.ttf")
-                        }
+                        installShareViewerFontRoutes()
                         // Static web viewer (index.html + viewer.js + css). Share URL:
                         // http://<host>:<port>/?t=<token>
                         // no-cache (revalidate, don't blindly reuse): the asset filenames aren't

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -971,11 +971,17 @@ object SessionShareManager {
             }
         }
 
+        val supportsPaneGraphics = hello?.capabilities?.contains(PANE_GRAPHICS_CAPABILITY) == true
+
         // Admit: Theme + Layout + a PaneSnapshot per pane, THEN register so the outbox
         // only carries output produced after the snapshot (avoids double-rendering).
-        share.initialMessages().forEach { send(it) }
+        share.initialMessages(includePaneGraphics = supportsPaneGraphics).forEach { send(it) }
         send(ServerMessage.Control(granted = canControl))
-        val vc = share.addViewer(canControl, hello?.name?.takeIf { it.isNotBlank() } ?: "Viewer (${clientId.take(6)})")
+        val vc = share.addViewer(
+            canControl,
+            hello?.name?.takeIf { it.isNotBlank() } ?: "Viewer (${clientId.take(6)})",
+            supportsPaneGraphics,
+        )
         vc.grantKey = accessKey // lets an approved mid-session upgrade persist into the grant
         val sc = serverCipher
         val writer = ws.launch {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -974,31 +974,36 @@ object SessionShareManager {
 
         val supportsPaneGraphics = hello?.capabilities?.contains(PANE_GRAPHICS_CAPABILITY) == true
 
-        // Admit: Theme + Layout + a PaneSnapshot per pane, THEN register so the outbox
-        // only carries output produced after the snapshot (avoids double-rendering).
-        share.initialMessages(includePaneGraphics = supportsPaneGraphics).forEach { send(it) }
-        send(ServerMessage.Control(granted = canControl))
+        // Register before encoding the snapshots. Output produced during encoding is queued in the
+        // viewer outbox, whose writer starts only after the direct initial frames have been sent.
+        // This preserves ordering while ensuring graphics changes in the admission window schedule
+        // a follow-up update instead of being dropped on an otherwise quiet pane.
         val vc = share.addViewer(
             canControl,
             hello?.name?.takeIf { it.isNotBlank() } ?: "Viewer (${clientId.take(6)})",
             supportsPaneGraphics,
         )
         vc.grantKey = accessKey // lets an approved mid-session upgrade persist into the grant
-        val sc = serverCipher
-        val writer = ws.launch {
-            vc.outbox.drainTo { text ->
-                sc?.let { ws.send(Frame.Binary(true, it.encrypt(text))) } ?: ws.send(Frame.Text(text))
-            }
-        }
         try {
-            for (frame in ws.incoming) {
-                val msg = decodeIncoming(frame)
-                if (msg != null) share.handleClient(vc, msg)  // input gated by role inside
+            share.initialMessages(includePaneGraphics = supportsPaneGraphics).forEach { send(it) }
+            send(ServerMessage.Control(granted = canControl))
+            val sc = serverCipher
+            val writer = ws.launch {
+                vc.outbox.drainTo { text ->
+                    sc?.let { ws.send(Frame.Binary(true, it.encrypt(text))) } ?: ws.send(Frame.Text(text))
+                }
             }
-        } catch (_: Throwable) {
-            // client gone
+            try {
+                for (frame in ws.incoming) {
+                    val msg = decodeIncoming(frame)
+                    if (msg != null) share.handleClient(vc, msg)  // input gated by role inside
+                }
+            } catch (_: Throwable) {
+                // client gone
+            } finally {
+                writer.cancel()
+            }
         } finally {
-            writer.cancel()
             share.removeViewer(vc)
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -776,7 +776,10 @@ object SessionShareManager {
                     routing {
                         webSocket("/ws/{token}") { serveViewer(this) }
                         installShareViewerFontRoutes()
-                        // Static web viewer (index.html + viewer.js + css). Share URL:
+                        // The shell is templated per request (its CSP names this request's own
+                        // WebSocket origin), so it owns "/" and "/index.html" outright.
+                        installShareViewerIndexRoute()
+                        // Static web viewer (viewer.js + css + vendor). Share URL:
                         // http://<host>:<port>/?t=<token>
                         // no-cache (revalidate, don't blindly reuse): the asset filenames aren't
                         // content-hashed, so without this a phone keeps running the viewer JS/HTML
@@ -784,8 +787,9 @@ object SessionShareManager {
                         // browser still caches but must revalidate each load — unchanged assets
                         // come back 304 (Ktor sets Last-Modified from the jar entry), so only a
                         // genuinely updated viewer is re-downloaded.
-                        staticResources("/", "share-viewer", index = "index.html") {
+                        staticResources("/", "share-viewer", index = null) {
                             cacheControl { listOf(CacheControl.NoCache(null)) }
+                            exclude { isShareViewerIndexResource(it.path) }
                         }
                     }
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -10,6 +10,7 @@ import io.ktor.server.cio.CIOApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.http.content.staticResources
+import io.ktor.server.plugins.defaultheaders.DefaultHeaders
 import io.ktor.server.routing.routing
 import io.ktor.server.websocket.WebSockets
 import io.ktor.server.websocket.webSocket
@@ -769,6 +770,9 @@ object SessionShareManager {
             try {
                 val started = embeddedServer(CIO, host = host, port = port) {
                     install(WebSockets)
+                    install(DefaultHeaders) {
+                        header("X-Frame-Options", "DENY")
+                    }
                     routing {
                         webSocket("/ws/{token}") { serveViewer(this) }
                         installShareViewerFontRoutes()
@@ -974,10 +978,11 @@ object SessionShareManager {
 
         val supportsPaneGraphics = hello?.capabilities?.contains(PANE_GRAPHICS_CAPABILITY) == true
 
-        // Register before encoding the snapshots. Output produced during encoding is queued in the
-        // viewer outbox, whose writer starts only after the direct initial frames have been sent.
-        // This preserves ordering while ensuring graphics changes in the admission window schedule
-        // a follow-up update instead of being dropped on an otherwise quiet pane.
+        // Capture before registration. Registering first queues output that the authoritative
+        // snapshot may already contain, deterministically replaying it below the snapshot. Once
+        // registered, addViewer schedules a graphics poll for every pane to close the graphics
+        // admission window even when the pane goes quiet.
+        val initialMessages = share.initialMessages(includePaneGraphics = supportsPaneGraphics)
         val vc = share.addViewer(
             canControl,
             hello?.name?.takeIf { it.isNotBlank() } ?: "Viewer (${clientId.take(6)})",
@@ -985,7 +990,7 @@ object SessionShareManager {
         )
         vc.grantKey = accessKey // lets an approved mid-session upgrade persist into the grant
         try {
-            share.initialMessages(includePaneGraphics = supportsPaneGraphics).forEach { send(it) }
+            initialMessages.forEach { send(it) }
             send(ServerMessage.Control(granted = canControl))
             val sc = serverCipher
             val writer = ws.launch {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -4,12 +4,15 @@ import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import io.ktor.http.CacheControl
+import io.ktor.http.HttpHeaders
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.cio.CIOApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.http.content.staticResources
+import io.ktor.server.response.respondResource
+import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.websocket.WebSockets
 import io.ktor.server.websocket.webSocket
@@ -771,8 +774,13 @@ object SessionShareManager {
                     install(WebSockets)
                     routing {
                         webSocket("/ws/{token}") { serveViewer(this) }
-                        staticResources("/fonts", "fonts") {
-                            cacheControl { listOf(CacheControl.NoCache(null)) }
+                        get("/fonts/MesloLGSNF-Regular.ttf") {
+                            call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
+                            call.respondResource("fonts/MesloLGSNF-Regular.ttf")
+                        }
+                        get("/fonts/NotoSansSymbols2-Regular.ttf") {
+                            call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
+                            call.respondResource("fonts/NotoSansSymbols2-Regular.ttf")
                         }
                         // Static web viewer (index.html + viewer.js + css). Share URL:
                         // http://<host>:<port>/?t=<token>

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -986,7 +986,7 @@ object SessionShareManager {
         vc.grantKey = accessKey // lets an approved mid-session upgrade persist into the grant
         val sc = serverCipher
         val writer = ws.launch {
-            for (text in vc.outbox) {
+            vc.outbox.drainTo { text ->
                 sc?.let { ws.send(Frame.Binary(true, it.encrypt(text))) } ?: ws.send(Frame.Text(text))
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -771,6 +771,9 @@ object SessionShareManager {
                     install(WebSockets)
                     routing {
                         webSocket("/ws/{token}") { serveViewer(this) }
+                        staticResources("/fonts", "fonts") {
+                            cacheControl { listOf(CacheControl.NoCache(null)) }
+                        }
                         // Static web viewer (index.html + viewer.js + css). Share URL:
                         // http://<host>:<port>/?t=<token>
                         // no-cache (revalidate, don't blindly reuse): the asset filenames aren't

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -60,6 +60,7 @@ object ShareProtocol {
  */
 internal fun webTerminalFontFamily(fontName: String?): String {
     val configured = fontName
+        ?.filterNot { it.code < 0x20 || it.code == 0x7f }
         ?.takeIf { it.isNotBlank() && it != BUNDLED_FONT_NAME }
         ?.replace("\\", "\\\\")
         ?.replace("\"", "\\\"")
@@ -108,8 +109,8 @@ sealed class ServerMessage {
 
     /**
      * One-time initial paint for a pane: scrollback+screen as a raw escape/text blob.
-     * [scrollbackLines] is the pane's actual host history cap. The browser must use the same cap
-     * because inline-image rows are absolute buffer coordinates and both sides trim in lockstep.
+     * [scrollbackLines] is the web-safe history cap (at most 100k rows). Inline-image rows use this
+     * coordinate window even when the host retains more history, keeping phone memory bounded.
      */
     @Serializable
     @SerialName("paneSnapshot")
@@ -147,6 +148,8 @@ sealed class ServerMessage {
         val removedImageIds: List<String> = emptyList(),
         val requiredImageIds: List<String> = emptyList(),
         val cells: List<SharedImageCellRun> = emptyList(),
+        /** Host history rows retained for this viewer; anchors absolute rows to xterm's baseY. */
+        val historyLines: Int = -1,
     ) : ServerMessage()
 
     /** Number of connected viewers. */
@@ -500,8 +503,9 @@ data class SharedTerminalImage(
  * A horizontally contiguous run of image cells. [row] is the zero-based absolute buffer index
  * (oldest retained history line = 0, followed by the screen). This stays stable when a screen line
  * first scrolls into growing history and matches xterm's `viewportY` coordinate system directly.
- * [ServerMessage.PaneSnapshot.scrollbackLines] configures xterm with the pane's real history cap,
- * while [PaneGraphicsTracker] publishes cheap row shifts whenever capped history trims.
+ * [ServerMessage.PaneSnapshot.scrollbackLines] configures xterm with the web-safe history cap,
+ * while [PaneGraphicsTracker] translates a larger host history and publishes cheap row shifts
+ * whenever either side trims.
  */
 @Serializable
 data class SharedImageCellRun(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.share
 
+import ai.rever.bossterm.compose.util.BUNDLED_FONT_NAME
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -48,6 +49,25 @@ object ShareProtocol {
     fun sha256Hex(s: String): String =
         java.security.MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
             .joinToString("") { "%02x".format(it) }
+}
+
+/**
+ * CSS font stack used by the browser viewer.
+ *
+ * A configured system font stays first when the viewing device also has it. BossTerm's bundled
+ * Nerd Font then provides the same private-use icons as the native renderer, platform emoji fonts
+ * cover color emoji, and the bundled Noto font supplies the remaining symbols.
+ */
+internal fun webTerminalFontFamily(fontName: String?): String {
+    val configured = fontName
+        ?.takeIf { it.isNotBlank() && it != BUNDLED_FONT_NAME }
+        ?.replace("\\", "\\\\")
+        ?.replace("\"", "\\\"")
+        ?.let { "\"$it\", " }
+        .orEmpty()
+    return configured +
+        "\"BossTerm Nerd Font\", \"Apple Color Emoji\", \"Segoe UI Emoji\", " +
+        "\"Noto Color Emoji\", \"BossTerm Symbols\", monospace"
 }
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -101,6 +101,24 @@ sealed class ServerMessage {
     @SerialName("paneResize")
     data class PaneResize(val paneId: String, val cols: Int, val rows: Int) : ServerMessage()
 
+    /**
+     * Authoritative inline-image state for one pane. The host decodes Sixel/Kitty (including
+     * host-local Kitty file transfers) and sends browser-safe raster data plus the exact cells
+     * occupied by each image. [cells] and [requiredImageIds] are always a complete placement
+     * snapshot; [images] is a delta unless [full] is true.
+     */
+    @Serializable
+    @SerialName("paneGraphics")
+    data class PaneGraphics(
+        val paneId: String,
+        val revision: Long,
+        val full: Boolean,
+        val images: List<SharedTerminalImage> = emptyList(),
+        val removedImageIds: List<String> = emptyList(),
+        val requiredImageIds: List<String> = emptyList(),
+        val cells: List<SharedImageCellRun> = emptyList(),
+    ) : ServerMessage()
+
     /** Number of connected viewers. */
     @Serializable
     @SerialName("presence")
@@ -271,7 +289,14 @@ sealed class ClientMessage {
         val name: String? = null,
         val clientId: String? = null,
         val key: String? = null,
+        /** Optional feature names understood by this peer (for example `paneGraphicsV1`). */
+        val capabilities: List<String> = emptyList(),
     ) : ClientMessage()
+
+    /** Ask the host for a full image-data + placement snapshot after a missed graphics delta. */
+    @Serializable
+    @SerialName("graphicsResync")
+    data class GraphicsResync(val paneId: String) : ClientMessage()
 
     /** Keystrokes for a specific pane. Honored only with controller role. */
     @Serializable
@@ -429,3 +454,31 @@ sealed class ClientMessage {
     @SerialName("attachMcp")
     data class AttachMcp(val target: String, val tabId: String? = null) : ClientMessage()
 }
+
+/** Browser-displayable image data referenced by [ServerMessage.PaneGraphics]. */
+@Serializable
+data class SharedTerminalImage(
+    /** String on the wire so JavaScript never loses a 64-bit terminal image id. */
+    val id: String,
+    val mimeType: String,
+    val data: String,
+    /** SHA-256 of the decoded bytes; lets the browser retain unchanged decoded images. */
+    val contentHash: String,
+)
+
+/**
+ * A horizontally contiguous run of image cells. [row] uses BossTerm buffer coordinates:
+ * negative values are scrollback, 0 is the top screen row. The browser maps it with xterm's
+ * current `baseY`, so deep scrollback truncation does not skew placement.
+ */
+@Serializable
+data class SharedImageCellRun(
+    val imageId: String,
+    val row: Int,
+    val col: Int,
+    val cellX: Int,
+    val cellY: Int,
+    val length: Int,
+    val totalCellsX: Int,
+    val totalCellsY: Int,
+)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -487,9 +487,9 @@ data class SharedTerminalImage(
 )
 
 /**
- * A horizontally contiguous run of image cells. [row] uses BossTerm buffer coordinates:
- * negative values are scrollback, 0 is the top screen row. The browser maps it with xterm's
- * current `baseY`, so deep scrollback truncation does not skew placement.
+ * A horizontally contiguous run of image cells. [row] is the zero-based absolute buffer index
+ * (oldest retained history line = 0, followed by the screen). This stays stable when a screen line
+ * first scrolls into growing history and matches xterm's `viewportY` coordinate system directly.
  */
 @Serializable
 data class SharedImageCellRun(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -109,7 +109,7 @@ sealed class ServerMessage {
 
     /**
      * One-time initial paint for a pane: scrollback+screen as a raw escape/text blob.
-     * [scrollbackLines] is the web-safe history cap (at most 100k rows). Inline-image rows use this
+     * [scrollbackLines] is the web-safe history cap (at most 20k rows). Inline-image rows use this
      * coordinate window even when the host retains more history, keeping phone memory bounded.
      */
     @Serializable
@@ -126,6 +126,14 @@ sealed class ServerMessage {
     @Serializable
     @SerialName("paneOutput")
     data class PaneOutput(val paneId: String, val data: String) : ServerMessage()
+
+    /**
+     * Authoritative visible-screen repaint that remains ordered with incremental pane output.
+     * Web viewers preserve their current distance from the bottom while applying it.
+     */
+    @Serializable
+    @SerialName("paneRepaint")
+    data class PaneRepaint(val paneId: String, val data: String) : ServerMessage()
 
     /** A pane's terminal dimensions changed. */
     @Serializable
@@ -150,6 +158,19 @@ sealed class ServerMessage {
         val cells: List<SharedImageCellRun> = emptyList(),
         /** Host history rows retained for this viewer; anchors absolute rows to xterm's baseY. */
         val historyLines: Int = -1,
+        /**
+         * The full frame could not be queued. The viewer must request another full frame without
+         * treating this sentinel as a new graphics revision.
+         */
+        val resyncRequired: Boolean = false,
+    ) : ServerMessage()
+
+    /** A graphics resync was throttled; retrying it after [retryAfterMs] does not spend an attempt. */
+    @Serializable
+    @SerialName("graphicsResyncDenied")
+    data class GraphicsResyncDenied(
+        val paneId: String,
+        val retryAfterMs: Long,
     ) : ServerMessage()
 
     /** Number of connected viewers. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -539,3 +539,13 @@ data class SharedImageCellRun(
     val totalCellsX: Int,
     val totalCellsY: Int,
 )
+
+/** Lightweight fallback when a full graphics frame cannot enter a viewer's bounded outbox. */
+internal fun ServerMessage.PaneGraphics.resyncSentinel(): ServerMessage.PaneGraphics = copy(
+    full = false,
+    images = emptyList(),
+    removedImageIds = emptyList(),
+    requiredImageIds = emptyList(),
+    cells = emptyList(),
+    resyncRequired = true,
+)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -106,10 +106,20 @@ sealed class ServerMessage {
         val sessionName: String? = null,
     ) : ServerMessage()
 
-    /** One-time initial paint for a pane: scrollback+screen as a raw escape/text blob. */
+    /**
+     * One-time initial paint for a pane: scrollback+screen as a raw escape/text blob.
+     * [scrollbackLines] is the pane's actual host history cap. The browser must use the same cap
+     * because inline-image rows are absolute buffer coordinates and both sides trim in lockstep.
+     */
     @Serializable
     @SerialName("paneSnapshot")
-    data class PaneSnapshot(val paneId: String, val data: String, val cols: Int, val rows: Int) : ServerMessage()
+    data class PaneSnapshot(
+        val paneId: String,
+        val data: String,
+        val cols: Int,
+        val rows: Int,
+        val scrollbackLines: Int = 10_000,
+    ) : ServerMessage()
 
     /** Incremental raw PTY output for a pane. */
     @Serializable
@@ -482,7 +492,7 @@ data class SharedTerminalImage(
     val id: String,
     val mimeType: String,
     val data: String,
-    /** Per-image-object change token; lets the browser retain unchanged decoded images. */
+    /** Stable content fingerprint; lets the browser retain unchanged decoded images across reconnects. */
     val contentHash: String,
 )
 
@@ -490,9 +500,8 @@ data class SharedTerminalImage(
  * A horizontally contiguous run of image cells. [row] is the zero-based absolute buffer index
  * (oldest retained history line = 0, followed by the screen). This stays stable when a screen line
  * first scrolls into growing history and matches xterm's `viewportY` coordinate system directly.
- * The viewer's scrollback limit intentionally matches
- * [ai.rever.bossterm.terminal.model.LinesStorage.DEFAULT_MAX_LINES_COUNT], while
- * [PaneGraphicsTracker] publishes cheap row shifts whenever capped history trims.
+ * [ServerMessage.PaneSnapshot.scrollbackLines] configures xterm with the pane's real history cap,
+ * while [PaneGraphicsTracker] publishes cheap row shifts whenever capped history trims.
  */
 @Serializable
 data class SharedImageCellRun(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareProtocol.kt
@@ -482,7 +482,7 @@ data class SharedTerminalImage(
     val id: String,
     val mimeType: String,
     val data: String,
-    /** SHA-256 of the decoded bytes; lets the browser retain unchanged decoded images. */
+    /** Per-image-object change token; lets the browser retain unchanged decoded images. */
     val contentHash: String,
 )
 
@@ -490,6 +490,9 @@ data class SharedTerminalImage(
  * A horizontally contiguous run of image cells. [row] is the zero-based absolute buffer index
  * (oldest retained history line = 0, followed by the screen). This stays stable when a screen line
  * first scrolls into growing history and matches xterm's `viewportY` coordinate system directly.
+ * The viewer's scrollback limit intentionally matches
+ * [ai.rever.bossterm.terminal.model.LinesStorage.DEFAULT_MAX_LINES_COUNT], while
+ * [PaneGraphicsTracker] publishes cheap row shifts whenever capped history trims.
  */
 @Serializable
 data class SharedImageCellRun(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareViewerResources.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareViewerResources.kt
@@ -1,0 +1,23 @@
+package ai.rever.bossterm.compose.share
+
+import io.ktor.http.HttpHeaders
+import io.ktor.server.response.respondResource
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+
+private const val IMMUTABLE_FONT_CACHE = "public, max-age=31536000, immutable"
+
+private val SHARE_VIEWER_FONTS = listOf(
+    "MesloLGSNF-Regular.ttf",
+    "NotoSansSymbols2-Regular.ttf",
+)
+
+/** Install only the font files referenced by the content-versioned viewer stylesheet. */
+internal fun Route.installShareViewerFontRoutes() {
+    for (name in SHARE_VIEWER_FONTS) {
+        get("/fonts/$name") {
+            call.response.headers.append(HttpHeaders.CacheControl, IMMUTABLE_FONT_CACHE)
+            call.respondResource("fonts/$name")
+        }
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareViewerResources.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareViewerResources.kt
@@ -7,14 +7,16 @@ import io.ktor.server.routing.get
 
 private const val IMMUTABLE_FONT_CACHE = "public, max-age=31536000, immutable"
 
-private val SHARE_VIEWER_FONTS = listOf(
+private val SHARE_VIEWER_FONT_RESOURCES = listOf(
     "MesloLGSNF-Regular.ttf",
+    "MesloLGSNF-NOTICE.txt",
     "NotoSansSymbols2-Regular.ttf",
+    "NotoSansSymbols2-OFL.txt",
 )
 
-/** Install only the font files referenced by the content-versioned viewer stylesheet. */
+/** Install only the font files referenced by the viewer stylesheet and their license notices. */
 internal fun Route.installShareViewerFontRoutes() {
-    for (name in SHARE_VIEWER_FONTS) {
+    for (name in SHARE_VIEWER_FONT_RESOURCES) {
         get("/fonts/$name") {
             call.response.headers.append(HttpHeaders.CacheControl, IMMUTABLE_FONT_CACHE)
             call.respondResource("fonts/$name")

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareViewerResources.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareViewerResources.kt
@@ -1,7 +1,11 @@
 package ai.rever.bossterm.compose.share
 
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.withCharset
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respondResource
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 
@@ -22,4 +26,65 @@ internal fun Route.installShareViewerFontRoutes() {
             call.respondResource("fonts/$name")
         }
     }
+}
+
+/** Placeholder inside the shell's `connect-src`, filled in per request by [respondShareViewerIndex]. */
+internal const val WS_ORIGIN_PLACEHOLDER = "__BOSSTERM_WS_ORIGINS__"
+
+/** Bare `host` / `host:port` / `[v6]:port` — anything else can't go in a CSP directive. */
+private val SAFE_HTTP_AUTHORITY =
+    Regex("""(?:[A-Za-z0-9._\-]+|\[[0-9A-Fa-f:.]+])(?::\d{1,5})?""")
+
+/**
+ * Serve the viewer shell with a `connect-src` that names THIS request's own WebSocket origin.
+ *
+ * `connect-src 'self'` matching `ws://`/`wss://` on the document's own host is CSP **Level 3**
+ * behavior. Older mobile WebKit/Blink required the scheme to be named explicitly and blocked the
+ * socket outright — which bricks the viewer rather than degrading it, and phones on a LAN are
+ * exactly this feature's audience. Naming the concrete authority keeps the policy as narrow as
+ * `'self'` (no `ws:` wildcard that would permit any host) while working on those browsers.
+ *
+ * Register alongside `staticResources(..., index = null)` with `index.html` excluded, so the
+ * un-templated file can never be served instead of this route.
+ */
+internal fun Route.installShareViewerIndexRoute() {
+    get("/") { call.respondShareViewerIndex() }
+    get("/index.html") { call.respondShareViewerIndex() }
+}
+
+/** True for the shell itself, which [installShareViewerIndexRoute] owns. */
+internal fun isShareViewerIndexResource(path: String): Boolean =
+    path.endsWith("/index.html") || path == "index.html"
+
+private object ShareViewerIndex {
+    val template: String by lazy {
+        checkNotNull(javaClass.classLoader.getResourceAsStream("share-viewer/index.html")) {
+            "missing resource: share-viewer/index.html"
+        }.bufferedReader().use { it.readText() }
+    }
+}
+
+private suspend fun ApplicationCall.respondShareViewerIndex() {
+    // no-cache so a phone re-validates the shell (filenames aren't content-hashed) — a 304 keeps
+    // it cheap, and the per-request CSP is never reused across a different Host.
+    response.headers.append(HttpHeaders.CacheControl, "no-cache")
+    respondText(
+        ShareViewerIndex.template.replace(
+            WS_ORIGIN_PLACEHOLDER,
+            webSocketCspSources(request.headers[HttpHeaders.Host]),
+        ),
+        ContentType.Text.Html.withCharset(Charsets.UTF_8),
+    )
+}
+
+/**
+ * The `ws:`/`wss:` sources for [hostHeader]'s origin, or empty when it is missing or not a bare
+ * authority — it is client-supplied and lands inside a CSP directive, so anything else (a space, a
+ * `;`, a path) could append a directive of its own. Falling back to no extra source leaves the
+ * policy at `'self'`, i.e. today's behavior on a CSP3 browser.
+ */
+internal fun webSocketCspSources(hostHeader: String?): String {
+    val authority = hostHeader?.trim().orEmpty()
+    if (!SAFE_HTTP_AUTHORITY.matches(authority)) return ""
+    return "ws://$authority wss://$authority"
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoder.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoder.kt
@@ -14,9 +14,14 @@ import ai.rever.bossterm.terminal.model.TerminalLine
  */
 object TerminalSnapshotEncoder {
 
-    fun encode(snapshot: BufferSnapshot, cursorX: Int, cursorY: Int): String {
+    fun encode(
+        snapshot: BufferSnapshot,
+        cursorX: Int,
+        cursorY: Int,
+        maxHistoryLines: Int = Int.MAX_VALUE,
+    ): String {
         val sb = StringBuilder()
-        var row = -snapshot.historyLinesCount
+        var row = -snapshot.historyLinesCount.coerceAtMost(maxHistoryLines.coerceAtLeast(0))
         while (row < snapshot.height) {
             appendStyledLine(sb, snapshot.getLine(row))
             if (row < snapshot.height - 1) sb.append("\r\n")

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoder.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoder.kt
@@ -36,6 +36,29 @@ object TerminalSnapshotEncoder {
         return sb.toString()
     }
 
+    /**
+     * Repaint only the visible screen without resetting terminal modes or retained scrollback.
+     *
+     * Graphics placement changes need text/cursor re-anchoring, but a full RIS + [encode] makes
+     * xterm rebuild every retained history row. Absolute cursor addressing and per-line erasure
+     * make this payload O(screen size) and leave a scrolled-up viewer's history intact.
+     */
+    fun encodeScreenRepaint(
+        snapshot: BufferSnapshot,
+        cursorX: Int,
+        cursorY: Int,
+    ): String {
+        val sb = StringBuilder()
+        for (row in 0 until snapshot.height) {
+            sb.append("\u001b[0m\u001b[").append(row + 1).append(";1H\u001b[2K")
+            appendStyledLine(sb, snapshot.getLine(row))
+        }
+        val cy = cursorY.coerceIn(1, snapshot.height)
+        val cx = cursorX.coerceAtLeast(1)
+        sb.append("\u001b[0m\u001b[$cy;${cx}H")
+        return sb.toString()
+    }
+
     /** Append one buffer line as SGR-prefixed styled runs, trimming invisible trailing padding. */
     private fun appendStyledLine(sb: StringBuilder, line: TerminalLine) {
         val runs = ArrayList<TerminalLine.TextEntry>()

--- a/compose-ui/src/desktopMain/resources/fonts/MesloLGSNF-NOTICE.txt
+++ b/compose-ui/src/desktopMain/resources/fonts/MesloLGSNF-NOTICE.txt
@@ -1,0 +1,42 @@
+MesloLGS NF Regular — third-party font notice
+
+The bundled font identifies itself as:
+  Meslo LG S Regular 1.210 (2013-01-06)
+  Patched with the Nerd Fonts Patcher
+
+Original Meslo LG copyright notices embedded in the font:
+  Copyright 2009 Apple Inc.
+  Copyright 2006 Tavmjong Bah.
+
+Meslo LG is licensed under the Apache License, Version 2.0. A complete copy is
+included at the repository root as LICENSE-APACHE-2.0.txt.
+
+Nerd Fonts project attribution:
+  Copyright (c) 2014 Ryan L McIntyre
+  https://github.com/ryanoasis/nerd-fonts
+
+Nerd Fonts' original patcher/source code is MIT licensed. Its patched fonts and
+glyph sources retain their respective upstream licenses. The current license and
+glyph-source audit is maintained at:
+  https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+  https://github.com/ryanoasis/nerd-fonts/blob/master/license-audit.md
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/compose-ui/src/desktopMain/resources/fonts/NotoSansSymbols2-OFL.txt
+++ b/compose-ui/src/desktopMain/resources/fonts/NotoSansSymbols2-OFL.txt
@@ -1,0 +1,93 @@
+Copyright 2018 The Noto Project Authors (github.com/googlei18n/noto-fonts)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -8,6 +8,7 @@
         content="default-src 'self'; connect-src 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
   <title>BossTerm — shared session</title>
   <!-- xterm.js vendored locally (works fully offline on a LAN). MIT licensed. -->
+  <!-- Bundled font notices: fonts/MesloLGSNF-NOTICE.txt and fonts/NotoSansSymbols2-OFL.txt -->
   <link rel="stylesheet" href="vendor/xterm.css" />
   <style>
     @font-face {

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -5,21 +5,21 @@
   <!-- Allow pinch-zoom + pan so wide/tall terminals are navigable on phones. -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; connect-src 'self' ws: wss:; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+        content="default-src 'self'; connect-src 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
   <title>BossTerm — shared session</title>
   <!-- xterm.js vendored locally (works fully offline on a LAN). MIT licensed. -->
   <link rel="stylesheet" href="vendor/xterm.css" />
   <style>
     @font-face {
       font-family: "BossTerm Nerd Font";
-      src: url("fonts/MesloLGSNF-Regular.ttf") format("truetype");
+      src: url("fonts/MesloLGSNF-Regular.ttf?v=d97946186e97") format("truetype");
       font-style: normal;
       font-weight: normal;
       font-display: swap;
     }
     @font-face {
       font-family: "BossTerm Symbols";
-      src: url("fonts/NotoSansSymbols2-Regular.ttf") format("truetype");
+      src: url("fonts/NotoSansSymbols2-Regular.ttf?v=630846d528db") format("truetype");
       font-style: normal;
       font-weight: normal;
       font-display: swap;

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -5,7 +5,7 @@
   <!-- Allow pinch-zoom + pan so wide/tall terminals are navigable on phones. -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; connect-src 'self' ws: wss:; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+        content="default-src 'self'; base-uri 'none'; form-action 'none'; connect-src 'self' ws: wss:; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
   <title>BossTerm — shared session</title>
   <!-- xterm.js vendored locally (works fully offline on a LAN). MIT licensed. -->
   <!-- Bundled font notices: fonts/MesloLGSNF-NOTICE.txt and fonts/NotoSansSymbols2-OFL.txt -->

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -5,7 +5,7 @@
   <!-- Allow pinch-zoom + pan so wide/tall terminals are navigable on phones. -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; connect-src 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+        content="default-src 'self'; connect-src 'self' ws: wss:; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
   <title>BossTerm — shared session</title>
   <!-- xterm.js vendored locally (works fully offline on a LAN). MIT licensed. -->
   <!-- Bundled font notices: fonts/MesloLGSNF-NOTICE.txt and fonts/NotoSansSymbols2-OFL.txt -->
@@ -225,6 +225,7 @@
   <script src="vendor/addon-webgl.js"></script>
   <!-- Clickable URLs (vendored @xterm/addon-web-links). Optional — viewer.js no-ops if absent. -->
   <script src="vendor/addon-web-links.js"></script>
+  <script src="viewer-logic.js"></script>
   <script src="viewer.js"></script>
 </body>
 </html>

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -5,7 +5,7 @@
   <!-- Allow pinch-zoom + pan so wide/tall terminals are navigable on phones. -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; base-uri 'none'; form-action 'none'; connect-src 'self' ws: wss:; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+        content="default-src 'self'; base-uri 'none'; form-action 'none'; connect-src 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
   <title>BossTerm — shared session</title>
   <!-- xterm.js vendored locally (works fully offline on a LAN). MIT licensed. -->
   <!-- Bundled font notices: fonts/MesloLGSNF-NOTICE.txt and fonts/NotoSansSymbols2-OFL.txt -->

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -8,6 +8,20 @@
   <!-- xterm.js vendored locally (works fully offline on a LAN). MIT licensed. -->
   <link rel="stylesheet" href="vendor/xterm.css" />
   <style>
+    @font-face {
+      font-family: "BossTerm Nerd Font";
+      src: url("fonts/MesloLGSNF-Regular.ttf") format("truetype");
+      font-style: normal;
+      font-weight: normal;
+      font-display: swap;
+    }
+    @font-face {
+      font-family: "BossTerm Symbols";
+      src: url("fonts/NotoSansSymbols2-Regular.ttf") format("truetype");
+      font-style: normal;
+      font-weight: normal;
+      font-display: swap;
+    }
     :root { color-scheme: dark; }
     html, body { margin: 0; height: 100%; background: #1e1e1e; color: #ddd;
                  font-family: -apple-system, Menlo, monospace; overflow: hidden;

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <!-- Allow pinch-zoom + pan so wide/tall terminals are navigable on phones. -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; connect-src 'self' ws: wss:; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
   <title>BossTerm — shared session</title>
   <!-- xterm.js vendored locally (works fully offline on a LAN). MIT licensed. -->
   <link rel="stylesheet" href="vendor/xterm.css" />

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -5,7 +5,7 @@
   <!-- Allow pinch-zoom + pan so wide/tall terminals are navigable on phones. -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; base-uri 'none'; form-action 'none'; connect-src 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+        content="default-src 'self'; base-uri 'none'; form-action 'none'; connect-src 'self' __BOSSTERM_WS_ORIGINS__; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
   <title>BossTerm — shared session</title>
   <!-- xterm.js vendored locally (works fully offline on a LAN). MIT licensed. -->
   <!-- Bundled font notices: fonts/MesloLGSNF-NOTICE.txt and fonts/NotoSansSymbols2-OFL.txt -->

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer-logic.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer-logic.js
@@ -1,0 +1,29 @@
+// Pure, executable state/coordinate helpers shared by viewer.js and the Node regression harness.
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  else root.BossTermViewerLogic = api;
+}(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  function nextReconnectAttempt(currentAttempt, maximumAttempts) {
+    if (currentAttempt >= maximumAttempts) {
+      return { retry: false, attempt: currentAttempt };
+    }
+    return { retry: true, attempt: currentAttempt + 1 };
+  }
+
+  function captureRowOffset(xtermBaseY, hostHistoryLines) {
+    return xtermBaseY - hostHistoryLines;
+  }
+
+  function visibleImageRow(absoluteRow, capturedOffset, viewportY) {
+    return absoluteRow + capturedOffset - viewportY;
+  }
+
+  return {
+    nextReconnectAttempt: nextReconnectAttempt,
+    captureRowOffset: captureRowOffset,
+    visibleImageRow: visibleImageRow
+  };
+}));

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer-logic.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer-logic.js
@@ -21,6 +21,11 @@
     return absoluteRow + capturedOffset - viewportY;
   }
 
+  function visibleHostRowRange(viewportY, capturedOffset, terminalRows) {
+    var first = viewportY - capturedOffset;
+    return { first: first, last: first + Math.max(0, terminalRows - 1) };
+  }
+
   function scrollLinesFromBottom(baseY, viewportY) {
     return Math.max(0, baseY - viewportY);
   }
@@ -51,6 +56,7 @@
     nextReconnectAttempt: nextReconnectAttempt,
     captureRowOffset: captureRowOffset,
     visibleImageRow: visibleImageRow,
+    visibleHostRowRange: visibleHostRowRange,
     scrollLinesFromBottom: scrollLinesFromBottom,
     scrollLineForDistance: scrollLineForDistance,
     graphicsMemoryFits: graphicsMemoryFits,

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer-logic.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer-logic.js
@@ -13,6 +13,10 @@
     return { retry: true, attempt: currentAttempt + 1 };
   }
 
+  function isTerminalWebSocketClose(code) {
+    return code === 1000 || code === 1003 || code === 1008;
+  }
+
   function captureRowOffset(xtermBaseY, hostHistoryLines) {
     return xtermBaseY - hostHistoryLines;
   }
@@ -32,6 +36,21 @@
 
   function scrollLineForDistance(updatedBaseY, linesFromBottom) {
     return Math.max(0, updatedBaseY - linesFromBottom);
+  }
+
+  function queuePaneRepaint(write, readBuffer, scrollToLine, data, complete) {
+    var restoreLinesFromBottom = 0;
+    // Queue both entries synchronously: later paneOutput writes must land after the repaint.
+    write("", function () {
+      var active = readBuffer();
+      restoreLinesFromBottom = scrollLinesFromBottom(active.baseY, active.viewportY);
+    });
+    write(data, function () {
+      if (restoreLinesFromBottom > 0) {
+        scrollToLine(scrollLineForDistance(readBuffer().baseY, restoreLinesFromBottom));
+      }
+      complete();
+    });
   }
 
   function graphicsMemoryFits(
@@ -54,11 +73,13 @@
 
   return {
     nextReconnectAttempt: nextReconnectAttempt,
+    isTerminalWebSocketClose: isTerminalWebSocketClose,
     captureRowOffset: captureRowOffset,
     visibleImageRow: visibleImageRow,
     visibleHostRowRange: visibleHostRowRange,
     scrollLinesFromBottom: scrollLinesFromBottom,
     scrollLineForDistance: scrollLineForDistance,
+    queuePaneRepaint: queuePaneRepaint,
     graphicsMemoryFits: graphicsMemoryFits,
     graphicsAttemptAfterDenied: graphicsAttemptAfterDenied
   };

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer-logic.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer-logic.js
@@ -21,9 +21,39 @@
     return absoluteRow + capturedOffset - viewportY;
   }
 
+  function scrollLinesFromBottom(baseY, viewportY) {
+    return Math.max(0, baseY - viewportY);
+  }
+
+  function scrollLineForDistance(updatedBaseY, linesFromBottom) {
+    return Math.max(0, updatedBaseY - linesFromBottom);
+  }
+
+  function graphicsMemoryFits(
+    paneBytes,
+    viewerBytes,
+    addedBytes,
+    replacedBytes,
+    paneLimit,
+    viewerLimit
+  ) {
+    var replaced = replacedBytes || 0;
+    return addedBytes <= paneLimit &&
+      paneBytes + addedBytes - replaced <= paneLimit &&
+      viewerBytes + addedBytes - replaced <= viewerLimit;
+  }
+
+  function graphicsAttemptAfterDenied(attempts, requestPending) {
+    return requestPending && attempts > 0 ? attempts - 1 : attempts;
+  }
+
   return {
     nextReconnectAttempt: nextReconnectAttempt,
     captureRowOffset: captureRowOffset,
-    visibleImageRow: visibleImageRow
+    visibleImageRow: visibleImageRow,
+    scrollLinesFromBottom: scrollLinesFromBottom,
+    scrollLineForDistance: scrollLineForDistance,
+    graphicsMemoryFits: graphicsMemoryFits,
+    graphicsAttemptAfterDenied: graphicsAttemptAfterDenied
   };
 }));

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -1017,17 +1017,23 @@
   // xterm.js 5 does not understand Kitty and cannot safely resolve file-backed Kitty transfers
   // from the host machine. BossTerm therefore sends normalized PNG/image bytes plus its exact
   // ImageCell placement grid; this transparent canvas mirrors the native renderer cell-for-cell.
-  var MAX_PANE_GRAPHICS_BYTES = 50 * 1024 * 1024; // matches each BossTerm terminal cache
-  var MAX_VIEWER_GRAPHICS_BYTES = 128 * 1024 * 1024; // hard bound across all shared panes
+  var MAX_PANE_GRAPHICS_BYTES = 16 * 1024 * 1024; // matches the host's web-raster budget
+  var MAX_VIEWER_GRAPHICS_BYTES = 64 * 1024 * 1024; // hard bound across all shared panes
   // PaneSnapshot replaces this compatibility fallback with the pane's real host history cap
   // before painting. Matching caps keep SharedImageCellRun absolute rows aligned after trims.
   var DEFAULT_WEB_VIEWER_SCROLLBACK_LINES = 10000;
+  var MAX_WEB_VIEWER_SCROLLBACK_LINES = 100000;
+  var ALLOWED_GRAPHICS_MIME_TYPES = {
+    "image/png": true, "image/jpeg": true, "image/gif": true,
+    "image/bmp": true, "image/webp": true
+  };
   var MAX_GRAPHICS_RESYNCS = 3;
   var GRAPHICS_RESYNC_TIMEOUT_MS = 3000;
   var viewerGraphicsBytes = 0;
 
   function newGraphicsState() {
     return { revision: null, cells: [], images: {}, pending: {}, bytes: 0, canvas: null, raf: 0,
+             historyLines: null,
              rejected: {}, resyncPending: false, resyncAttempts: 0, resyncTimer: null,
              resyncDegraded: false };
   }
@@ -1160,13 +1166,17 @@
 
     var buffer = p.term.buffer.active;
     var viewportY = buffer.viewportY || 0;
+    var hostHistoryLines = typeof g.historyLines === "number" ? g.historyLines : buffer.baseY;
+    var rowOffset = buffer.baseY - hostHistoryLines;
     var cellW = rect.width / p.term.cols;
     var cellH = rect.height / p.term.rows;
     g.cells.forEach(function (run) {
       var cached = g.images[String(run.imageId)];
       var image = cached && cached.image;
       if (!image || !image.complete || !image.naturalWidth || !image.naturalHeight) return;
-      var visibleRow = run.row - viewportY;
+      // Anchor host absolute rows to xterm's current baseY. If best-effort output was dropped,
+      // the overlay remains aligned to the live screen instead of drifting by the missing rows.
+      var visibleRow = run.row + rowOffset - viewportY;
       if (visibleRow < 0 || visibleRow >= p.term.rows) return;
       var anchorCol = run.col - run.cellX;
       var availableCols = Math.max(1, p.term.cols - anchorCol);
@@ -1322,10 +1332,14 @@
         retryBudgetRejectedImages();
         scheduleGraphicsDraw(p);
       };
-      image.src = "data:" + (wire.mimeType || "image/png") + ";base64," + wire.data;
+      var mimeType = ALLOWED_GRAPHICS_MIME_TYPES[wire.mimeType] ? wire.mimeType : "image/png";
+      image.src = "data:" + mimeType + ";base64," + wire.data;
     });
     if (freedBudget) retryBudgetRejectedImages();
     g.cells = m.cells || [];
+    if (typeof m.historyLines === "number" && m.historyLines >= 0) {
+      g.historyLines = m.historyLines;
+    }
     g.revision = m.revision;
     var missing = Object.keys(required).some(function (id) {
       return !g.images[id] && !g.pending[id] && !g.rejected[id];
@@ -2307,7 +2321,10 @@
       case "paneSnapshot": {
         var p = getPane(m.paneId);
         if (typeof m.scrollbackLines === "number" && m.scrollbackLines >= 0) {
-          p.term.options.scrollback = Math.floor(m.scrollbackLines);
+          p.term.options.scrollback = Math.min(
+            MAX_WEB_VIEWER_SCROLLBACK_LINES,
+            Math.floor(m.scrollbackLines)
+          );
         }
         if (m.cols && m.rows) p.term.resize(m.cols, m.rows);
         p.term.reset();

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -10,6 +10,17 @@
   "use strict";
 
   var viewerLogic = window.BossTermViewerLogic;
+  if (!viewerLogic) {
+    // Same origin and same cache policy as this file, so this should be unreachable — but every
+    // reconnect/graphics path below dereferences it, and a bare TypeError deep inside a socket
+    // callback reads as "the share is broken". Fail once, legibly, instead.
+    var logicError = document.createElement("div");
+    logicError.style.padding = "24px";
+    logicError.style.font = "13px -apple-system, Menlo, monospace";
+    logicError.textContent = "The viewer failed to load (viewer-logic.js). Reload to try again.";
+    (document.body || document.documentElement).appendChild(logicError);
+    return;
+  }
   var params = new URLSearchParams(location.search);
   var token = params.get("t");
 
@@ -984,14 +995,20 @@
     }, RECONNECT_STABLE_MS);
   }
 
+  // Drop a pending "this connection settled" timer. A session that ended for good must not leave
+  // one armed to hand a dead socket a fresh retry budget.
+  function disarmConnectionHealth() {
+    if (reconnectStableTimer) clearTimeout(reconnectStableTimer);
+    reconnectStableTimer = null;
+  }
+
   // Retry a transient drop before asking the user.
   function handleConnectionLost(socket) {
     if (socket && ws !== socket) return; // stale event from a superseded connection
     if (socket) ws = null;               // disarm its pending encrypt/decrypt callbacks
     setStatus("down");
     if (sessionEnded || reconnectTimer) return;
-    if (reconnectStableTimer) clearTimeout(reconnectStableTimer);
-    reconnectStableTimer = null;
+    disarmConnectionHealth();
     var decision = viewerLogic.nextReconnectAttempt(reconnectAttempt, MAX_AUTO_RECONNECTS);
     if (!decision.retry) {
       showDisconnected();
@@ -1044,11 +1061,12 @@
              resyncDegraded: false };
   }
 
-  function disposeGraphics(p) {
+  function disposeGraphics(paneId, p) {
     if (!p || !p.graphics) return;
     var g = p.graphics;
     if (g.raf) cancelAnimationFrame(g.raf);
     if (g.resyncTimer) clearTimeout(g.resyncTimer);
+    clearGraphicsDegraded(paneId, g); // a closed pane must not keep warning about its graphics
     Object.keys(g.pending).forEach(function (id) { removePendingGraphicsImage(g, id); });
     Object.keys(g.images).forEach(function (id) { removeGraphicsImage(g, id); });
     if (g.canvas && g.canvas.parentNode) g.canvas.parentNode.removeChild(g.canvas);
@@ -1146,8 +1164,13 @@
 
   function scheduleGraphicsDraw(p) {
     if (!p || !p.graphics || p.graphics.raf) return;
-    p.graphics.raf = requestAnimationFrame(function () {
-      p.graphics.raf = 0;
+    var g = p.graphics;
+    // onRender/onScroll/onResize fire for every pane, and the overwhelming majority never carry
+    // graphics. With nothing placed, nothing decoding, and no canvas left to tear down there is
+    // no frame to draw — skip it rather than queue one rAF per render per pane.
+    if (!g.cells.length && !g.canvas && !Object.keys(g.pending).length) return;
+    g.raf = requestAnimationFrame(function () {
+      g.raf = 0;
       drawPaneGraphics(p);
     });
   }
@@ -1226,12 +1249,25 @@
     }
   }
 
+  // The status dot is shared by every pane, so its tooltip tracks the SET of degraded panes:
+  // one pane recovering must not clear the warning while another is still out of sync.
+  var degradedGraphicsPanes = {};
+  function updateGraphicsStatusTitle() {
+    var degraded = Object.keys(degradedGraphicsPanes).length;
+    statusEl.title = degraded
+      ? (degraded === 1 ? "Terminal graphics are temporarily out of sync in one pane; live output is unaffected."
+                        : "Terminal graphics are temporarily out of sync in " + degraded +
+                          " panes; live output is unaffected.")
+      : "";
+  }
+
   function requestGraphicsResync(paneId, g) {
     if (g.resyncPending) return;
     if (g.resyncAttempts >= MAX_GRAPHICS_RESYNCS) {
       if (!g.resyncDegraded) {
         g.resyncDegraded = true;
-        statusEl.title = "Terminal graphics are temporarily out of sync; live output is unaffected.";
+        degradedGraphicsPanes[paneId] = true;
+        updateGraphicsStatusTitle();
       }
       return;
     }
@@ -1268,15 +1304,19 @@
     }, retryAfterMs);
   }
 
-  function resetGraphicsResync(g) {
+  function resetGraphicsResync(paneId, g) {
     if (g.resyncTimer) clearTimeout(g.resyncTimer);
     g.resyncTimer = null;
     g.resyncPending = false;
     g.resyncAttempts = 0;
-    if (g.resyncDegraded) {
-      g.resyncDegraded = false;
-      statusEl.title = "";
-    }
+    clearGraphicsDegraded(paneId, g);
+  }
+
+  function clearGraphicsDegraded(paneId, g) {
+    if (!g.resyncDegraded) return;
+    g.resyncDegraded = false;
+    delete degradedGraphicsPanes[paneId];
+    updateGraphicsStatusTitle();
   }
 
   function retryBudgetRejectedImages(skipPaneId, skipImageId) {
@@ -1428,7 +1468,7 @@
       return !g.images[id] && !g.pending[id] && !g.rejected[id];
     });
     if (revisionGap || missing) requestGraphicsResync(m.paneId, g);
-    else resetGraphicsResync(g);
+    else resetGraphicsResync(m.paneId, g);
     scheduleGraphicsDraw(p);
   }
 
@@ -2289,7 +2329,7 @@
     m.tabs.forEach(function (t) { collectPaneIds(t.tree, live); });
     Object.keys(panes).forEach(function (id) {
       if (!live[id]) {
-        disposeGraphics(panes[id]);
+        disposeGraphics(id, panes[id]);
         try { panes[id].term.dispose(); } catch (e) {}
         delete panes[id];
       }

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -9,6 +9,7 @@
 (function () {
   "use strict";
 
+  var viewerLogic = window.BossTermViewerLogic;
   var params = new URLSearchParams(location.search);
   var token = params.get("t");
 
@@ -991,11 +992,12 @@
     if (sessionEnded || reconnectTimer) return;
     if (reconnectStableTimer) clearTimeout(reconnectStableTimer);
     reconnectStableTimer = null;
-    if (reconnectAttempt >= MAX_AUTO_RECONNECTS) {
+    var decision = viewerLogic.nextReconnectAttempt(reconnectAttempt, MAX_AUTO_RECONNECTS);
+    if (!decision.retry) {
       showDisconnected();
       return;
     }
-    reconnectAttempt += 1;
+    reconnectAttempt = decision.attempt;
     var attempt = reconnectAttempt;
     showOverlay(
       "Reconnecting…",
@@ -1033,7 +1035,7 @@
 
   function newGraphicsState() {
     return { revision: null, cells: [], images: {}, pending: {}, bytes: 0, canvas: null, raf: 0,
-             historyLines: null,
+             historyLines: null, rowOffset: 0,
              rejected: {}, resyncPending: false, resyncAttempts: 0, resyncTimer: null,
              resyncDegraded: false };
   }
@@ -1166,8 +1168,6 @@
 
     var buffer = p.term.buffer.active;
     var viewportY = buffer.viewportY || 0;
-    var hostHistoryLines = typeof g.historyLines === "number" ? g.historyLines : buffer.baseY;
-    var rowOffset = buffer.baseY - hostHistoryLines;
     var cellW = rect.width / p.term.cols;
     var cellH = rect.height / p.term.rows;
     g.cells.forEach(function (run) {
@@ -1176,7 +1176,7 @@
       if (!image || !image.complete || !image.naturalWidth || !image.naturalHeight) return;
       // Anchor host absolute rows to xterm's current baseY. If best-effort output was dropped,
       // the overlay remains aligned to the live screen instead of drifting by the missing rows.
-      var visibleRow = run.row + rowOffset - viewportY;
+      var visibleRow = viewerLogic.visibleImageRow(run.row, g.rowOffset, viewportY);
       if (visibleRow < 0 || visibleRow >= p.term.rows) return;
       var anchorCol = run.col - run.cellX;
       var availableCols = Math.max(1, p.term.cols - anchorCol);
@@ -1184,15 +1184,14 @@
       var effectiveRows = Math.max(1, Math.round(Math.max(1, run.totalCellsY) *
         effectiveCols / Math.max(1, run.totalCellsX)));
       if (run.cellY < 0 || run.cellY >= effectiveRows) return;
-      var start = Math.max(0, -run.col, -run.cellX);
       var length = Math.min(
-        run.length - start,
-        p.term.cols - (run.col + start),
-        effectiveCols - (run.cellX + start)
+        run.length,
+        p.term.cols - run.col,
+        effectiveCols - run.cellX
       );
       if (length <= 0) return;
-      var sourceCellX = run.cellX + start;
-      var destCol = run.col + start;
+      var sourceCellX = run.cellX;
+      var destCol = run.col;
       var sx1 = Math.floor(sourceCellX * image.naturalWidth / effectiveCols);
       var sx2 = Math.floor((sourceCellX + length) * image.naturalWidth / effectiveCols);
       var sy1 = Math.floor(run.cellY * image.naturalHeight / effectiveRows);
@@ -1341,6 +1340,23 @@
       g.historyLines = m.historyLines;
     }
     g.revision = m.revision;
+    if (g.historyLines !== null) {
+      var appliedGraphicsRevision = g.revision;
+      g.rowOffset = viewerLogic.captureRowOffset(
+        p.term.buffer.active.baseY,
+        g.historyLines
+      );
+      // Capture once after all previously queued xterm writes have drained. Recomputing this from
+      // live baseY during every draw would pin old images to the viewport as ordinary output scrolls.
+      p.term.write("", function () {
+        if (g.revision !== appliedGraphicsRevision) return;
+        g.rowOffset = viewerLogic.captureRowOffset(
+          p.term.buffer.active.baseY,
+          g.historyLines
+        );
+        scheduleGraphicsDraw(p);
+      });
+    }
     var missing = Object.keys(required).some(function (id) {
       return !g.images[id] && !g.pending[id] && !g.rejected[id];
     });

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -1019,8 +1019,11 @@
   // xterm.js 5 does not understand Kitty and cannot safely resolve file-backed Kitty transfers
   // from the host machine. BossTerm therefore sends normalized PNG/image bytes plus its exact
   // ImageCell placement grid; this transparent canvas mirrors the native renderer cell-for-cell.
-  var MAX_PANE_GRAPHICS_BYTES = 16 * 1024 * 1024; // matches the host's web-raster budget
-  var MAX_VIEWER_GRAPHICS_BYTES = 64 * 1024 * 1024; // hard bound across all shared panes
+  // The host separately caps encoded wire rasters at 16 MiB per pane. Browser memory also holds
+  // decoded RGBA, which can be much larger than PNG/JPEG bytes, so its bounded heap limits must
+  // leave room for normal compression ratios.
+  var MAX_PANE_GRAPHICS_BYTES = 96 * 1024 * 1024;
+  var MAX_VIEWER_GRAPHICS_BYTES = 192 * 1024 * 1024;
   // PaneSnapshot replaces this compatibility fallback with the pane's real host history cap
   // before painting. Matching caps keep SharedImageCellRun absolute rows aligned after trims.
   var DEFAULT_WEB_VIEWER_SCROLLBACK_LINES = 10000;
@@ -2401,7 +2404,22 @@
     // WebSocket failures emit error then close. Only close consumes a retry so the pair cannot
     // double-count one failure; error updates the status immediately while close schedules it.
     socket.onerror = function () { if (ws === socket) setStatus("down"); };
-    socket.onclose = function () { handleConnectionLost(socket); };
+    socket.onclose = function (ev) {
+      if (ws !== socket) return;
+      if (viewerLogic.isTerminalWebSocketClose(ev && ev.code)) {
+        disarmConnectionHealth();
+        ws = null;
+        sessionEnded = true;
+        setStatus("down");
+        showOverlay(
+          "Connection ended",
+          (ev && ev.reason) || "The shared session is unavailable or no longer accepts this link.",
+          false
+        );
+        return;
+      }
+      handleConnectionLost(socket);
+    };
   }
 
   function dispatch(m) {
@@ -2452,24 +2470,13 @@
       case "paneRepaint":
         if (m.data) {
           var repaintPane = getPane(m.paneId);
-          // Enter xterm's write queue before measuring so prior paneOutput frames are reflected in
-          // baseY/viewportY. The repaint remains ordered while preserving the reader's position.
-          repaintPane.term.write("", function () {
-            var activeBuffer = repaintPane.term.buffer.active;
-            var restoreLinesFromBottom = viewerLogic.scrollLinesFromBottom(
-              activeBuffer.baseY,
-              activeBuffer.viewportY
-            );
-            repaintPane.term.write(m.data, function () {
-              if (restoreLinesFromBottom > 0) {
-                var updated = repaintPane.term.buffer.active;
-                repaintPane.term.scrollToLine(
-                  viewerLogic.scrollLineForDistance(updated.baseY, restoreLinesFromBottom)
-                );
-              }
-              scheduleGraphicsDraw(repaintPane);
-            });
-          });
+          viewerLogic.queuePaneRepaint(
+            function (data, callback) { repaintPane.term.write(data, callback); },
+            function () { return repaintPane.term.buffer.active; },
+            function (line) { repaintPane.term.scrollToLine(line); },
+            m.data,
+            function () { scheduleGraphicsDraw(repaintPane); }
+          );
         }
         break;
       case "paneGraphics": applyPaneGraphics(m); break;

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -66,18 +66,18 @@
     });
   }
   // Frame = nonce(12) || AES-256-GCM(ciphertext||tag), AAD = 1 direction byte (0x00 c2s, 0x01 s2c).
-  function encryptFrame(text) {
+  function encryptFrame(text, state) {
     var iv = randBytes(12);
     return crypto.subtle.encrypt(
       { name: "AES-GCM", iv: iv, additionalData: new Uint8Array([0x00]), tagLength: 128 },
-      crypState.kc2s, enc.encode(text)
+      state.kc2s, enc.encode(text)
     ).then(function (ct) { return concatBytes(iv, new Uint8Array(ct)).buffer; });
   }
-  function decryptFrame(buf) {
+  function decryptFrame(buf, state) {
     var u = new Uint8Array(buf), iv = u.subarray(0, 12), body = u.subarray(12);
     return crypto.subtle.decrypt(
       { name: "AES-GCM", iv: iv, additionalData: new Uint8Array([0x01]), tagLength: 128 },
-      crypState.ks2c, body
+      state.ks2c, body
     ).then(function (pt) { return dec.decode(pt); });
   }
   // Show the verification code (first 8 hex of SHA-256 of the secret) so the user can compare
@@ -101,13 +101,15 @@
     return diff === 0;
   }
   var cryptoFailed = false;
-  function onCryptoFailure() {
+  function onCryptoFailure(socket) {
+    // A promise from a socket that already dropped must not poison its replacement.
+    if (socket && ws !== socket) return;
     if (cryptoFailed) return;
     cryptoFailed = true;
     sessionEnded = true; // terminal — don't let "Disconnected" overwrite it
     showOverlay("This link is missing its key",
       "Re-copy the full share link from BossTerm — it must include the part after #.", false);
-    try { ws.close(); } catch (e) {}
+    try { (socket || ws).close(); } catch (e) {}
   }
 
   var statusEl = document.getElementById("status");
@@ -252,12 +254,16 @@
   // rapid keystrokes can't be reordered by async encrypt resolution. Plaintext: send directly.
   function sendMsg(o) {
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    var socket = ws;
     if (canE2E) {
-      sendChain = sendChain.then(function () { return encryptFrame(JSON.stringify(o)); })
-        .then(function (buf) { if (ws && ws.readyState === WebSocket.OPEN) ws.send(buf); })
-        .catch(function () { onCryptoFailure(); }); // never silently drop a keystroke
+      var state = crypState;
+      sendChain = sendChain.then(function () { return encryptFrame(JSON.stringify(o), state); })
+        .then(function (buf) {
+          if (ws === socket && socket.readyState === WebSocket.OPEN) socket.send(buf);
+        })
+        .catch(function () { onCryptoFailure(socket); }); // never silently drop a keystroke
     } else {
-      ws.send(JSON.stringify(o));
+      socket.send(JSON.stringify(o));
     }
   }
 
@@ -501,6 +507,7 @@
     requestAnimationFrame(function () {
       var sc = p.host.querySelector(".xterm-screen");
       if (sc) { var w = Math.ceil(sc.getBoundingClientRect().width); if (w > 0) p.host.style.width = w + "px"; }
+      scheduleGraphicsDraw(p);
     });
   }
   function softKeyboardUp() {
@@ -509,6 +516,7 @@
   }
   function onViewportChange() {
     relayoutSinglePane();
+    Object.keys(panes).forEach(function (id) { scheduleGraphicsDraw(panes[id]); });
     autoFitPending = true;
     maybeAutoFit();
   }
@@ -525,7 +533,10 @@
   function curFont() { return viewerFont || (theme && theme.fontSize) || 13; }
   function applyFont(px) {
     viewerFont = Math.max(6, Math.min(40, Math.round(px)));
-    Object.keys(panes).forEach(function (id) { try { panes[id].term.options.fontSize = viewerFont; } catch (e) {} });
+    Object.keys(panes).forEach(function (id) {
+      try { panes[id].term.options.fontSize = viewerFont; } catch (e) {}
+      scheduleGraphicsDraw(panes[id]);
+    });
     relayoutSinglePane();
   }
   // Fit the active pane's font so the whole width shows (zoom-out to fit).
@@ -913,9 +924,13 @@
   function hideOverlay() { overlayEl.style.display = "none"; }
 
   var sessionEnded = false;   // host denied/expired → don't offer a pointless reconnect
-  var disconnectShown = false; // de-dupe onerror + onclose firing together
-  // The link dropped (host stopped sharing, network blip, etc.): tell the user instead of
-  // just flipping the status dot red, and offer to reconnect (reload) or close.
+  var disconnectShown = false; // final prompt is shown at most once
+  var reconnectAttempt = 0;
+  var reconnectTimer = null;
+  var connectionWasHealthy = false; // a Layout arrived on this connection
+  var MAX_AUTO_RECONNECTS = 3;
+  // The automatic budget is exhausted: offer a manual retry (which reloads the page and gives
+  // it a fresh budget) or close. Terminal failures such as denial / bad E2E keys never get here.
   function showDisconnected() {
     setStatus("down");
     if (sessionEnded || disconnectShown) return;
@@ -925,12 +940,218 @@
       { label: "Close", onClick: function () {
           window.close(); // ignored for user-opened tabs — fall back to a hint
           showOverlay("Disconnected", "You can close this tab.", false, []);
-        } }
+      } }
     ]);
+  }
+  // Retry a transient drop before asking the user. A connection that rendered a Layout was
+  // healthy, so it receives a fresh three-attempt budget just like the native remote client.
+  function handleConnectionLost(socket) {
+    if (socket && ws !== socket) return; // stale event from a superseded connection
+    if (socket) ws = null;               // disarm its pending encrypt/decrypt callbacks
+    setStatus("down");
+    if (sessionEnded || reconnectTimer) return;
+    if (connectionWasHealthy) {
+      reconnectAttempt = 0;
+      connectionWasHealthy = false;
+    }
+    if (reconnectAttempt >= MAX_AUTO_RECONNECTS) {
+      showDisconnected();
+      return;
+    }
+    reconnectAttempt += 1;
+    var attempt = reconnectAttempt;
+    showOverlay(
+      "Reconnecting…",
+      "The connection was lost. Automatic attempt " + attempt + " of " + MAX_AUTO_RECONNECTS + ".",
+      true
+    );
+    reconnectTimer = setTimeout(function () {
+      reconnectTimer = null;
+      if (!sessionEnded) connectWebSocket();
+    }, attempt * 1500);
   }
 
   function deviceName() {
     return localStorage.getItem("bossterm.name") || navigator.platform || "browser";
+  }
+
+  // ---- host-decoded Sixel / Kitty graphics ----
+  // xterm.js 5 does not understand Kitty and cannot safely resolve file-backed Kitty transfers
+  // from the host machine. BossTerm therefore sends normalized PNG/image bytes plus its exact
+  // ImageCell placement grid; this transparent canvas mirrors the native renderer cell-for-cell.
+  var MAX_PANE_GRAPHICS_BYTES = 50 * 1024 * 1024; // matches each BossTerm terminal cache
+  var MAX_VIEWER_GRAPHICS_BYTES = 128 * 1024 * 1024; // hard bound across all shared panes
+  var viewerGraphicsBytes = 0;
+
+  function newGraphicsState() {
+    return { revision: null, cells: [], images: {}, bytes: 0, canvas: null, raf: 0,
+             rejected: {}, resyncPending: false };
+  }
+
+  function disposeGraphics(p) {
+    if (!p || !p.graphics) return;
+    var g = p.graphics;
+    if (g.raf) cancelAnimationFrame(g.raf);
+    Object.keys(g.images).forEach(function (id) { removeGraphicsImage(g, id); });
+    if (g.canvas && g.canvas.parentNode) g.canvas.parentNode.removeChild(g.canvas);
+    g.images = {}; g.cells = []; g.bytes = 0; g.canvas = null; g.raf = 0;
+  }
+
+  function removeGraphicsImage(g, id) {
+    var item = g.images[id];
+    if (!item) return;
+    if (item.image) { item.image.onload = null; item.image.onerror = null; }
+    g.bytes = Math.max(0, g.bytes - item.bytes);
+    viewerGraphicsBytes = Math.max(0, viewerGraphicsBytes - item.bytes);
+    delete g.images[id];
+  }
+
+  function base64Bytes(data) {
+    if (!data) return 0;
+    var padding = data.endsWith("==") ? 2 : (data.endsWith("=") ? 1 : 0);
+    return Math.max(0, Math.floor(data.length * 3 / 4) - padding);
+  }
+
+  function ensureGraphicsCanvas(p) {
+    var screen = p.host.querySelector(".xterm-screen");
+    if (!screen) return null;
+    var g = p.graphics;
+    if (!g.canvas) {
+      var canvas = document.createElement("canvas");
+      canvas.className = "bossterm-graphics";
+      canvas.setAttribute("aria-hidden", "true");
+      canvas.style.position = "absolute";
+      canvas.style.inset = "0";
+      canvas.style.pointerEvents = "none";
+      g.canvas = canvas;
+    }
+    if (g.canvas.parentNode !== screen) {
+      // Keep images below xterm's glyph/selection/cursor renderer. The terminal's default
+      // background is transparent; the term host supplies the opaque theme background.
+      screen.insertBefore(g.canvas, screen.querySelector("canvas"));
+    }
+    return g.canvas;
+  }
+
+  function scheduleGraphicsDraw(p) {
+    if (!p || !p.graphics || p.graphics.raf) return;
+    p.graphics.raf = requestAnimationFrame(function () {
+      p.graphics.raf = 0;
+      drawPaneGraphics(p);
+    });
+  }
+
+  function drawPaneGraphics(p) {
+    var g = p.graphics, canvas = ensureGraphicsCanvas(p);
+    if (!canvas) return;
+    var screen = p.host.querySelector(".xterm-screen");
+    var rect = screen && screen.getBoundingClientRect();
+    if (!rect || !(rect.width > 0) || !(rect.height > 0)) return;
+    var scale = window.devicePixelRatio || 1;
+    var pixelW = Math.max(1, Math.round(rect.width * scale));
+    var pixelH = Math.max(1, Math.round(rect.height * scale));
+    if (canvas.width !== pixelW) canvas.width = pixelW;
+    if (canvas.height !== pixelH) canvas.height = pixelH;
+    canvas.style.width = rect.width + "px";
+    canvas.style.height = rect.height + "px";
+    var ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(scale, 0, 0, scale, 0, 0);
+    ctx.clearRect(0, 0, rect.width, rect.height);
+    if (!g.cells.length || !p.term.cols || !p.term.rows) return;
+
+    var buffer = p.term.buffer.active;
+    var baseY = buffer.baseY || 0;
+    var viewportY = buffer.viewportY || 0;
+    var cellW = rect.width / p.term.cols;
+    var cellH = rect.height / p.term.rows;
+    g.cells.forEach(function (run) {
+      var cached = g.images[String(run.imageId)];
+      var image = cached && cached.image;
+      if (!image || !image.complete || !image.naturalWidth || !image.naturalHeight) return;
+      var visibleRow = baseY + run.row - viewportY;
+      if (visibleRow < 0 || visibleRow >= p.term.rows) return;
+      var anchorCol = run.col - run.cellX;
+      var availableCols = Math.max(1, p.term.cols - anchorCol);
+      var effectiveCols = Math.min(Math.max(1, run.totalCellsX), availableCols);
+      var effectiveRows = Math.max(1, Math.round(Math.max(1, run.totalCellsY) *
+        effectiveCols / Math.max(1, run.totalCellsX)));
+      for (var i = 0; i < run.length; i++) {
+        var sourceCellX = run.cellX + i;
+        var destCol = run.col + i;
+        if (destCol < 0 || destCol >= p.term.cols ||
+            sourceCellX < 0 || sourceCellX >= effectiveCols ||
+            run.cellY < 0 || run.cellY >= effectiveRows) continue;
+        var sx1 = Math.floor(sourceCellX * image.naturalWidth / effectiveCols);
+        var sx2 = Math.floor((sourceCellX + 1) * image.naturalWidth / effectiveCols);
+        var sy1 = Math.floor(run.cellY * image.naturalHeight / effectiveRows);
+        var sy2 = Math.floor((run.cellY + 1) * image.naturalHeight / effectiveRows);
+        ctx.drawImage(
+          image, sx1, sy1, Math.max(1, sx2 - sx1), Math.max(1, sy2 - sy1),
+          destCol * cellW, visibleRow * cellH, cellW, cellH
+        );
+      }
+    });
+  }
+
+  function requestGraphicsResync(paneId, g) {
+    if (g.resyncPending) return;
+    g.resyncPending = true;
+    sendMsg({ t: "graphicsResync", paneId: paneId });
+  }
+
+  function applyPaneGraphics(m) {
+    var p = getPane(m.paneId), g = p.graphics;
+    var required = {};
+    (m.requiredImageIds || []).forEach(function (id) { required[String(id)] = true; });
+    var revisionGap = !m.full && g.revision !== null && m.revision !== g.revision + 1;
+
+    if (m.full) {
+      Object.keys(g.images).forEach(function (id) {
+        if (!required[id]) removeGraphicsImage(g, id);
+      });
+      Object.keys(g.rejected).forEach(function (id) {
+        if (!required[id]) delete g.rejected[id];
+      });
+      g.resyncPending = false;
+    }
+    (m.removedImageIds || []).forEach(function (id) {
+      id = String(id);
+      removeGraphicsImage(g, id);
+      delete g.rejected[id];
+    });
+    (m.images || []).forEach(function (wire) {
+      var id = String(wire.id), old = g.images[id];
+      if (old && old.hash === wire.contentHash) return;
+      if (old) removeGraphicsImage(g, id);
+      delete g.rejected[id];
+      var bytes = base64Bytes(wire.data);
+      // Host-side caches are bounded too. If aggregate pane state exceeds the browser budget,
+      // omit that raster (and remember the rejection) instead of retry-looping or growing forever.
+      if (bytes > MAX_PANE_GRAPHICS_BYTES || g.bytes + bytes > MAX_PANE_GRAPHICS_BYTES ||
+          viewerGraphicsBytes + bytes > MAX_VIEWER_GRAPHICS_BYTES) {
+        g.rejected[id] = true;
+        return;
+      }
+      var image = new Image();
+      var item = { image: image, hash: wire.contentHash, bytes: bytes };
+      g.images[id] = item;
+      g.bytes += bytes;
+      viewerGraphicsBytes += bytes;
+      image.onload = function () { scheduleGraphicsDraw(p); };
+      image.onerror = function () {
+        if (g.images[id] === item) removeGraphicsImage(g, id);
+        requestGraphicsResync(m.paneId, g);
+      };
+      image.src = "data:" + (wire.mimeType || "image/png") + ";base64," + wire.data;
+    });
+    g.cells = m.cells || [];
+    g.revision = m.revision;
+    var missing = Object.keys(required).some(function (id) {
+      return !g.images[id] && !g.rejected[id];
+    });
+    if (revisionGap || missing) requestGraphicsResync(m.paneId, g);
+    scheduleGraphicsDraw(p);
   }
 
   // ---- xterm pool ----
@@ -940,9 +1161,11 @@
     var host = document.createElement("div");
     host.className = "termhost";
     var opts = { cursorBlink: true, convertEol: false, scrollback: 5000,
+                 allowTransparency: true,
                  fontFamily: "Menlo, Monaco, monospace", fontSize: 13,
-                 theme: { background: "#1e1e1e", foreground: "#f8f8f2" } };
+                 theme: { background: "rgba(0,0,0,0)", foreground: "#f8f8f2" } };
     if (theme) applyThemeToOpts(opts);
+    host.style.background = (theme && theme.background) || "#1e1e1e";
     var term = new Terminal(opts);
     term.open(host);
     // GPU rendering (WebGL addon) — the DOM renderer rebuilds row nodes on every scroll
@@ -985,7 +1208,10 @@
       followRaf = requestAnimationFrame(function () { followRaf = 0; followCursor(); });
     });
     attachTouchScroll(host, term);
-    p = { term: term, host: host };
+    p = { term: term, host: host, graphics: newGraphicsState() };
+    term.onRender(function () { scheduleGraphicsDraw(p); });
+    term.onScroll(function () { scheduleGraphicsDraw(p); });
+    term.onResize(function () { scheduleGraphicsDraw(p); });
     panes[paneId] = p;
     return p;
   }
@@ -1066,7 +1292,7 @@
   function applyThemeToOpts(opts) {
     var a = theme.ansi || [];
     opts.theme = {
-      background: theme.background, foreground: theme.foreground, cursor: theme.cursor,
+      background: "rgba(0,0,0,0)", foreground: theme.foreground, cursor: theme.cursor,
       cursorAccent: theme.cursorAccent, selectionBackground: theme.selectionBackground,
       black: a[0], red: a[1], green: a[2], yellow: a[3], blue: a[4], magenta: a[5], cyan: a[6], white: a[7],
       brightBlack: a[8], brightRed: a[9], brightGreen: a[10], brightYellow: a[11],
@@ -1082,6 +1308,7 @@
       var o = {}; applyThemeToOpts(o);
       var t = panes[id].term;
       t.options.theme = o.theme;
+      panes[id].host.style.background = m.background || "#1e1e1e";
       if (o.fontFamily) t.options.fontFamily = o.fontFamily;
       if (o.fontSize) t.options.fontSize = o.fontSize;
     });
@@ -1092,6 +1319,7 @@
     }
     // The host theme may carry a fontSize; keep the viewer's chosen zoom if set.
     if (viewerFont) Object.keys(panes).forEach(function (id) { try { panes[id].term.options.fontSize = viewerFont; } catch (e) {} });
+    Object.keys(panes).forEach(function (id) { scheduleGraphicsDraw(panes[id]); });
     relayoutSinglePane();
   }
 
@@ -1744,6 +1972,7 @@
   }
 
   function onLayout(m) {
+    connectionWasHealthy = true;
     layout = m;
     tabBarOnLeft = !!m.tabBarOnLeft;
     summaryMode = !!m.summaryMode;
@@ -1755,7 +1984,11 @@
     var live = {};
     m.tabs.forEach(function (t) { collectPaneIds(t.tree, live); });
     Object.keys(panes).forEach(function (id) {
-      if (!live[id]) { try { panes[id].term.dispose(); } catch (e) {} delete panes[id]; }
+      if (!live[id]) {
+        disposeGraphics(panes[id]);
+        try { panes[id].term.dispose(); } catch (e) {}
+        delete panes[id];
+      }
     });
     renderTabBar();
     // Mid divider-drag, the host echoes ratio changes back as layouts — don't rebuild the
@@ -1778,53 +2011,97 @@
 
   // ---- websocket ----
   var wsProto = location.protocol === "https:" ? "wss" : "ws";
-  ws = new WebSocket(wsProto + "://" + location.host + "/ws/" + encodeURIComponent(token));
-  if (canE2E) { ws.binaryType = "arraybuffer"; secretBytes = b64urlToBytes(secretB64); saltC = randBytes(16); }
-  var sentHello = false;
-  function sendHello() { sentHello = true; sendMsg({ t: "hello", name: deviceName(), clientId: clientId, key: loadKey() }); }
+  function connectWebSocket() {
+    // Every reconnect gets fresh ordered queues and E2E keys/salts. Pending work from the old
+    // socket captures that socket/state below and is ignored once [ws] points elsewhere.
+    crypState = { ready: false, kc2s: null, ks2c: null };
+    sendChain = Promise.resolve();
+    recvChain = Promise.resolve();
+    saltC = null;
+    var socket;
+    try {
+      socket = new WebSocket(wsProto + "://" + location.host + "/ws/" + encodeURIComponent(token));
+    } catch (e) {
+      ws = null;
+      handleConnectionLost(null);
+      return;
+    }
+    ws = socket;
+    var state = crypState;
+    var sentHello = false;
+    if (canE2E) {
+      socket.binaryType = "arraybuffer";
+      secretBytes = b64urlToBytes(secretB64);
+      saltC = randBytes(16);
+    }
+    var connectionSalt = saltC;
+    function sendHello() {
+      if (ws !== socket || sentHello) return;
+      sentHello = true;
+      sendMsg({
+        t: "hello",
+        name: deviceName(),
+        clientId: clientId,
+        key: loadKey(),
+        capabilities: ["paneGraphicsV1"]
+      });
+    }
 
-  ws.onopen = function () {
-    if (e2eMissing) { onCryptoFailure(); return; } // truncated link — don't downgrade to plaintext
-    setStatus("live");
-    // E2E: open with a plaintext Kex (our salt); the Hello waits until keys are derived from
-    // the host's reply. Plaintext: send the Hello immediately, as before.
-    if (canE2E) ws.send(JSON.stringify({ t: "kex", v: 1, salt: bytesToB64url(saltC) }));
-    else sendHello();
-  };
+    socket.onopen = function () {
+      if (ws !== socket) return;
+      if (e2eMissing) { onCryptoFailure(socket); return; } // truncated link — don't downgrade to plaintext
+      setStatus("live");
+      // E2E: open with a plaintext Kex (our salt); the Hello waits until keys are derived from
+      // the host's reply. Plaintext: send the Hello immediately, as before.
+      if (canE2E) socket.send(JSON.stringify({ t: "kex", v: 1, salt: bytesToB64url(connectionSalt) }));
+      else sendHello();
+    };
 
-  ws.onmessage = function (ev) {
-    // E2E handshake: the host's reply is a plaintext Kex (a string frame). Derive keys, verify
-    // its confirmation tag (wrong/missing #k ⇒ fail loudly), then send the encrypted Hello.
-    if (canE2E && !crypState.ready) {
-      if (typeof ev.data !== "string") return;
-      var k; try { k = JSON.parse(ev.data); } catch (e) { return; }
-      if (k.salt == null) return;
-      if (k.v && k.v !== 1) { // a newer host we can't speak to
-        sessionEnded = true;
-        showOverlay("Update BossTerm", "This session uses a newer encryption version than this viewer.", false);
-        try { ws.close(); } catch (e) {}
+    socket.onmessage = function (ev) {
+      if (ws !== socket) return;
+      // E2E handshake: the host's reply is a plaintext Kex (a string frame). Derive keys, verify
+      // its confirmation tag (wrong/missing #k ⇒ fail loudly), then send the encrypted Hello.
+      if (canE2E && !state.ready) {
+        if (typeof ev.data !== "string") return;
+        var k; try { k = JSON.parse(ev.data); } catch (e) { return; }
+        if (k.salt == null) return;
+        if (k.v && k.v !== 1) { // a newer host we can't speak to
+          sessionEnded = true;
+          showOverlay("Update BossTerm", "This session uses a newer encryption version than this viewer.", false);
+          try { socket.close(); } catch (e) {}
+          return;
+        }
+        deriveSessionKeys(secretBytes, connectionSalt, b64urlToBytes(k.salt)).then(function (keys) {
+          if (ws !== socket) return;
+          if (!constantTimeEq(keys.confirmB64, k.confirm)) { onCryptoFailure(socket); return; }
+          state.kc2s = keys.kc2s; state.ks2c = keys.ks2c; state.ready = true;
+          showE2EBadge();
+          sendHello();
+        }).catch(function () { onCryptoFailure(socket); });
         return;
       }
-      deriveSessionKeys(secretBytes, saltC, b64urlToBytes(k.salt)).then(function (keys) {
-        if (!constantTimeEq(keys.confirmB64, k.confirm)) { onCryptoFailure(); return; }
-        crypState.kc2s = keys.kc2s; crypState.ks2c = keys.ks2c; crypState.ready = true;
-        showE2EBadge();
-        if (!sentHello) sendHello();
-      }).catch(function () { onCryptoFailure(); });
-      return;
-    }
-    // E2E steady state: decrypt (ORDERED, so PaneOutput applies in order) then dispatch.
-    if (canE2E) {
-      recvChain = recvChain.then(function () { return decryptFrame(ev.data); })
-        .then(function (text) { var m; try { m = JSON.parse(text); } catch (e) { return; } dispatch(m); })
-        // A decrypt failure ends the session (onCryptoFailure closes the socket, so no further
-        // frames arrive); don't rethrow — that would leave a dangling unhandled rejection.
-        .catch(function () { onCryptoFailure(); });
-      return;
-    }
-    var m; try { m = JSON.parse(ev.data); } catch (e) { return; }
-    dispatch(m);
-  };
+      // E2E steady state: decrypt (ORDERED, so PaneOutput applies in order) then dispatch.
+      if (canE2E) {
+        recvChain = recvChain.then(function () { return decryptFrame(ev.data, state); })
+          .then(function (text) {
+            if (ws !== socket) return;
+            var m; try { m = JSON.parse(text); } catch (e) { return; }
+            dispatch(m);
+          })
+          // A decrypt failure ends the session (onCryptoFailure closes the socket, so no further
+          // frames arrive); don't rethrow — that would leave a dangling unhandled rejection.
+          .catch(function () { onCryptoFailure(socket); });
+        return;
+      }
+      var m; try { m = JSON.parse(ev.data); } catch (e) { return; }
+      dispatch(m);
+    };
+
+    // WebSocket failures emit error then close. Only close consumes a retry so the pair cannot
+    // double-count one failure; error updates the status immediately while close schedules it.
+    socket.onerror = function () { if (ws === socket) setStatus("down"); };
+    socket.onclose = function () { handleConnectionLost(socket); };
+  }
 
   function dispatch(m) {
     switch (m.t) {
@@ -1849,17 +2126,27 @@
         var p = getPane(m.paneId);
         if (m.cols && m.rows) p.term.resize(m.cols, m.rows);
         p.term.reset();
-        if (m.data) p.term.write(m.data);
+        if (m.data) p.term.write(m.data, function () { scheduleGraphicsDraw(p); });
+        else scheduleGraphicsDraw(p);
         relayoutSinglePane();
         updateDims();
         autoFitPending = true;
         maybeAutoFit();
         break;
       }
-      case "paneOutput": if (m.data) getPane(m.paneId).term.write(m.data); break;
+      case "paneOutput":
+        if (m.data) {
+          var outputPane = getPane(m.paneId);
+          outputPane.term.write(m.data, function () { scheduleGraphicsDraw(outputPane); });
+        }
+        break;
+      case "paneGraphics": applyPaneGraphics(m); break;
       case "paneResize":
         if (m.cols && m.rows) {
-          getPane(m.paneId).term.resize(m.cols, m.rows); relayoutSinglePane(); updateDims();
+          var resizedPane = getPane(m.paneId);
+          resizedPane.term.resize(m.cols, m.rows);
+          scheduleGraphicsDraw(resizedPane);
+          relayoutSinglePane(); updateDims();
           autoFitPending = true;
           maybeAutoFit();
         }
@@ -1907,6 +2194,5 @@
     }
   };
 
-  ws.onclose = showDisconnected;
-  ws.onerror = showDisconnected;
+  connectWebSocket();
 })();

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -491,28 +491,30 @@
     '"BossTerm Nerd Font", "Apple Color Emoji", "Segoe UI Emoji", ' +
     '"Noto Color Emoji", "BossTerm Symbols", monospace';
 
-  // xterm's WebGL renderer caches glyphs. Trigger both bundled downloads eagerly and invalidate
-  // each terminal after they finish so a first frame rendered during the download cannot leave
-  // Nerd Font icons or emoji stuck as missing-glyph boxes.
-  if (document.fonts && typeof document.fonts.load === "function") {
-    Promise.all([
-      document.fonts.load('13px "BossTerm Nerd Font"'),
-      document.fonts.load('13px "BossTerm Symbols"'),
-    ]).then(function () {
-      Object.keys(panes).forEach(function (id) {
-        var p = panes[id], t = p.term;
-        try {
+  // xterm's WebGL renderer caches glyphs. Let CSS fetch the primary/fallback faces only when
+  // content needs them, then invalidate the atlas so icons do not remain missing-glyph boxes.
+  function refreshTerminalFonts(remeasure) {
+    Object.keys(panes).forEach(function (id) {
+      var p = panes[id], t = p.term;
+      try {
+        if (remeasure) {
           var family = t.options.fontFamily;
-          // Force xterm to remeasure cells as well as rebuilding the WebGL glyph atlas.
           t.options.fontFamily = family + " ";
           t.options.fontFamily = family;
-          t.clearTextureAtlas();
-          t.refresh(0, t.rows - 1);
-        } catch (e) {}
-        scheduleGraphicsDraw(p);
-      });
-      relayoutSinglePane();
-    }).catch(function () { /* system fallbacks remain available if a font cannot load */ });
+        }
+        t.clearTextureAtlas();
+        t.refresh(0, t.rows - 1);
+      } catch (e) {}
+      scheduleGraphicsDraw(p);
+    });
+    relayoutSinglePane();
+  }
+  if (document.fonts) {
+    document.fonts.ready.then(function () { refreshTerminalFonts(true); })
+      .catch(function () { /* system fallbacks remain available if a font cannot load */ });
+    if (typeof document.fonts.addEventListener === "function") {
+      document.fonts.addEventListener("loadingdone", function () { refreshTerminalFonts(false); });
+    }
   }
   // Give the active single pane its NATURAL width so a wide host terminal scrolls
   // horizontally inside #stage. (xterm's own viewport is a y-scroll container that clips
@@ -1017,13 +1019,17 @@
   // ImageCell placement grid; this transparent canvas mirrors the native renderer cell-for-cell.
   var MAX_PANE_GRAPHICS_BYTES = 50 * 1024 * 1024; // matches each BossTerm terminal cache
   var MAX_VIEWER_GRAPHICS_BYTES = 128 * 1024 * 1024; // hard bound across all shared panes
+  // SharedImageCellRun rows use the host's absolute buffer index. Keep this equal to
+  // LinesStorage.DEFAULT_MAX_LINES_COUNT; PaneGraphicsTracker explicitly shifts rows on trims.
+  var WEB_VIEWER_SCROLLBACK_LINES = 5000;
   var MAX_GRAPHICS_RESYNCS = 3;
   var GRAPHICS_RESYNC_TIMEOUT_MS = 3000;
   var viewerGraphicsBytes = 0;
 
   function newGraphicsState() {
-    return { revision: null, cells: [], images: {}, bytes: 0, canvas: null, raf: 0,
-             required: {}, rejected: {}, resyncPending: false, resyncAttempts: 0, resyncTimer: null };
+    return { revision: null, cells: [], images: {}, pending: {}, bytes: 0, canvas: null, raf: 0,
+             rejected: {}, resyncPending: false, resyncAttempts: 0, resyncTimer: null,
+             resyncDegraded: false };
   }
 
   function disposeGraphics(p) {
@@ -1031,9 +1037,11 @@
     var g = p.graphics;
     if (g.raf) cancelAnimationFrame(g.raf);
     if (g.resyncTimer) clearTimeout(g.resyncTimer);
+    Object.keys(g.pending).forEach(function (id) { removePendingGraphicsImage(g, id); });
     Object.keys(g.images).forEach(function (id) { removeGraphicsImage(g, id); });
     if (g.canvas && g.canvas.parentNode) g.canvas.parentNode.removeChild(g.canvas);
-    g.images = {}; g.cells = []; g.bytes = 0; g.canvas = null; g.raf = 0; g.resyncTimer = null;
+    g.images = {}; g.pending = {}; g.cells = []; g.bytes = 0; g.canvas = null; g.raf = 0;
+    g.resyncTimer = null;
     setPaneGraphicsMode(p, false);
   }
 
@@ -1044,6 +1052,21 @@
     g.bytes = Math.max(0, g.bytes - item.bytes);
     viewerGraphicsBytes = Math.max(0, viewerGraphicsBytes - item.bytes);
     delete g.images[id];
+  }
+
+  function removePendingGraphicsImage(g, id) {
+    var item = g.pending[id];
+    if (!item) return;
+    if (item.image) { item.image.onload = null; item.image.onerror = null; }
+    g.bytes = Math.max(0, g.bytes - item.bytes);
+    viewerGraphicsBytes = Math.max(0, viewerGraphicsBytes - item.bytes);
+    delete g.pending[id];
+  }
+
+  function graphicsMemoryFits(g, addedBytes, replacedBytes) {
+    return addedBytes <= MAX_PANE_GRAPHICS_BYTES &&
+      g.bytes + addedBytes - (replacedBytes || 0) <= MAX_PANE_GRAPHICS_BYTES &&
+      viewerGraphicsBytes + addedBytes - (replacedBytes || 0) <= MAX_VIEWER_GRAPHICS_BYTES;
   }
 
   function base64Bytes(data) {
@@ -1108,6 +1131,9 @@
       return image && image.complete && image.naturalWidth && image.naturalHeight;
     });
     if (!g.cells.length || !hasDrawableImage) {
+      // Keep the last decoded frame visible while a replacement raster is in flight. Clearing
+      // here would flash the terminal background and rebuild xterm's texture atlas twice.
+      if (g.canvas && Object.keys(g.pending).length) return;
       if (g.canvas && g.canvas.parentNode) g.canvas.parentNode.removeChild(g.canvas);
       g.canvas = null;
       setPaneGraphicsMode(p, false);
@@ -1147,26 +1173,36 @@
       var effectiveCols = Math.min(Math.max(1, run.totalCellsX), availableCols);
       var effectiveRows = Math.max(1, Math.round(Math.max(1, run.totalCellsY) *
         effectiveCols / Math.max(1, run.totalCellsX)));
-      for (var i = 0; i < run.length; i++) {
-        var sourceCellX = run.cellX + i;
-        var destCol = run.col + i;
-        if (destCol < 0 || destCol >= p.term.cols ||
-            sourceCellX < 0 || sourceCellX >= effectiveCols ||
-            run.cellY < 0 || run.cellY >= effectiveRows) continue;
-        var sx1 = Math.floor(sourceCellX * image.naturalWidth / effectiveCols);
-        var sx2 = Math.floor((sourceCellX + 1) * image.naturalWidth / effectiveCols);
-        var sy1 = Math.floor(run.cellY * image.naturalHeight / effectiveRows);
-        var sy2 = Math.floor((run.cellY + 1) * image.naturalHeight / effectiveRows);
-        ctx.drawImage(
-          image, sx1, sy1, Math.max(1, sx2 - sx1), Math.max(1, sy2 - sy1),
-          destCol * cellW, visibleRow * cellH, cellW, cellH
-        );
-      }
+      if (run.cellY < 0 || run.cellY >= effectiveRows) return;
+      var start = Math.max(0, -run.col, -run.cellX);
+      var length = Math.min(
+        run.length - start,
+        p.term.cols - (run.col + start),
+        effectiveCols - (run.cellX + start)
+      );
+      if (length <= 0) return;
+      var sourceCellX = run.cellX + start;
+      var destCol = run.col + start;
+      var sx1 = Math.floor(sourceCellX * image.naturalWidth / effectiveCols);
+      var sx2 = Math.floor((sourceCellX + length) * image.naturalWidth / effectiveCols);
+      var sy1 = Math.floor(run.cellY * image.naturalHeight / effectiveRows);
+      var sy2 = Math.floor((run.cellY + 1) * image.naturalHeight / effectiveRows);
+      ctx.drawImage(
+        image, sx1, sy1, Math.max(1, sx2 - sx1), Math.max(1, sy2 - sy1),
+        destCol * cellW, visibleRow * cellH, length * cellW, cellH
+      );
     });
   }
 
   function requestGraphicsResync(paneId, g) {
-    if (g.resyncPending || g.resyncAttempts >= MAX_GRAPHICS_RESYNCS) return;
+    if (g.resyncPending) return;
+    if (g.resyncAttempts >= MAX_GRAPHICS_RESYNCS) {
+      if (!g.resyncDegraded) {
+        g.resyncDegraded = true;
+        statusEl.title = "Terminal graphics are temporarily out of sync; live output is unaffected.";
+      }
+      return;
+    }
     g.resyncPending = true;
     g.resyncAttempts += 1;
     sendMsg({ t: "graphicsResync", paneId: paneId });
@@ -1174,13 +1210,25 @@
       g.resyncTimer = null;
       g.resyncPending = false;
       requestGraphicsResync(paneId, g);
-    }, GRAPHICS_RESYNC_TIMEOUT_MS);
+    }, GRAPHICS_RESYNC_TIMEOUT_MS * g.resyncAttempts);
   }
 
-  function retryBudgetRejectedImages() {
+  function resetGraphicsResync(g) {
+    if (g.resyncTimer) clearTimeout(g.resyncTimer);
+    g.resyncTimer = null;
+    g.resyncPending = false;
+    g.resyncAttempts = 0;
+    if (g.resyncDegraded) {
+      g.resyncDegraded = false;
+      statusEl.title = "";
+    }
+  }
+
+  function retryBudgetRejectedImages(skipPaneId, skipImageId) {
     Object.keys(panes).forEach(function (paneId) {
       var g = panes[paneId].graphics, cleared = false;
       Object.keys(g.rejected).forEach(function (id) {
+        if (paneId === skipPaneId && id === skipImageId) return;
         if (g.rejected[id].reason === "budget") {
           delete g.rejected[id];
           cleared = true;
@@ -1198,7 +1246,6 @@
     var g = p.graphics;
     var required = {};
     (m.requiredImageIds || []).forEach(function (id) { required[String(id)] = true; });
-    g.required = required;
     var revisionGap = !m.full && g.revision !== null && m.revision !== g.revision + 1;
     var freedBudget = false;
 
@@ -1209,44 +1256,65 @@
           removeGraphicsImage(g, id);
         }
       });
+      Object.keys(g.pending).forEach(function (id) {
+        if (!required[id]) {
+          freedBudget = true;
+          removePendingGraphicsImage(g, id);
+        }
+      });
       Object.keys(g.rejected).forEach(function (id) {
         if (!required[id]) delete g.rejected[id];
       });
-      if (g.resyncTimer) clearTimeout(g.resyncTimer);
-      g.resyncTimer = null;
-      g.resyncPending = false;
-      g.resyncAttempts = 0;
     }
     (m.removedImageIds || []).forEach(function (id) {
       id = String(id);
-      if (g.images[id]) freedBudget = true;
+      if (g.images[id] || g.pending[id]) freedBudget = true;
       removeGraphicsImage(g, id);
+      removePendingGraphicsImage(g, id);
       delete g.rejected[id];
     });
     (m.images || []).forEach(function (wire) {
-      var id = String(wire.id), old = g.images[id];
+      var id = String(wire.id), old = g.images[id], pending = g.pending[id];
       if (old && old.hash === wire.contentHash) return;
-      if (old) removeGraphicsImage(g, id);
+      if (pending && pending.hash === wire.contentHash) return;
       var rejected = g.rejected[id];
       if (rejected && rejected.reason === "decode" && rejected.hash === wire.contentHash) return;
+      if (pending) removePendingGraphicsImage(g, id);
       delete g.rejected[id];
       var bytes = base64Bytes(wire.data);
-      // Host-side caches are bounded too. If aggregate pane state exceeds the browser budget,
-      // omit that raster (and remember the rejection) instead of retry-looping or growing forever.
-      if (bytes > MAX_PANE_GRAPHICS_BYTES || g.bytes + bytes > MAX_PANE_GRAPHICS_BYTES ||
-          viewerGraphicsBytes + bytes > MAX_VIEWER_GRAPHICS_BYTES) {
+      // The pending encoded source and decoded RGBA backing store both count against the bound.
+      // Keep the old decoded raster live until the replacement has decoded successfully.
+      if (!graphicsMemoryFits(g, bytes, old ? old.bytes : 0)) {
         g.rejected[id] = { reason: "budget", hash: wire.contentHash };
         return;
       }
       var image = new Image();
       var item = { image: image, hash: wire.contentHash, bytes: bytes };
-      g.images[id] = item;
+      g.pending[id] = item;
       g.bytes += bytes;
       viewerGraphicsBytes += bytes;
-      image.onload = function () { scheduleGraphicsDraw(p); };
+      image.onload = function () {
+        if (g.pending[id] !== item) return;
+        var decodedBytes = image.naturalWidth * image.naturalHeight * 4;
+        if (!graphicsMemoryFits(g, decodedBytes, old ? old.bytes : 0)) {
+          removePendingGraphicsImage(g, id);
+          g.rejected[id] = { reason: "budget", hash: wire.contentHash };
+          retryBudgetRejectedImages(m.paneId, id);
+          scheduleGraphicsDraw(p);
+          return;
+        }
+        if (g.images[id] === old) removeGraphicsImage(g, id);
+        removePendingGraphicsImage(g, id);
+        item.bytes = bytes + decodedBytes;
+        g.images[id] = item;
+        g.bytes += item.bytes;
+        viewerGraphicsBytes += item.bytes;
+        if (old && old.bytes > item.bytes) retryBudgetRejectedImages(m.paneId, id);
+        scheduleGraphicsDraw(p);
+      };
       image.onerror = function () {
-        if (g.images[id] === item) {
-          removeGraphicsImage(g, id);
+        if (g.pending[id] === item) {
+          removePendingGraphicsImage(g, id);
           // The same bytes will not become decodable after a full-state resend. Keep the rejected
           // hash until the host replaces or removes it, avoiding an infinite full-payload loop.
           g.rejected[id] = { reason: "decode", hash: wire.contentHash };
@@ -1260,9 +1328,10 @@
     g.cells = m.cells || [];
     g.revision = m.revision;
     var missing = Object.keys(required).some(function (id) {
-      return !g.images[id] && !g.rejected[id];
+      return !g.images[id] && !g.pending[id] && !g.rejected[id];
     });
     if (revisionGap || missing) requestGraphicsResync(m.paneId, g);
+    else resetGraphicsResync(g);
     scheduleGraphicsDraw(p);
   }
 
@@ -1272,7 +1341,7 @@
     if (p) return p;
     var host = document.createElement("div");
     host.className = "termhost";
-    var opts = { cursorBlink: true, convertEol: false, scrollback: 5000,
+    var opts = { cursorBlink: true, convertEol: false, scrollback: WEB_VIEWER_SCROLLBACK_LINES,
                  allowTransparency: false,
                  fontFamily: DEFAULT_TERMINAL_FONT_FAMILY, fontSize: 13,
                  theme: { background: (theme && theme.background) || "#1e1e1e", foreground: "#f8f8f2" } };

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -1024,7 +1024,7 @@
   // PaneSnapshot replaces this compatibility fallback with the pane's real host history cap
   // before painting. Matching caps keep SharedImageCellRun absolute rows aligned after trims.
   var DEFAULT_WEB_VIEWER_SCROLLBACK_LINES = 10000;
-  var MAX_WEB_VIEWER_SCROLLBACK_LINES = 100000;
+  var MAX_WEB_VIEWER_SCROLLBACK_LINES = 20000;
   var ALLOWED_GRAPHICS_MIME_TYPES = {
     "image/png": true, "image/jpeg": true, "image/gif": true,
     "image/bmp": true, "image/webp": true

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -1019,9 +1019,9 @@
   // ImageCell placement grid; this transparent canvas mirrors the native renderer cell-for-cell.
   var MAX_PANE_GRAPHICS_BYTES = 50 * 1024 * 1024; // matches each BossTerm terminal cache
   var MAX_VIEWER_GRAPHICS_BYTES = 128 * 1024 * 1024; // hard bound across all shared panes
-  // SharedImageCellRun rows use the host's absolute buffer index. Keep this equal to
-  // LinesStorage.DEFAULT_MAX_LINES_COUNT; PaneGraphicsTracker explicitly shifts rows on trims.
-  var WEB_VIEWER_SCROLLBACK_LINES = 5000;
+  // PaneSnapshot replaces this compatibility fallback with the pane's real host history cap
+  // before painting. Matching caps keep SharedImageCellRun absolute rows aligned after trims.
+  var DEFAULT_WEB_VIEWER_SCROLLBACK_LINES = 10000;
   var MAX_GRAPHICS_RESYNCS = 3;
   var GRAPHICS_RESYNC_TIMEOUT_MS = 3000;
   var viewerGraphicsBytes = 0;
@@ -1341,7 +1341,7 @@
     if (p) return p;
     var host = document.createElement("div");
     host.className = "termhost";
-    var opts = { cursorBlink: true, convertEol: false, scrollback: WEB_VIEWER_SCROLLBACK_LINES,
+    var opts = { cursorBlink: true, convertEol: false, scrollback: DEFAULT_WEB_VIEWER_SCROLLBACK_LINES,
                  allowTransparency: false,
                  fontFamily: DEFAULT_TERMINAL_FONT_FAMILY, fontSize: 13,
                  theme: { background: (theme && theme.background) || "#1e1e1e", foreground: "#f8f8f2" } };
@@ -2306,6 +2306,9 @@
       case "layout": hideOverlay(); onLayout(m); break;
       case "paneSnapshot": {
         var p = getPane(m.paneId);
+        if (typeof m.scrollbackLines === "number" && m.scrollbackLines >= 0) {
+          p.term.options.scrollback = Math.floor(m.scrollbackLines);
+        }
         if (m.cols && m.rows) p.term.resize(m.cols, m.rows);
         p.term.reset();
         if (m.data) p.term.write(m.data, function () { scheduleGraphicsDraw(p); });
@@ -2319,7 +2322,20 @@
       case "paneOutput":
         if (m.data) {
           var outputPane = getPane(m.paneId);
-          outputPane.term.write(m.data, function () { scheduleGraphicsDraw(outputPane); });
+          // A graphics placement re-anchor begins with RIS + a full text snapshot. Preserve how
+          // far the reader was scrolled from the bottom so an image-heavy TUI does not yank them
+          // back to live output on every re-anchor.
+          var activeBuffer = outputPane.term.buffer.active;
+          var restoreLinesFromBottom = m.data.indexOf("\u001bc") === 0
+            ? Math.max(0, activeBuffer.baseY - activeBuffer.viewportY)
+            : 0;
+          outputPane.term.write(m.data, function () {
+            if (restoreLinesFromBottom > 0) {
+              var updated = outputPane.term.buffer.active;
+              outputPane.term.scrollToLine(Math.max(0, updated.baseY - restoreLinesFromBottom));
+            }
+            scheduleGraphicsDraw(outputPane);
+          });
         }
         break;
       case "paneGraphics": applyPaneGraphics(m); break;

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -1072,9 +1072,14 @@
   }
 
   function graphicsMemoryFits(g, addedBytes, replacedBytes) {
-    return addedBytes <= MAX_PANE_GRAPHICS_BYTES &&
-      g.bytes + addedBytes - (replacedBytes || 0) <= MAX_PANE_GRAPHICS_BYTES &&
-      viewerGraphicsBytes + addedBytes - (replacedBytes || 0) <= MAX_VIEWER_GRAPHICS_BYTES;
+    return viewerLogic.graphicsMemoryFits(
+      g.bytes,
+      viewerGraphicsBytes,
+      addedBytes,
+      replacedBytes,
+      MAX_PANE_GRAPHICS_BYTES,
+      MAX_VIEWER_GRAPHICS_BYTES
+    );
   }
 
   function base64Bytes(data) {
@@ -1222,6 +1227,29 @@
     }, GRAPHICS_RESYNC_TIMEOUT_MS * g.resyncAttempts);
   }
 
+  function handleGraphicsResyncDenied(m) {
+    var p = panes[m.paneId];
+    if (!p) return;
+    var g = p.graphics;
+    if (g.resyncTimer) clearTimeout(g.resyncTimer);
+    g.resyncTimer = null;
+    // A host throttle is an acknowledgement, not a failed transport attempt. Give the attempt
+    // back and keep one pending retry so repeated denials cannot force permanent degradation.
+    g.resyncAttempts = viewerLogic.graphicsAttemptAfterDenied(
+      g.resyncAttempts,
+      g.resyncPending
+    );
+    g.resyncPending = true;
+    var retryAfterMs = Number(m.retryAfterMs);
+    if (!isFinite(retryAfterMs)) retryAfterMs = GRAPHICS_RESYNC_TIMEOUT_MS;
+    retryAfterMs = Math.max(1, Math.min(60000, Math.floor(retryAfterMs)));
+    g.resyncTimer = setTimeout(function () {
+      g.resyncTimer = null;
+      g.resyncPending = false;
+      requestGraphicsResync(m.paneId, g);
+    }, retryAfterMs);
+  }
+
   function resetGraphicsResync(g) {
     if (g.resyncTimer) clearTimeout(g.resyncTimer);
     g.resyncTimer = null;
@@ -1238,7 +1266,13 @@
       var g = panes[paneId].graphics, cleared = false;
       Object.keys(g.rejected).forEach(function (id) {
         if (paneId === skipPaneId && id === skipImageId) return;
-        if (g.rejected[id].reason === "budget") {
+        var rejected = g.rejected[id];
+        var current = g.images[id];
+        var replacedBytes = current && current.hash === rejected.replacedHash
+          ? current.bytes
+          : 0;
+        if (rejected.reason === "budget" &&
+            graphicsMemoryFits(g, rejected.requiredBytes || 0, replacedBytes)) {
           delete g.rejected[id];
           cleared = true;
         }
@@ -1253,6 +1287,10 @@
     var p = panes[m.paneId];
     if (!p) return;
     var g = p.graphics;
+    if (m.resyncRequired) {
+      requestGraphicsResync(m.paneId, g);
+      return;
+    }
     var required = {};
     (m.requiredImageIds || []).forEach(function (id) { required[String(id)] = true; });
     var revisionGap = !m.full && g.revision !== null && m.revision !== g.revision + 1;
@@ -1294,7 +1332,12 @@
       // The pending encoded source and decoded RGBA backing store both count against the bound.
       // Keep the old decoded raster live until the replacement has decoded successfully.
       if (!graphicsMemoryFits(g, bytes, old ? old.bytes : 0)) {
-        g.rejected[id] = { reason: "budget", hash: wire.contentHash };
+        g.rejected[id] = {
+          reason: "budget",
+          hash: wire.contentHash,
+          requiredBytes: bytes,
+          replacedHash: old ? old.hash : null
+        };
         return;
       }
       var image = new Image();
@@ -1307,7 +1350,12 @@
         var decodedBytes = image.naturalWidth * image.naturalHeight * 4;
         if (!graphicsMemoryFits(g, decodedBytes, old ? old.bytes : 0)) {
           removePendingGraphicsImage(g, id);
-          g.rejected[id] = { reason: "budget", hash: wire.contentHash };
+          g.rejected[id] = {
+            reason: "budget",
+            hash: wire.contentHash,
+            requiredBytes: bytes + decodedBytes,
+            replacedHash: old ? old.hash : null
+          };
           retryBudgetRejectedImages(m.paneId, id);
           scheduleGraphicsDraw(p);
           return;
@@ -1499,6 +1547,33 @@
     host.addEventListener("touchcancel", function () { axis = null; vel = 0; unmarkTouchScrollSoon(); }, { passive: true, capture: true });
   }
 
+  var themeColorProbe = document.createElement("span");
+
+  function safeCssColor(value, fallback) {
+    if (typeof value !== "string") return fallback;
+    themeColorProbe.style.color = "";
+    themeColorProbe.style.color = value;
+    return themeColorProbe.style.color ? value : fallback;
+  }
+
+  function validatedTheme(m) {
+    m = m || {};
+    var next = {
+      background: safeCssColor(m.background, "#1e1e1e"),
+      foreground: safeCssColor(m.foreground, "#f8f8f2"),
+      cursor: safeCssColor(m.cursor, "#f8f8f2"),
+      cursorAccent: safeCssColor(m.cursorAccent, "#1e1e1e"),
+      selectionBackground: safeCssColor(m.selectionBackground, "rgba(255,255,255,0.25)"),
+      ansi: [],
+      fontFamily: typeof m.fontFamily === "string" ? m.fontFamily : DEFAULT_TERMINAL_FONT_FAMILY,
+      fontSize: isFinite(Number(m.fontSize))
+        ? Math.max(8, Math.min(72, Math.floor(Number(m.fontSize))))
+        : 13
+    };
+    var ansi = Array.isArray(m.ansi) ? m.ansi : [];
+    for (var i = 0; i < 16; i += 1) next.ansi[i] = safeCssColor(ansi[i], undefined);
+    return next;
+  }
 
   function applyThemeToOpts(opts) {
     var a = theme.ansi || [];
@@ -1514,21 +1589,19 @@
   }
 
   function applyTheme(m) {
-    theme = m;
+    theme = validatedTheme(m);
     Object.keys(panes).forEach(function (id) {
       var o = {}; applyThemeToOpts(o);
       var t = panes[id].term;
       if (panes[id].graphicsTransparent) o.theme.background = "rgba(0,0,0,0)";
       t.options.theme = o.theme;
-      panes[id].host.style.background = m.background || "#1e1e1e";
+      panes[id].host.style.background = theme.background;
       if (o.fontFamily) t.options.fontFamily = o.fontFamily;
       if (o.fontSize) t.options.fontSize = o.fontSize;
     });
-    if (m.background) {
-      document.documentElement.style.background = m.background;
-      document.body.style.background = m.background;
-      stageEl.style.background = m.background;
-    }
+    document.documentElement.style.background = theme.background;
+    document.body.style.background = theme.background;
+    stageEl.style.background = theme.background;
     // The host theme may carry a fontSize; keep the viewer's chosen zoom if set.
     if (viewerFont) Object.keys(panes).forEach(function (id) { try { panes[id].term.options.fontSize = viewerFont; } catch (e) {} });
     Object.keys(panes).forEach(function (id) { scheduleGraphicsDraw(panes[id]); });
@@ -2355,23 +2428,36 @@
       case "paneOutput":
         if (m.data) {
           var outputPane = getPane(m.paneId);
-          // A graphics placement re-anchor begins with RIS + a full text snapshot. Preserve how
-          // far the reader was scrolled from the bottom so an image-heavy TUI does not yank them
-          // back to live output on every re-anchor.
-          var activeBuffer = outputPane.term.buffer.active;
-          var restoreLinesFromBottom = m.data.indexOf("\u001bc") === 0
-            ? Math.max(0, activeBuffer.baseY - activeBuffer.viewportY)
-            : 0;
           outputPane.term.write(m.data, function () {
-            if (restoreLinesFromBottom > 0) {
-              var updated = outputPane.term.buffer.active;
-              outputPane.term.scrollToLine(Math.max(0, updated.baseY - restoreLinesFromBottom));
-            }
             scheduleGraphicsDraw(outputPane);
           });
         }
         break;
+      case "paneRepaint":
+        if (m.data) {
+          var repaintPane = getPane(m.paneId);
+          // Enter xterm's write queue before measuring so prior paneOutput frames are reflected in
+          // baseY/viewportY. The repaint remains ordered while preserving the reader's position.
+          repaintPane.term.write("", function () {
+            var activeBuffer = repaintPane.term.buffer.active;
+            var restoreLinesFromBottom = viewerLogic.scrollLinesFromBottom(
+              activeBuffer.baseY,
+              activeBuffer.viewportY
+            );
+            repaintPane.term.write(m.data, function () {
+              if (restoreLinesFromBottom > 0) {
+                var updated = repaintPane.term.buffer.active;
+                repaintPane.term.scrollToLine(
+                  viewerLogic.scrollLineForDistance(updated.baseY, restoreLinesFromBottom)
+                );
+              }
+              scheduleGraphicsDraw(repaintPane);
+            });
+          });
+        }
+        break;
       case "paneGraphics": applyPaneGraphics(m); break;
+      case "graphicsResyncDenied": handleGraphicsResyncDenied(m); break;
       case "paneResize":
         if (m.cols && m.rows) {
           var resizedPane = getPane(m.paneId);

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -487,6 +487,33 @@
   var activeTabId = null;         // client-side selected tab
   var panes = {};                 // paneId -> { term, host(el) }
   var ws = null;
+  var DEFAULT_TERMINAL_FONT_FAMILY =
+    '"BossTerm Nerd Font", "Apple Color Emoji", "Segoe UI Emoji", ' +
+    '"Noto Color Emoji", "BossTerm Symbols", monospace';
+
+  // xterm's WebGL renderer caches glyphs. Trigger both bundled downloads eagerly and invalidate
+  // each terminal after they finish so a first frame rendered during the download cannot leave
+  // Nerd Font icons or emoji stuck as missing-glyph boxes.
+  if (document.fonts && typeof document.fonts.load === "function") {
+    Promise.all([
+      document.fonts.load('13px "BossTerm Nerd Font"'),
+      document.fonts.load('13px "BossTerm Symbols"'),
+    ]).then(function () {
+      Object.keys(panes).forEach(function (id) {
+        var p = panes[id], t = p.term;
+        try {
+          var family = t.options.fontFamily;
+          // Force xterm to remeasure cells as well as rebuilding the WebGL glyph atlas.
+          t.options.fontFamily = family + " ";
+          t.options.fontFamily = family;
+          t.clearTextureAtlas();
+          t.refresh(0, t.rows - 1);
+        } catch (e) {}
+        scheduleGraphicsDraw(p);
+      });
+      relayoutSinglePane();
+    }).catch(function () { /* system fallbacks remain available if a font cannot load */ });
+  }
   // Give the active single pane its NATURAL width so a wide host terminal scrolls
   // horizontally inside #stage. (xterm's own viewport is a y-scroll container that clips
   // x, so we can't get native horizontal scroll from it — instead we expose the full
@@ -1162,7 +1189,7 @@
     host.className = "termhost";
     var opts = { cursorBlink: true, convertEol: false, scrollback: 5000,
                  allowTransparency: true,
-                 fontFamily: "Menlo, Monaco, monospace", fontSize: 13,
+                 fontFamily: DEFAULT_TERMINAL_FONT_FAMILY, fontSize: 13,
                  theme: { background: "rgba(0,0,0,0)", foreground: "#f8f8f2" } };
     if (theme) applyThemeToOpts(opts);
     host.style.background = (theme && theme.background) || "#1e1e1e";

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -1034,7 +1034,8 @@
   var viewerGraphicsBytes = 0;
 
   function newGraphicsState() {
-    return { revision: null, cells: [], images: {}, pending: {}, bytes: 0, canvas: null, raf: 0,
+    return { revision: null, cells: [], cellsByRow: {}, images: {}, pending: {},
+             bytes: 0, canvas: null, raf: 0,
              historyLines: null, rowOffset: 0,
              rejected: {}, resyncPending: false, resyncAttempts: 0, resyncTimer: null,
              resyncDegraded: false };
@@ -1048,7 +1049,8 @@
     Object.keys(g.pending).forEach(function (id) { removePendingGraphicsImage(g, id); });
     Object.keys(g.images).forEach(function (id) { removeGraphicsImage(g, id); });
     if (g.canvas && g.canvas.parentNode) g.canvas.parentNode.removeChild(g.canvas);
-    g.images = {}; g.pending = {}; g.cells = []; g.bytes = 0; g.canvas = null; g.raf = 0;
+    g.images = {}; g.pending = {}; g.cells = []; g.cellsByRow = {};
+    g.bytes = 0; g.canvas = null; g.raf = 0;
     g.resyncTimer = null;
     setPaneGraphicsMode(p, false);
   }
@@ -1087,6 +1089,16 @@
     var padding = data.length > 1 && data.charAt(data.length - 2) === "=" ? 2 :
       (data.charAt(data.length - 1) === "=" ? 1 : 0);
     return Math.max(0, Math.floor(data.length * 3 / 4) - padding);
+  }
+
+  function indexGraphicsCells(cells) {
+    var byRow = {};
+    cells.forEach(function (run) {
+      var row = String(run.row);
+      if (!byRow[row]) byRow[row] = [];
+      byRow[row].push(run);
+    });
+    return byRow;
   }
 
   function setPaneGraphicsMode(p, enabled) {
@@ -1175,37 +1187,40 @@
     var viewportY = buffer.viewportY || 0;
     var cellW = rect.width / p.term.cols;
     var cellH = rect.height / p.term.rows;
-    g.cells.forEach(function (run) {
-      var cached = g.images[String(run.imageId)];
-      var image = cached && cached.image;
-      if (!image || !image.complete || !image.naturalWidth || !image.naturalHeight) return;
-      // Anchor host absolute rows to xterm's current baseY. If best-effort output was dropped,
-      // the overlay remains aligned to the live screen instead of drifting by the missing rows.
-      var visibleRow = viewerLogic.visibleImageRow(run.row, g.rowOffset, viewportY);
-      if (visibleRow < 0 || visibleRow >= p.term.rows) return;
-      var anchorCol = run.col - run.cellX;
-      var availableCols = Math.max(1, p.term.cols - anchorCol);
-      var effectiveCols = Math.min(Math.max(1, run.totalCellsX), availableCols);
-      var effectiveRows = Math.max(1, Math.round(Math.max(1, run.totalCellsY) *
-        effectiveCols / Math.max(1, run.totalCellsX)));
-      if (run.cellY < 0 || run.cellY >= effectiveRows) return;
-      var length = Math.min(
-        run.length,
-        p.term.cols - run.col,
-        effectiveCols - run.cellX
-      );
-      if (length <= 0) return;
-      var sourceCellX = run.cellX;
-      var destCol = run.col;
-      var sx1 = Math.floor(sourceCellX * image.naturalWidth / effectiveCols);
-      var sx2 = Math.floor((sourceCellX + length) * image.naturalWidth / effectiveCols);
-      var sy1 = Math.floor(run.cellY * image.naturalHeight / effectiveRows);
-      var sy2 = Math.floor((run.cellY + 1) * image.naturalHeight / effectiveRows);
-      ctx.drawImage(
-        image, sx1, sy1, Math.max(1, sx2 - sx1), Math.max(1, sy2 - sy1),
-        destCol * cellW, visibleRow * cellH, length * cellW, cellH
-      );
-    });
+    var visibleRows = viewerLogic.visibleHostRowRange(viewportY, g.rowOffset, p.term.rows);
+    for (var row = visibleRows.first; row <= visibleRows.last; row += 1) {
+      (g.cellsByRow[String(row)] || []).forEach(function (run) {
+        var cached = g.images[String(run.imageId)];
+        var image = cached && cached.image;
+        if (!image || !image.complete || !image.naturalWidth || !image.naturalHeight) return;
+        // Anchor host absolute rows to xterm's current baseY. If best-effort output was dropped,
+        // the overlay remains aligned to the live screen instead of drifting by the missing rows.
+        var visibleRow = viewerLogic.visibleImageRow(run.row, g.rowOffset, viewportY);
+        if (visibleRow < 0 || visibleRow >= p.term.rows) return;
+        var anchorCol = run.col - run.cellX;
+        var availableCols = Math.max(1, p.term.cols - anchorCol);
+        var effectiveCols = Math.min(Math.max(1, run.totalCellsX), availableCols);
+        var effectiveRows = Math.max(1, Math.round(Math.max(1, run.totalCellsY) *
+          effectiveCols / Math.max(1, run.totalCellsX)));
+        if (run.cellY < 0 || run.cellY >= effectiveRows) return;
+        var length = Math.min(
+          run.length,
+          p.term.cols - run.col,
+          effectiveCols - run.cellX
+        );
+        if (length <= 0) return;
+        var sourceCellX = run.cellX;
+        var destCol = run.col;
+        var sx1 = Math.floor(sourceCellX * image.naturalWidth / effectiveCols);
+        var sx2 = Math.floor((sourceCellX + length) * image.naturalWidth / effectiveCols);
+        var sy1 = Math.floor(run.cellY * image.naturalHeight / effectiveRows);
+        var sy2 = Math.floor((run.cellY + 1) * image.naturalHeight / effectiveRows);
+        ctx.drawImage(
+          image, sx1, sy1, Math.max(1, sx2 - sx1), Math.max(1, sy2 - sy1),
+          destCol * cellW, visibleRow * cellH, length * cellW, cellH
+        );
+      });
+    }
   }
 
   function requestGraphicsResync(paneId, g) {
@@ -1384,6 +1399,7 @@
     });
     if (freedBudget) retryBudgetRejectedImages();
     g.cells = m.cells || [];
+    g.cellsByRow = indexGraphicsCells(g.cells);
     if (typeof m.historyLines === "number" && m.historyLines >= 0) {
       g.historyLines = m.historyLines;
     }

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -954,8 +954,9 @@
   var disconnectShown = false; // final prompt is shown at most once
   var reconnectAttempt = 0;
   var reconnectTimer = null;
-  var connectionWasHealthy = false; // a Layout arrived on this connection
+  var reconnectStableTimer = null;
   var MAX_AUTO_RECONNECTS = 3;
+  var RECONNECT_STABLE_MS = 30000;
   // The automatic budget is exhausted: offer a manual retry (which reloads the page and gives
   // it a fresh budget) or close. Terminal failures such as denial / bad E2E keys never get here.
   function showDisconnected() {
@@ -970,17 +971,24 @@
       } }
     ]);
   }
-  // Retry a transient drop before asking the user. A connection that rendered a Layout was
-  // healthy, so it receives a fresh three-attempt budget just like the native remote client.
+  // A reconnect only earns a fresh budget after remaining healthy continuously. A host that
+  // accepts, sends Layout, then immediately drops therefore still exhausts the three attempts.
+  function markConnectionHealthy(socket) {
+    if (!socket || reconnectAttempt === 0 || reconnectStableTimer) return;
+    reconnectStableTimer = setTimeout(function () {
+      reconnectStableTimer = null;
+      if (ws === socket && socket.readyState === 1) reconnectAttempt = 0;
+    }, RECONNECT_STABLE_MS);
+  }
+
+  // Retry a transient drop before asking the user.
   function handleConnectionLost(socket) {
     if (socket && ws !== socket) return; // stale event from a superseded connection
     if (socket) ws = null;               // disarm its pending encrypt/decrypt callbacks
     setStatus("down");
     if (sessionEnded || reconnectTimer) return;
-    if (connectionWasHealthy) {
-      reconnectAttempt = 0;
-      connectionWasHealthy = false;
-    }
+    if (reconnectStableTimer) clearTimeout(reconnectStableTimer);
+    reconnectStableTimer = null;
     if (reconnectAttempt >= MAX_AUTO_RECONNECTS) {
       showDisconnected();
       return;
@@ -992,10 +1000,11 @@
       "The connection was lost. Automatic attempt " + attempt + " of " + MAX_AUTO_RECONNECTS + ".",
       true
     );
+    var retryDelay = Math.max(500, attempt * 1500 + Math.floor(Math.random() * 501) - 250);
     reconnectTimer = setTimeout(function () {
       reconnectTimer = null;
       if (!sessionEnded) connectWebSocket();
-    }, attempt * 1500);
+    }, retryDelay);
   }
 
   function deviceName() {
@@ -1008,20 +1017,24 @@
   // ImageCell placement grid; this transparent canvas mirrors the native renderer cell-for-cell.
   var MAX_PANE_GRAPHICS_BYTES = 50 * 1024 * 1024; // matches each BossTerm terminal cache
   var MAX_VIEWER_GRAPHICS_BYTES = 128 * 1024 * 1024; // hard bound across all shared panes
+  var MAX_GRAPHICS_RESYNCS = 3;
+  var GRAPHICS_RESYNC_TIMEOUT_MS = 3000;
   var viewerGraphicsBytes = 0;
 
   function newGraphicsState() {
     return { revision: null, cells: [], images: {}, bytes: 0, canvas: null, raf: 0,
-             rejected: {}, resyncPending: false };
+             required: {}, rejected: {}, resyncPending: false, resyncAttempts: 0, resyncTimer: null };
   }
 
   function disposeGraphics(p) {
     if (!p || !p.graphics) return;
     var g = p.graphics;
     if (g.raf) cancelAnimationFrame(g.raf);
+    if (g.resyncTimer) clearTimeout(g.resyncTimer);
     Object.keys(g.images).forEach(function (id) { removeGraphicsImage(g, id); });
     if (g.canvas && g.canvas.parentNode) g.canvas.parentNode.removeChild(g.canvas);
-    g.images = {}; g.cells = []; g.bytes = 0; g.canvas = null; g.raf = 0;
+    g.images = {}; g.cells = []; g.bytes = 0; g.canvas = null; g.raf = 0; g.resyncTimer = null;
+    setPaneGraphicsMode(p, false);
   }
 
   function removeGraphicsImage(g, id) {
@@ -1035,8 +1048,27 @@
 
   function base64Bytes(data) {
     if (!data) return 0;
-    var padding = data.endsWith("==") ? 2 : (data.endsWith("=") ? 1 : 0);
+    var padding = data.length > 1 && data.charAt(data.length - 2) === "=" ? 2 :
+      (data.charAt(data.length - 1) === "=" ? 1 : 0);
     return Math.max(0, Math.floor(data.length * 3 / 4) - padding);
+  }
+
+  function setPaneGraphicsMode(p, enabled) {
+    if (!p || p.graphicsTransparent === enabled) return;
+    var current = p.term.options.theme || {};
+    var next = {}, key;
+    for (key in current) if (Object.prototype.hasOwnProperty.call(current, key)) next[key] = current[key];
+    next.background = enabled ? "rgba(0,0,0,0)" : ((theme && theme.background) || "#1e1e1e");
+    try {
+      if (enabled) {
+        p.term.options.allowTransparency = true;
+        p.term.options.theme = next;
+      } else {
+        p.term.options.theme = next;
+        p.term.options.allowTransparency = false;
+      }
+      p.graphicsTransparent = enabled;
+    } catch (e) {}
   }
 
   function ensureGraphicsCanvas(p) {
@@ -1054,7 +1086,8 @@
     }
     if (g.canvas.parentNode !== screen) {
       // Keep images below xterm's glyph/selection/cursor renderer. The terminal's default
-      // background is transparent; the term host supplies the opaque theme background.
+      // background becomes transparent only while this pane has drawable graphics; the term
+      // host supplies the opaque theme background behind both layers.
       screen.insertBefore(g.canvas, screen.querySelector("canvas"));
     }
     return g.canvas;
@@ -1069,7 +1102,19 @@
   }
 
   function drawPaneGraphics(p) {
-    var g = p.graphics, canvas = ensureGraphicsCanvas(p);
+    var g = p.graphics;
+    var hasDrawableImage = Object.keys(g.images).some(function (id) {
+      var image = g.images[id].image;
+      return image && image.complete && image.naturalWidth && image.naturalHeight;
+    });
+    if (!g.cells.length || !hasDrawableImage) {
+      if (g.canvas && g.canvas.parentNode) g.canvas.parentNode.removeChild(g.canvas);
+      g.canvas = null;
+      setPaneGraphicsMode(p, false);
+      return;
+    }
+    setPaneGraphicsMode(p, true);
+    var canvas = ensureGraphicsCanvas(p);
     if (!canvas) return;
     var screen = p.host.querySelector(".xterm-screen");
     var rect = screen && screen.getBoundingClientRect();
@@ -1085,10 +1130,9 @@
     if (!ctx) return;
     ctx.setTransform(scale, 0, 0, scale, 0, 0);
     ctx.clearRect(0, 0, rect.width, rect.height);
-    if (!g.cells.length || !p.term.cols || !p.term.rows) return;
+    if (!p.term.cols || !p.term.rows) return;
 
     var buffer = p.term.buffer.active;
-    var baseY = buffer.baseY || 0;
     var viewportY = buffer.viewportY || 0;
     var cellW = rect.width / p.term.cols;
     var cellH = rect.height / p.term.rows;
@@ -1096,7 +1140,7 @@
       var cached = g.images[String(run.imageId)];
       var image = cached && cached.image;
       if (!image || !image.complete || !image.naturalWidth || !image.naturalHeight) return;
-      var visibleRow = baseY + run.row - viewportY;
+      var visibleRow = run.row - viewportY;
       if (visibleRow < 0 || visibleRow >= p.term.rows) return;
       var anchorCol = run.col - run.cellX;
       var availableCols = Math.max(1, p.term.cols - anchorCol);
@@ -1122,28 +1166,60 @@
   }
 
   function requestGraphicsResync(paneId, g) {
-    if (g.resyncPending) return;
+    if (g.resyncPending || g.resyncAttempts >= MAX_GRAPHICS_RESYNCS) return;
     g.resyncPending = true;
+    g.resyncAttempts += 1;
     sendMsg({ t: "graphicsResync", paneId: paneId });
+    g.resyncTimer = setTimeout(function () {
+      g.resyncTimer = null;
+      g.resyncPending = false;
+      requestGraphicsResync(paneId, g);
+    }, GRAPHICS_RESYNC_TIMEOUT_MS);
+  }
+
+  function retryBudgetRejectedImages() {
+    Object.keys(panes).forEach(function (paneId) {
+      var g = panes[paneId].graphics, cleared = false;
+      Object.keys(g.rejected).forEach(function (id) {
+        if (g.rejected[id].reason === "budget") {
+          delete g.rejected[id];
+          cleared = true;
+        }
+      });
+      if (cleared) requestGraphicsResync(paneId, g);
+    });
   }
 
   function applyPaneGraphics(m) {
-    var p = getPane(m.paneId), g = p.graphics;
+    // Layout + PaneSnapshot create every live pane before graphics arrive. Ignore a stale frame
+    // instead of materializing an orphan xterm for an id that has already left the layout.
+    var p = panes[m.paneId];
+    if (!p) return;
+    var g = p.graphics;
     var required = {};
     (m.requiredImageIds || []).forEach(function (id) { required[String(id)] = true; });
+    g.required = required;
     var revisionGap = !m.full && g.revision !== null && m.revision !== g.revision + 1;
+    var freedBudget = false;
 
     if (m.full) {
       Object.keys(g.images).forEach(function (id) {
-        if (!required[id]) removeGraphicsImage(g, id);
+        if (!required[id]) {
+          freedBudget = true;
+          removeGraphicsImage(g, id);
+        }
       });
       Object.keys(g.rejected).forEach(function (id) {
         if (!required[id]) delete g.rejected[id];
       });
+      if (g.resyncTimer) clearTimeout(g.resyncTimer);
+      g.resyncTimer = null;
       g.resyncPending = false;
+      g.resyncAttempts = 0;
     }
     (m.removedImageIds || []).forEach(function (id) {
       id = String(id);
+      if (g.images[id]) freedBudget = true;
       removeGraphicsImage(g, id);
       delete g.rejected[id];
     });
@@ -1151,13 +1227,15 @@
       var id = String(wire.id), old = g.images[id];
       if (old && old.hash === wire.contentHash) return;
       if (old) removeGraphicsImage(g, id);
+      var rejected = g.rejected[id];
+      if (rejected && rejected.reason === "decode" && rejected.hash === wire.contentHash) return;
       delete g.rejected[id];
       var bytes = base64Bytes(wire.data);
       // Host-side caches are bounded too. If aggregate pane state exceeds the browser budget,
       // omit that raster (and remember the rejection) instead of retry-looping or growing forever.
       if (bytes > MAX_PANE_GRAPHICS_BYTES || g.bytes + bytes > MAX_PANE_GRAPHICS_BYTES ||
           viewerGraphicsBytes + bytes > MAX_VIEWER_GRAPHICS_BYTES) {
-        g.rejected[id] = true;
+        g.rejected[id] = { reason: "budget", hash: wire.contentHash };
         return;
       }
       var image = new Image();
@@ -1167,11 +1245,18 @@
       viewerGraphicsBytes += bytes;
       image.onload = function () { scheduleGraphicsDraw(p); };
       image.onerror = function () {
-        if (g.images[id] === item) removeGraphicsImage(g, id);
-        requestGraphicsResync(m.paneId, g);
+        if (g.images[id] === item) {
+          removeGraphicsImage(g, id);
+          // The same bytes will not become decodable after a full-state resend. Keep the rejected
+          // hash until the host replaces or removes it, avoiding an infinite full-payload loop.
+          g.rejected[id] = { reason: "decode", hash: wire.contentHash };
+        }
+        retryBudgetRejectedImages();
+        scheduleGraphicsDraw(p);
       };
       image.src = "data:" + (wire.mimeType || "image/png") + ";base64," + wire.data;
     });
+    if (freedBudget) retryBudgetRejectedImages();
     g.cells = m.cells || [];
     g.revision = m.revision;
     var missing = Object.keys(required).some(function (id) {
@@ -1188,9 +1273,9 @@
     var host = document.createElement("div");
     host.className = "termhost";
     var opts = { cursorBlink: true, convertEol: false, scrollback: 5000,
-                 allowTransparency: true,
+                 allowTransparency: false,
                  fontFamily: DEFAULT_TERMINAL_FONT_FAMILY, fontSize: 13,
-                 theme: { background: "rgba(0,0,0,0)", foreground: "#f8f8f2" } };
+                 theme: { background: (theme && theme.background) || "#1e1e1e", foreground: "#f8f8f2" } };
     if (theme) applyThemeToOpts(opts);
     host.style.background = (theme && theme.background) || "#1e1e1e";
     var term = new Terminal(opts);
@@ -1235,7 +1320,7 @@
       followRaf = requestAnimationFrame(function () { followRaf = 0; followCursor(); });
     });
     attachTouchScroll(host, term);
-    p = { term: term, host: host, graphics: newGraphicsState() };
+    p = { term: term, host: host, graphics: newGraphicsState(), graphicsTransparent: false };
     term.onRender(function () { scheduleGraphicsDraw(p); });
     term.onScroll(function () { scheduleGraphicsDraw(p); });
     term.onResize(function () { scheduleGraphicsDraw(p); });
@@ -1319,7 +1404,7 @@
   function applyThemeToOpts(opts) {
     var a = theme.ansi || [];
     opts.theme = {
-      background: "rgba(0,0,0,0)", foreground: theme.foreground, cursor: theme.cursor,
+      background: theme.background || "#1e1e1e", foreground: theme.foreground, cursor: theme.cursor,
       cursorAccent: theme.cursorAccent, selectionBackground: theme.selectionBackground,
       black: a[0], red: a[1], green: a[2], yellow: a[3], blue: a[4], magenta: a[5], cyan: a[6], white: a[7],
       brightBlack: a[8], brightRed: a[9], brightGreen: a[10], brightYellow: a[11],
@@ -1334,6 +1419,7 @@
     Object.keys(panes).forEach(function (id) {
       var o = {}; applyThemeToOpts(o);
       var t = panes[id].term;
+      if (panes[id].graphicsTransparent) o.theme.background = "rgba(0,0,0,0)";
       t.options.theme = o.theme;
       panes[id].host.style.background = m.background || "#1e1e1e";
       if (o.fontFamily) t.options.fontFamily = o.fontFamily;
@@ -1999,7 +2085,7 @@
   }
 
   function onLayout(m) {
-    connectionWasHealthy = true;
+    markConnectionHealthy(ws);
     layout = m;
     tabBarOnLeft = !!m.tabBarOnLeft;
     summaryMode = !!m.summaryMode;

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServerTest.kt
@@ -105,6 +105,11 @@ class DaemonShareServerTest {
                 httpStatus(port, "/fonts/NotoSansSymbols2-Regular.ttf", hostHeader = "127.0.0.1:$port"),
                 "the bundled symbol fallback must be served",
             )
+            assertEquals(
+                404,
+                httpStatus(port, "/fonts/not-public.txt", hostHeader = "127.0.0.1:$port"),
+                "the font route must expose only the two explicit viewer assets",
+            )
             assertTrue(
                 httpStatus(port, "/", hostHeader = "evil.example.com") != 403,
                 "share server is token-gated, not Host-gated — must not 403 by Host",

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServerTest.kt
@@ -95,6 +95,16 @@ class DaemonShareServerTest {
             // allowlisting (unlike the loopback-only MCP/attach servers). So it serves the viewer
             // regardless of Host; a foreign Host must NOT be rejected with the rebinding 403.
             assertEquals(200, httpStatus(port, "/", hostHeader = "127.0.0.1:$port"), "viewer index must be served")
+            assertEquals(
+                200,
+                httpStatus(port, "/fonts/MesloLGSNF-Regular.ttf", hostHeader = "127.0.0.1:$port"),
+                "the bundled Nerd Font must be served for terminal icons",
+            )
+            assertEquals(
+                200,
+                httpStatus(port, "/fonts/NotoSansSymbols2-Regular.ttf", hostHeader = "127.0.0.1:$port"),
+                "the bundled symbol fallback must be served",
+            )
             assertTrue(
                 httpStatus(port, "/", hostHeader = "evil.example.com") != 403,
                 "share server is token-gated, not Host-gated — must not 403 by Host",

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServerTest.kt
@@ -106,9 +106,14 @@ class DaemonShareServerTest {
                 "the bundled symbol fallback must be served",
             )
             assertEquals(
+                200,
+                httpStatus(port, "/fonts/MesloLGSNF-NOTICE.txt", hostHeader = "127.0.0.1:$port"),
+                "the bundled Nerd Font attribution must travel with the font",
+            )
+            assertEquals(
                 404,
                 httpStatus(port, "/fonts/not-public.txt", hostHeader = "127.0.0.1:$port"),
-                "the font route must expose only the two explicit viewer assets",
+                "the font route must expose only the explicit viewer assets and notices",
             )
             assertTrue(
                 httpStatus(port, "/", hostHeader = "evil.example.com") != 403,

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
@@ -255,6 +255,27 @@ class FrameOutboxTest {
     }
 
     @Test
+    fun `recoverable graphics overflow keeps the connection and queues resync metadata`() {
+        val outbox = FrameOutbox(controlCapacity = 100, controlCapacityBytes = 12)
+        outbox.sendControl(ctrl("12345")) // 10 UTF-16 bytes
+        outbox.sendRecoverableControl(
+            frame = ctrl("abcdef"), // another 12 bytes cannot fit
+            recoveryFrame = ctrl("r"), // 2-byte metadata frame does fit
+        )
+        outbox.sendOutput("pane", "still-connected")
+        outbox.close()
+
+        assertEquals(
+            listOf(
+                ctrl("12345"),
+                ctrl("r"),
+                FrameOutbox.Frame.Output("pane", "still-connected"),
+            ),
+            drainAll(outbox),
+        )
+    }
+
+    @Test
     fun `default control budget admits the largest legal raster frame`() {
         val maximumRawRasterBytes = 16L * 1024 * 1024
         val maximumBase64Chars = (maximumRawRasterBytes + 2) / 3 * 4

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
@@ -104,6 +104,26 @@ class FrameOutboxTest {
     }
 
     @Test
+    fun `repaint is an ordered barrier between pane output frames`() {
+        val outbox = FrameOutbox()
+        outbox.sendOutput("pane", "before-1")
+        outbox.sendOutput("pane", "before-2")
+        outbox.sendRepaint("pane", "screen")
+        outbox.sendOutput("pane", "after-1")
+        outbox.sendOutput("pane", "after-2")
+        outbox.close()
+
+        assertEquals(
+            listOf(
+                FrameOutbox.Frame.Output("pane", "before-1before-2"),
+                FrameOutbox.Frame.Output("pane", "screen", repaint = true),
+                FrameOutbox.Frame.Output("pane", "after-1after-2"),
+            ),
+            drainAll(outbox),
+        )
+    }
+
+    @Test
     fun `a control backlog does not starve output (fairness cap)`() {
         val outbox = FrameOutbox(controlCapacity = 4096)
         val controlCount = FrameOutbox.CONTROL_BURST * 3

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
@@ -239,4 +239,18 @@ class FrameOutboxTest {
             "only the pre-overflow buffered frames survive",
         )
     }
+
+    @Test
+    fun `control lane is also bounded by payload bytes`() {
+        val outbox = FrameOutbox(controlCapacity = 100, controlCapacityBytes = 12)
+        outbox.sendControl(ctrl("12345")) // 10 UTF-16 bytes
+        outbox.sendControl(ctrl("67")) // exceeds the 12-byte aggregate cap and closes
+        outbox.sendControl(ctrl("after-close"))
+
+        assertEquals(
+            listOf(ctrl("12345")),
+            drainAll(outbox),
+            "a large-frame backlog must close at the byte bound even below the frame-count cap",
+        )
+    }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
@@ -296,6 +296,42 @@ class FrameOutboxTest {
     }
 
     @Test
+    fun `a snapshot backlog defers into the re-snapshot heal instead of closing`() {
+        // A window share beginning many panes at once queues more snapshot bytes than the writer has
+        // drained. The lane is momentarily full, but the connection is fine — the pane must be
+        // reported for a healing re-snapshot, not disconnected (which also burns a reconnect).
+        val outbox = FrameOutbox(controlCapacity = 100, controlCapacityBytes = 12)
+        val deferred = ConcurrentLinkedQueue<String>()
+        outbox.onOutputDropped = { deferred.add(it) }
+        outbox.sendSnapshot("pane-a", ctrl("12345")) // 10 UTF-16 bytes — fits
+        outbox.sendSnapshot("pane-b", ctrl("67")) // +4 bytes exceeds the aggregate ceiling
+        outbox.sendOutput("pane-a", "still-connected")
+        outbox.close()
+
+        assertEquals(listOf("pane-b"), deferred.toList(), "the deferred pane must be reported for a heal")
+        assertEquals(
+            listOf(
+                ctrl("12345"),
+                FrameOutbox.Frame.Output("pane-a", "still-connected"),
+            ),
+            drainAll(outbox),
+            "the connection survives a transient snapshot backlog",
+        )
+    }
+
+    @Test
+    fun `a snapshot too large for the whole ceiling is unrecoverable and closes`() {
+        val outbox = FrameOutbox(controlCapacity = 100, controlCapacityBytes = 12)
+        val deferred = ConcurrentLinkedQueue<String>()
+        outbox.onOutputDropped = { deferred.add(it) }
+        outbox.sendSnapshot("pane", ctrl("1234567")) // 14 bytes > the 12-byte ceiling: never fits
+        outbox.sendOutput("pane", "after-close")
+
+        assertTrue(deferred.isEmpty(), "an impossible frame must not schedule an endless heal loop")
+        assertEquals(emptyList<FrameOutbox.Frame>(), drainAll(outbox), "the outbox is closed")
+    }
+
+    @Test
     fun `default control budget admits the largest legal raster frame`() {
         val maximumRawRasterBytes = 16L * 1024 * 1024
         val maximumBase64Chars = (maximumRawRasterBytes + 2) / 3 * 4

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
@@ -253,4 +253,16 @@ class FrameOutboxTest {
             "a large-frame backlog must close at the byte bound even below the frame-count cap",
         )
     }
+
+    @Test
+    fun `default control budget admits the largest legal raster frame`() {
+        val maximumRawRasterBytes = 50L * 1024 * 1024
+        val maximumBase64Chars = (maximumRawRasterBytes + 2) / 3 * 4
+        val estimatedUtf16Bytes = maximumBase64Chars * 2
+
+        assertTrue(
+            FrameOutbox.DEFAULT_CONTROL_CAPACITY_BYTES > estimatedUtf16Bytes,
+            "the queue must not disconnect a viewer for one legal full-graphics frame",
+        )
+    }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/daemon/FrameOutboxTest.kt
@@ -256,7 +256,7 @@ class FrameOutboxTest {
 
     @Test
     fun `default control budget admits the largest legal raster frame`() {
-        val maximumRawRasterBytes = 50L * 1024 * 1024
+        val maximumRawRasterBytes = 16L * 1024 * 1024
         val maximumBase64Chars = (maximumRawRasterBytes + 2) / 3 * 4
         val estimatedUtf16Bytes = maximumBase64Chars * 2
 

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/BoundedViewerOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/BoundedViewerOutboxTest.kt
@@ -1,0 +1,29 @@
+package ai.rever.bossterm.compose.share
+
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BoundedViewerOutboxTest {
+    @Test
+    fun `queue evicts oldest frames at its character bound`() = runBlocking {
+        val outbox = BoundedViewerOutbox(capacityChars = 10, capacityFrames = 10)
+        assertTrue(outbox.trySend("123456"))
+        assertTrue(outbox.trySend("abcdef"))
+        outbox.close()
+
+        val drained = mutableListOf<String>()
+        outbox.drainTo { drained.add(it) }
+
+        assertEquals(listOf("abcdef"), drained)
+    }
+
+    @Test
+    fun `single frame larger than the bound is rejected`() {
+        val outbox = BoundedViewerOutbox(capacityChars = 5, capacityFrames = 10)
+
+        assertFalse(outbox.trySend("123456"))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/BoundedViewerOutboxTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/BoundedViewerOutboxTest.kt
@@ -26,4 +26,17 @@ class BoundedViewerOutboxTest {
 
         assertFalse(outbox.trySend("123456"))
     }
+
+    @Test
+    fun `recoverable frame never evicts queued pane output`() = runBlocking {
+        val outbox = BoundedViewerOutbox(capacityChars = 10, capacityFrames = 10)
+        assertTrue(outbox.trySend("output"))
+        assertFalse(outbox.trySendWithoutEviction("graphic"))
+        outbox.close()
+
+        val drained = mutableListOf<String>()
+        outbox.drainTo { drained.add(it) }
+
+        assertEquals(listOf("output"), drained)
+    }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/DeferredPaneRepaintTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/DeferredPaneRepaintTest.kt
@@ -19,9 +19,10 @@ class DeferredPaneRepaintTest {
             send = sent::add,
         )
 
-        sender.offer("older screen")
+        var screen = "older screen"
+        sender.offer { screen }
         runCurrent()
-        sender.offer("latest screen")
+        screen = "latest screen"
         advanceTimeBy(100)
         runCurrent()
 
@@ -37,7 +38,7 @@ class DeferredPaneRepaintTest {
             send = sent::add,
         )
 
-        sender.offer("screen")
+        sender.offer { "screen" }
         runCurrent()
         sender.cancel()
         advanceTimeBy(200)

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/DeferredPaneRepaintTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/DeferredPaneRepaintTest.kt
@@ -1,0 +1,48 @@
+package ai.rever.bossterm.compose.share
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeferredPaneRepaintTest {
+    @Test
+    fun `throttled repaints coalesce and send the latest screen after the delay`() = runTest {
+        val sent = mutableListOf<String>()
+        var admission = 0
+        val sender = DeferredPaneRepaint(
+            scope = this,
+            admit = { if (admission++ == 0) 100 else null },
+            send = sent::add,
+        )
+
+        sender.offer("older screen")
+        runCurrent()
+        sender.offer("latest screen")
+        advanceTimeBy(100)
+        runCurrent()
+
+        assertEquals(listOf("latest screen"), sent)
+    }
+
+    @Test
+    fun `cancel clears a deferred repaint`() = runTest {
+        val sent = mutableListOf<String>()
+        val sender = DeferredPaneRepaint(
+            scope = this,
+            admit = { 100 },
+            send = sent::add,
+        )
+
+        sender.offer("screen")
+        runCurrent()
+        sender.cancel()
+        advanceTimeBy(200)
+        runCurrent()
+
+        assertEquals(emptyList(), sent)
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/NodeHarness.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/NodeHarness.kt
@@ -1,0 +1,46 @@
+package ai.rever.bossterm.compose.share
+
+import org.junit.Assume.assumeTrue
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Shared plumbing for the web-viewer regression harnesses, which run the SHIPPED viewer JavaScript
+ * under Node rather than asserting on its source text.
+ *
+ * Node is required in CI (a silently skipped browser suite is worse than no suite) and merely
+ * assumed locally, so a dev without Node still gets a green build.
+ */
+internal object NodeHarness {
+
+    fun requireOrSkipNode() {
+        val available = nodeAvailable()
+        if (System.getenv("CI").equals("true", ignoreCase = true)) {
+            assertTrue(available, "Node.js is required for the web-viewer regression harness in CI")
+        } else {
+            assumeTrue("Node.js is not available on PATH", available)
+        }
+    }
+
+    /** Run [script] with [args], failing with the harness's own output when it exits non-zero. */
+    fun run(script: Path, vararg args: String) {
+        val process = ProcessBuilder(listOf("node", script.toString()) + args)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        assertEquals(0, process.waitFor(), output)
+    }
+
+    fun readResource(path: String): String =
+        checkNotNull(javaClass.classLoader.getResourceAsStream(path)) { "missing resource: $path" }
+            .use { it.readBytes().decodeToString() }
+
+    private fun nodeAvailable(): Boolean = runCatching {
+        val process = ProcessBuilder("node", "--version")
+            .redirectErrorStream(true)
+            .start()
+        process.inputStream.bufferedReader().use { it.readText() }
+        process.waitFor() == 0
+    }.getOrDefault(false)
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
@@ -161,7 +161,9 @@ class PaneGraphicsTrackerTest {
         buffer.scrollArea(scrollRegionTop = 1, dy = -1, scrollRegionBottom = 4)
 
         assertNull(tracker.pollUpdate())
-        assertEquals(1, tracker.fullMessage().cells.single().row)
+        val afterScroll = tracker.fullMessage()
+        assertEquals(1, afterScroll.cells.single().row)
+        assertEquals(1, afterScroll.historyLines)
     }
 
     @Test
@@ -314,6 +316,11 @@ class PaneGraphicsTrackerTest {
         val truncated = GraphicsOutputFilter(maxDiscardChars = 3)
         assertEquals("hello", truncated.filter("\u001bPqabchello").output)
 
+        val oscAborted = GraphicsOutputFilter(maxOscDiscardChars = 3)
+        assertEquals("hello", oscAborted.filter("\u001b]1337;File=abchello").output)
+        assertEquals("tail", GraphicsOutputFilter()
+            .filter("\u001b]1337;File=x:payload\u0000tail").output)
+
         val repeatedEscape = GraphicsOutputFilter()
         assertEquals("\u001bhello", repeatedEscape.filter("\u001b\u001bPqpayload\u009chello").output)
 
@@ -322,6 +329,24 @@ class PaneGraphicsTrackerTest {
         assertEquals(" tail", kittyPlacement.filter("$placeholder\u0301\u0302tail").output)
         assertEquals(" ", kittyPlacement.filter(placeholder).output)
         assertEquals("tail", kittyPlacement.filter("\u0301\u0302tail").output)
+    }
+
+    @Test
+    fun `graphics filter strips iterm multipart payload chunks`() {
+        val filter = GraphicsOutputFilter()
+
+        assertEquals(
+            "one",
+            filter.filter("\u001b]1337;MultipartFile=name=x\u0007one").output,
+        )
+        assertEquals(
+            "two",
+            filter.filter("\u001b]1337;FilePart=base64\u0007two").output,
+        )
+        assertEquals(
+            "three",
+            filter.filter("\u001b]1337;FileEnd\u0007three").output,
+        )
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
@@ -421,4 +421,77 @@ class PaneGraphicsTrackerTest {
 
         assertEquals(MAX_WEB_VIEWER_SCROLLBACK_LINES, webViewerScrollbackLines(buffer))
     }
+
+    @Test
+    fun `an unlimited host history maps to the browser cap, not to zero scrollback`() {
+        // LinesStorage documents a negative count as unlimited. Clamping it numerically would give
+        // an embedder-configured unlimited buffer a viewer with no scrollback at all — and no
+        // history-row image placements, since they are addressed relative to the retained window.
+        val unlimited = TerminalTextBuffer(
+            width = 8,
+            height = 2,
+            styleState = StyleState(),
+            maxHistoryLinesCount = -1,
+        )
+
+        assertEquals(MAX_WEB_VIEWER_SCROLLBACK_LINES, webViewerScrollbackLines(unlimited))
+    }
+
+    @Test
+    fun `the raster budget always keeps the newest image and fills the rest greedily`() {
+        val buffer = TerminalTextBuffer(8, 5, StyleState())
+        buffer.getLine(4)
+        val cache = ImageDataCache()
+        val mib = 1024 * 1024
+        // Oldest to newest: 6, 8, 8, 1 MiB against a 16 MiB pane budget. Selection runs newest-first,
+        // so the newest (1 MiB) is always admitted — the per-image cap is half the pane budget, so
+        // the first candidate cannot be too large for an empty budget. The second (8) fits at 9 MiB,
+        // the third (8) would overflow and is SKIPPED, and the oldest (6) then uses the space that
+        // would otherwise be wasted. Stopping at the first overflow instead would silently drop that
+        // last image for no gain, since the newest was never at risk.
+        listOf(6, 8, 8, 1).forEachIndexed { index, sizeMib ->
+            val image = TerminalImage(
+                id = 70L + index,
+                data = ByteArray(sizeMib * mib) { index.toByte() },
+                format = ImageFormat.PNG,
+            )
+            cache.storeImage(image)
+            buffer.writeImageCellRow(index, 0, image.id, 0, 1, 1)
+        }
+
+        val frame = PaneGraphicsTracker("pane", buffer, cache).fullMessage()
+
+        assertEquals(listOf("70", "72", "73"), frame.requiredImageIds.sorted())
+        assertTrue("73" in frame.requiredImageIds, "the newest image must never lose the budget")
+        assertEquals(listOf("70", "72", "73"), frame.cells.map { it.imageId }.sorted())
+    }
+
+    @Test
+    fun `shell integration OSC sequences skip the per-character state machine`() {
+        val filter = GraphicsOutputFilter()
+        // This repo's own shell-integration guide has users emit OSC 7 + OSC 133 on EVERY prompt, so
+        // these are the common case, not the rare one. assertSame proves the chunk came back
+        // untouched: the fast path neither copied it nor walked it character by character.
+        val osc7 = "\u001b]7;file:///Users/dev\u0007prompt> "
+        assertSame(osc7, filter.filter(osc7).output)
+        val osc133 = "\u001b]133;D;0\u0007\u001b]133;A\u0007prompt> "
+        assertSame(osc133, filter.filter(osc133).output)
+        val eightBitOsc = "\u009d0;a window title\u0007text"
+        assertSame(eightBitOsc, filter.filter(eightBitOsc).output)
+
+        // An iTerm2 OSC that is NOT an image transfer shares the 1337; discriminator, so it does
+        // enter the machine — but it must pass through byte for byte.
+        val userVar = "\u001b]1337;SetUserVar=k=dg==\u0007"
+        val userVarResult = filter.filter(userVar)
+        assertFalse(userVarResult.detectedGraphics)
+        assertEquals(userVar, userVarResult.output)
+
+        // …and a real image OSC is still stripped, including when the chunk boundary falls inside
+        // the discriminating prefix, where the filter has to carry state across chunks.
+        val split = GraphicsOutputFilter()
+        assertEquals("before", split.filter("before\u001b]13").output)
+        val tail = split.filter("37;File=name=x:AAAA\u0007after")
+        assertTrue(tail.detectedGraphics)
+        assertEquals("after", tail.output)
+    }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
@@ -245,6 +245,7 @@ class PaneGraphicsTrackerTest {
         val cappedFrame = PaneGraphicsTracker("pane", buffer, cache).fullMessage()
         assertEquals(2, cappedFrame.images.size)
         assertEquals(2, cappedFrame.cells.size)
+        assertEquals(listOf("92", "93"), cappedFrame.requiredImageIds.sorted())
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PaneGraphicsTrackerTest {
@@ -124,11 +125,14 @@ class PaneGraphicsTrackerTest {
         cache.storeImage(first)
         buffer.writeImageCellRow(0, 0, first.id, 0, 1, 1)
 
-        val firstHash = PaneGraphicsTracker("pane", buffer, cache)
-            .fullMessage().images.single().contentHash
-        val reconnectHash = PaneGraphicsTracker("pane", buffer, cache)
-            .fullMessage().images.single().contentHash
+        val firstWire = PaneGraphicsTracker("pane", buffer, cache)
+            .fullMessage().images.single()
+        val reconnectWire = PaneGraphicsTracker("pane", buffer, cache)
+            .fullMessage().images.single()
+        val firstHash = firstWire.contentHash
+        val reconnectHash = reconnectWire.contentHash
         assertEquals(firstHash, reconnectHash)
+        assertSame(firstWire.data, reconnectWire.data, "base64 must be shared across viewer trackers")
 
         cache.storeImage(first.copy(data = byteArrayOf(3, 2, 1)))
         val replacedHash = PaneGraphicsTracker("pane", buffer, cache)
@@ -186,6 +190,59 @@ class PaneGraphicsTrackerTest {
         assertTrue(trimmed.message.images.isEmpty(), "a row trim must not resend raster bytes")
         assertEquals(listOf("8"), trimmed.message.removedImageIds)
         assertTrue(trimmed.message.cells.isEmpty())
+    }
+
+    @Test
+    fun `web history cap shifts rows before the larger host history trims`() {
+        val buffer = TerminalTextBuffer(8, 2, StyleState(), maxHistoryLinesCount = 3)
+        buffer.getLine(1)
+        val cache = ImageDataCache()
+        val image = TerminalImage(id = 81, data = byteArrayOf(1), format = ImageFormat.PNG)
+        cache.storeImage(image)
+        buffer.writeImageCellRow(0, 0, image.id, 0, 1, 1)
+        val tracker = PaneGraphicsTracker("pane", buffer, cache, scrollbackLines = 1)
+        tracker.fullMessage()
+
+        buffer.scrollArea(scrollRegionTop = 1, dy = -1, scrollRegionBottom = 2)
+        assertNull(tracker.pollUpdate(), "the first retained history row keeps its absolute position")
+
+        buffer.scrollArea(scrollRegionTop = 1, dy = -1, scrollRegionBottom = 2)
+        val shifted = tracker.pollUpdate()!!
+        assertEquals(listOf("81"), shifted.message.removedImageIds)
+        assertTrue(shifted.message.cells.isEmpty())
+        assertEquals(1, shifted.message.historyLines)
+    }
+
+    @Test
+    fun `web raster budget skips oversized and excess images`() {
+        val buffer = TerminalTextBuffer(8, 4, StyleState())
+        buffer.getLine(3)
+        val cache = ImageDataCache()
+        val oversized = TerminalImage(
+            id = 90,
+            data = ByteArray(MAX_WEB_IMAGE_RASTER_BYTES + 1),
+            format = ImageFormat.PNG,
+        )
+        cache.storeImage(oversized)
+        buffer.writeImageCellRow(0, 0, oversized.id, 0, 1, 1)
+        val oversizedFrame = PaneGraphicsTracker("pane", buffer, cache).fullMessage()
+        assertTrue(oversizedFrame.images.isEmpty())
+        assertTrue(oversizedFrame.cells.isEmpty())
+
+        buffer.clearImageCells(oversized.id)
+        cache.removeImage(oversized.id)
+        repeat(3) { index ->
+            val image = TerminalImage(
+                id = 91L + index,
+                data = ByteArray(6 * 1024 * 1024) { index.toByte() },
+                format = ImageFormat.PNG,
+            )
+            cache.storeImage(image)
+            buffer.writeImageCellRow(index, 0, image.id, 0, 1, 1)
+        }
+        val cappedFrame = PaneGraphicsTracker("pane", buffer, cache).fullMessage()
+        assertEquals(2, cappedFrame.images.size)
+        assertEquals(2, cappedFrame.cells.size)
     }
 
     @Test
@@ -256,6 +313,15 @@ class PaneGraphicsTrackerTest {
 
         val truncated = GraphicsOutputFilter(maxDiscardChars = 3)
         assertEquals("hello", truncated.filter("\u001bPqabchello").output)
+
+        val repeatedEscape = GraphicsOutputFilter()
+        assertEquals("\u001bhello", repeatedEscape.filter("\u001b\u001bPqpayload\u009chello").output)
+
+        val kittyPlacement = GraphicsOutputFilter()
+        val placeholder = String(Character.toChars(0x10EEEE))
+        assertEquals(" tail", kittyPlacement.filter("$placeholder\u0301\u0302tail").output)
+        assertEquals(" ", kittyPlacement.filter(placeholder).output)
+        assertEquals("tail", kittyPlacement.filter("\u0301\u0302tail").output)
     }
 
     @Test
@@ -279,5 +345,33 @@ class PaneGraphicsTrackerTest {
         assertTrue(limiter.tryAcquire("pane", estimatedBytes = 60, nowNanos = 1_000))
         assertFalse(limiter.tryAcquire("pane", estimatedBytes = 41, nowNanos = 1_001))
         assertTrue(limiter.tryAcquire("pane", estimatedBytes = 100, nowNanos = 2_000))
+    }
+
+    @Test
+    fun `denied resync does not advance the rolling window`() {
+        val limiter = GraphicsResyncLimiter(
+            minimumIntervalNanos = 0,
+            maximumBytesPerWindow = 100,
+            windowNanos = 1_000,
+        )
+        assertTrue(limiter.tryAcquire("pane", estimatedBytes = 60, nowNanos = 1_000))
+        assertFalse(limiter.tryAcquire("pane", estimatedBytes = 101, nowNanos = 2_000))
+        assertTrue(limiter.tryAcquire("pane", estimatedBytes = 60, nowNanos = 2_500))
+        assertFalse(
+            limiter.tryAcquire("pane", estimatedBytes = 60, nowNanos = 3_001),
+            "the denied request must not have started a new window at t=2000",
+        )
+    }
+
+    @Test
+    fun `web scrollback cap matches the supported settings ceiling`() {
+        val buffer = TerminalTextBuffer(
+            width = 8,
+            height = 2,
+            styleState = StyleState(),
+            maxHistoryLinesCount = 500_000,
+        )
+
+        assertEquals(MAX_WEB_VIEWER_SCROLLBACK_LINES, webViewerScrollbackLines(buffer))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
@@ -1,0 +1,98 @@
+package ai.rever.bossterm.compose.share
+
+import ai.rever.bossterm.terminal.model.StyleState
+import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import ai.rever.bossterm.terminal.model.image.ImageDataCache
+import ai.rever.bossterm.terminal.model.image.ImageFormat
+import ai.rever.bossterm.terminal.model.image.TerminalImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PaneGraphicsTrackerTest {
+    @Test
+    fun `cell runs group adjacent slices and omit images missing from cache`() {
+        val buffer = TerminalTextBuffer(8, 4, StyleState())
+        buffer.getLine(3) // Materialize the lazily allocated screen rows.
+        buffer.writeImageCellRow(
+            row = 1,
+            startCol = 2,
+            imageId = 11,
+            cellY = 0,
+            cellWidth = 3,
+            cellHeight = 2,
+        )
+        buffer.writeImageCellRow(
+            row = 2,
+            startCol = 0,
+            imageId = 99,
+            cellY = 1,
+            cellWidth = 2,
+            cellHeight = 2,
+        )
+
+        val runs = PaneGraphicsTracker.cellRuns(buffer.createIncrementalSnapshot(), setOf(11))
+
+        assertEquals(
+            listOf(SharedImageCellRun("11", row = 1, col = 2, cellX = 0, cellY = 0,
+                length = 3, totalCellsX = 3, totalCellsY = 2)),
+            runs,
+        )
+    }
+
+    @Test
+    fun `tracker sends raster bytes once then full placements and removals`() {
+        val buffer = TerminalTextBuffer(8, 4, StyleState())
+        buffer.getLine(3) // Materialize the lazily allocated screen rows.
+        val cache = ImageDataCache()
+        val image = TerminalImage(
+            id = 42,
+            data = byteArrayOf(
+                0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            ),
+            format = ImageFormat.PNG,
+            intrinsicWidth = 1,
+            intrinsicHeight = 1,
+        )
+        cache.storeImage(image)
+        buffer.writeImageCellRow(0, 1, image.id, 0, 2, 1)
+        val tracker = PaneGraphicsTracker("pane", buffer, cache)
+
+        val initial = tracker.fullMessage()
+        assertTrue(initial.full)
+        assertEquals(listOf("42"), initial.requiredImageIds)
+        assertEquals(1, initial.images.size)
+        assertEquals("image/png", initial.images.single().mimeType)
+
+        val firstDelta = tracker.pollUpdate()!!
+        assertFalse(firstDelta.full)
+        assertEquals(1L, firstDelta.revision)
+        assertEquals(1, firstDelta.images.size)
+        assertNull(tracker.pollUpdate())
+
+        buffer.clearImageCells(image.id)
+        val removal = tracker.pollUpdate()!!
+        assertEquals(2L, removal.revision)
+        assertEquals(listOf("42"), removal.removedImageIds)
+        assertTrue(removal.requiredImageIds.isEmpty())
+        assertTrue(removal.cells.isEmpty())
+        assertFalse(tracker.hasVisibleGraphics())
+    }
+
+    @Test
+    fun `sequence detector recognizes fragmented Sixel Kitty and placeholders`() {
+        val sixel = GraphicsSequenceDetector()
+        assertFalse(sixel.inspect("\u001b"))
+        assertFalse(sixel.inspect("P0;"))
+        assertTrue(sixel.inspect("0qpayload"))
+
+        val kitty = GraphicsSequenceDetector()
+        assertFalse(kitty.inspect("\u001b_"))
+        assertTrue(kitty.inspect("Ga=t;payload"))
+
+        val placeholder = GraphicsSequenceDetector()
+        assertTrue(placeholder.inspect(String(Character.toChars(0x10EEEE))))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
@@ -299,7 +299,10 @@ class PaneGraphicsTrackerTest {
         assertFalse(queryResult.detectedGraphics)
         assertEquals("\u001bP\$qm\u001b\\", queryResult.output)
 
-        assertEquals("ordinary output", sixel.filter("ordinary output").output)
+        val ordinary = "ordinary output"
+        assertSame(ordinary, sixel.filter(ordinary).output)
+        val colored = "\u001b[31mred\u001b[0m"
+        assertSame(colored, sixel.filter(colored).output)
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
@@ -112,6 +112,31 @@ class PaneGraphicsTrackerTest {
     }
 
     @Test
+    fun `content fingerprint is stable across tracker lifetimes`() {
+        val buffer = TerminalTextBuffer(8, 4, StyleState())
+        buffer.getLine(3)
+        val cache = ImageDataCache()
+        val first = TerminalImage(
+            id = 55,
+            data = byteArrayOf(1, 2, 3),
+            format = ImageFormat.PNG,
+        )
+        cache.storeImage(first)
+        buffer.writeImageCellRow(0, 0, first.id, 0, 1, 1)
+
+        val firstHash = PaneGraphicsTracker("pane", buffer, cache)
+            .fullMessage().images.single().contentHash
+        val reconnectHash = PaneGraphicsTracker("pane", buffer, cache)
+            .fullMessage().images.single().contentHash
+        assertEquals(firstHash, reconnectHash)
+
+        cache.storeImage(first.copy(data = byteArrayOf(3, 2, 1)))
+        val replacedHash = PaneGraphicsTracker("pane", buffer, cache)
+            .fullMessage().images.single().contentHash
+        assertTrue(replacedHash != firstHash)
+    }
+
+    @Test
     fun `ordinary scrolling keeps absolute image rows stable and emits no graphics delta`() {
         val buffer = TerminalTextBuffer(8, 4, StyleState())
         buffer.getLine(3)
@@ -216,6 +241,21 @@ class PaneGraphicsTrackerTest {
         assertEquals("\u001bP\$qm\u001b\\", queryResult.output)
 
         assertEquals("ordinary output", sixel.filter("ordinary output").output)
+    }
+
+    @Test
+    fun `graphics filter recovers from emulator abort conditions`() {
+        val cancelled = GraphicsOutputFilter()
+        assertEquals("hello", cancelled.filter("\u001bPqpayload\u0018hello").output)
+
+        val substituted = GraphicsOutputFilter()
+        assertEquals("hello", substituted.filter("\u001bPqpayload\u001ahello").output)
+
+        val strayEscape = GraphicsOutputFilter()
+        assertEquals("hello", strayEscape.filter("\u001bPqpayload\u001bXhello").output)
+
+        val truncated = GraphicsOutputFilter(maxDiscardChars = 3)
+        assertEquals("hello", truncated.filter("\u001bPqabchello").output)
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
@@ -81,6 +81,37 @@ class PaneGraphicsTrackerTest {
     }
 
     @Test
+    fun `cache replacement sends one raster delta without a text reanchor`() {
+        val buffer = TerminalTextBuffer(8, 4, StyleState())
+        buffer.getLine(3)
+        val cache = ImageDataCache()
+        val first = TerminalImage(
+            id = 5,
+            data = byteArrayOf(1),
+            format = ImageFormat.PNG,
+            intrinsicWidth = 1,
+            intrinsicHeight = 1,
+        )
+        cache.storeImage(first)
+        buffer.writeImageCellRow(0, 0, first.id, 0, 1, 1)
+        val tracker = PaneGraphicsTracker("pane", buffer, cache)
+        val firstFull = tracker.fullMessage()
+
+        cache.storeImage(TerminalImage(
+            id = 5,
+            data = byteArrayOf(2),
+            format = ImageFormat.PNG,
+            intrinsicWidth = 1,
+            intrinsicHeight = 1,
+        ))
+        val replacement = tracker.pollUpdate()!!
+
+        assertFalse(replacement.requiresTextSnapshot)
+        assertEquals(1, replacement.message.images.size)
+        assertTrue(replacement.message.images.single().contentHash != firstFull.images.single().contentHash)
+    }
+
+    @Test
     fun `ordinary scrolling keeps absolute image rows stable and emits no graphics delta`() {
         val buffer = TerminalTextBuffer(8, 4, StyleState())
         buffer.getLine(3)
@@ -102,6 +133,34 @@ class PaneGraphicsTrackerTest {
 
         assertNull(tracker.pollUpdate())
         assertEquals(1, tracker.fullMessage().cells.single().row)
+    }
+
+    @Test
+    fun `capped history trim shifts placements without a full raster resend`() {
+        val buffer = TerminalTextBuffer(8, 2, StyleState(), maxHistoryLinesCount = 1)
+        buffer.getLine(1)
+        val cache = ImageDataCache()
+        val image = TerminalImage(
+            id = 8,
+            data = byteArrayOf(1),
+            format = ImageFormat.PNG,
+            intrinsicWidth = 1,
+            intrinsicHeight = 1,
+        )
+        cache.storeImage(image)
+        buffer.writeImageCellRow(0, 0, image.id, 0, 1, 1)
+        val tracker = PaneGraphicsTracker("pane", buffer, cache)
+        tracker.fullMessage()
+
+        buffer.scrollArea(scrollRegionTop = 1, dy = -1, scrollRegionBottom = 2)
+        assertNull(tracker.pollUpdate(), "moving into uncapped history preserves the absolute row")
+
+        buffer.scrollArea(scrollRegionTop = 1, dy = -1, scrollRegionBottom = 2)
+        val trimmed = tracker.pollUpdate()!!
+        assertFalse(trimmed.requiresTextSnapshot)
+        assertTrue(trimmed.message.images.isEmpty(), "a row trim must not resend raster bytes")
+        assertEquals(listOf("8"), trimmed.message.removedImageIds)
+        assertTrue(trimmed.message.cells.isEmpty())
     }
 
     @Test
@@ -127,25 +186,36 @@ class PaneGraphicsTrackerTest {
     }
 
     @Test
-    fun `sequence detector recognizes fragmented Sixel Kitty and placeholders`() {
-        val sixel = GraphicsSequenceDetector()
-        assertFalse(sixel.inspect("\u001b"))
-        assertFalse(sixel.inspect("P0;"))
-        assertTrue(sixel.inspect("0qpayload"))
+    fun `graphics filter strips fragmented payloads and preserves ordinary output`() {
+        val sixel = GraphicsOutputFilter()
+        assertEquals("", sixel.filter("\u001b").output)
+        assertEquals("", sixel.filter("P0;").output)
+        val sixelEnd = sixel.filter("0qpayload\u001b\\tail")
+        assertTrue(sixelEnd.detectedGraphics)
+        assertEquals("tail", sixelEnd.output)
 
-        val kitty = GraphicsSequenceDetector()
-        assertFalse(kitty.inspect("\u001b_"))
-        assertTrue(kitty.inspect("Ga=t;payload"))
+        val kitty = GraphicsOutputFilter()
+        assertEquals("", kitty.filter("\u001b_").output)
+        val kittyEnd = kitty.filter("Ga=t;payload\u009ctail")
+        assertTrue(kittyEnd.detectedGraphics)
+        assertEquals("tail", kittyEnd.output)
 
-        val placeholder = GraphicsSequenceDetector()
-        assertTrue(placeholder.inspect(String(Character.toChars(0x10EEEE))))
+        val iterm = GraphicsOutputFilter()
+        val itermEnd = iterm.filter("\u001b]1337;File=name=x:base64\u0007tail")
+        assertTrue(itermEnd.detectedGraphics)
+        assertEquals("tail", itermEnd.output)
 
-        val query = GraphicsSequenceDetector()
-        assertFalse(query.inspect("\u001bP\$qm\u001b\\"))
+        val placeholder = GraphicsOutputFilter()
+        val placeholderResult = placeholder.filter(String(Character.toChars(0x10EEEE)))
+        assertTrue(placeholderResult.detectedGraphics)
+        assertEquals(" ", placeholderResult.output)
 
-        val oneShot = GraphicsSequenceDetector()
-        assertTrue(oneShot.inspect("\u001bP0;0qpayload"))
-        assertFalse(oneShot.inspect("ordinary output"))
+        val query = GraphicsOutputFilter()
+        val queryResult = query.filter("\u001bP\$qm\u001b\\")
+        assertFalse(queryResult.detectedGraphics)
+        assertEquals("\u001bP\$qm\u001b\\", queryResult.output)
+
+        assertEquals("ordinary output", sixel.filter("ordinary output").output)
     }
 
     @Test
@@ -155,5 +225,19 @@ class PaneGraphicsTrackerTest {
         assertFalse(limiter.tryAcquire("a", nowNanos = 1_499))
         assertTrue(limiter.tryAcquire("b", nowNanos = 1_499))
         assertTrue(limiter.tryAcquire("a", nowNanos = 1_500))
+        limiter.remove("a")
+        assertTrue(limiter.tryAcquire("a", nowNanos = 1_501))
+    }
+
+    @Test
+    fun `graphics resync limiter also enforces a rolling byte budget`() {
+        val limiter = GraphicsResyncLimiter(
+            minimumIntervalNanos = 0,
+            maximumBytesPerWindow = 100,
+            windowNanos = 1_000,
+        )
+        assertTrue(limiter.tryAcquire("pane", estimatedBytes = 60, nowNanos = 1_000))
+        assertFalse(limiter.tryAcquire("pane", estimatedBytes = 41, nowNanos = 1_001))
+        assertTrue(limiter.tryAcquire("pane", estimatedBytes = 100, nowNanos = 2_000))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
@@ -66,19 +66,64 @@ class PaneGraphicsTrackerTest {
         assertEquals(1, initial.images.size)
         assertEquals("image/png", initial.images.single().mimeType)
 
-        val firstDelta = tracker.pollUpdate()!!
-        assertFalse(firstDelta.full)
-        assertEquals(1L, firstDelta.revision)
-        assertEquals(1, firstDelta.images.size)
+        // fullMessage commits its captured state, so attach does not immediately double-send it.
         assertNull(tracker.pollUpdate())
 
         buffer.clearImageCells(image.id)
-        val removal = tracker.pollUpdate()!!
+        val removalUpdate = tracker.pollUpdate()!!
+        assertFalse(removalUpdate.requiresTextSnapshot)
+        val removal = removalUpdate.message
         assertEquals(2L, removal.revision)
         assertEquals(listOf("42"), removal.removedImageIds)
         assertTrue(removal.requiredImageIds.isEmpty())
         assertTrue(removal.cells.isEmpty())
         assertFalse(tracker.hasVisibleGraphics())
+    }
+
+    @Test
+    fun `ordinary scrolling keeps absolute image rows stable and emits no graphics delta`() {
+        val buffer = TerminalTextBuffer(8, 4, StyleState())
+        buffer.getLine(3)
+        val cache = ImageDataCache()
+        val image = TerminalImage(
+            id = 7,
+            data = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47),
+            format = ImageFormat.PNG,
+            intrinsicWidth = 1,
+            intrinsicHeight = 1,
+        )
+        cache.storeImage(image)
+        buffer.writeImageCellRow(1, 0, image.id, 0, 1, 1)
+        val tracker = PaneGraphicsTracker("pane", buffer, cache)
+        val initial = tracker.fullMessage()
+        assertEquals(1, initial.cells.single().row)
+
+        buffer.scrollArea(scrollRegionTop = 1, dy = -1, scrollRegionBottom = 4)
+
+        assertNull(tracker.pollUpdate())
+        assertEquals(1, tracker.fullMessage().cells.single().row)
+    }
+
+    @Test
+    fun `unknown image bytes are not sent to browsers`() {
+        val buffer = TerminalTextBuffer(8, 4, StyleState())
+        buffer.getLine(3)
+        val cache = ImageDataCache()
+        val image = TerminalImage(
+            id = 9,
+            data = byteArrayOf(1, 2, 3),
+            format = ImageFormat.UNKNOWN,
+            intrinsicWidth = 1,
+            intrinsicHeight = 1,
+        )
+        cache.storeImage(image)
+        buffer.writeImageCellRow(0, 0, image.id, 0, 1, 1)
+
+        val full = PaneGraphicsTracker("pane", buffer, cache).fullMessage()
+
+        assertTrue(full.images.isEmpty())
+        assertTrue(full.cells.isEmpty())
+        assertTrue(full.requiredImageIds.isEmpty())
     }
 
     @Test
@@ -94,5 +139,21 @@ class PaneGraphicsTrackerTest {
 
         val placeholder = GraphicsSequenceDetector()
         assertTrue(placeholder.inspect(String(Character.toChars(0x10EEEE))))
+
+        val query = GraphicsSequenceDetector()
+        assertFalse(query.inspect("\u001bP\$qm\u001b\\"))
+
+        val oneShot = GraphicsSequenceDetector()
+        assertTrue(oneShot.inspect("\u001bP0;0qpayload"))
+        assertFalse(oneShot.inspect("ordinary output"))
+    }
+
+    @Test
+    fun `graphics resync limiter is per pane and rate limited`() {
+        val limiter = GraphicsResyncLimiter(minimumIntervalNanos = 500)
+        assertTrue(limiter.tryAcquire("a", nowNanos = 1_000))
+        assertFalse(limiter.tryAcquire("a", nowNanos = 1_499))
+        assertTrue(limiter.tryAcquire("b", nowNanos = 1_499))
+        assertTrue(limiter.tryAcquire("a", nowNanos = 1_500))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/PaneGraphicsTrackerTest.kt
@@ -373,6 +373,24 @@ class PaneGraphicsTrackerTest {
     }
 
     @Test
+    fun `graphics resync limiter reports when a denied request can retry`() {
+        val limiter = GraphicsResyncLimiter(
+            minimumIntervalNanos = 500_000_000,
+            maximumBytesPerWindow = 100,
+            windowNanos = 2_000_000_000,
+        )
+        assertTrue(limiter.tryAcquire("pane", estimatedBytes = 60, nowNanos = 1_000_000_000))
+        assertEquals(
+            500,
+            limiter.retryAfterMillis("pane", estimatedBytes = 20, nowNanos = 1_000_000_000),
+        )
+        assertEquals(
+            2_000,
+            limiter.retryAfterMillis("pane", estimatedBytes = 41, nowNanos = 1_000_000_000),
+        )
+    }
+
+    @Test
     fun `denied resync does not advance the rolling window`() {
         val limiter = GraphicsResyncLimiter(
             minimumIntervalNanos = 0,

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -25,6 +25,18 @@ class ShareProtocolTest {
 
         val presence = ShareProtocol.encodeServer(ServerMessage.Presence(3))
         assertTrue(presence.contains("\"viewers\":3"))
+
+        val graphics = ServerMessage.PaneGraphics(
+            paneId = "p1",
+            revision = 7,
+            full = true,
+            images = listOf(SharedTerminalImage("42", "image/png", "cG5n", "abc")),
+            requiredImageIds = listOf("42"),
+            cells = listOf(SharedImageCellRun("42", -1, 2, 0, 0, 3, 3, 2)),
+        )
+        val graphicsJson = ShareProtocol.encodeServer(graphics)
+        assertTrue(graphicsJson.contains("\"t\":\"paneGraphics\""))
+        assertEquals(graphics, ShareProtocol.decodeServer(graphicsJson))
     }
 
     @Test
@@ -52,9 +64,20 @@ class ShareProtocolTest {
 
     @Test
     fun `client messages decode by discriminator`() {
-        val hello = ShareProtocol.decodeClient("""{"t":"hello","name":"phone"}""")
+        val hello = ShareProtocol.decodeClient(
+            """{"t":"hello","name":"phone","capabilities":["paneGraphicsV1"]}"""
+        )
         assertIs<ClientMessage.Hello>(hello)
         assertEquals("phone", hello.name)
+        assertEquals(listOf("paneGraphicsV1"), hello.capabilities)
+
+        val legacyHello = ShareProtocol.decodeClient("""{"t":"hello","name":"old"}""")
+        assertIs<ClientMessage.Hello>(legacyHello)
+        assertTrue(legacyHello.capabilities.isEmpty())
+
+        val graphicsResync = ShareProtocol.decodeClient("""{"t":"graphicsResync","paneId":"p1"}""")
+        assertIs<ClientMessage.GraphicsResync>(graphicsResync)
+        assertEquals("p1", graphicsResync.paneId)
 
         val input = ShareProtocol.decodeClient("""{"t":"input","paneId":"p2","data":"ls\n"}""")
         assertIs<ClientMessage.Input>(input)

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -1,14 +1,30 @@
 package ai.rever.bossterm.compose.share
 
+import ai.rever.bossterm.compose.util.BUNDLED_FONT_NAME
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlin.test.assertIs
 
 /** Round-trip + discriminator checks for the window/tab/pane sharing protocol (issue #276). */
 class ShareProtocolTest {
+
+    @Test
+    fun `web terminal font stack preserves configured font and bundled icon fallbacks`() {
+        val bundled = webTerminalFontFamily(null)
+        assertTrue(bundled.startsWith("\"BossTerm Nerd Font\""))
+        assertTrue(bundled.contains("\"Apple Color Emoji\""))
+        assertTrue(bundled.contains("\"BossTerm Symbols\""))
+        assertEquals(bundled, webTerminalFontFamily(BUNDLED_FONT_NAME))
+
+        val configured = webTerminalFontFamily("JetBrains Mono")
+        assertTrue(configured.startsWith("\"JetBrains Mono\", \"BossTerm Nerd Font\""))
+
+        val escaped = webTerminalFontFamily("Font \"Quoted\"")
+        assertTrue(escaped.startsWith("\"Font \\\"Quoted\\\"\", "))
+    }
 
     @Test
     fun `server messages encode with the t discriminator`() {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -32,9 +32,12 @@ class ShareProtocolTest {
         assertTrue(out.contains("\"t\":\"paneOutput\""), "expected paneOutput discriminator in: $out")
         assertTrue(out.contains("\"paneId\":\"p1\""))
 
-        val snap = ShareProtocol.encodeServer(ServerMessage.PaneSnapshot("p1", "scrollback", 120, 40))
+        val snap = ShareProtocol.encodeServer(
+            ServerMessage.PaneSnapshot("p1", "scrollback", 120, 40, scrollbackLines = 12_345)
+        )
         assertTrue(snap.contains("\"t\":\"paneSnapshot\""))
         assertTrue(snap.contains("\"cols\":120") && snap.contains("\"rows\":40"))
+        assertTrue(snap.contains("\"scrollbackLines\":12345"))
 
         val resize = ShareProtocol.encodeServer(ServerMessage.PaneResize("p1", 80, 24))
         assertTrue(resize.contains("\"t\":\"paneResize\""))

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -72,6 +72,13 @@ class ShareProtocolTest {
 
         val denied = ServerMessage.GraphicsResyncDenied("p1", retryAfterMs = 750)
         assertEquals(denied, ShareProtocol.decodeServer(ShareProtocol.encodeServer(denied)))
+
+        val recovery = graphics.resyncSentinel()
+        assertEquals(graphics.revision, recovery.revision)
+        assertTrue(recovery.resyncRequired)
+        assertTrue(recovery.images.isEmpty())
+        assertTrue(recovery.requiredImageIds.isEmpty())
+        assertTrue(recovery.cells.isEmpty())
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -35,6 +35,9 @@ class ShareProtocolTest {
         assertTrue(out.contains("\"t\":\"paneOutput\""), "expected paneOutput discriminator in: $out")
         assertTrue(out.contains("\"paneId\":\"p1\""))
 
+        val repaint = ShareProtocol.encodeServer(ServerMessage.PaneRepaint("p1", "screen"))
+        assertTrue(repaint.contains("\"t\":\"paneRepaint\""))
+
         val snap = ShareProtocol.encodeServer(
             ServerMessage.PaneSnapshot("p1", "scrollback", 120, 40, scrollbackLines = 12_345)
         )
@@ -55,10 +58,20 @@ class ShareProtocolTest {
             images = listOf(SharedTerminalImage("42", "image/png", "cG5n", "abc")),
             requiredImageIds = listOf("42"),
             cells = listOf(SharedImageCellRun("42", 4, 2, 0, 0, 3, 3, 2)),
+            resyncRequired = true,
         )
         val graphicsJson = ShareProtocol.encodeServer(graphics)
         assertTrue(graphicsJson.contains("\"t\":\"paneGraphics\""))
         assertEquals(graphics, ShareProtocol.decodeServer(graphicsJson))
+
+        val legacyGraphics = ShareProtocol.decodeServer(
+            """{"t":"paneGraphics","paneId":"p1","revision":1,"full":false}"""
+        )
+        assertIs<ServerMessage.PaneGraphics>(legacyGraphics)
+        assertEquals(false, legacyGraphics.resyncRequired)
+
+        val denied = ServerMessage.GraphicsResyncDenied("p1", retryAfterMs = 750)
+        assertEquals(denied, ShareProtocol.decodeServer(ShareProtocol.encodeServer(denied)))
     }
 
     @Test
@@ -233,6 +246,10 @@ class ShareProtocolTest {
         val out = ShareProtocol.decodeServer("""{"t":"paneOutput","paneId":"p1","data":"hi"}""")
         assertIs<ServerMessage.PaneOutput>(out)
         assertEquals("hi", out.data)
+
+        val repaint = ShareProtocol.decodeServer("""{"t":"paneRepaint","paneId":"p1","data":"screen"}""")
+        assertIs<ServerMessage.PaneRepaint>(repaint)
+        assertEquals("screen", repaint.data)
 
         // encodeClient is the client write path (handshake).
         val hello = ShareProtocol.encodeClient(ClientMessage.Hello(name = "dev", clientId = "c1", key = null))

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -48,7 +48,7 @@ class ShareProtocolTest {
             full = true,
             images = listOf(SharedTerminalImage("42", "image/png", "cG5n", "abc")),
             requiredImageIds = listOf("42"),
-            cells = listOf(SharedImageCellRun("42", -1, 2, 0, 0, 3, 3, 2)),
+            cells = listOf(SharedImageCellRun("42", 4, 2, 0, 0, 3, 3, 2)),
         )
         val graphicsJson = ShareProtocol.encodeServer(graphics)
         assertTrue(graphicsJson.contains("\"t\":\"paneGraphics\""))

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareProtocolTest.kt
@@ -24,6 +24,9 @@ class ShareProtocolTest {
 
         val escaped = webTerminalFontFamily("Font \"Quoted\"")
         assertTrue(escaped.startsWith("\"Font \\\"Quoted\\\"\", "))
+
+        val controlsRemoved = webTerminalFontFamily("Unsafe\nFont\u0000")
+        assertTrue(controlsRemoved.startsWith("\"UnsafeFont\", "))
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
@@ -62,8 +62,7 @@ class ShareViewerAssetTest {
             .substringBefore("case \"paneGraphics\":")
 
         assertFalse(paneOutput.contains("scrollToLine"))
-        assertTrue(paneRepaint.contains("scrollLinesFromBottom"))
-        assertTrue(paneRepaint.contains("scrollToLine"))
+        assertTrue(paneRepaint.contains("viewerLogic.queuePaneRepaint"))
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
@@ -48,7 +48,7 @@ class ShareViewerAssetTest {
         assertTrue(paneSnapshot.contains("m.scrollbackLines"))
         assertTrue(paneSnapshot.contains("MAX_WEB_VIEWER_SCROLLBACK_LINES"))
         assertTrue(js.contains("DEFAULT_WEB_VIEWER_SCROLLBACK_LINES = 10000"))
-        assertTrue(js.contains("MAX_WEB_VIEWER_SCROLLBACK_LINES = 100000"))
+        assertTrue(js.contains("MAX_WEB_VIEWER_SCROLLBACK_LINES = 20000"))
         assertFalse(js.contains("WEB_VIEWER_SCROLLBACK_LINES = 5000"))
     }
 
@@ -79,6 +79,8 @@ class ShareViewerAssetTest {
         val html = resource("share-viewer/index.html")
 
         assertTrue(html.contains("default-src 'self'"))
+        assertTrue(html.contains("base-uri 'none'"))
+        assertTrue(html.contains("form-action 'none'"))
         assertTrue(html.contains("img-src 'self' data:"))
         assertTrue(html.contains("connect-src 'self' ws: wss:"))
         assertTrue(html.contains("MesloLGSNF-Regular.ttf?v=d97946186e97"))

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
@@ -32,6 +32,7 @@ class ShareViewerAssetTest {
         assertTrue(js.contains("g.resyncAttempts >= MAX_GRAPHICS_RESYNCS"))
         assertTrue(js.contains("GRAPHICS_RESYNC_TIMEOUT_MS"))
         assertTrue(js.contains("RECONNECT_STABLE_MS"))
+        assertTrue(js.contains("viewerLogic.nextReconnectAttempt"))
         assertFalse(
             js.substringAfter("function handleConnectionLost").substringBefore("function deviceName")
                 .contains("reconnectAttempt = 0")
@@ -79,8 +80,7 @@ class ShareViewerAssetTest {
 
         assertTrue(html.contains("default-src 'self'"))
         assertTrue(html.contains("img-src 'self' data:"))
-        assertTrue(html.contains("connect-src 'self'"))
-        assertFalse(html.contains("connect-src 'self' ws: wss:"))
+        assertTrue(html.contains("connect-src 'self' ws: wss:"))
         assertTrue(html.contains("MesloLGSNF-Regular.ttf?v=d97946186e97"))
         assertFalse(resource("share-viewer/viewer.js").contains("document.fonts.load("))
     }
@@ -108,7 +108,8 @@ class ShareViewerAssetTest {
         val js = resource("share-viewer/viewer.js")
 
         assertTrue(js.contains("ALLOWED_GRAPHICS_MIME_TYPES[wire.mimeType]"))
-        assertTrue(js.contains("buffer.baseY - hostHistoryLines"))
+        assertTrue(js.contains("viewerLogic.captureRowOffset"))
+        assertTrue(js.contains("viewerLogic.visibleImageRow"))
         assertTrue(js.contains("g.historyLines = m.historyLines"))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
@@ -1,6 +1,8 @@
 package ai.rever.bossterm.compose.share
 
+import java.security.MessageDigest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -9,6 +11,10 @@ class ShareViewerAssetTest {
         checkNotNull(javaClass.classLoader.getResourceAsStream(path)) { "missing resource: $path" }
             .bufferedReader()
             .use { it.readText() }
+
+    private fun resourceBytes(path: String): ByteArray =
+        checkNotNull(javaClass.classLoader.getResourceAsStream(path)) { "missing resource: $path" }
+            .use { it.readBytes() }
 
     @Test
     fun `image decode failure is rejected without requesting another full payload`() {
@@ -39,8 +45,9 @@ class ShareViewerAssetTest {
             .substringBefore("case \"paneOutput\":")
 
         assertTrue(paneSnapshot.contains("m.scrollbackLines"))
-        assertTrue(paneSnapshot.contains("p.term.options.scrollback = Math.floor(m.scrollbackLines)"))
+        assertTrue(paneSnapshot.contains("MAX_WEB_VIEWER_SCROLLBACK_LINES"))
         assertTrue(js.contains("DEFAULT_WEB_VIEWER_SCROLLBACK_LINES = 10000"))
+        assertTrue(js.contains("MAX_WEB_VIEWER_SCROLLBACK_LINES = 100000"))
         assertFalse(js.contains("WEB_VIEWER_SCROLLBACK_LINES = 5000"))
     }
 
@@ -76,5 +83,32 @@ class ShareViewerAssetTest {
         assertFalse(html.contains("connect-src 'self' ws: wss:"))
         assertTrue(html.contains("MesloLGSNF-Regular.ttf?v=d97946186e97"))
         assertFalse(resource("share-viewer/viewer.js").contains("document.fonts.load("))
+    }
+
+    @Test
+    fun `font cache tokens match the bundled bytes`() {
+        val html = resource("share-viewer/index.html")
+        val fonts = listOf(
+            "MesloLGSNF-Regular.ttf",
+            "NotoSansSymbols2-Regular.ttf",
+        )
+        for (font in fonts) {
+            val token = Regex("""${Regex.escape(font)}\?v=([0-9a-f]+)""")
+                .find(html)?.groupValues?.get(1)
+            assertTrue(!token.isNullOrEmpty(), "missing content token for $font")
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(resourceBytes("fonts/$font"))
+                .joinToString("") { "%02x".format(it) }
+            assertEquals(digest.take(token.length), token, "stale immutable cache token for $font")
+        }
+    }
+
+    @Test
+    fun `viewer allowlists raster mime types and aligns rows to xterm base`() {
+        val js = resource("share-viewer/viewer.js")
+
+        assertTrue(js.contains("ALLOWED_GRAPHICS_MIME_TYPES[wire.mimeType]"))
+        assertTrue(js.contains("buffer.baseY - hostHistoryLines"))
+        assertTrue(js.contains("g.historyLines = m.historyLines"))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
@@ -1,0 +1,53 @@
+package ai.rever.bossterm.compose.share
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ShareViewerAssetTest {
+    private fun resource(path: String): String =
+        checkNotNull(javaClass.classLoader.getResourceAsStream(path)) { "missing resource: $path" }
+            .bufferedReader()
+            .use { it.readText() }
+
+    @Test
+    fun `image decode failure is rejected without requesting another full payload`() {
+        val js = resource("share-viewer/viewer.js")
+        val onError = js.substringAfter("image.onerror = function () {").substringBefore("image.src =")
+
+        assertTrue(onError.contains("reason: \"decode\""))
+        assertFalse(onError.contains("requestGraphicsResync"))
+    }
+
+    @Test
+    fun `graphics resync and reconnect retries are bounded`() {
+        val js = resource("share-viewer/viewer.js")
+
+        assertTrue(js.contains("g.resyncAttempts >= MAX_GRAPHICS_RESYNCS"))
+        assertTrue(js.contains("GRAPHICS_RESYNC_TIMEOUT_MS"))
+        assertTrue(js.contains("RECONNECT_STABLE_MS"))
+        assertFalse(
+            js.substringAfter("function handleConnectionLost").substringBefore("function deviceName")
+                .contains("reconnectAttempt = 0")
+        )
+    }
+
+    @Test
+    fun `graphics canvas and transparency stay lazy for text-only panes`() {
+        val js = resource("share-viewer/viewer.js")
+        val draw = js.substringAfter("function drawPaneGraphics").substringBefore("function requestGraphicsResync")
+
+        assertTrue(draw.indexOf("if (!g.cells.length") < draw.indexOf("ensureGraphicsCanvas(p)"))
+        assertTrue(js.contains("allowTransparency: false"))
+        assertTrue(js.contains("setPaneGraphicsMode(p, true)"))
+    }
+
+    @Test
+    fun `viewer content security policy allows only required local capabilities`() {
+        val html = resource("share-viewer/index.html")
+
+        assertTrue(html.contains("default-src 'self'"))
+        assertTrue(html.contains("img-src 'self' data:"))
+        assertTrue(html.contains("connect-src 'self' ws: wss:"))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
@@ -6,6 +6,14 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+/**
+ * Facts about the viewer ASSETS themselves — the served HTML's policy and its font cache tokens.
+ *
+ * Viewer *behavior* is covered by running the script: [ShareViewerScriptTest] (viewer.js under a
+ * fake browser) and [ViewerLogicTest] (viewer-logic.js under Node). Assertions about viewer.js
+ * source text belong in neither place — they break on a rename while proving nothing about
+ * execution — so they are not added back here.
+ */
 class ShareViewerAssetTest {
     private fun resource(path: String): String =
         checkNotNull(javaClass.classLoader.getResourceAsStream(path)) { "missing resource: $path" }
@@ -17,67 +25,6 @@ class ShareViewerAssetTest {
             .use { it.readBytes() }
 
     @Test
-    fun `image decode failure is rejected without requesting another full payload`() {
-        val js = resource("share-viewer/viewer.js")
-        val onError = js.substringAfter("image.onerror = function () {").substringBefore("image.src =")
-
-        assertTrue(onError.contains("reason: \"decode\""))
-        assertFalse(onError.contains("requestGraphicsResync"))
-    }
-
-    @Test
-    fun `graphics resync and reconnect retries are bounded`() {
-        val js = resource("share-viewer/viewer.js")
-
-        assertTrue(js.contains("g.resyncAttempts >= MAX_GRAPHICS_RESYNCS"))
-        assertTrue(js.contains("GRAPHICS_RESYNC_TIMEOUT_MS"))
-        assertTrue(js.contains("graphicsAttemptAfterDenied"))
-        assertTrue(js.contains("RECONNECT_STABLE_MS"))
-        assertTrue(js.contains("viewerLogic.nextReconnectAttempt"))
-        assertFalse(
-            js.substringAfter("function handleConnectionLost").substringBefore("function deviceName")
-                .contains("reconnectAttempt = 0")
-        )
-    }
-
-    @Test
-    fun `pane snapshots configure xterm with the host scrollback cap`() {
-        val js = resource("share-viewer/viewer.js")
-        val paneSnapshot = js.substringAfter("case \"paneSnapshot\": {")
-            .substringBefore("case \"paneOutput\":")
-
-        assertTrue(paneSnapshot.contains("m.scrollbackLines"))
-        assertTrue(paneSnapshot.contains("MAX_WEB_VIEWER_SCROLLBACK_LINES"))
-        assertTrue(js.contains("DEFAULT_WEB_VIEWER_SCROLLBACK_LINES = 10000"))
-        assertTrue(js.contains("MAX_WEB_VIEWER_SCROLLBACK_LINES = 20000"))
-        assertFalse(js.contains("WEB_VIEWER_SCROLLBACK_LINES = 5000"))
-    }
-
-    @Test
-    fun `graphics text reanchors preserve the viewer scroll position`() {
-        val js = resource("share-viewer/viewer.js")
-        val paneOutput = js.substringAfter("case \"paneOutput\":")
-            .substringBefore("case \"paneRepaint\":")
-        val paneRepaint = js.substringAfter("case \"paneRepaint\":")
-            .substringBefore("case \"paneGraphics\":")
-
-        assertFalse(paneOutput.contains("scrollToLine"))
-        assertTrue(paneRepaint.contains("viewerLogic.queuePaneRepaint"))
-    }
-
-    @Test
-    fun `graphics canvas and transparency stay lazy for text-only panes`() {
-        val js = resource("share-viewer/viewer.js")
-        val draw = js.substringAfter("function drawPaneGraphics").substringBefore("function requestGraphicsResync")
-
-        assertTrue(draw.indexOf("if (!g.cells.length") < draw.indexOf("ensureGraphicsCanvas(p)"))
-        assertFalse(draw.contains("for (var i = 0; i < run.length"))
-        assertTrue(draw.contains("Object.keys(g.pending).length"))
-        assertTrue(js.contains("allowTransparency: false"))
-        assertTrue(js.contains("setPaneGraphicsMode(p, true)"))
-    }
-
-    @Test
     fun `viewer content security policy allows only required local capabilities`() {
         val html = resource("share-viewer/index.html")
 
@@ -85,21 +32,13 @@ class ShareViewerAssetTest {
         assertTrue(html.contains("base-uri 'none'"))
         assertTrue(html.contains("form-action 'none'"))
         assertTrue(html.contains("img-src 'self' data:"))
-        assertTrue(html.contains("connect-src 'self'"))
-        assertFalse(html.contains("connect-src 'self' ws: wss:"))
+        assertTrue(html.contains("script-src 'self'"))
+        // The WebSocket origin is filled in per request (see installShareViewerIndexRoute), because
+        // 'self' covering ws:// is CSP3-only. It must stay an origin placeholder, never a scheme
+        // wildcard that would permit connecting to any host.
+        assertTrue(html.contains("connect-src 'self' $WS_ORIGIN_PLACEHOLDER;"))
+        assertFalse(html.contains("ws: wss:"))
         assertTrue(html.contains("MesloLGSNF-Regular.ttf?v=d97946186e97"))
-        assertFalse(resource("share-viewer/viewer.js").contains("document.fonts.load("))
-    }
-
-    @Test
-    fun `viewer validates host colors and impossible raster retries`() {
-        val js = resource("share-viewer/viewer.js")
-
-        assertTrue(js.contains("safeCssColor"))
-        assertTrue(js.contains("validatedTheme(m)"))
-        assertTrue(js.contains("rejected.requiredBytes"))
-        assertTrue(js.contains("graphicsMemoryFits(g, rejected.requiredBytes"))
-        assertTrue(js.contains("if (m.resyncRequired)"))
     }
 
     @Test
@@ -118,15 +57,5 @@ class ShareViewerAssetTest {
                 .joinToString("") { "%02x".format(it) }
             assertEquals(digest.take(token.length), token, "stale immutable cache token for $font")
         }
-    }
-
-    @Test
-    fun `viewer allowlists raster mime types and aligns rows to xterm base`() {
-        val js = resource("share-viewer/viewer.js")
-
-        assertTrue(js.contains("ALLOWED_GRAPHICS_MIME_TYPES[wire.mimeType]"))
-        assertTrue(js.contains("viewerLogic.captureRowOffset"))
-        assertTrue(js.contains("viewerLogic.visibleImageRow"))
-        assertTrue(js.contains("g.historyLines = m.historyLines"))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
@@ -31,6 +31,7 @@ class ShareViewerAssetTest {
 
         assertTrue(js.contains("g.resyncAttempts >= MAX_GRAPHICS_RESYNCS"))
         assertTrue(js.contains("GRAPHICS_RESYNC_TIMEOUT_MS"))
+        assertTrue(js.contains("graphicsAttemptAfterDenied"))
         assertTrue(js.contains("RECONNECT_STABLE_MS"))
         assertTrue(js.contains("viewerLogic.nextReconnectAttempt"))
         assertFalse(
@@ -56,10 +57,13 @@ class ShareViewerAssetTest {
     fun `graphics text reanchors preserve the viewer scroll position`() {
         val js = resource("share-viewer/viewer.js")
         val paneOutput = js.substringAfter("case \"paneOutput\":")
+            .substringBefore("case \"paneRepaint\":")
+        val paneRepaint = js.substringAfter("case \"paneRepaint\":")
             .substringBefore("case \"paneGraphics\":")
 
-        assertTrue(paneOutput.contains("activeBuffer.baseY - activeBuffer.viewportY"))
-        assertTrue(paneOutput.contains("scrollToLine"))
+        assertFalse(paneOutput.contains("scrollToLine"))
+        assertTrue(paneRepaint.contains("scrollLinesFromBottom"))
+        assertTrue(paneRepaint.contains("scrollToLine"))
     }
 
     @Test
@@ -82,9 +86,21 @@ class ShareViewerAssetTest {
         assertTrue(html.contains("base-uri 'none'"))
         assertTrue(html.contains("form-action 'none'"))
         assertTrue(html.contains("img-src 'self' data:"))
-        assertTrue(html.contains("connect-src 'self' ws: wss:"))
+        assertTrue(html.contains("connect-src 'self'"))
+        assertFalse(html.contains("connect-src 'self' ws: wss:"))
         assertTrue(html.contains("MesloLGSNF-Regular.ttf?v=d97946186e97"))
         assertFalse(resource("share-viewer/viewer.js").contains("document.fonts.load("))
+    }
+
+    @Test
+    fun `viewer validates host colors and impossible raster retries`() {
+        val js = resource("share-viewer/viewer.js")
+
+        assertTrue(js.contains("safeCssColor"))
+        assertTrue(js.contains("validatedTheme(m)"))
+        assertTrue(js.contains("rejected.requiredBytes"))
+        assertTrue(js.contains("graphicsMemoryFits(g, rejected.requiredBytes"))
+        assertTrue(js.contains("if (m.resyncRequired)"))
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
@@ -33,6 +33,28 @@ class ShareViewerAssetTest {
     }
 
     @Test
+    fun `pane snapshots configure xterm with the host scrollback cap`() {
+        val js = resource("share-viewer/viewer.js")
+        val paneSnapshot = js.substringAfter("case \"paneSnapshot\": {")
+            .substringBefore("case \"paneOutput\":")
+
+        assertTrue(paneSnapshot.contains("m.scrollbackLines"))
+        assertTrue(paneSnapshot.contains("p.term.options.scrollback = Math.floor(m.scrollbackLines)"))
+        assertTrue(js.contains("DEFAULT_WEB_VIEWER_SCROLLBACK_LINES = 10000"))
+        assertFalse(js.contains("WEB_VIEWER_SCROLLBACK_LINES = 5000"))
+    }
+
+    @Test
+    fun `graphics text reanchors preserve the viewer scroll position`() {
+        val js = resource("share-viewer/viewer.js")
+        val paneOutput = js.substringAfter("case \"paneOutput\":")
+            .substringBefore("case \"paneGraphics\":")
+
+        assertTrue(paneOutput.contains("activeBuffer.baseY - activeBuffer.viewportY"))
+        assertTrue(paneOutput.contains("scrollToLine"))
+    }
+
+    @Test
     fun `graphics canvas and transparency stay lazy for text-only panes`() {
         val js = resource("share-viewer/viewer.js")
         val draw = js.substringAfter("function drawPaneGraphics").substringBefore("function requestGraphicsResync")

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
@@ -38,6 +38,8 @@ class ShareViewerAssetTest {
         val draw = js.substringAfter("function drawPaneGraphics").substringBefore("function requestGraphicsResync")
 
         assertTrue(draw.indexOf("if (!g.cells.length") < draw.indexOf("ensureGraphicsCanvas(p)"))
+        assertFalse(draw.contains("for (var i = 0; i < run.length"))
+        assertTrue(draw.contains("Object.keys(g.pending).length"))
         assertTrue(js.contains("allowTransparency: false"))
         assertTrue(js.contains("setPaneGraphicsMode(p, true)"))
     }
@@ -48,6 +50,9 @@ class ShareViewerAssetTest {
 
         assertTrue(html.contains("default-src 'self'"))
         assertTrue(html.contains("img-src 'self' data:"))
-        assertTrue(html.contains("connect-src 'self' ws: wss:"))
+        assertTrue(html.contains("connect-src 'self'"))
+        assertFalse(html.contains("connect-src 'self' ws: wss:"))
+        assertTrue(html.contains("MesloLGSNF-Regular.ttf?v=d97946186e97"))
+        assertFalse(resource("share-viewer/viewer.js").contains("document.fonts.load("))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerCspTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerCspTest.kt
@@ -1,0 +1,49 @@
+package ai.rever.bossterm.compose.share
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The viewer shell's `connect-src` names the request's own WebSocket origin, because `'self'`
+ * covering `ws://` is CSP Level 3 behavior and older mobile WebKit blocked the socket outright.
+ * The origin comes from the client-supplied Host header, so it is only ever interpolated when it
+ * is a bare authority — otherwise it could close the directive and append another.
+ */
+class ShareViewerCspTest {
+
+    @Test
+    fun `a bare authority becomes the ws and wss sources for its own origin`() {
+        assertEquals(
+            "ws://192.168.1.20:8770 wss://192.168.1.20:8770",
+            webSocketCspSources("192.168.1.20:8770"),
+        )
+        assertEquals("ws://share.example wss://share.example", webSocketCspSources("share.example"))
+        assertEquals("ws://[::1]:8770 wss://[::1]:8770", webSocketCspSources("[::1]:8770"))
+        assertEquals(
+            "ws://a-tunnel.trycloudflare.com wss://a-tunnel.trycloudflare.com",
+            webSocketCspSources(" a-tunnel.trycloudflare.com "),
+            "surrounding whitespace is trimmed, not treated as an injection",
+        )
+    }
+
+    @Test
+    fun `anything that could inject a directive contributes no source at all`() {
+        val hostile = listOf(
+            "evil.example; script-src *",
+            "evil.example ws://attacker.example",
+            "evil.example/path",
+            "evil.example\nscript-src *",
+            "'unsafe-inline'",
+            "*",
+            "",
+            null,
+        )
+        for (header in hostile) {
+            assertEquals(
+                "",
+                webSocketCspSources(header),
+                "must not interpolate a non-authority Host header: ${header?.let { "'$it'" } ?: "null"}",
+            )
+        }
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerScriptTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerScriptTest.kt
@@ -1,0 +1,34 @@
+package ai.rever.bossterm.compose.share
+
+import java.nio.file.Files
+import kotlin.io.path.writeText
+import kotlin.test.Test
+
+/**
+ * Runs the shipped `share-viewer/viewer.js` under a fake browser (DOM, xterm Terminal, WebSocket,
+ * clock and rAF queue) and drives it with the frames a real session sends.
+ *
+ * This exists because viewer.js is where the web viewer's behavior actually lives, and it cannot be
+ * covered by asserting on its source text: a grep proves nothing about execution and cannot catch an
+ * undefined identifier on a live code path — the harness caught exactly that (`disarmConnectionHealth`
+ * was called on every terminal close and never defined). Scenarios and their assertions live in
+ * `share-viewer-harness/viewer-harness.cjs`; this test only supplies Node and the viewer assets.
+ */
+class ShareViewerScriptTest {
+
+    @Test
+    fun `node harness drives the shipped web viewer`() {
+        NodeHarness.requireOrSkipNode()
+        val dir = Files.createTempDirectory("bossterm-share-viewer-")
+        try {
+            for (asset in listOf("viewer-logic.js", "viewer.js")) {
+                dir.resolve(asset).writeText(NodeHarness.readResource("share-viewer/$asset"))
+            }
+            val harness = dir.resolve("viewer-harness.cjs")
+            harness.writeText(NodeHarness.readResource("share-viewer-harness/viewer-harness.cjs"))
+            NodeHarness.run(harness, dir.toString())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoderTest.kt
@@ -1,0 +1,34 @@
+package ai.rever.bossterm.compose.share
+
+import ai.rever.bossterm.terminal.model.CharBuffer
+import ai.rever.bossterm.terminal.model.StyleState
+import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TerminalSnapshotEncoderTest {
+    @Test
+    fun `screen repaint excludes history and preserves it without RIS`() {
+        val buffer = TerminalTextBuffer(12, 2, StyleState(), maxHistoryLinesCount = 10)
+        buffer.getLine(1)
+        buffer.writeString(0, 1, CharBuffer("history"))
+        buffer.scrollArea(scrollRegionTop = 1, dy = -1, scrollRegionBottom = 2)
+        buffer.writeString(0, 1, CharBuffer("screen"))
+        val snapshot = buffer.createSnapshot()
+
+        val repaint = TerminalSnapshotEncoder.encodeScreenRepaint(
+            snapshot = snapshot,
+            cursorX = 3,
+            cursorY = 2,
+        )
+
+        assertEquals(1, snapshot.historyLinesCount)
+        assertTrue(repaint.contains("screen"))
+        assertFalse(repaint.contains("history"))
+        assertFalse(repaint.contains("\u001bc"), "screen repaint must not reset or clear scrollback")
+        assertTrue(repaint.contains("\u001b[1;1H\u001b[2K"))
+        assertTrue(repaint.endsWith("\u001b[0m\u001b[2;3H"))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.share
 
+import org.junit.Assume.assumeTrue
 import java.nio.file.Files
 import kotlin.io.path.deleteIfExists
 import kotlin.test.Test
@@ -9,7 +10,12 @@ import kotlin.test.assertTrue
 class ViewerLogicTest {
     @Test
     fun `node harness exercises reconnect budget and captured row offset`() {
-        assertTrue(nodeAvailable(), "Node.js is required to execute the web-viewer regression harness")
+        val hasNode = nodeAvailable()
+        if (System.getenv("CI").equals("true", ignoreCase = true)) {
+            assertTrue(hasNode, "Node.js is required for the web-viewer regression harness in CI")
+        } else {
+            assumeTrue("Node.js is not available on PATH", hasNode)
+        }
         val logic = checkNotNull(javaClass.classLoader.getResourceAsStream("share-viewer/viewer-logic.js"))
             .use { it.readBytes().decodeToString() }
         val harness = logic + "\n" + """
@@ -38,6 +44,10 @@ class ViewerLogicTest {
                 const offset = logic.captureRowOffset(95, 100);
                 assert.strictEqual(logic.visibleImageRow(100, offset, 95), 0);
                 assert.strictEqual(logic.visibleImageRow(100, offset, 100), -5);
+                assert.deepStrictEqual(logic.visibleHostRowRange(100, offset, 24), {
+                  first: 105,
+                  last: 128
+                });
 
                 // A paneRepaint preserves the reader's distance from the bottom and clamps after
                 // history trims instead of relying on an obsolete RIS prefix.

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
@@ -1,5 +1,7 @@
 package ai.rever.bossterm.compose.share
 
+import java.nio.file.Files
+import kotlin.io.path.deleteIfExists
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -35,10 +37,16 @@ class ViewerLogicTest {
                 assert.strictEqual(logic.visibleImageRow(100, offset, 95), 0);
                 assert.strictEqual(logic.visibleImageRow(100, offset, 100), -5);
             """.trimIndent()
-        val process = ProcessBuilder("node", "-e", harness)
-            .redirectErrorStream(true)
-            .start()
-        val output = process.inputStream.bufferedReader().use { it.readText() }
-        assertEquals(0, process.waitFor(), output)
+        val script = Files.createTempFile("bossterm-viewer-logic-", ".cjs")
+        try {
+            Files.writeString(script, harness)
+            val process = ProcessBuilder("node", script.toString())
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().use { it.readText() }
+            assertEquals(0, process.waitFor(), output)
+        } finally {
+            script.deleteIfExists()
+        }
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
@@ -1,0 +1,52 @@
+package ai.rever.bossterm.compose.share
+
+import java.nio.file.Files
+import kotlin.io.path.deleteIfExists
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ViewerLogicTest {
+    @Test
+    fun `node harness exercises reconnect budget and captured row offset`() {
+        val logic = checkNotNull(javaClass.classLoader.getResourceAsStream("share-viewer/viewer-logic.js"))
+            .use { it.readBytes() }
+        val module = Files.createTempFile("bossterm-viewer-logic-", ".js")
+        try {
+            Files.write(module, logic)
+            val harness = """
+                const assert = require("assert");
+                const logic = require(process.argv[1]);
+
+                // Fake-WebSocket close harness: initial connection + exactly three automatic
+                // reconnects, then one manual prompt.
+                let attempt = 0, connections = 1, prompts = 0;
+                function closeSocket() {
+                  const decision = logic.nextReconnectAttempt(attempt, 3);
+                  if (decision.retry) {
+                    attempt = decision.attempt;
+                    connections += 1;
+                  } else {
+                    prompts += 1;
+                  }
+                }
+                closeSocket(); closeSocket(); closeSocket(); closeSocket();
+                assert.strictEqual(connections, 4);
+                assert.strictEqual(attempt, 3);
+                assert.strictEqual(prompts, 1);
+
+                // Capture correction once. Five later scrolls move the image five rows upward;
+                // recomputing from live baseY would incorrectly keep this at zero.
+                const offset = logic.captureRowOffset(95, 100);
+                assert.strictEqual(logic.visibleImageRow(100, offset, 95), 0);
+                assert.strictEqual(logic.visibleImageRow(100, offset, 100), -5);
+            """.trimIndent()
+            val process = ProcessBuilder("node", "-e", harness, module.toString())
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().use { it.readText() }
+            assertEquals(0, process.waitFor(), output)
+        } finally {
+            module.deleteIfExists()
+        }
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
@@ -1,23 +1,14 @@
 package ai.rever.bossterm.compose.share
 
-import org.junit.Assume.assumeTrue
 import java.nio.file.Files
 import kotlin.io.path.deleteIfExists
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class ViewerLogicTest {
     @Test
     fun `node harness exercises reconnect budget and captured row offset`() {
-        val hasNode = nodeAvailable()
-        if (System.getenv("CI").equals("true", ignoreCase = true)) {
-            assertTrue(hasNode, "Node.js is required for the web-viewer regression harness in CI")
-        } else {
-            assumeTrue("Node.js is not available on PATH", hasNode)
-        }
-        val logic = checkNotNull(javaClass.classLoader.getResourceAsStream("share-viewer/viewer-logic.js"))
-            .use { it.readBytes().decodeToString() }
+        NodeHarness.requireOrSkipNode()
+        val logic = NodeHarness.readResource("share-viewer/viewer-logic.js")
         val harness = logic + "\n" + """
                 const assert = require("assert");
                 const logic = module.exports;
@@ -107,21 +98,9 @@ class ViewerLogicTest {
         val script = Files.createTempFile("bossterm-viewer-logic-", ".cjs")
         try {
             Files.writeString(script, harness)
-            val process = ProcessBuilder("node", script.toString())
-                .redirectErrorStream(true)
-                .start()
-            val output = process.inputStream.bufferedReader().use { it.readText() }
-            assertEquals(0, process.waitFor(), output)
+            NodeHarness.run(script)
         } finally {
             script.deleteIfExists()
         }
     }
-
-    private fun nodeAvailable(): Boolean = runCatching {
-        val process = ProcessBuilder("node", "--version")
-            .redirectErrorStream(true)
-            .start()
-        process.inputStream.bufferedReader().use { it.readText() }
-        process.waitFor() == 0
-    }.getOrDefault(false)
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.share
 
+import org.junit.Assume.assumeTrue
 import java.nio.file.Files
 import kotlin.io.path.deleteIfExists
 import kotlin.test.Test
@@ -8,6 +9,7 @@ import kotlin.test.assertEquals
 class ViewerLogicTest {
     @Test
     fun `node harness exercises reconnect budget and captured row offset`() {
+        assumeTrue("Node.js is not available on PATH", nodeAvailable())
         val logic = checkNotNull(javaClass.classLoader.getResourceAsStream("share-viewer/viewer-logic.js"))
             .use { it.readBytes().decodeToString() }
         val harness = logic + "\n" + """
@@ -49,4 +51,12 @@ class ViewerLogicTest {
             script.deleteIfExists()
         }
     }
+
+    private fun nodeAvailable(): Boolean = runCatching {
+        val process = ProcessBuilder("node", "--version")
+            .redirectErrorStream(true)
+            .start()
+        process.inputStream.bufferedReader().use { it.readText() }
+        process.waitFor() == 0
+    }.getOrDefault(false)
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
@@ -1,7 +1,5 @@
 package ai.rever.bossterm.compose.share
 
-import java.nio.file.Files
-import kotlin.io.path.deleteIfExists
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -9,13 +7,10 @@ class ViewerLogicTest {
     @Test
     fun `node harness exercises reconnect budget and captured row offset`() {
         val logic = checkNotNull(javaClass.classLoader.getResourceAsStream("share-viewer/viewer-logic.js"))
-            .use { it.readBytes() }
-        val module = Files.createTempFile("bossterm-viewer-logic-", ".js")
-        try {
-            Files.write(module, logic)
-            val harness = """
+            .use { it.readBytes().decodeToString() }
+        val harness = logic + "\n" + """
                 const assert = require("assert");
-                const logic = require(process.argv[1]);
+                const logic = module.exports;
 
                 // Fake-WebSocket close harness: initial connection + exactly three automatic
                 // reconnects, then one manual prompt.
@@ -40,13 +35,10 @@ class ViewerLogicTest {
                 assert.strictEqual(logic.visibleImageRow(100, offset, 95), 0);
                 assert.strictEqual(logic.visibleImageRow(100, offset, 100), -5);
             """.trimIndent()
-            val process = ProcessBuilder("node", "-e", harness, module.toString())
-                .redirectErrorStream(true)
-                .start()
-            val output = process.inputStream.bufferedReader().use { it.readText() }
-            assertEquals(0, process.waitFor(), output)
-        } finally {
-            module.deleteIfExists()
-        }
+        val process = ProcessBuilder("node", "-e", harness)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        assertEquals(0, process.waitFor(), output)
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
@@ -1,15 +1,15 @@
 package ai.rever.bossterm.compose.share
 
-import org.junit.Assume.assumeTrue
 import java.nio.file.Files
 import kotlin.io.path.deleteIfExists
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ViewerLogicTest {
     @Test
     fun `node harness exercises reconnect budget and captured row offset`() {
-        assumeTrue("Node.js is not available on PATH", nodeAvailable())
+        assertTrue(nodeAvailable(), "Node.js is required to execute the web-viewer regression harness")
         val logic = checkNotNull(javaClass.classLoader.getResourceAsStream("share-viewer/viewer-logic.js"))
             .use { it.readBytes().decodeToString() }
         val harness = logic + "\n" + """
@@ -38,6 +38,32 @@ class ViewerLogicTest {
                 const offset = logic.captureRowOffset(95, 100);
                 assert.strictEqual(logic.visibleImageRow(100, offset, 95), 0);
                 assert.strictEqual(logic.visibleImageRow(100, offset, 100), -5);
+
+                // A paneRepaint preserves the reader's distance from the bottom and clamps after
+                // history trims instead of relying on an obsolete RIS prefix.
+                const distance = logic.scrollLinesFromBottom(120, 87);
+                assert.strictEqual(distance, 33);
+                assert.strictEqual(logic.scrollLineForDistance(140, distance), 107);
+                assert.strictEqual(logic.scrollLineForDistance(20, distance), 0);
+
+                // Host-side throttle denials are acknowledgements and never consume the bounded
+                // timeout budget, even when repeated.
+                let graphicsAttempts = 1;
+                graphicsAttempts = logic.graphicsAttemptAfterDenied(graphicsAttempts, true);
+                assert.strictEqual(graphicsAttempts, 0);
+                assert.strictEqual(logic.graphicsAttemptAfterDenied(graphicsAttempts, true), 0);
+
+                // A raster whose encoded+decoded peak cannot fit the per-pane budget remains
+                // rejected even after unrelated images are freed.
+                const MiB = 1024 * 1024;
+                assert.strictEqual(
+                  logic.graphicsMemoryFits(0, 0, 17 * MiB, 0, 16 * MiB, 64 * MiB),
+                  false
+                );
+                assert.strictEqual(
+                  logic.graphicsMemoryFits(8 * MiB, 20 * MiB, 6 * MiB, 4 * MiB, 16 * MiB, 64 * MiB),
+                  true
+                );
             """.trimIndent()
         val script = Files.createTempFile("bossterm-viewer-logic-", ".cjs")
         try {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ViewerLogicTest.kt
@@ -38,6 +38,10 @@ class ViewerLogicTest {
                 assert.strictEqual(connections, 4);
                 assert.strictEqual(attempt, 3);
                 assert.strictEqual(prompts, 1);
+                assert.strictEqual(logic.isTerminalWebSocketClose(1000), true);
+                assert.strictEqual(logic.isTerminalWebSocketClose(1003), true);
+                assert.strictEqual(logic.isTerminalWebSocketClose(1008), true);
+                assert.strictEqual(logic.isTerminalWebSocketClose(1006), false);
 
                 // Capture correction once. Five later scrolls move the image five rows upward;
                 // recomputing from live baseY would incorrectly keep this at zero.
@@ -56,6 +60,27 @@ class ViewerLogicTest {
                 assert.strictEqual(logic.scrollLineForDistance(140, distance), 107);
                 assert.strictEqual(logic.scrollLineForDistance(20, distance), 0);
 
+                // Queue the probe and repaint synchronously. A later output frame must stay behind
+                // both, while the probe still measures after all earlier writes have drained.
+                const writes = [];
+                let activeBuffer = { baseY: 120, viewportY: 90 };
+                let restoredLine = null, repaintCompleted = false;
+                function queuedWrite(data, callback) { writes.push({ data, callback }); }
+                logic.queuePaneRepaint(
+                  queuedWrite,
+                  () => activeBuffer,
+                  line => { restoredLine = line; },
+                  "repaint",
+                  () => { repaintCompleted = true; }
+                );
+                queuedWrite("later-output", () => {});
+                assert.deepStrictEqual(writes.map(entry => entry.data), ["", "repaint", "later-output"]);
+                writes.shift().callback();
+                activeBuffer = { baseY: 125, viewportY: 95 };
+                writes.shift().callback();
+                assert.strictEqual(restoredLine, 95);
+                assert.strictEqual(repaintCompleted, true);
+
                 // Host-side throttle denials are acknowledgements and never consume the bounded
                 // timeout budget, even when repeated.
                 let graphicsAttempts = 1;
@@ -72,6 +97,10 @@ class ViewerLogicTest {
                 );
                 assert.strictEqual(
                   logic.graphicsMemoryFits(8 * MiB, 20 * MiB, 6 * MiB, 4 * MiB, 16 * MiB, 64 * MiB),
+                  true
+                );
+                assert.strictEqual(
+                  logic.graphicsMemoryFits(0, 0, 72 * MiB, 0, 96 * MiB, 192 * MiB),
                   true
                 );
             """.trimIndent()

--- a/compose-ui/src/desktopTest/resources/share-viewer-harness/viewer-harness.cjs
+++ b/compose-ui/src/desktopTest/resources/share-viewer-harness/viewer-harness.cjs
@@ -1,0 +1,900 @@
+// Behavioural harness for the SHIPPED share-viewer/viewer.js.
+//
+// viewer.js is a browser IIFE with no exports, so the only way to test it is to give it a browser:
+// a fake DOM, a fake xterm Terminal, a fake WebSocket, and a controllable clock / rAF queue. Every
+// scenario below then drives it the way a real session does — frames in, DOM and socket state out.
+//
+// This is deliberately NOT a source-text test. Grepping viewer.js for identifiers proves nothing
+// about execution and cannot catch an undefined global on a live code path; loading and running it
+// catches both. Usage: node viewer-harness.cjs <dir containing viewer-logic.js and viewer.js>
+
+"use strict";
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const assetDir = process.argv[2];
+const readAsset = (name) => fs.readFileSync(path.join(assetDir, name), "utf8");
+
+// ---------------------------------------------------------------- clock + frames
+
+let now = 0;
+let timerSeq = 0;
+let timers = new Map();
+
+function installClock() {
+  now = 0;
+  timerSeq = 0;
+  timers = new Map();
+}
+
+function fakeSetTimeout(fn, ms) {
+  const id = ++timerSeq;
+  timers.set(id, { at: now + (Number(ms) || 0), fn });
+  return id;
+}
+
+function fakeClearTimeout(id) {
+  timers.delete(id);
+}
+
+/** Run every timer due within [ms], in due order, so retry ladders unfold deterministically. */
+function advance(ms) {
+  const target = now + ms;
+  for (;;) {
+    let due = null;
+    for (const [id, timer] of timers) {
+      if (timer.at <= target && (due === null || timer.at < due.timer.at)) due = { id, timer };
+    }
+    if (due === null) break;
+    timers.delete(due.id);
+    now = due.timer.at;
+    due.timer.fn();
+  }
+  now = target;
+}
+
+let rafSeq = 0;
+let frames = new Map();
+
+function fakeRequestAnimationFrame(fn) {
+  const id = ++rafSeq;
+  frames.set(id, fn);
+  return id;
+}
+
+function fakeCancelAnimationFrame(id) {
+  frames.delete(id);
+}
+
+function flushFrames() {
+  const pending = Array.from(frames.values());
+  frames.clear();
+  pending.forEach((fn) => fn(now));
+}
+
+// ---------------------------------------------------------------- DOM
+
+class ClassList {
+  constructor(node) {
+    this.node = node;
+  }
+  _read() {
+    return String(this.node.className || "").split(/\s+/).filter(Boolean);
+  }
+  _write(names) {
+    this.node.className = names.join(" ");
+  }
+  add(...names) {
+    const set = new Set(this._read());
+    names.forEach((n) => set.add(n));
+    this._write(Array.from(set));
+  }
+  remove(...names) {
+    const set = new Set(this._read());
+    names.forEach((n) => set.delete(n));
+    this._write(Array.from(set));
+  }
+  toggle(name, force) {
+    const set = new Set(this._read());
+    const want = force === undefined ? !set.has(name) : !!force;
+    if (want) set.add(name);
+    else set.delete(name);
+    this._write(Array.from(set));
+    return want;
+  }
+  contains(name) {
+    return this._read().indexOf(name) >= 0;
+  }
+}
+
+function newStyle() {
+  const style = {
+    cssText: "",
+    setProperty(key, value) {
+      style[key] = value;
+    },
+    removeProperty(key) {
+      delete style[key];
+    },
+  };
+  return style;
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = String(tag).toUpperCase();
+    this.className = "";
+    this.classList = new ClassList(this);
+    this.style = newStyle();
+    this.attributes = {};
+    this.childNodes = [];
+    this.parentNode = null;
+    this.listeners = {};
+    this._text = "";
+    this._html = "";
+    this.title = "";
+    this.value = "";
+    // Non-zero so viewer.js measurement paths (fit / graphics draw) run instead of bailing out.
+    this.clientWidth = 800;
+    this.clientHeight = 480;
+    this.offsetWidth = 800;
+    this.offsetHeight = 480;
+    this.rect = { left: 0, top: 0, width: 800, height: 480, right: 800, bottom: 480 };
+    this.dataset = {};
+  }
+
+  get children() {
+    return this.childNodes.filter((n) => n instanceof FakeElement);
+  }
+  get firstChild() {
+    return this.childNodes[0] || null;
+  }
+
+  get textContent() {
+    if (this.childNodes.length === 0) return this._text;
+    return this.childNodes.map((n) => n.textContent || "").join("");
+  }
+  set textContent(value) {
+    this.childNodes = [];
+    this._text = String(value);
+  }
+
+  get innerHTML() {
+    return this._html;
+  }
+  set innerHTML(value) {
+    // Every assignment in viewer.js is either "" (a clear) or a static SVG on a fresh button, so
+    // recording the markup and dropping children is faithful enough for behavioural assertions.
+    this.childNodes = [];
+    this._html = String(value);
+  }
+
+  appendChild(child) {
+    if (child.parentNode) child.parentNode.removeChild(child);
+    child.parentNode = this;
+    this.childNodes.push(child);
+    return child;
+  }
+  insertBefore(child, reference) {
+    if (child.parentNode) child.parentNode.removeChild(child);
+    child.parentNode = this;
+    const at = reference ? this.childNodes.indexOf(reference) : -1;
+    if (at < 0) this.childNodes.push(child);
+    else this.childNodes.splice(at, 0, child);
+    return child;
+  }
+  removeChild(child) {
+    const at = this.childNodes.indexOf(child);
+    if (at >= 0) this.childNodes.splice(at, 1);
+    child.parentNode = null;
+    return child;
+  }
+  remove() {
+    if (this.parentNode) this.parentNode.removeChild(this);
+  }
+  contains(node) {
+    for (let n = node; n; n = n.parentNode) if (n === this) return true;
+    return false;
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+    if (name === "class") this.className = String(value);
+  }
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null;
+  }
+  removeAttribute(name) {
+    delete this.attributes[name];
+  }
+
+  addEventListener(type, fn) {
+    (this.listeners[type] || (this.listeners[type] = [])).push(fn);
+  }
+  removeEventListener(type, fn) {
+    const list = this.listeners[type];
+    if (!list) return;
+    const at = list.indexOf(fn);
+    if (at >= 0) list.splice(at, 1);
+  }
+  dispatchEvent(event) {
+    (this.listeners[event.type] || []).forEach((fn) => fn(event));
+    const inline = this["on" + event.type];
+    if (typeof inline === "function") inline(event);
+    return true;
+  }
+
+  getBoundingClientRect() {
+    return this.rect;
+  }
+  focus() {
+    fakeDocument.activeElement = this;
+  }
+  blur() {
+    if (fakeDocument.activeElement === this) fakeDocument.activeElement = fakeDocument.body;
+  }
+  scrollIntoView() {}
+
+  matchesSelector(selector) {
+    if (selector.charAt(0) === ".") return this.classList.contains(selector.slice(1));
+    if (selector.charAt(0) === "#") return this.attributes.id === selector.slice(1) || this.id === selector.slice(1);
+    return this.tagName === selector.toUpperCase();
+  }
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] || null;
+  }
+  querySelectorAll(selector) {
+    const found = [];
+    const walk = (node) => {
+      node.children.forEach((child) => {
+        if (child.matchesSelector(selector)) found.push(child);
+        walk(child);
+      });
+    };
+    walk(this);
+    return found;
+  }
+
+  // Canvas surface — records draw calls so graphics assertions can look at real output.
+  getContext(kind) {
+    if (kind !== "2d") return null;
+    if (!this.ctx) {
+      const calls = [];
+      this.drawCalls = calls;
+      this.ctx = {
+        calls: calls,
+        setTransform() {},
+        clearRect() {},
+        drawImage(...args) {
+          calls.push(args);
+        },
+      };
+    }
+    return this.ctx;
+  }
+}
+
+let fakeDocument = null;
+
+function installDocument() {
+  const byId = {};
+  const documentElement = new FakeElement("html");
+  const body = new FakeElement("body");
+  documentElement.appendChild(body);
+  fakeDocument = {
+    documentElement: documentElement,
+    body: body,
+    activeElement: body,
+    // Undefined `fonts` exercises the same branch as a browser without the Font Loading API.
+    fonts: undefined,
+    listeners: {},
+    createElement(tag) {
+      return new FakeElement(tag);
+    },
+    createTextNode(text) {
+      const node = new FakeElement("#text");
+      node.textContent = text;
+      return node;
+    },
+    getElementById(id) {
+      if (!byId[id]) {
+        const el = new FakeElement("div");
+        el.id = id;
+        el.setAttribute("id", id);
+        byId[id] = el;
+        body.appendChild(el);
+      }
+      return byId[id];
+    },
+    querySelector(selector) {
+      return documentElement.querySelector(selector);
+    },
+    addEventListener(type, fn) {
+      (fakeDocument.listeners[type] || (fakeDocument.listeners[type] = [])).push(fn);
+    },
+    removeEventListener() {},
+    execCommand() {
+      return true;
+    },
+    get title() {
+      return this._title || "";
+    },
+    set title(value) {
+      this._title = value;
+    },
+  };
+  return fakeDocument;
+}
+
+// ---------------------------------------------------------------- xterm + WebSocket doubles
+
+class FakeTerminal {
+  constructor(options) {
+    FakeTerminal.created.push(this);
+    this.options = Object.assign({ scrollback: 1000, theme: {} }, options);
+    this.cols = 80;
+    this.rows = 24;
+    this.written = [];
+    this.buffer = { active: { baseY: 0, viewportY: 0, cursorY: 0, cursorX: 0, length: 24 } };
+    this.handlers = { render: [], scroll: [], resize: [], cursorMove: [], data: [] };
+    this.disposed = false;
+    this.scrolledToLine = null;
+    this.textarea = new FakeElement("textarea");
+    this.textarea.classList.add("xterm-helper-textarea");
+  }
+  open(host) {
+    this.host = host;
+    const wrapper = new FakeElement("div");
+    wrapper.classList.add("xterm");
+    const screen = new FakeElement("div");
+    screen.classList.add("xterm-screen");
+    const glyphs = new FakeElement("canvas");
+    screen.appendChild(glyphs);
+    wrapper.appendChild(screen);
+    wrapper.appendChild(this.textarea);
+    host.appendChild(wrapper);
+    this.screen = screen;
+  }
+  write(data, callback) {
+    if (data) this.written.push(data);
+    if (typeof callback === "function") callback();
+  }
+  reset() {
+    this.written = [];
+  }
+  resize(cols, rows) {
+    this.cols = cols;
+    this.rows = rows;
+    this.handlers.resize.forEach((fn) => fn({ cols: cols, rows: rows }));
+  }
+  scrollToLine(line) {
+    this.scrolledToLine = line;
+  }
+  scrollToBottom() {}
+  scrollLines() {}
+  clear() {}
+  selectAll() {}
+  clearSelection() {}
+  hasSelection() {
+    return false;
+  }
+  getSelection() {
+    return "";
+  }
+  focus() {}
+  loadAddon() {}
+  dispose() {
+    this.disposed = true;
+  }
+  onRender(fn) {
+    this.handlers.render.push(fn);
+    return { dispose() {} };
+  }
+  onScroll(fn) {
+    this.handlers.scroll.push(fn);
+    return { dispose() {} };
+  }
+  onResize(fn) {
+    this.handlers.resize.push(fn);
+    return { dispose() {} };
+  }
+  onCursorMove(fn) {
+    this.handlers.cursorMove.push(fn);
+    return { dispose() {} };
+  }
+  onData(fn) {
+    this.handlers.data.push(fn);
+    return { dispose() {} };
+  }
+  /** What xterm fires after painting — the hook whose rAF cost this suite guards. */
+  emitRender() {
+    this.handlers.render.forEach((fn) => fn({ start: 0, end: this.rows - 1 }));
+  }
+}
+FakeTerminal.created = [];
+
+class FakeImage {
+  constructor() {
+    this.complete = false;
+    this.naturalWidth = 0;
+    this.naturalHeight = 0;
+    this._src = "";
+    FakeImage.pending.push(this);
+  }
+  get src() {
+    return this._src;
+  }
+  set src(value) {
+    this._src = value;
+  }
+  /** Simulate a successful decode of a [width]×[height] raster. */
+  decodeAs(width, height) {
+    this.complete = true;
+    this.naturalWidth = width;
+    this.naturalHeight = height;
+    if (this.onload) this.onload();
+  }
+  failDecode() {
+    if (this.onerror) this.onerror();
+  }
+}
+FakeImage.pending = [];
+
+class FakeWebSocket {
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0;
+    this.sent = [];
+    FakeWebSocket.instances.push(this);
+  }
+  send(data) {
+    this.sent.push(data);
+  }
+  close() {
+    this.readyState = 3;
+  }
+  /** Complete the handshake the way a live host does. */
+  open() {
+    this.readyState = 1;
+    if (this.onopen) this.onopen({});
+  }
+  deliver(message) {
+    if (this.onmessage) this.onmessage({ data: JSON.stringify(message) });
+  }
+  /** 1006 = abnormal closure, i.e. the transient drop the retry budget exists for. */
+  drop(code) {
+    this.readyState = 3;
+    if (this.onerror) this.onerror({});
+    if (this.onclose) this.onclose({ code: code === undefined ? 1006 : code, reason: "" });
+  }
+  static reset() {
+    FakeWebSocket.instances = [];
+  }
+  static get latest() {
+    return FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+  }
+}
+FakeWebSocket.instances = [];
+// viewer.js gates every send on `ws.readyState !== WebSocket.OPEN`, so these class constants are
+// part of the contract, not decoration.
+FakeWebSocket.CONNECTING = 0;
+FakeWebSocket.OPEN = 1;
+FakeWebSocket.CLOSING = 2;
+FakeWebSocket.CLOSED = 3;
+
+// ---------------------------------------------------------------- load
+
+/**
+ * Install a browser and run the two viewer scripts in it.
+ *
+ * `vm.runInThisContext` (not require) matters twice: viewer-logic.js's UMD wrapper must take its
+ * BROWSER branch (no CommonJS `module` in scope) so it publishes window.BossTermViewerLogic exactly
+ * as the served page does, and viewer.js must see the same globals a page would.
+ */
+function loadViewer(options) {
+  const opts = options || {};
+  installClock();
+  frames = new Map();
+  FakeWebSocket.reset();
+  FakeImage.pending = [];
+  FakeTerminal.created = [];
+  const document = installDocument();
+
+  const store = {};
+  const win = global;
+  // Several of these (navigator, crypto, WebSocket, …) are accessor-only on modern Node, so
+  // define rather than assign — a plain `=` throws in strict mode.
+  const define = (name, value) =>
+    Object.defineProperty(win, name, { value: value, writable: true, configurable: true, enumerable: true });
+
+  delete win.BossTermViewerLogic;
+  define("window", win);
+  define("document", document);
+  define("location", {
+    protocol: "http:",
+    host: "192.168.1.20:8770",
+    search: "?t=view-token",
+    hash: "",
+    reloaded: 0,
+    reload() {
+      win.location.reloaded += 1;
+    },
+  });
+  define("navigator", { platform: "TestPhone", userAgent: "harness", clipboard: undefined });
+  define("localStorage", {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    setItem(key, value) {
+      store[key] = String(value);
+    },
+    removeItem(key) {
+      delete store[key];
+    },
+  });
+  // Plaintext LAN link: no secure context and no crypto.subtle, so the E2E branch stays out of the
+  // way and frames are the plain JSON a http:// share actually exchanges.
+  define("isSecureContext", false);
+  define("crypto", undefined);
+  define("devicePixelRatio", 2);
+  define("innerWidth", 390);
+  define("innerHeight", 780);
+  define("visualViewport", undefined);
+  define("matchMedia", () => ({
+    matches: false,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+  }));
+  define("confirm", () => false);
+  define("prompt", () => null);
+  define("open", () => null);
+  define("close", () => {});
+  define("WebglAddon", undefined);
+  define("WebLinksAddon", undefined);
+  define("Terminal", FakeTerminal);
+  define("Image", FakeImage);
+  define("WebSocket", FakeWebSocket);
+  define("setTimeout", fakeSetTimeout);
+  define("clearTimeout", fakeClearTimeout);
+  define("setInterval", fakeSetTimeout);
+  define("clearInterval", fakeClearTimeout);
+  define("requestAnimationFrame", fakeRequestAnimationFrame);
+  define("cancelAnimationFrame", fakeCancelAnimationFrame);
+  define("addEventListener", () => {});
+  define("removeEventListener", () => {});
+
+  if (!opts.withoutViewerLogic) {
+    vm.runInThisContext(readAsset("viewer-logic.js"), { filename: "viewer-logic.js" });
+    assert.ok(win.BossTermViewerLogic, "viewer-logic.js must publish window.BossTermViewerLogic");
+  }
+  vm.runInThisContext(readAsset("viewer.js"), { filename: "viewer.js" });
+  return { document: document };
+}
+
+const el = (id) => fakeDocument.getElementById(id);
+const overlayTitle = () => el("overlay-title").textContent;
+const overlayActions = () => el("overlay-actions").children.map((b) => b.textContent);
+const lastTerminal = () => FakeTerminal.created[FakeTerminal.created.length - 1];
+
+/** Bring a fresh viewer to the state a real one reaches right after Layout + PaneSnapshot. */
+function connectPanes(paneIds) {
+  const socket = FakeWebSocket.latest;
+  socket.open();
+  socket.deliver({
+    t: "layout",
+    tabs: [
+      {
+        id: "tab-1",
+        title: "zsh",
+        tree: paneIds.length === 1
+          ? { t: "pane", paneId: paneIds[0] }
+          : { t: "split", v: true, a: { t: "pane", paneId: paneIds[0] }, b: { t: "pane", paneId: paneIds[1] } },
+      },
+    ],
+    activeTabId: "tab-1",
+  });
+  paneIds.forEach((paneId) => {
+    socket.deliver({ t: "paneSnapshot", paneId: paneId, data: "$ ", cols: 80, rows: 24, scrollbackLines: 12000 });
+  });
+  flushFrames();
+  return socket;
+}
+
+const IMAGE_FRAME = (paneId, revision, full) => ({
+  t: "paneGraphics",
+  paneId: paneId,
+  revision: revision,
+  full: full,
+  images: [{ id: "7", mimeType: "image/png", data: "AAAA", contentHash: "4-abc" }],
+  removedImageIds: [],
+  requiredImageIds: ["7"],
+  cells: [
+    { imageId: "7", row: 0, col: 0, cellX: 0, cellY: 0, length: 4, totalCellsX: 4, totalCellsY: 2 },
+  ],
+  historyLines: 0,
+});
+
+// ---------------------------------------------------------------- scenarios
+
+const scenarios = {
+  "viewer.js loads and connects with no undefined globals on the startup path"() {
+    loadViewer();
+    assert.strictEqual(FakeWebSocket.instances.length, 1, "startup must open exactly one socket");
+    assert.strictEqual(
+      FakeWebSocket.latest.url,
+      "ws://192.168.1.20:8770/ws/view-token",
+      "the socket must target this document's own origin (what the CSP has to allow)"
+    );
+    const socket = connectPanes(["pane-1"]);
+    assert.deepStrictEqual(
+      JSON.parse(socket.sent[0]).capabilities,
+      ["paneGraphicsV1"],
+      "the Hello must advertise host-decoded graphics"
+    );
+  },
+
+  "a transient drop retries three times, then prompts once"() {
+    loadViewer();
+    connectPanes(["pane-1"]);
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const before = FakeWebSocket.instances.length;
+      FakeWebSocket.latest.drop(1006);
+      assert.ok(
+        /Reconnecting/.test(overlayTitle()),
+        "attempt " + attempt + " must show the automatic-retry overlay, saw: " + overlayTitle()
+      );
+      advance(10000);
+      assert.strictEqual(
+        FakeWebSocket.instances.length,
+        before + 1,
+        "attempt " + attempt + " must open a new socket"
+      );
+      FakeWebSocket.latest.open();
+    }
+    const beforePrompt = FakeWebSocket.instances.length;
+    FakeWebSocket.latest.drop(1006);
+    advance(60000);
+    assert.strictEqual(FakeWebSocket.instances.length, beforePrompt, "the fourth drop must not retry");
+    assert.strictEqual(overlayTitle(), "Disconnected");
+    assert.deepStrictEqual(overlayActions(), ["Reconnect", "Close"]);
+    assert.strictEqual(el("status").className, "down");
+  },
+
+  "staying healthy for the stable window earns a fresh retry budget"() {
+    loadViewer();
+    connectPanes(["pane-1"]);
+    FakeWebSocket.latest.drop(1006);
+    advance(10000);
+    FakeWebSocket.latest.open();
+    connectPanes(["pane-1"]); // a live session: Layout arrives and the connection settles
+    advance(60000); // longer than RECONNECT_STABLE_MS
+    // Budget reset — three more automatic attempts must be available before the prompt.
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const before = FakeWebSocket.instances.length;
+      FakeWebSocket.latest.drop(1006);
+      advance(10000);
+      assert.strictEqual(
+        FakeWebSocket.instances.length,
+        before + 1,
+        "post-heal attempt " + attempt + " must retry"
+      );
+      FakeWebSocket.latest.open();
+    }
+  },
+
+  "a terminal close code ends the session without retrying"() {
+    loadViewer();
+    connectPanes(["pane-1"]);
+    const before = FakeWebSocket.instances.length;
+    FakeWebSocket.latest.drop(1000);
+    advance(60000);
+    assert.strictEqual(FakeWebSocket.instances.length, before, "1000 must not consume a retry");
+    assert.strictEqual(overlayTitle(), "Connection ended");
+  },
+
+  "an error without a close does not consume a retry"() {
+    loadViewer();
+    connectPanes(["pane-1"]);
+    const socket = FakeWebSocket.latest;
+    if (socket.onerror) socket.onerror({});
+    advance(60000);
+    assert.strictEqual(FakeWebSocket.instances.length, 1, "error alone must not reconnect");
+    assert.strictEqual(el("status").className, "down");
+  },
+
+  "a text-only pane schedules no graphics frame when xterm renders"() {
+    loadViewer();
+    connectPanes(["pane-1"]);
+    flushFrames();
+    const terminal = lastTerminal();
+    assert.ok(terminal, "a pane terminal must exist");
+    terminal.emitRender();
+    terminal.handlers.scroll.forEach((fn) => fn(0));
+    assert.strictEqual(
+      frames.size,
+      0,
+      "a pane with no images, nothing decoding and no canvas must not queue a rAF per render"
+    );
+  },
+
+  "graphics frames paint an overlay canvas below xterm's own"() {
+    loadViewer();
+    const socket = connectPanes(["pane-1"]);
+    socket.deliver(IMAGE_FRAME("pane-1", 1, true));
+    assert.strictEqual(FakeImage.pending.length, 1, "the raster must start decoding");
+    FakeImage.pending[0].decodeAs(64, 32);
+    flushFrames();
+    const terminal = lastTerminal();
+    const canvases = terminal.screen.querySelectorAll("canvas");
+    assert.strictEqual(canvases.length, 2, "one overlay canvas plus xterm's glyph canvas");
+    assert.strictEqual(canvases[0].className, "bossterm-graphics", "images must paint UNDER the glyphs");
+    assert.ok(canvases[0].drawCalls && canvases[0].drawCalls.length > 0, "the decoded raster must be drawn");
+    // A render after the images are placed SHOULD schedule a frame — the text-only gate must not
+    // suppress real graphics work.
+    terminal.emitRender();
+    assert.strictEqual(frames.size, 1, "a pane with placements must still repaint on render");
+  },
+
+  "one pane recovering keeps the out-of-sync warning while another is still degraded"() {
+    loadViewer();
+    const socket = connectPanes(["pane-1", "pane-2"]);
+    // Both panes require an image they never receive → each burns its resync budget and degrades.
+    const missing = (paneId) => ({
+      t: "paneGraphics",
+      paneId: paneId,
+      revision: 1,
+      full: true,
+      images: [],
+      removedImageIds: [],
+      requiredImageIds: ["9"],
+      cells: [],
+      historyLines: 0,
+    });
+    [1, 2].forEach((n) => {
+      for (let round = 0; round < 6; round += 1) {
+        socket.deliver(missing("pane-" + n));
+        advance(30000);
+      }
+    });
+    assert.ok(/out of sync/.test(el("status").title), "both panes degraded must warn: " + el("status").title);
+    // pane-1 recovers; pane-2 has not.
+    socket.deliver(IMAGE_FRAME("pane-1", 2, true));
+    FakeImage.pending.forEach((img) => img.decodeAs(16, 16));
+    assert.ok(
+      /out of sync/.test(el("status").title),
+      "the shared tooltip must survive one pane recovering, saw: '" + el("status").title + "'"
+    );
+    // pane-2 recovers too → the warning clears.
+    socket.deliver(IMAGE_FRAME("pane-2", 2, true));
+    FakeImage.pending.forEach((img) => img.decodeAs(16, 16));
+    assert.strictEqual(el("status").title, "", "the warning clears once every pane is in sync");
+  },
+
+  "transparency is enabled only while a pane actually has drawable graphics"() {
+    loadViewer();
+    const socket = connectPanes(["pane-1"]);
+    const terminal = lastTerminal();
+    assert.strictEqual(terminal.options.allowTransparency, false, "a text-only pane stays opaque");
+    socket.deliver(IMAGE_FRAME("pane-1", 1, true));
+    FakeImage.pending[0].decodeAs(64, 32);
+    flushFrames();
+    assert.strictEqual(terminal.options.allowTransparency, true, "images need a transparent terminal");
+    // Host clears the image: the overlay canvas and the transparency must both go away, or the
+    // pane keeps paying for a compositing path it no longer needs.
+    socket.deliver({
+      t: "paneGraphics", paneId: "pane-1", revision: 2, full: true,
+      images: [], removedImageIds: ["7"], requiredImageIds: [], cells: [], historyLines: 0,
+    });
+    flushFrames();
+    assert.strictEqual(terminal.options.allowTransparency, false, "transparency must be released");
+    assert.strictEqual(
+      terminal.screen.querySelectorAll("canvas").length,
+      1,
+      "only xterm's own canvas should remain"
+    );
+  },
+
+  "an undecodable raster is not retried with another full payload"() {
+    loadViewer();
+    const socket = connectPanes(["pane-1"]);
+    socket.deliver(IMAGE_FRAME("pane-1", 1, true));
+    const sentBefore = socket.sent.length;
+    FakeImage.pending[0].failDecode();
+    flushFrames();
+    // The same bytes cannot become decodable, so a resync would loop forever over a multi-MB frame.
+    socket.deliver(IMAGE_FRAME("pane-1", 2, false));
+    advance(60000);
+    const resyncs = socket.sent.slice(sentBefore).filter((raw) => JSON.parse(raw).t === "graphicsResync");
+    assert.deepStrictEqual(resyncs, [], "a decode failure must not request a full resync");
+  },
+
+  "an unknown raster mime type falls back to png instead of being trusted"() {
+    loadViewer();
+    const socket = connectPanes(["pane-1"]);
+    const frame = IMAGE_FRAME("pane-1", 1, true);
+    frame.images[0].mimeType = "text/html";
+    socket.deliver(frame);
+    assert.strictEqual(
+      FakeImage.pending[0].src,
+      "data:image/png;base64,AAAA",
+      "a host-supplied mime type must be allowlisted before it reaches a data: URL"
+    );
+  },
+
+  "host theme numbers are clamped and non-string colors fall back"() {
+    loadViewer();
+    const socket = connectPanes(["pane-1"]);
+    socket.deliver({ t: "theme", background: { evil: true }, fontSize: 9999, fontFamily: 42 });
+    const terminal = lastTerminal();
+    assert.strictEqual(terminal.options.fontSize, 72, "an absurd host font size must be clamped");
+    assert.strictEqual(
+      terminal.options.theme.background,
+      "#1e1e1e",
+      "a non-string background must fall back to the default"
+    );
+    socket.deliver({ t: "theme", fontSize: "not a number" });
+    assert.strictEqual(terminal.options.fontSize, 13, "an unparseable font size falls back");
+  },
+
+  "pane output never moves the viewer's scroll position"() {
+    loadViewer();
+    const socket = connectPanes(["pane-1"]);
+    const terminal = lastTerminal();
+    terminal.buffer.active.baseY = 120;
+    terminal.buffer.active.viewportY = 90;
+    socket.deliver({ t: "paneOutput", paneId: "pane-1", data: "hello" });
+    assert.strictEqual(terminal.scrolledToLine, null, "incremental output must not re-anchor the reader");
+    assert.ok(terminal.written.indexOf("hello") >= 0);
+  },
+
+  "a repaint restores the reader's distance from the bottom"() {
+    loadViewer();
+    const socket = connectPanes(["pane-1"]);
+    const terminal = lastTerminal();
+    terminal.buffer.active.baseY = 120;
+    terminal.buffer.active.viewportY = 87;
+    socket.deliver({ t: "paneRepaint", paneId: "pane-1", data: "SCREEN" });
+    assert.strictEqual(terminal.scrolledToLine, 87, "the viewer must not be yanked to the bottom");
+    assert.ok(terminal.written.indexOf("SCREEN") >= 0, "the repaint payload must reach xterm");
+  },
+
+  "a pane snapshot clamps the host scrollback to the browser cap"() {
+    loadViewer();
+    const socket = FakeWebSocket.latest;
+    socket.open();
+    socket.deliver({ t: "layout", tabs: [{ id: "t", title: "z", tree: { t: "pane", paneId: "p" } }], activeTabId: "t" });
+    socket.deliver({ t: "paneSnapshot", paneId: "p", data: "", cols: 80, rows: 24, scrollbackLines: 999999 });
+    assert.strictEqual(lastTerminal().options.scrollback, 20000, "the viewer cap must win over a huge host cap");
+  },
+
+  "a viewer.js without viewer-logic.js fails visibly instead of throwing"() {
+    loadViewer({ withoutViewerLogic: true });
+    assert.strictEqual(FakeWebSocket.instances.length, 0, "it must not try to connect");
+    assert.ok(
+      /failed to load/.test(fakeDocument.body.textContent),
+      "the page must say so: '" + fakeDocument.body.textContent + "'"
+    );
+  },
+};
+
+let failures = 0;
+Object.keys(scenarios).forEach((name) => {
+  try {
+    scenarios[name]();
+    process.stdout.write("ok   " + name + "\n");
+  } catch (e) {
+    failures += 1;
+    process.stdout.write("FAIL " + name + "\n     " + (e && e.message) + "\n");
+    if (e && e.stack) process.stdout.write("     " + e.stack.split("\n").slice(1, 4).join("\n     ") + "\n");
+  }
+});
+
+if (failures > 0) {
+  process.stdout.write(failures + " viewer scenario(s) failed\n");
+  process.exit(1);
+}


### PR DESCRIPTION
## What

- retry transient web-viewer disconnects three times before showing the manual reconnect prompt
- add a capability-gated, host-decoded graphics protocol for Sixel and Kitty images
- render authoritative image-cell placements in a bounded browser canvas cache
- support initial state, live updates, deletion, scrolling, revision-gap resync, desktop-hosted shares, and daemon-hosted shares
- publish complete inline-image model changes atomically so viewers never capture partially written image rows
- serve BossTerm's bundled Meslo Nerd Font and Noto Symbols font to web viewers, with platform emoji fallbacks
- reload xterm's glyph metrics and WebGL atlas after the bundled fonts finish loading

## Why

The web viewer previously prompted immediately after any network blip and xterm.js 5 ignored Sixel/Kitty graphics. Direct browser-side Kitty parsing is also insufficient for host-local file transfers, so BossTerm now remains the decoding source of truth and sends normalized raster data plus exact cell placements only to capable browser peers. Native remote peers continue consuming the raw terminal stream unchanged.

Yazi icons and emoji were also missing because the browser received a desktop font-family name that commonly was not installed on the viewing device, while the native renderer loads BossTerm's bundled Nerd Font and symbol fallbacks directly.

## Impact

Web shares recover automatically from short disconnects and display Sixel/Kitty content with native-aligned scrolling, resizing, cursor layering, and image lifecycle behavior. Encoded wire rasters are bounded to 16 MiB per pane; decoded browser graphics memory is bounded to 96 MiB per pane and 192 MiB across the viewer. The web viewer now renders Nerd Font private-use icons, emoji, and symbols using the same fallback coverage as native BossTerm. Existing/older peers remain protocol-compatible through optional Hello capabilities and defaulted fields.

## Root cause

Disconnect handling wired both WebSocket `error` and `close` directly to the final prompt, with no retry budget. Graphics were forwarded only as raw PTY bytes, but the bundled xterm.js version has no Kitty renderer and cannot resolve file-backed transfers on the host filesystem. The viewer also named host fonts without serving BossTerm's bundled fonts, so missing viewer-device fonts produced missing-glyph boxes that WebGL then cached.

## Checks

- `node --check compose-ui/src/desktopMain/resources/share-viewer/viewer.js`
- reconnect fake-WebSocket harness: initial connection + exactly three automatic retries, then prompt
- `./gradlew :bossterm-core-mpp:jvmTest :compose-ui:desktopTest --no-daemon`
- `./gradlew :compose-ui:desktopTest --tests 'ai.rever.bossterm.compose.share.ShareProtocolTest' --tests 'ai.rever.bossterm.compose.daemon.DaemonShareServerTest' --no-daemon`
- targeted protocol, Sixel, Kitty, image sizing, graphics tracker, font-stack, and font-serving tests
