### PR TITLE
Cancel in-flight work in SessionShareManager.shutdown() so a parked pre-warm can't re-bind the share server

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -18,7 +18,6 @@ import io.ktor.websocket.CloseReason
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -73,6 +72,11 @@ object SessionShareManager {
      * process-wide singleton; tests point this at a throwaway manager so exercising the
      * pre-warm / shutdown paths can neither read nor rewrite a developer's real
      * `~/.bossterm/settings.json`.
+     *
+     * NOTE: this covers THIS class's reads only. [MirrorShare] still resolves the singleton
+     * directly (~10 sites, one of them a write), so a future test that gets as far as constructing
+     * a share would read — and could rewrite — the developer's real settings file. Extend the seam
+     * there before writing one.
      */
     @Volatile
     internal var settingsManagerOverrideForTest: SettingsManager? = null
@@ -90,6 +94,19 @@ object SessionShareManager {
      * coroutine may bind".
      */
     @Volatile private var shuttingDown = false
+
+    /**
+     * Bumped by every [shutdown]. [shuttingDown] alone is not a sound basis for a re-check inside a
+     * long operation, because [start] clears it: a dispose/re-init cycle that completes while a bind
+     * is still in flight would leave the binder's re-check reading `false` and adopting a server the
+     * manager no longer knows about. The epoch only ever moves forward — the same tool, for the same
+     * "did someone supersede me while I was working" question, as [remoteOp].
+     */
+    private val shutdownEpoch = java.util.concurrent.atomic.AtomicInteger(0)
+
+    /** True if a [shutdown] has begun, or has begun *and finished*, since [epoch] was taken. */
+    private fun supersededByShutdown(epoch: Int): Boolean =
+        shuttingDown || shutdownEpoch.get() != epoch
 
     /**
      * Embedder hook for "Fit host to my screen" when BossTerm is hosted inside
@@ -486,6 +503,7 @@ object SessionShareManager {
         val settings = settingsManager.settings.value
         if (!settings.sessionSharingEnabled) return null
         return mutex.withLock {
+            val epoch = shutdownEpoch.get()
             if (!ensureEngineLocked(settings)) return@withLock null
             val share = sharesByTab[tabId] ?: MirrorShare(tabId, scope, onEnded = { unshare(tabId) }).also {
                 it.start()
@@ -499,7 +517,7 @@ object SessionShareManager {
             // land anywhere above, including between a check and the registration. A MirrorShare
             // left behind a shut-down manager runs observer coroutines on its OWN scope, which our
             // cancelChildren() never reaches — it would keep observing terminal state forever.
-            if (shuttingDown) {
+            if (supersededByShutdown(epoch)) {
                 log.warn("Share for {} was registered while shutting down — reverting", tabId)
                 unregisterShareLocked(tabId, share)
                 return@withLock null
@@ -537,7 +555,7 @@ object SessionShareManager {
      * remote access is off. Runs off the UI thread.
      */
     fun refreshRemoteLink() {
-        if (shuttingDown) return
+        if (shuttingDown) { log.debug("Ignoring refreshRemoteLink(): the manager is shut down"); return }
         scope.launch {
             val port = boundPort ?: return@launch
             val mode = settingsManager.settings.value.shareTailscaleMode
@@ -554,7 +572,7 @@ object SessionShareManager {
      * isn't active (no bound port) this is a no-op; the persisted setting applies next share.
      */
     fun applyRemoteMode(mode: String) {
-        if (shuttingDown) return
+        if (shuttingDown) { log.debug("Ignoring applyRemoteMode({}): the manager is shut down", mode); return }
         scope.launch {
             val port = boundPort ?: return@launch
             val op = claimRemoteOp() // supersede any in-flight establish (it will bail + self-clean)
@@ -724,13 +742,12 @@ object SessionShareManager {
 
     /** Stop sharing [tabId]; stops the server if it was the last share. */
     fun unshare(tabId: String) {
-        if (shuttingDown) return // shutdown() already stopped and cleared every share, inline
+        // shutdown() already stopped and cleared every share, inline.
+        if (shuttingDown) { log.debug("Ignoring unshare({}): the manager is shut down", tabId); return }
         scope.launch {
             mutex.withLock {
                 val share = sharesByTab[tabId] ?: return@withLock
                 unregisterShareLocked(tabId, share)
-                failPendingFor(tabId)
-                releaseEmbeddedFit(tabId) // sharing stopped → restore any fit-resized host window
                 // Keep the engine + tunnel warm when sharing stays enabled with a remote provider,
                 // so a re-share is instant; otherwise tear down as before.
                 if (sharesByTab.isEmpty() && !keepWarm()) stopEngineLocked()
@@ -748,6 +765,8 @@ object SessionShareManager {
         sharesByToken.remove(share.viewToken)
         sharesByToken.remove(share.controlToken)
         grants.values.removeIf { it.shareId == share.viewToken }
+        failPendingFor(tabId)
+        releaseEmbeddedFit(tabId) // sharing stopped → restore any fit-resized host window
         runCatching { share.stop() }
         _sharedTabIds.value = sharesByTab.keys.toSet()
     }
@@ -794,8 +813,11 @@ object SessionShareManager {
      */
     @Synchronized
     fun shutdown() {
-        // 1. Latch first, so an uninterruptible binder refuses (see [shuttingDown]).
+        // 1. Latch first, so an uninterruptible binder refuses (see [shuttingDown]), and bump the
+        //    epoch so a binder that started before this call can tell it has been superseded even
+        //    if a re-init clears the latch under it.
         shuttingDown = true
+        shutdownEpoch.incrementAndGet()
         // 2. Supersede any in-flight remote establish. Cancellation cannot do this job:
         //    cloudflared's awaitUrl/awaitReady are plain blocking calls, so an establish
         //    sitting in one keeps running until its next suspension point. The op token is
@@ -875,6 +897,7 @@ object SessionShareManager {
             return false
         }
         if (engine != null) return true
+        val epoch = shutdownEpoch.get()
         val host = resolveBindHost(settings)
         val desiredPort = settings.sessionSharingPort
         for (offset in 0 until MAX_PORT_FALLBACK) {
@@ -934,7 +957,9 @@ object SessionShareManager {
                 // its whole teardown while we were binding, reading a still-null engine and leaving
                 // ours alive behind it. Bounded (200ms grace / 800ms cap) and loud, because a server
                 // that outlives its manager is exactly the leak this guard exists to prevent.
-                if (shuttingDown) {
+                // Against the epoch, not just the latch: a dispose/re-init that completed while we
+                // were binding would have cleared the latch (see [shutdownEpoch]).
+                if (supersededByShutdown(epoch)) {
                     log.warn(
                         "Session-sharing server bound on {}:{} while shutting down — stopping it again",
                         host, port
@@ -983,29 +1008,27 @@ object SessionShareManager {
 
     private suspend fun stopEngineLocked() {
         val e = engine ?: return
-        // Tear down any active remote-access exposure first (best-effort, off the UI thread).
-        // Bump the op so an in-flight establish bails + self-cleans instead of racing teardown.
-        claimRemoteOp()
-        withContext(Dispatchers.IO) { teardownRemoteAccess(boundPort) }
-        try {
-            // NonCancellable: [shutdown] cancels this scope, and this teardown runs on it. Being
-            // cancelled between "decided to stop the engine" and "stopped it" would run the finally
-            // below — clearing [engine] — while the server is still bound, and shutdown() would then
-            // find nothing left to stop. Bounded by the same 300ms/1000ms stop budget, so the
-            // uninterruptible stretch stays short.
-            withContext(Dispatchers.IO + NonCancellable) { e.stop(300, 1000) }
-            log.info("Session-sharing server stopped (port {})", boundPort)
-        } catch (c: CancellationException) {
-            // Defensive: NonCancellable above means the outer cancel can't surface inside this
-            // try today. If a future edit adds a cancellable suspension point here, a deliberate
-            // cancellation must propagate rather than be logged as a stop failure.
-            throw c
-        } catch (t: Throwable) {
-            log.warn("Error stopping session-sharing server: {}", t.message)
-        } finally {
-            engine = null
-            boundPort = null
-            boundHost = null
+        // NonCancellable for the whole teardown, not just the engine stop. [shutdown] cancels this
+        // scope, and this function runs on it; a cancel landing anywhere in here leaves the job
+        // half-done — on the remote teardown, a Tailscale mapping stays published and the `finally`
+        // never runs, so [engine] stays set; on the stop, the `finally` clears [engine] while the
+        // server is still bound and shutdown() then finds nothing to stop. Neither is worth the
+        // interruptibility: everything below is teardown we have already committed to, and it is
+        // bounded by the CLI timeouts plus the 300ms/1000ms stop budget.
+        withContext(Dispatchers.IO + NonCancellable) {
+            // Bump the op so an in-flight establish bails + self-cleans instead of racing teardown.
+            claimRemoteOp()
+            teardownRemoteAccess(boundPort)
+            try {
+                e.stop(300, 1000)
+                log.info("Session-sharing server stopped (port {})", boundPort)
+            } catch (t: Throwable) {
+                log.warn("Error stopping session-sharing server: {}", t.message)
+            } finally {
+                engine = null
+                boundPort = null
+                boundHost = null
+            }
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -409,31 +410,38 @@ object SessionShareManager {
         if (!lifecycle.isActive) lifecycle = SupervisorJob() // re-arm after a shutdown
         if (watcherJob?.isActive == true) return
         watcherJob = scope.launch {
-            settingsManager.settings
-                .map { it.sessionSharingEnabled to it.shareTailscaleMode }
-                .distinctUntilChanged()
-                .collect { (enabled, mode) ->
-                    if (!enabled) { stopAll(); return@collect }
-                    // EAGER prefetch: as soon as cloudflare sharing is enabled, fetch cloudflared in
-                    // the background so the first share doesn't pay the download. No-op when a
-                    // bundled/PATH/managed binary already works; single-flight via prefetchJob.
-                    if (mode == "cloudflare" && prefetchJob?.isActive != true) {
-                        prefetchJob = launch(Dispatchers.IO) {
-                            if (!CloudflaredExposer.isInstalled() && CloudflaredExposer.canAutoInstall()) {
-                                log.info("Prefetching cloudflared for session sharing…")
-                                val ok = CloudflaredExposer.ensureInstalled()
-                                log.info("cloudflared prefetch {}", if (ok) "ready" else "failed (will retry at share time)")
+            // supervisorScope so the launches below are children of THIS watcher — cancelled with
+            // it, and never adopted by a re-armed lifecycle — without a failure in one of them
+            // cancelling the collect. `launch` builds a plain Job, so without this a throwing
+            // pre-warm or prefetch would silently kill the settings observer for good: no
+            // pre-warm, no teardown on disable, and nothing logged.
+            supervisorScope {
+                settingsManager.settings
+                    .map { it.sessionSharingEnabled to it.shareTailscaleMode }
+                    .distinctUntilChanged()
+                    .collect { (enabled, mode) ->
+                        if (!enabled) { stopAll(); return@collect }
+                        // EAGER prefetch: as soon as cloudflare sharing is enabled, fetch cloudflared in
+                        // the background so the first share doesn't pay the download. No-op when a
+                        // bundled/PATH/managed binary already works; single-flight via prefetchJob.
+                        if (mode == "cloudflare" && prefetchJob?.isActive != true) {
+                            prefetchJob = launch(Dispatchers.IO) {
+                                if (!CloudflaredExposer.isInstalled() && CloudflaredExposer.canAutoInstall()) {
+                                    log.info("Prefetching cloudflared for session sharing…")
+                                    val ok = CloudflaredExposer.ensureInstalled()
+                                    log.info("cloudflared prefetch {}", if (ok) "ready" else "failed (will retry at share time)")
+                                }
                             }
                         }
+                        // PRE-WARM: bind the engine and bring the tunnel up now, before the user shares,
+                        // so the verified public URL is already published when the share dialog opens
+                        // (the QR shows the Cloudflare link instantly instead of after a 5-15s verify).
+                        // Unqualified launch: a child of THIS watcher, not of whatever [lifecycle]
+                        // resolves to at the moment it runs. Cancelling the watcher takes it with it,
+                        // and a re-arm between the check above and here cannot adopt it.
+                        if (mode != "off") launch { prewarmRemote() }
                     }
-                    // PRE-WARM: bind the engine and bring the tunnel up now, before the user shares,
-                    // so the verified public URL is already published when the share dialog opens
-                    // (the QR shows the Cloudflare link instantly instead of after a 5-15s verify).
-                    // Unqualified launch: a child of THIS watcher, not of whatever [lifecycle]
-                    // resolves to at the moment it runs. Cancelling the watcher takes it with it,
-                    // and a re-arm between the check above and here cannot adopt it.
-                    if (mode != "off") launch { prewarmRemote() }
-                }
+            }
         }
     }
 
@@ -797,6 +805,7 @@ object SessionShareManager {
     }
 
     private fun stopAll() {
+        if (shuttingDown) { log.debug("Ignoring stopAll(): the manager is shut down"); return }
         scope.launch {
             mutex.withLock {
                 sharesByTab.values.forEach { it.stop() }
@@ -832,9 +841,11 @@ object SessionShareManager {
      * follows. Everything else queued there — pre-warm, establish, respawn, the cloudflared
      * prefetch — is *setup*, so cancelling it is the point, not a cost.
      *
-     * Idempotent, and safe when nothing ever started. The one thing it can leave outstanding is
-     * the `share-late-bind-stop` thread in [ensureEngineLocked], on the narrow path where a bind
-     * completed while this was running — a thread stopping a server beats a server nobody stops.
+     * Idempotent, and safe when nothing ever started. Two things can outlive it, both bounded: the
+     * `share-late-bind-stop` thread in [ensureEngineLocked], on the narrow path where a bind
+     * completed while this was running (a thread stopping a server beats a server nobody stops),
+     * and a [stopEngineLocked] already inside its NonCancellable fence — which is why that function
+     * refuses to start one once this has latched.
      */
     fun shutdown() {
         val (embedder, fitted) = shutdownLocked()
@@ -1051,6 +1062,11 @@ object SessionShareManager {
 
     private suspend fun stopEngineLocked() {
         val e = engine ?: return
+        // shutdown() does all of this itself, inline — and the NonCancellable fence below means
+        // that once we enter it, cancellation is no longer a lever: a teardown started here would
+        // go on to spawn a `tailscale` child process and stop the engine after shutdown() returned,
+        // inside the classloader being unloaded.
+        if (shuttingDown) return
         val port = boundPort // captured: shutdown() can null the field while we are stopping
         // NonCancellable for the whole teardown, not just the engine stop. [shutdown] cancels this
         // scope, and this function runs on it; a cancel landing anywhere in here leaves the job

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -156,6 +156,9 @@ object SessionShareManager {
      * handled (caller skips the standalone window-resize path), false otherwise.
      */
     internal fun requestEmbeddedFit(tabId: String, deltaWidthPx: Float, deltaHeightPx: Float): Boolean {
+        // Refuse once shutdown has drained [fitActiveTabs]: a fit registered after that is one
+        // nothing will ever undo, on an embedder we have already let go of.
+        if (shuttingDown) return false
         val embedder = fitHostEmbedder ?: return false
         fitActiveTabs.add(tabId)
         runCatching { embedder.onFitHost(tabId, deltaWidthPx, deltaHeightPx) }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -74,6 +74,7 @@ object SessionShareManager {
      * pre-warm / shutdown paths can neither read nor rewrite a developer's real
      * `~/.bossterm/settings.json`.
      */
+    @Volatile
     internal var settingsManagerOverrideForTest: SettingsManager? = null
     private val settingsManager: SettingsManager
         get() = settingsManagerOverrideForTest ?: SettingsManager.instance
@@ -196,7 +197,9 @@ object SessionShareManager {
     /** Tab ids currently being shared — drives the UI indicator + Share/Stop menu state. */
     val sharedTabIds: StateFlow<Set<String>> = _sharedTabIds.asStateFlow()
 
-    private var watcherJob: Job? = null
+    // @Volatile: written by [shutdown] from a shutdown-hook / embedder-dispose thread while
+    // [start] reads and writes it from another.
+    @Volatile private var watcherJob: Job? = null
 
     // Eager cloudflared prefetch: when sharing is enabled in cloudflare mode we fetch the binary
     // in the background so the first share is instant. @Volatile + the isActive guard keep it
@@ -475,6 +478,12 @@ object SessionShareManager {
         if (!settings.sessionSharingEnabled) return null
         return mutex.withLock {
             if (!ensureEngineLocked(settings)) return@withLock null
+            // ensureEngineLocked returns early when the engine is already up, which skips its own
+            // post-bind re-check — and [shutdown] cannot take this mutex, so it may have torn
+            // everything down between that read and here. Re-check before registering a share:
+            // a started MirrorShare behind a shut-down manager is the same straggler hazard as a
+            // late bind, just with terminal observers instead of a socket.
+            if (shuttingDown) return@withLock null
             val share = sharesByTab[tabId] ?: MirrorShare(tabId, scope, onEnded = { unshare(tabId) }).also {
                 it.start()
                 sharesByToken[it.viewToken] = TokenRef(it, canControl = false)
@@ -515,6 +524,7 @@ object SessionShareManager {
      * remote access is off. Runs off the UI thread.
      */
     fun refreshRemoteLink() {
+        if (shuttingDown) return
         scope.launch {
             val port = boundPort ?: return@launch
             val mode = settingsManager.settings.value.shareTailscaleMode
@@ -531,6 +541,7 @@ object SessionShareManager {
      * isn't active (no bound port) this is a no-op; the persisted setting applies next share.
      */
     fun applyRemoteMode(mode: String) {
+        if (shuttingDown) return
         scope.launch {
             val port = boundPort ?: return@launch
             val op = claimRemoteOp() // supersede any in-flight establish (it will bail + self-clean)
@@ -596,6 +607,10 @@ object SessionShareManager {
      */
     private fun registerRespawn(proc: Process, port: Int, op: Int) {
         proc.onExit().thenAccept {
+            // This callback runs on a ForkJoinPool thread OUTSIDE the scope, so [shutdown]'s
+            // cancellation cannot reach it — a cloudflared process exiting after shutdown would
+            // otherwise schedule a fresh coroutine inside a classloader that is being unloaded.
+            if (shuttingDown) return@thenAccept
             scope.launch {
                 if (!isCurrentRemoteOp(op)) return@launch // a cooperative teardown/switch superseded us
                 val s = settingsManager.settings.value
@@ -692,6 +707,7 @@ object SessionShareManager {
 
     /** Stop sharing [tabId]; stops the server if it was the last share. */
     fun unshare(tabId: String) {
+        if (shuttingDown) return // shutdown() already stopped and cleared every share, inline
         scope.launch {
             mutex.withLock {
                 val share = sharesByTab.remove(tabId) ?: return@withLock
@@ -896,7 +912,13 @@ object SessionShareManager {
                     engine = null
                     boundPort = null
                     boundHost = null
-                    runCatching { started.stop(200, 800) }
+                    // Off-thread: this function runs synchronously on the caller's thread, and
+                    // share() reaches it from a rememberCoroutineScope (the Compose UI thread) —
+                    // the very reason the establish kick below is pushed off this path. A plain
+                    // daemon thread rather than the scope, which shutdown() has just cancelled.
+                    Thread { runCatching { started.stop(200, 800) } }
+                        .apply { isDaemon = true; name = "share-late-bind-stop" }
+                        .start()
                     return false
                 }
                 log.info("Session-sharing server bound on {}:{} (bind={})", host, port, settings.sessionSharingBind)
@@ -944,7 +966,9 @@ object SessionShareManager {
             withContext(Dispatchers.IO + NonCancellable) { e.stop(300, 1000) }
             log.info("Session-sharing server stopped (port {})", boundPort)
         } catch (c: CancellationException) {
-            // Deliberate cancellation is not a failure — never log it as one.
+            // Defensive: NonCancellable above means the outer cancel can't surface inside this
+            // try today. If a future edit adds a cancellable suspension point here, a deliberate
+            // cancellation must propagate rather than be logged as a stop failure.
             throw c
         } catch (t: Throwable) {
             log.warn("Error stopping session-sharing server: {}", t.message)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -418,7 +418,7 @@ object SessionShareManager {
                     // the background so the first share doesn't pay the download. No-op when a
                     // bundled/PATH/managed binary already works; single-flight via prefetchJob.
                     if (mode == "cloudflare" && prefetchJob?.isActive != true) {
-                        prefetchJob = scope.launch(Dispatchers.IO) {
+                        prefetchJob = launch(Dispatchers.IO) {
                             if (!CloudflaredExposer.isInstalled() && CloudflaredExposer.canAutoInstall()) {
                                 log.info("Prefetching cloudflared for session sharing…")
                                 val ok = CloudflaredExposer.ensureInstalled()
@@ -429,7 +429,10 @@ object SessionShareManager {
                     // PRE-WARM: bind the engine and bring the tunnel up now, before the user shares,
                     // so the verified public URL is already published when the share dialog opens
                     // (the QR shows the Cloudflare link instantly instead of after a 5-15s verify).
-                    if (mode != "off") scope.launch { prewarmRemote() }
+                    // Unqualified launch: a child of THIS watcher, not of whatever [lifecycle]
+                    // resolves to at the moment it runs. Cancelling the watcher takes it with it,
+                    // and a re-arm between the check above and here cannot adopt it.
+                    if (mode != "off") launch { prewarmRemote() }
                 }
         }
     }
@@ -833,8 +836,16 @@ object SessionShareManager {
      * the `share-late-bind-stop` thread in [ensureEngineLocked], on the narrow path where a bind
      * completed while this was running — a thread stopping a server beats a server nobody stops.
      */
-    @Synchronized
     fun shutdown() {
+        val (embedder, fitted) = shutdownLocked()
+        // Host callbacks OUTSIDE the monitor: an embedder that marshals this onto its UI thread
+        // would deadlock against a start() already running there.
+        fitted.forEach { runCatching { embedder?.onRestoreHostSize(it) } }
+    }
+
+    /** [shutdown]'s body. Returns the embedder + the tabs whose host fit it still has to undo. */
+    @Synchronized
+    private fun shutdownLocked(): Pair<FitHostEmbedder?, List<String>> {
         // 1. Latch first, so an uninterruptible binder refuses (see [shuttingDown]), and bump the
         //    epoch so a binder that started before this call can tell it has been superseded even
         //    if a re-init clears the latch under it.
@@ -853,11 +864,12 @@ object SessionShareManager {
         lifecycle.cancel()
         watcherJob = null
         prefetchJob = null
-        // Release any fit-resized host window BEFORE dropping the embedder that has to undo it,
-        // then drop it: it belongs to the host disposing us, and holding it pins that host (and,
-        // when this class outlives one embedder, its classloader).
-        fitActiveTabs.toList().forEach { releaseEmbeddedFit(it) }
-        fitActiveTabs.clear() // belt: releaseEmbeddedFit already removes each one
+        // Hand the caller any fit-resized host window still to be undone, and drop the embedder:
+        // it belongs to the host disposing us, and holding it pins that host (and, when this class
+        // outlives one embedder, its classloader). The callbacks themselves run outside the monitor.
+        val embedder = fitHostEmbedder
+        val fitted = fitActiveTabs.toList()
+        fitActiveTabs.clear()
         fitHostEmbedder = null
         sharesByTab.values.forEach { runCatching { it.stop() } }
         sharesByTab.clear()
@@ -873,6 +885,7 @@ object SessionShareManager {
         boundPort = null
         boundHost = null
         if (e != null) runCatching { e.stop(200, 800) }
+        return embedder to fitted
     }
 
     // ---- engine lifecycle (mutex-guarded) ----
@@ -1049,7 +1062,7 @@ object SessionShareManager {
         withContext(Dispatchers.IO + NonCancellable) {
             // Bump the op so an in-flight establish bails + self-cleans instead of racing teardown.
             claimRemoteOp()
-            teardownRemoteAccess(boundPort)
+            teardownRemoteAccess(port)
             try {
                 e.stop(300, 1000)
                 log.info("Session-sharing server stopped (port {})", port)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -139,7 +139,9 @@ object SessionShareManager {
     @Volatile
     private var engine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
     @Volatile private var boundPort: Int? = null
-    private var boundHost: String? = null
+    // @Volatile for the same reason as [boundPort]: cleared by [shutdown] off-thread, read from
+    // Ktor/IO threads via advertisedHost().
+    @Volatile private var boundHost: String? = null
     // Remote access (Phase 3): the published public/tunnel URL + which provider is live.
     // [activeRemoteMode] mirrors a TerminalSettings.shareTailscaleMode value:
     // "off" | "serve" | "funnel" (Tailscale) | "cloudflare" (Cloudflare Quick Tunnel).
@@ -356,7 +358,14 @@ object SessionShareManager {
      * Also re-arms the manager after a [shutdown]: the singleton outlives one embedder's
      * lifecycle (bossterm-app and the BossConsole terminal plugin both call [start]/[shutdown]),
      * so shutting down must not leave it permanently inert.
+     *
+     * `@Synchronized` with [shutdown] so the pair is ordered: without it a shutdown racing a start
+     * could cancel the freshly-launched watcher and then null [watcherJob], leaving the manager
+     * latch-clear but with no settings observer — no pre-warm, no teardown on disable, nothing
+     * logged. Unreachable from bossterm-app's start-once/stop-in-the-hook shape, but the embedded
+     * plugin's dispose/re-init path is exactly where it would show up.
      */
+    @Synchronized
     fun start() {
         shuttingDown = false
         if (watcherJob?.isActive == true) return
@@ -478,18 +487,22 @@ object SessionShareManager {
         if (!settings.sessionSharingEnabled) return null
         return mutex.withLock {
             if (!ensureEngineLocked(settings)) return@withLock null
-            // ensureEngineLocked returns early when the engine is already up, which skips its own
-            // post-bind re-check — and [shutdown] cannot take this mutex, so it may have torn
-            // everything down between that read and here. Re-check before registering a share:
-            // a started MirrorShare behind a shut-down manager is the same straggler hazard as a
-            // late bind, just with terminal observers instead of a socket.
-            if (shuttingDown) return@withLock null
             val share = sharesByTab[tabId] ?: MirrorShare(tabId, scope, onEnded = { unshare(tabId) }).also {
                 it.start()
                 sharesByToken[it.viewToken] = TokenRef(it, canControl = false)
                 sharesByToken[it.controlToken] = TokenRef(it, canControl = true)
                 sharesByTab[tabId] = it
                 _sharedTabIds.value = sharesByTab.keys.toSet()
+            }
+            // Adopt, then re-check — the same shape [ensureEngineLocked] uses for the engine.
+            // A pre-check would not do: [shutdown] deliberately does not take this mutex, so it can
+            // land anywhere above, including between a check and the registration. A MirrorShare
+            // left behind a shut-down manager runs observer coroutines on its OWN scope, which our
+            // cancelChildren() never reaches — it would keep observing terminal state forever.
+            if (shuttingDown) {
+                log.warn("Share for {} was registered while shutting down — reverting", tabId)
+                unregisterShareLocked(tabId, share)
+                return@withLock null
             }
             val url = buildUrl(share.viewToken) ?: return@withLock null
             val controlUrl = buildUrl(share.controlToken) ?: url
@@ -654,7 +667,11 @@ object SessionShareManager {
         }
         var refreshes = 0
         // Already runs on Dispatchers.IO (manager scope / caller's withContext), so the
-        // blocking awaitUrl/awaitReady don't need their own withContext.
+        // blocking awaitUrl/awaitReady don't need their own withContext. That is now
+        // load-bearing rather than merely tidy: [shutdown] cancels this scope, and the loop
+        // below has no try/finally around its tunnel — leak-safety rests on reaching one of the
+        // tunnel.destroy() exits. Wrapping these blocking calls in a withContext would add a
+        // cancellable suspension point and leak a cloudflared process on cancel.
         while (isCurrentRemoteOp(op)) {
             val tunnel = CloudflaredExposer.start(port) ?: return null
             val url = tunnel.awaitUrl()
@@ -710,19 +727,29 @@ object SessionShareManager {
         if (shuttingDown) return // shutdown() already stopped and cleared every share, inline
         scope.launch {
             mutex.withLock {
-                val share = sharesByTab.remove(tabId) ?: return@withLock
-                sharesByToken.remove(share.viewToken)
-                sharesByToken.remove(share.controlToken)
-                grants.values.removeIf { it.shareId == share.viewToken }
+                val share = sharesByTab[tabId] ?: return@withLock
+                unregisterShareLocked(tabId, share)
                 failPendingFor(tabId)
                 releaseEmbeddedFit(tabId) // sharing stopped → restore any fit-resized host window
-                share.stop()
-                _sharedTabIds.value = sharesByTab.keys.toSet()
                 // Keep the engine + tunnel warm when sharing stays enabled with a remote provider,
                 // so a re-share is instant; otherwise tear down as before.
                 if (sharesByTab.isEmpty() && !keepWarm()) stopEngineLocked()
             }
         }
+    }
+
+    /**
+     * Drop [share]'s registrations and stop it. Callers hold [mutex]. Shared by [unshare] and by
+     * [share]'s revert path, so a share that loses a race with [shutdown] is torn down exactly the
+     * way an ordinary unshare tears one down.
+     */
+    private fun unregisterShareLocked(tabId: String, share: MirrorShare) {
+        sharesByTab.remove(tabId)
+        sharesByToken.remove(share.viewToken)
+        sharesByToken.remove(share.controlToken)
+        grants.values.removeIf { it.shareId == share.viewToken }
+        runCatching { share.stop() }
+        _sharedTabIds.value = sharesByTab.keys.toSet()
     }
 
     private fun stopAll() {
@@ -761,8 +788,11 @@ object SessionShareManager {
      * follows. Everything else queued there — pre-warm, establish, respawn, the cloudflared
      * prefetch — is *setup*, so cancelling it is the point, not a cost.
      *
-     * Idempotent, and safe when nothing ever started.
+     * Idempotent, and safe when nothing ever started. The one thing it can leave outstanding is
+     * the `share-late-bind-stop` thread in [ensureEngineLocked], on the narrow path where a bind
+     * completed while this was running — a thread stopping a server beats a server nobody stops.
      */
+    @Synchronized
     fun shutdown() {
         // 1. Latch first, so an uninterruptible binder refuses (see [shuttingDown]).
         shuttingDown = true
@@ -776,8 +806,8 @@ object SessionShareManager {
         //    it sleeps up to 5s waiting for the MCP port and then binds the server.
         //    cancelChildren rather than cancel() so [start] can re-arm the singleton — a
         //    cancelled scope would be dead for the rest of the process.
-        runCatching { scope.coroutineContext.cancelChildren() }
-        runCatching { watcherJob?.cancel() } // subsumed by the above; explicit for intent
+        scope.coroutineContext.cancelChildren()
+        watcherJob?.cancel() // subsumed by the above; explicit for intent
         watcherJob = null
         prefetchJob = null
         sharesByTab.values.forEach { runCatching { it.stop() } }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -19,13 +19,13 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -64,7 +64,19 @@ import java.util.concurrent.ConcurrentHashMap
 object SessionShareManager {
 
     private val log = LoggerFactory.getLogger(SessionShareManager::class.java)
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Parent job for everything this manager launches, replaced by [start] and cancelled by
+     * [shutdown] — one job per embedder lifecycle.
+     *
+     * Not a long-lived job plus `cancelChildren()`: that cancels the children that exist, but the
+     * `SupervisorJob` stays Active, so a `scope.launch` already past its guard (the settings
+     * watcher's, notably) still produces a live child *after* shutdown cancelled everything. A
+     * cancelled job makes every later launch inert, which is the guarantee we actually want; a
+     * fresh job in [start] is what lets the singleton re-arm for the next embedder.
+     */
+    @Volatile private var lifecycle: CompletableJob = SupervisorJob()
+    private val scope: CoroutineScope get() = CoroutineScope(lifecycle + Dispatchers.IO)
     private val mutex = Mutex()
 
     /**
@@ -94,6 +106,15 @@ object SessionShareManager {
      * coroutine may bind".
      */
     @Volatile private var shuttingDown = false
+
+    /**
+     * @suppress Test seam: invoked by [ensureEngineLocked] after the socket is listening but before
+     * [engine] is assigned — the one interleaving where a concurrent shutdown reads a null [engine],
+     * stops nothing, and leaves the adopt-then-re-check as the only thing standing between us and a
+     * bound server nobody owns. Lets that be driven deterministically instead of by wall clock.
+     */
+    @Volatile
+    internal var afterBindBeforeRecheckForTest: (() -> Unit)? = null
 
     /**
      * Bumped by every [shutdown]. [shuttingDown] alone is not a sound basis for a re-check inside a
@@ -385,6 +406,7 @@ object SessionShareManager {
     @Synchronized
     fun start() {
         shuttingDown = false
+        if (!lifecycle.isActive) lifecycle = SupervisorJob() // re-arm after a shutdown
         if (watcherJob?.isActive == true) return
         watcherJob = scope.launch {
             settingsManager.settings
@@ -518,7 +540,7 @@ object SessionShareManager {
             // left behind a shut-down manager runs observer coroutines on its OWN scope, which our
             // cancelChildren() never reaches — it would keep observing terminal state forever.
             if (supersededByShutdown(epoch)) {
-                log.warn("Share for {} was registered while shutting down — reverting", tabId)
+                log.warn("Share for {} lost a race with shutdown — tearing it back down", tabId)
                 unregisterShareLocked(tabId, share)
                 return@withLock null
             }
@@ -825,13 +847,18 @@ object SessionShareManager {
         //    we've torn down.
         claimRemoteOp()
         // 3. Cancel our own in-flight work. A parked prewarmRemote() is the one that matters:
-        //    it sleeps up to 5s waiting for the MCP port and then binds the server.
-        //    cancelChildren rather than cancel() so [start] can re-arm the singleton — a
-        //    cancelled scope would be dead for the rest of the process.
-        scope.coroutineContext.cancelChildren()
-        watcherJob?.cancel() // subsumed by the above; explicit for intent
+        //    it sleeps up to 5s waiting for the MCP port and then binds the server. Cancelling the
+        //    lifecycle job — not just its children — also makes any launch that slips through
+        //    afterwards inert; [start] installs a fresh one.
+        lifecycle.cancel()
         watcherJob = null
         prefetchJob = null
+        // Release any fit-resized host window BEFORE dropping the embedder that has to undo it,
+        // then drop it: it belongs to the host disposing us, and holding it pins that host (and,
+        // when this class outlives one embedder, its classloader).
+        fitActiveTabs.toList().forEach { releaseEmbeddedFit(it) }
+        fitActiveTabs.clear() // belt: releaseEmbeddedFit already removes each one
+        fitHostEmbedder = null
         sharesByTab.values.forEach { runCatching { it.stop() } }
         sharesByTab.clear()
         sharesByToken.clear()
@@ -949,6 +976,9 @@ object SessionShareManager {
                     }
                 }
                 started.start(wait = false)
+                // @suppress Test seam: the only point where a shutdown can interleave such that it
+                // sees a still-null [engine] and stops nothing. Production leaves it null.
+                afterBindBeforeRecheckForTest?.invoke()
                 engine = started
                 boundPort = port
                 boundHost = host
@@ -1008,6 +1038,7 @@ object SessionShareManager {
 
     private suspend fun stopEngineLocked() {
         val e = engine ?: return
+        val port = boundPort // captured: shutdown() can null the field while we are stopping
         // NonCancellable for the whole teardown, not just the engine stop. [shutdown] cancels this
         // scope, and this function runs on it; a cancel landing anywhere in here leaves the job
         // half-done — on the remote teardown, a Tailscale mapping stays published and the `finally`
@@ -1021,7 +1052,7 @@ object SessionShareManager {
             teardownRemoteAccess(boundPort)
             try {
                 e.stop(300, 1000)
-                log.info("Session-sharing server stopped (port {})", boundPort)
+                log.info("Session-sharing server stopped (port {})", port)
             } catch (t: Throwable) {
                 log.warn("Error stopping session-sharing server: {}", t.message)
             } finally {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/SessionShareManager.kt
@@ -18,12 +18,15 @@ import io.ktor.websocket.CloseReason
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -64,6 +67,28 @@ object SessionShareManager {
     private val log = LoggerFactory.getLogger(SessionShareManager::class.java)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val mutex = Mutex()
+
+    /**
+     * @suppress Test seam: where settings are read from. Production always resolves the
+     * process-wide singleton; tests point this at a throwaway manager so exercising the
+     * pre-warm / shutdown paths can neither read nor rewrite a developer's real
+     * `~/.bossterm/settings.json`.
+     */
+    internal var settingsManagerOverrideForTest: SettingsManager? = null
+    private val settingsManager: SettingsManager
+        get() = settingsManagerOverrideForTest ?: SettingsManager.instance
+
+    /**
+     * Latched by [shutdown] before it tears anything down; cleared by [start].
+     *
+     * Cancelling the manager's scope is what stops in-flight work, but it can't stop *all*
+     * of it: cancellation is cooperative, and [ensureEngineLocked] contains no suspension
+     * point, so a pre-warm that has already passed its last one runs to completion no matter
+     * what. This flag is the authority such an uninterruptible binder checks — it is what
+     * makes "shut down" mean "no server may be bound", rather than merely "no *waiting*
+     * coroutine may bind".
+     */
+    @Volatile private var shuttingDown = false
 
     /**
      * Embedder hook for "Fit host to my screen" when BossTerm is hosted inside
@@ -108,6 +133,9 @@ object SessionShareManager {
      *  remote-driven fit is active on that tab, it's released (window restores). */
     fun notifyHostInteraction(tabId: String) = releaseEmbeddedFit(tabId)
 
+    // @Volatile: written by whichever coroutine wins the bind (under [mutex]) and read by
+    // [shutdown], which is synchronous and therefore cannot take the mutex.
+    @Volatile
     private var engine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
     @Volatile private var boundPort: Int? = null
     private var boundHost: String? = null
@@ -278,7 +306,7 @@ object SessionShareManager {
      * Cloudflare Quick Tunnel, or a custom public URL), since LAN/Serve reach is trusted.
      */
     private fun requiresApproval(): Boolean {
-        val s = SettingsManager.instance.settings.value
+        val s = settingsManager.settings.value
         return when (s.sessionSharingApprovalScope) {
             "all" -> true
             "off" -> false
@@ -293,7 +321,7 @@ object SessionShareManager {
      * tears everything down (the settings observer's stopAll, and applyRemoteMode).
      */
     private fun keepWarm(): Boolean {
-        val s = SettingsManager.instance.settings.value
+        val s = settingsManager.settings.value
         return s.sessionSharingEnabled && s.shareTailscaleMode != "off"
     }
 
@@ -319,11 +347,18 @@ object SessionShareManager {
         val e2eCode: String? = null,
     )
 
-    /** Begin observing settings. Idempotent. Call once from main(). */
+    /**
+     * Begin observing settings. Idempotent. Call once from main().
+     *
+     * Also re-arms the manager after a [shutdown]: the singleton outlives one embedder's
+     * lifecycle (bossterm-app and the BossConsole terminal plugin both call [start]/[shutdown]),
+     * so shutting down must not leave it permanently inert.
+     */
     fun start() {
+        shuttingDown = false
         if (watcherJob?.isActive == true) return
         watcherJob = scope.launch {
-            SettingsManager.instance.settings
+            settingsManager.settings
                 .map { it.sessionSharingEnabled to it.shareTailscaleMode }
                 .distinctUntilChanged()
                 .collect { (enabled, mode) ->
@@ -405,7 +440,8 @@ object SessionShareManager {
      * inline establish kick in [ensureEngineLocked] fires once per lifecycle). Off the UI thread.
      */
     private suspend fun prewarmRemote() {
-        val settings = SettingsManager.instance.settings.value
+        if (shuttingDown) return
+        val settings = settingsManager.settings.value
         if (!settings.sessionSharingEnabled || settings.shareTailscaleMode == "off") return
         // Let the BossTerm MCP server claim its port FIRST. It shares the 7676+ range with the
         // share server; pre-warm runs at app launch concurrently with the MCP server, so if both
@@ -417,6 +453,11 @@ object SessionShareManager {
         if (settings.mcpEnabled) {
             withTimeoutOrNull(5000) { McpTerminalRegistry.runningPort.first { it != null } }
         }
+        // The wait above is the widest window in this manager's whole lifecycle — up to 5s of
+        // suspended coroutine holding a live intent to bind a server. [shutdown] cancels this
+        // scope, so normally we never get here after it; this re-check covers the sliver where
+        // the wait completed just as shutdown ran, and keeps the "Pre-warming…" log honest.
+        if (shuttingDown) return
         mutex.withLock {
             if (engine == null) log.info("Pre-warming session-sharing remote access ({})", settings.shareTailscaleMode)
             ensureEngineLocked(settings) // binds the server + kicks establishRemote once
@@ -430,7 +471,7 @@ object SessionShareManager {
      * when sharing is disabled or the server can't bind. Idempotent per [tabId].
      */
     suspend fun share(tabId: String, scope: ShareScope = ShareScope.TAB): ShareInfo? {
-        val settings = SettingsManager.instance.settings.value
+        val settings = settingsManager.settings.value
         if (!settings.sessionSharingEnabled) return null
         return mutex.withLock {
             if (!ensureEngineLocked(settings)) return@withLock null
@@ -476,7 +517,7 @@ object SessionShareManager {
     fun refreshRemoteLink() {
         scope.launch {
             val port = boundPort ?: return@launch
-            val mode = SettingsManager.instance.settings.value.shareTailscaleMode
+            val mode = settingsManager.settings.value.shareTailscaleMode
             if (mode == "off") return@launch
             val op = claimRemoteOp()
             withContext(Dispatchers.IO) { establishRemote(mode, port, op) }
@@ -557,7 +598,7 @@ object SessionShareManager {
         proc.onExit().thenAccept {
             scope.launch {
                 if (!isCurrentRemoteOp(op)) return@launch // a cooperative teardown/switch superseded us
-                val s = SettingsManager.instance.settings.value
+                val s = settingsManager.settings.value
                 if (!s.sessionSharingEnabled || s.shareTailscaleMode != "cloudflare") return@launch
                 if (engine == null) return@launch
                 delay(2000) // brief backoff; a teardown during this window bumps the op
@@ -687,22 +728,56 @@ object SessionShareManager {
      * and any Tailscale serve/funnel mapping without the coroutine scope (which would
      * not drain at process exit). Crucially this tears down the Tailscale tunnel so it
      * isn't left published after the app quits. Best-effort; every step is guarded.
+     *
+     * Also called by an embedder that is unloading BossTerm — the BossConsole terminal
+     * plugin's `dispose()` — where "after shutdown" means "inside a classloader that is
+     * being closed", and any straggler coroutine that wakes up is running against dead
+     * classes. Hence the ordering below.
+     *
+     * **Ordering: stop the manager before stopping the server, not after.** The first
+     * three statements latch the shutdown, supersede any in-flight remote operation, and
+     * cancel this manager's own in-flight work; only then does the teardown proper run.
+     * Doing it the other way round leaves the entire engine-stop window — up to 800ms, and
+     * ending with the port freed — open for a parked [prewarmRemote] to wake and re-bind the
+     * server behind a manager that has already declared itself down. Nothing is lost by
+     * going first: this function performs every teardown step itself, inline, and the only
+     * cleanup-shaped bodies on the scope ([unshare], [stopAll]) are strict subsets of what
+     * follows. Everything else queued there — pre-warm, establish, respawn, the cloudflared
+     * prefetch — is *setup*, so cancelling it is the point, not a cost.
+     *
+     * Idempotent, and safe when nothing ever started.
      */
     fun shutdown() {
-        runCatching { watcherJob?.cancel() }
+        // 1. Latch first, so an uninterruptible binder refuses (see [shuttingDown]).
+        shuttingDown = true
+        // 2. Supersede any in-flight remote establish. Cancellation cannot do this job:
+        //    cloudflared's awaitUrl/awaitReady are plain blocking calls, so an establish
+        //    sitting in one keeps running until its next suspension point. The op token is
+        //    what makes it bail and destroy its own tunnel instead of adopting one after
+        //    we've torn down.
+        claimRemoteOp()
+        // 3. Cancel our own in-flight work. A parked prewarmRemote() is the one that matters:
+        //    it sleeps up to 5s waiting for the MCP port and then binds the server.
+        //    cancelChildren rather than cancel() so [start] can re-arm the singleton — a
+        //    cancelled scope would be dead for the rest of the process.
+        runCatching { scope.coroutineContext.cancelChildren() }
+        runCatching { watcherJob?.cancel() } // subsumed by the above; explicit for intent
+        watcherJob = null
+        prefetchJob = null
         sharesByTab.values.forEach { runCatching { it.stop() } }
         sharesByTab.clear()
         sharesByToken.clear()
         grants.clear()
         failAllPending()
         _sharedTabIds.value = emptySet()
-        claimRemoteOp() // cancel any in-flight establish before tearing down
         teardownRemoteAccess(boundPort)
-        val e = engine ?: return
-        runCatching { e.stop(200, 800) }
+        // Clear the bookkeeping before the (bounded, up to 1s) engine stop, so a second
+        // shutdown() — or anything reading boundPort — never sees a half-torn-down manager.
+        val e = engine
         engine = null
         boundPort = null
         boundHost = null
+        if (e != null) runCatching { e.stop(200, 800) }
     }
 
     // ---- engine lifecycle (mutex-guarded) ----
@@ -740,8 +815,19 @@ object SessionShareManager {
         }
     }
 
-    /** Start the engine if not already running. Returns true if running afterwards. */
+    /**
+     * Start the engine if not already running. Returns true if running afterwards.
+     *
+     * Refuses outright once [shutdown] has latched. This function has no suspension point, so
+     * cancellation cannot reach a pre-warm that is already inside it — and a pre-warm that woke
+     * a moment before the cancel landed still arrives here holding a live intent to bind. The
+     * latch turns both into a no-op. It also covers a [share] racing an embedder's dispose.
+     */
     private fun ensureEngineLocked(settings: TerminalSettings): Boolean {
+        if (shuttingDown) {
+            log.debug("Session-sharing engine start refused: the manager is shutting down")
+            return false
+        }
         if (engine != null) return true
         val host = resolveBindHost(settings)
         val desiredPort = settings.sessionSharingPort
@@ -797,6 +883,22 @@ object SessionShareManager {
                 engine = started
                 boundPort = port
                 boundHost = host
+                // Adopt, then re-check — the same shape establishCloudflareVerified uses for its
+                // tunnel. [shutdown] is synchronous and so cannot take this mutex; it may have run
+                // its whole teardown while we were binding, reading a still-null engine and leaving
+                // ours alive behind it. Bounded (200ms grace / 800ms cap) and loud, because a server
+                // that outlives its manager is exactly the leak this guard exists to prevent.
+                if (shuttingDown) {
+                    log.warn(
+                        "Session-sharing server bound on {}:{} while shutting down — stopping it again",
+                        host, port
+                    )
+                    engine = null
+                    boundPort = null
+                    boundHost = null
+                    runCatching { started.stop(200, 800) }
+                    return false
+                }
                 log.info("Session-sharing server bound on {}:{} (bind={})", host, port, settings.sessionSharingBind)
                 // Phase 3: expose remotely via the configured provider, if any. Best-effort —
                 // failure just leaves us on the LAN/loopback URL. Run it OFF the share path
@@ -834,8 +936,16 @@ object SessionShareManager {
         claimRemoteOp()
         withContext(Dispatchers.IO) { teardownRemoteAccess(boundPort) }
         try {
-            withContext(Dispatchers.IO) { e.stop(300, 1000) }
+            // NonCancellable: [shutdown] cancels this scope, and this teardown runs on it. Being
+            // cancelled between "decided to stop the engine" and "stopped it" would run the finally
+            // below — clearing [engine] — while the server is still bound, and shutdown() would then
+            // find nothing left to stop. Bounded by the same 300ms/1000ms stop budget, so the
+            // uninterruptible stretch stays short.
+            withContext(Dispatchers.IO + NonCancellable) { e.stop(300, 1000) }
             log.info("Session-sharing server stopped (port {})", boundPort)
+        } catch (c: CancellationException) {
+            // Deliberate cancellation is not a failure — never log it as one.
+            throw c
         } catch (t: Throwable) {
             log.warn("Error stopping session-sharing server: {}", t.message)
         } finally {
@@ -1033,7 +1143,7 @@ object SessionShareManager {
      */
     private fun buildUrl(token: String): String? {
         val base = remoteUrl?.let { "${it.trimEnd('/')}/?t=$token" }
-            ?: SettingsManager.instance.settings.value.sessionSharingPublicUrl.takeIf { it.isNotBlank() }
+            ?: settingsManager.settings.value.sessionSharingPublicUrl.takeIf { it.isNotBlank() }
                 ?.let { "${it.trimEnd('/')}/?t=$token" }
             ?: boundPort?.let { "http://${advertisedHost()}:$it/?t=$token" }
             ?: return null
@@ -1069,7 +1179,7 @@ object SessionShareManager {
      */
     private fun requireE2E(): Boolean {
         val url = remoteUrl
-            ?: SettingsManager.instance.settings.value.sessionSharingPublicUrl.takeIf { it.isNotBlank() }
+            ?: settingsManager.settings.value.sessionSharingPublicUrl.takeIf { it.isNotBlank() }
             ?: return false
         return e2eCapable(url)
     }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
@@ -4,6 +4,7 @@ import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.File
@@ -66,8 +67,8 @@ class SessionShareShutdownTest {
         /** Generous upper bound for "the pre-warm would have bound by now". */
         const val SETTLE_MS = 2_000L
 
-        /** Children the manager's scope holds once the pre-warm is in flight: the settings
-         *  watcher, plus the pre-warm the watcher launched. */
+        /** Active jobs under the manager's lifecycle once the pre-warm is in flight: the settings
+         *  watcher, plus the pre-warm nested inside it. */
         const val SCOPE_CHILDREN_WITH_PREWARM = 2
     }
 
@@ -114,9 +115,11 @@ class SessionShareShutdownTest {
         SessionShareManager.fitHostEmbedder = null
         SessionShareManager.shutdown()
         SessionShareManager.settingsManagerOverrideForTest = null
-        // shutdown() latches the singleton shut, and it outlives this class. Leaving it latched
-        // would make a later test's share() return a silent null that looks like a product bug.
+        // shutdown() latches the singleton shut and kills its lifecycle job, and the singleton
+        // outlives this class: left that way, a later test's share() returns a silent null and its
+        // launches go nowhere, both of which read as product bugs. Re-arm the way start() does.
         setShuttingDown(false)
+        resetLifecycle()
         McpTerminalRegistry.setStopped()
         settingsDir.deleteRecursively()
     }
@@ -311,10 +314,15 @@ class SessionShareShutdownTest {
         )
     }
 
-    /** Active children of the manager's lifecycle job. Reflection because the job is an internal
-     *  implementation detail we nevertheless need to make an assertion about. */
-    private fun managerScopeChildren(): Int =
-        (readPrivate("lifecycle") as Job).children.count { it.isActive }
+    /**
+     * Active jobs anywhere under the manager's lifecycle job. Counted transitively: the pre-warm is
+     * launched as a child of the settings watcher, not of the lifecycle job directly. Reflection
+     * because the job is an internal implementation detail we nevertheless need to assert about.
+     */
+    private fun managerScopeChildren(): Int {
+        fun count(job: Job): Int = job.children.sumOf { (if (it.isActive) 1 else 0) + count(it) }
+        return count(readPrivate("lifecycle") as Job)
+    }
 
     /** True when the manager holds no engine — the deterministic counterpart to [rangeIsFree],
      *  which depends on nothing else on the machine grabbing one of the probed ports. */
@@ -324,6 +332,13 @@ class SessionShareShutdownTest {
         SessionShareManager::class.java.getDeclaredField(name)
             .apply { isAccessible = true }
             .get(SessionShareManager)
+
+    /** Install a fresh lifecycle job, as [SessionShareManager.start] would. */
+    private fun resetLifecycle() {
+        SessionShareManager::class.java.getDeclaredField("lifecycle")
+            .apply { isAccessible = true }
+            .set(SessionShareManager, SupervisorJob())
+    }
 
     /** Clear the shutdown latch so the singleton isn't left inert for the rest of the JVM. */
     private fun setShuttingDown(value: Boolean) {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
@@ -1,0 +1,252 @@
+package ai.rever.bossterm.compose.share
+
+import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
+import ai.rever.bossterm.compose.settings.SettingsManager
+import ai.rever.bossterm.compose.settings.TerminalSettings
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Shutdown contract for [SessionShareManager] — specifically the window in which work that was
+ * already in flight when [SessionShareManager.shutdown] ran could come back and re-bind the share
+ * server behind a manager that had already declared itself down.
+ *
+ * The vehicle is `prewarmRemote()`: the settings watcher launches it **on the manager's own scope**
+ * (not as a child of the watcher job), and it parks for up to 5 seconds waiting for the BossTerm MCP
+ * server to claim its port before binding. `shutdown()` used to cancel only the watcher, so a
+ * pre-warm parked in that wait woke up afterwards and bound a fresh Ktor server — which, when
+ * BossTerm is embedded in a plugin whose classloader is closing, runs against dead classes.
+ *
+ * ### How these tests are kept honest
+ * - The share server binds by scanning `sessionSharingPort .. +9`, so every test reserves a run of
+ *   **ten consecutive free ports** and asserts over the whole range. "Nothing bound" is therefore a
+ *   real observation, not an artefact of the manager failing to find a port.
+ * - Asserting "free" by probing (rather than by holding the ports) means a test cannot pass
+ *   vacuously by making the bind impossible in the first place.
+ * - [`pre-warm binds the share server once the MCP port is known`] is the positive control. It
+ *   proves the pre-warm really is parked at the moment the other tests shut down (nothing is bound
+ *   before the MCP port is published, something is bound right after), and it fails if a fix
+ *   over-reaches and leaves the manager permanently inert.
+ * - The remote-provider mode is [TEST_REMOTE_MODE]: any value other than `"off"` arms the pre-warm,
+ *   and an unrecognised one makes `establishRemote`'s `when` fall through to `null`. So these tests
+ *   exercise the bind without ever shelling out to `tailscale` or `cloudflared`.
+ * - Settings come from a throwaway [SettingsManager] injected via
+ *   [SessionShareManager.settingsManagerOverrideForTest], so nothing here can read or rewrite a
+ *   developer's real `~/.bossterm/settings.json`.
+ *
+ * [SessionShareManager] is a singleton, so every test tears it back down in [tearDown]; the fact
+ * that the tests pass in any order is itself coverage of `start()` re-arming after `shutdown()`.
+ */
+class SessionShareShutdownTest {
+
+    private companion object {
+        /** Not "off" (so the pre-warm arms) and not a provider `establishRemote` knows (so it
+         *  resolves to "no remote link" without launching a process). */
+        const val TEST_REMOTE_MODE = "test-no-provider"
+
+        /** How long the manager's ports are scanned over — mirrors `MAX_PORT_FALLBACK`. */
+        const val PORT_RANGE = 10
+
+        /** Long enough for the settings watcher to collect and park the pre-warm in its MCP wait;
+         *  far short of that wait's own 5s budget. Validated by the positive-control test. */
+        const val PARK_MS = 400L
+
+        /** Generous upper bound for "the pre-warm would have bound by now". */
+        const val SETTLE_MS = 2_000L
+    }
+
+    private val settingsDir = createTempDirectory("session-share-shutdown-test").toFile()
+        .apply { deleteOnExit() }
+
+    private var basePort = 0
+    private lateinit var settings: SettingsManager
+
+    /** A non-null MCP port to publish; deliberately outside [basePort]'s range so the manager's
+     *  "never take the MCP port" skip can't shift the bind out from under the assertions. */
+    private val mcpPort: Int get() = basePort + 100
+
+    @BeforeTest
+    fun setUp() {
+        McpTerminalRegistry.setStopped()
+        basePort = reserveFreeRange()
+        settings = SettingsManager(File(settingsDir, "settings.json").absolutePath)
+        SessionShareManager.settingsManagerOverrideForTest = settings
+        settings.updateSettings(
+            TerminalSettings.DEFAULT.copy(
+                sessionSharingEnabled = true,
+                sessionSharingBind = "loopback",
+                sessionSharingPort = basePort,
+                shareTailscaleMode = TEST_REMOTE_MODE,
+                // The pre-warm only waits when MCP is enabled — that wait is the window under test.
+                mcpEnabled = true,
+            )
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        SessionShareManager.shutdown()
+        SessionShareManager.settingsManagerOverrideForTest = null
+        McpTerminalRegistry.setStopped()
+    }
+
+    // ---- positive control -------------------------------------------------------------------
+
+    @Test
+    fun `pre-warm binds the share server once the MCP port is known`() = runBlocking {
+        SessionShareManager.start()
+        delay(PARK_MS)
+        assertTrue(
+            rangeIsFree(),
+            "the pre-warm must still be parked in its MCP wait — nothing may bind before the " +
+                "MCP port is published"
+        )
+
+        McpTerminalRegistry.setRunning(mcpPort) // release the wait
+
+        assertTrue(
+            awaitUntil(SETTLE_MS) { !rangeIsFree() },
+            "the pre-warm should have bound the share server in $basePort..${basePort + PORT_RANGE - 1}"
+        )
+    }
+
+    // ---- the regression ---------------------------------------------------------------------
+
+    @Test
+    fun `shutdown during an in-flight pre-warm prevents a late re-bind`() = runBlocking {
+        SessionShareManager.start()
+        delay(PARK_MS) // pre-warm is now parked in its MCP wait (see the positive control)
+
+        SessionShareManager.shutdown()
+
+        // Complete the thing it was parked on. Before the fix the pre-warm woke here, took the
+        // mutex and bound a brand-new Ktor server behind the shut-down manager.
+        McpTerminalRegistry.setRunning(mcpPort)
+        delay(SETTLE_MS)
+
+        assertTrue(
+            rangeIsFree(),
+            "nothing may bind after shutdown(): ports $basePort..${basePort + PORT_RANGE - 1} " +
+                "must all still be free"
+        )
+    }
+
+    @Test
+    fun `shutdown cancels the manager's own in-flight work`() = runBlocking {
+        SessionShareManager.start()
+        delay(PARK_MS)
+        assertTrue(
+            managerScopeChildren() > 0,
+            "expected in-flight work (the settings watcher and a parked pre-warm) on the " +
+                "manager's scope"
+        )
+
+        SessionShareManager.shutdown()
+
+        assertEquals(
+            0,
+            managerScopeChildren(),
+            "shutdown() must leave no active work on the manager's scope — a straggler that " +
+                "resumes inside a closing classloader is the whole bug"
+        )
+    }
+
+    @Test
+    fun `share is refused after shutdown`() = runBlocking {
+        SessionShareManager.start()
+        SessionShareManager.shutdown()
+
+        // share() reaches the binder without suspending anywhere cancellation could catch it, so
+        // only the shutdown latch can stop it. Guarded because an un-refused share would go on to
+        // build a MirrorShare against terminal state this test never created.
+        val info = runCatching { SessionShareManager.share("tab-after-shutdown") }.getOrNull()
+
+        assertNull(info, "share() must return null once the manager has been shut down")
+        assertTrue(rangeIsFree(), "share() after shutdown() must not bind a server")
+    }
+
+    // ---- idempotency ------------------------------------------------------------------------
+
+    @Test
+    fun `shutdown is idempotent`() = runBlocking {
+        SessionShareManager.start()
+        delay(PARK_MS)
+        McpTerminalRegistry.setRunning(mcpPort)
+        assertTrue(awaitUntil(SETTLE_MS) { !rangeIsFree() }, "expected a bound server to tear down")
+
+        SessionShareManager.shutdown()
+        SessionShareManager.shutdown() // must not throw, must not resurrect anything
+
+        assertTrue(
+            awaitUntil(SETTLE_MS) { rangeIsFree() },
+            "a double shutdown() must leave the share server stopped"
+        )
+    }
+
+    @Test
+    fun `shutdown with nothing started is safe`() {
+        // No start(), no share, no engine — the state an embedder is in when it disposes BossTerm
+        // without the user ever having enabled sharing.
+        SessionShareManager.shutdown()
+        SessionShareManager.shutdown()
+
+        assertTrue(rangeIsFree(), "shutting down an idle manager must not bind anything")
+    }
+
+    // ---- helpers ----------------------------------------------------------------------------
+
+    /** Active children of the manager's private scope. Reflection because the scope is an internal
+     *  implementation detail we nevertheless need to make an assertion about. */
+    private fun managerScopeChildren(): Int {
+        val field = SessionShareManager::class.java.getDeclaredField("scope").apply { isAccessible = true }
+        val scope = field.get(SessionShareManager) as kotlinx.coroutines.CoroutineScope
+        val job = scope.coroutineContext[Job] ?: return 0
+        return job.children.count { it.isActive }
+    }
+
+    /** True while every port the manager could bind is still free. */
+    private fun rangeIsFree(): Boolean = (basePort until basePort + PORT_RANGE).all { portIsFree(it) }
+
+    private fun portIsFree(port: Int): Boolean = runCatching {
+        ServerSocket().use { ss ->
+            ss.reuseAddress = false
+            ss.bind(InetSocketAddress("127.0.0.1", port))
+        }
+        true
+    }.getOrDefault(false)
+
+    /** A base port with [PORT_RANGE] consecutive free ports after it, so the manager's port-fallback
+     *  scan cannot land outside the range these tests assert on. */
+    private fun reserveFreeRange(): Int {
+        var candidate = 20_000 + (System.nanoTime() % 30_000).toInt()
+        repeat(200) {
+            if ((candidate until candidate + PORT_RANGE).all { portIsFree(it) } &&
+                portIsFree(candidate + 100) // the stand-in MCP port
+            ) {
+                return candidate
+            }
+            candidate += PORT_RANGE + 1
+        }
+        error("could not reserve $PORT_RANGE consecutive free ports for the test")
+    }
+
+    private suspend fun awaitUntil(timeoutMs: Long, predicate: () -> Boolean): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return true
+            delay(25)
+        }
+        return predicate()
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
@@ -3,6 +3,7 @@ package ai.rever.bossterm.compose.share
 import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.TerminalSettings
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -34,16 +35,19 @@ import kotlin.test.assertTrue
  *   real observation, not an artefact of the manager failing to find a port.
  * - Asserting "free" by probing (rather than by holding the ports) means a test cannot pass
  *   vacuously by making the bind impossible in the first place.
- * - [`pre-warm binds the share server once the MCP port is known`] is the positive control. It
- *   proves the pre-warm really is parked at the moment the other tests shut down (nothing is bound
- *   before the MCP port is published, something is bound right after), and it fails if a fix
- *   over-reaches and leaves the manager permanently inert.
+ * - No test shuts down on a timer: [awaitPrewarmLaunched] waits for the pre-warm coroutine to
+ *   actually exist on the manager's scope, so "shutdown during an in-flight pre-warm" cannot
+ *   degrade into "shutdown before the pre-warm ever started".
+ * - [`pre-warm binds the share server once the MCP port is known`] is the positive control: nothing
+ *   is bound while the pre-warm is parked, something is bound once the MCP port is published. It
+ *   fails if a fix over-reaches and leaves the manager permanently inert.
  * - The remote-provider mode is [TEST_REMOTE_MODE]: any value other than `"off"` arms the pre-warm,
  *   and an unrecognised one makes `establishRemote`'s `when` fall through to `null`. So these tests
  *   exercise the bind without ever shelling out to `tailscale` or `cloudflared`.
  * - Settings come from a throwaway [SettingsManager] injected via
- *   [SessionShareManager.settingsManagerOverrideForTest], so nothing here can read or rewrite a
- *   developer's real `~/.bossterm/settings.json`.
+ *   [SessionShareManager.settingsManagerOverrideForTest]. That covers every read the manager itself
+ *   makes; `MirrorShare` still reads the process singleton directly, which no path here reaches
+ *   because every share these tests attempt is refused before one is constructed.
  *
  * [SessionShareManager] is a singleton, so every test tears it back down in [tearDown]; the fact
  * that the tests pass in any order is itself coverage of `start()` re-arming after `shutdown()`.
@@ -58,16 +62,15 @@ class SessionShareShutdownTest {
         /** How long the manager's ports are scanned over — mirrors `MAX_PORT_FALLBACK`. */
         const val PORT_RANGE = 10
 
-        /** Long enough for the settings watcher to collect and park the pre-warm in its MCP wait;
-         *  far short of that wait's own 5s budget. Validated by the positive-control test. */
-        const val PARK_MS = 400L
-
         /** Generous upper bound for "the pre-warm would have bound by now". */
         const val SETTLE_MS = 2_000L
+
+        /** Children the manager's scope holds once the pre-warm is in flight: the settings
+         *  watcher, plus the pre-warm the watcher launched. */
+        const val SCOPE_CHILDREN_WITH_PREWARM = 2
     }
 
     private val settingsDir = createTempDirectory("session-share-shutdown-test").toFile()
-        .apply { deleteOnExit() }
 
     private var basePort = 0
     private lateinit var settings: SettingsManager
@@ -98,7 +101,11 @@ class SessionShareShutdownTest {
     fun tearDown() {
         SessionShareManager.shutdown()
         SessionShareManager.settingsManagerOverrideForTest = null
+        // shutdown() latches the singleton shut, and it outlives this class. Leaving it latched
+        // would make a later test's share() return a silent null that looks like a product bug.
+        setShuttingDown(false)
         McpTerminalRegistry.setStopped()
+        settingsDir.deleteRecursively()
     }
 
     // ---- positive control -------------------------------------------------------------------
@@ -106,7 +113,7 @@ class SessionShareShutdownTest {
     @Test
     fun `pre-warm binds the share server once the MCP port is known`() = runBlocking {
         SessionShareManager.start()
-        delay(PARK_MS)
+        awaitPrewarmLaunched()
         assertTrue(
             rangeIsFree(),
             "the pre-warm must still be parked in its MCP wait — nothing may bind before the " +
@@ -126,7 +133,7 @@ class SessionShareShutdownTest {
     @Test
     fun `shutdown during an in-flight pre-warm prevents a late re-bind`() = runBlocking {
         SessionShareManager.start()
-        delay(PARK_MS) // pre-warm is now parked in its MCP wait (see the positive control)
+        awaitPrewarmLaunched() // it exists and is waiting on the MCP port — not merely "soon"
 
         SessionShareManager.shutdown()
 
@@ -145,12 +152,7 @@ class SessionShareShutdownTest {
     @Test
     fun `shutdown cancels the manager's own in-flight work`() = runBlocking {
         SessionShareManager.start()
-        delay(PARK_MS)
-        assertTrue(
-            managerScopeChildren() > 0,
-            "expected in-flight work (the settings watcher and a parked pre-warm) on the " +
-                "manager's scope"
-        )
+        awaitPrewarmLaunched()
 
         SessionShareManager.shutdown()
 
@@ -168,9 +170,9 @@ class SessionShareShutdownTest {
         SessionShareManager.shutdown()
 
         // share() reaches the binder without suspending anywhere cancellation could catch it, so
-        // only the shutdown latch can stop it. Guarded because an un-refused share would go on to
-        // build a MirrorShare against terminal state this test never created.
-        val info = runCatching { SessionShareManager.share("tab-after-shutdown") }.getOrNull()
+        // only the shutdown latch can stop it. Called directly, not guarded: the point is a *clean*
+        // refusal, so an exception here should fail rather than read as a pass.
+        val info = SessionShareManager.share("tab-after-shutdown")
 
         assertNull(info, "share() must return null once the manager has been shut down")
         assertTrue(rangeIsFree(), "share() after shutdown() must not bind a server")
@@ -181,7 +183,7 @@ class SessionShareShutdownTest {
     @Test
     fun `shutdown is idempotent`() = runBlocking {
         SessionShareManager.start()
-        delay(PARK_MS)
+        awaitPrewarmLaunched()
         McpTerminalRegistry.setRunning(mcpPort)
         assertTrue(awaitUntil(SETTLE_MS) { !rangeIsFree() }, "expected a bound server to tear down")
 
@@ -206,13 +208,39 @@ class SessionShareShutdownTest {
 
     // ---- helpers ----------------------------------------------------------------------------
 
+    /**
+     * Block until the settings watcher has launched the pre-warm, so a test that shuts down "during
+     * an in-flight pre-warm" really does. The pre-warm cannot bind before the MCP port is published,
+     * so once its coroutine exists it is either in that wait or about to enter it — either way it is
+     * live work on the manager's scope, which is what the shutdown has to deal with.
+     */
+    private suspend fun awaitPrewarmLaunched() {
+        assertTrue(
+            awaitUntil(SETTLE_MS) { managerScopeChildren() >= SCOPE_CHILDREN_WITH_PREWARM },
+            "the settings watcher should have launched the pre-warm onto the manager's scope " +
+                "(saw ${managerScopeChildren()} active children, expected " +
+                "$SCOPE_CHILDREN_WITH_PREWARM)"
+        )
+    }
+
     /** Active children of the manager's private scope. Reflection because the scope is an internal
      *  implementation detail we nevertheless need to make an assertion about. */
     private fun managerScopeChildren(): Int {
-        val field = SessionShareManager::class.java.getDeclaredField("scope").apply { isAccessible = true }
-        val scope = field.get(SessionShareManager) as kotlinx.coroutines.CoroutineScope
+        val scope = readPrivate("scope") as CoroutineScope
         val job = scope.coroutineContext[Job] ?: return 0
         return job.children.count { it.isActive }
+    }
+
+    private fun readPrivate(name: String): Any? =
+        SessionShareManager::class.java.getDeclaredField(name)
+            .apply { isAccessible = true }
+            .get(SessionShareManager)
+
+    /** Clear the shutdown latch so the singleton isn't left inert for the rest of the JVM. */
+    private fun setShuttingDown(value: Boolean) {
+        SessionShareManager::class.java.getDeclaredField("shuttingDown")
+            .apply { isAccessible = true }
+            .setBoolean(SessionShareManager, value)
     }
 
     /** True while every port the manager could bind is still free. */
@@ -226,10 +254,17 @@ class SessionShareShutdownTest {
         true
     }.getOrDefault(false)
 
-    /** A base port with [PORT_RANGE] consecutive free ports after it, so the manager's port-fallback
-     *  scan cannot land outside the range these tests assert on. */
+    /**
+     * A base port with [PORT_RANGE] consecutive free ports after it, so the manager's port-fallback
+     * scan cannot land outside the range these tests assert on.
+     *
+     * Deliberately kept well below 32768 — and the scan below can only add ~2200 — so the window
+     * never overlaps Linux's default ephemeral range (32768-60999). Otherwise an unrelated outbound
+     * connection from the test JVM could occupy one of these ports mid-assertion and fail a test for
+     * reasons that have nothing to do with session sharing.
+     */
     private fun reserveFreeRange(): Int {
-        var candidate = 20_000 + (System.nanoTime() % 30_000).toInt()
+        var candidate = 20_000 + (System.nanoTime() % 10_000).toInt()
         repeat(200) {
             if ((candidate until candidate + PORT_RANGE).all { portIsFree(it) } &&
                 portIsFree(candidate + 100) // the stand-in MCP port

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
@@ -30,9 +30,10 @@ import kotlin.test.assertTrue
  * BossTerm is embedded in a plugin whose classloader is closing, runs against dead classes.
  *
  * ### How these tests are kept honest
- * - The share server binds by scanning `sessionSharingPort .. +9`, so every test reserves a run of
- *   **ten consecutive free ports** and asserts over the whole range. "Nothing bound" is therefore a
- *   real observation, not an artefact of the manager failing to find a port.
+ * - The share server binds by scanning forward from `sessionSharingPort`, so every test reserves a
+ *   run of [portRange] consecutive free ports — the production constant, not a copy of it — and
+ *   asserts over the whole range. "Nothing bound" is therefore a real observation, not an artefact
+ *   of the manager failing to find a port.
  * - Asserting "free" by probing (rather than by holding the ports) means a test cannot pass
  *   vacuously by making the bind impossible in the first place.
  * - No test shuts down on a timer: [awaitPrewarmLaunched] waits for the pre-warm coroutine to
@@ -51,7 +52,8 @@ import kotlin.test.assertTrue
  *
  * [SessionShareManager] is a singleton, so every test tears it back down in [tearDown] — including
  * clearing the shutdown latch, which is why re-arming gets its own test rather than riding on test
- * ordering.
+ * ordering. That, and the two process-wide singletons this class drives, mean these tests assume
+ * sequential execution within the JVM; they would need rethinking under in-JVM parallelism.
  */
 class SessionShareShutdownTest {
 
@@ -60,9 +62,6 @@ class SessionShareShutdownTest {
          *  resolves to "no remote link" without launching a process). */
         const val TEST_REMOTE_MODE = "test-no-provider"
 
-        /** How long the manager's ports are scanned over — mirrors `MAX_PORT_FALLBACK`. */
-        const val PORT_RANGE = 10
-
         /** Generous upper bound for "the pre-warm would have bound by now". */
         const val SETTLE_MS = 2_000L
 
@@ -70,6 +69,16 @@ class SessionShareShutdownTest {
          *  watcher, plus the pre-warm the watcher launched. */
         const val SCOPE_CHILDREN_WITH_PREWARM = 2
     }
+
+    /**
+     * How many ports the manager scans from `sessionSharingPort`. Read from the production constant
+     * rather than duplicated, so widening the fallback can't silently leave these assertions
+     * covering less than the manager can reach.
+     */
+    private val portRange: Int =
+        SessionShareManager::class.java.getDeclaredField("MAX_PORT_FALLBACK")
+            .apply { isAccessible = true }
+            .getInt(SessionShareManager)
 
     private val settingsDir = createTempDirectory("session-share-shutdown-test").toFile()
 
@@ -125,7 +134,7 @@ class SessionShareShutdownTest {
 
         assertTrue(
             awaitUntil(SETTLE_MS) { !rangeIsFree() },
-            "the pre-warm should have bound the share server in $basePort..${basePort + PORT_RANGE - 1}"
+            "the pre-warm should have bound the share server in $basePort..${basePort + portRange - 1}"
         )
     }
 
@@ -145,7 +154,7 @@ class SessionShareShutdownTest {
 
         assertTrue(
             rangeIsFree(),
-            "nothing may bind after shutdown(): ports $basePort..${basePort + PORT_RANGE - 1} " +
+            "nothing may bind after shutdown(): ports $basePort..${basePort + portRange - 1} " +
                 "must all still be free"
         )
     }
@@ -263,7 +272,7 @@ class SessionShareShutdownTest {
     }
 
     /** True while every port the manager could bind is still free. */
-    private fun rangeIsFree(): Boolean = (basePort until basePort + PORT_RANGE).all { portIsFree(it) }
+    private fun rangeIsFree(): Boolean = (basePort until basePort + portRange).all { portIsFree(it) }
 
     private fun portIsFree(port: Int): Boolean = runCatching {
         ServerSocket().use { ss ->
@@ -274,7 +283,7 @@ class SessionShareShutdownTest {
     }.getOrDefault(false)
 
     /**
-     * A base port with [PORT_RANGE] consecutive free ports after it, so the manager's port-fallback
+     * A base port with [portRange] consecutive free ports after it, so the manager's port-fallback
      * scan cannot land outside the range these tests assert on.
      *
      * Deliberately kept well below 32768 — and the scan below can only add ~2200 — so the window
@@ -286,19 +295,19 @@ class SessionShareShutdownTest {
         // floorMod, not %: nanoTime's origin is arbitrary and it is allowed to be negative.
         var candidate = 20_000 + Math.floorMod(System.nanoTime(), 10_000L).toInt()
         repeat(200) {
-            if ((candidate until candidate + PORT_RANGE).all { portIsFree(it) } &&
+            if ((candidate until candidate + portRange).all { portIsFree(it) } &&
                 portIsFree(candidate + 100) // the stand-in MCP port
             ) {
                 return candidate
             }
-            candidate += PORT_RANGE + 1
+            candidate += portRange + 1
         }
-        error("could not reserve $PORT_RANGE consecutive free ports for the test")
+        error("could not reserve $portRange consecutive free ports for the test")
     }
 
     private suspend fun awaitUntil(timeoutMs: Long, predicate: () -> Boolean): Boolean {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000  // nanoTime: monotonic
+        while (System.nanoTime() < deadline) {
             if (predicate()) return true
             delay(25)
         }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
@@ -3,13 +3,14 @@ package ai.rever.bossterm.compose.share
 import ai.rever.bossterm.compose.mcp.McpTerminalRegistry
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.TerminalSettings
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.net.InetSocketAddress
 import java.net.ServerSocket
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -109,6 +110,8 @@ class SessionShareShutdownTest {
 
     @AfterTest
     fun tearDown() {
+        SessionShareManager.afterBindBeforeRecheckForTest = null
+        SessionShareManager.fitHostEmbedder = null
         SessionShareManager.shutdown()
         SessionShareManager.settingsManagerOverrideForTest = null
         // shutdown() latches the singleton shut, and it outlives this class. Leaving it latched
@@ -152,6 +155,7 @@ class SessionShareShutdownTest {
         McpTerminalRegistry.setRunning(mcpPort)
         delay(SETTLE_MS)
 
+        assertTrue(engineIsNull(), "the manager must hold no engine after shutdown()")
         assertTrue(
             rangeIsFree(),
             "nothing may bind after shutdown(): ports $basePort..${basePort + portRange - 1} " +
@@ -201,7 +205,7 @@ class SessionShareShutdownTest {
         SessionShareManager.shutdown() // must not throw, must not resurrect anything
 
         assertTrue(
-            awaitUntil(SETTLE_MS) { rangeIsFree() },
+            awaitUntil(SETTLE_MS) { engineIsNull() && rangeIsFree() },
             "a double shutdown() must leave the share server stopped"
         )
     }
@@ -221,6 +225,62 @@ class SessionShareShutdownTest {
         assertTrue(
             awaitUntil(SETTLE_MS) { !rangeIsFree() },
             "start() must clear the shutdown latch so the manager binds again"
+        )
+    }
+
+    @Test
+    fun `a bind that loses to a shutdown plus re-init is undone`() = runBlocking {
+        // Drive the one interleaving that the shutdown latch alone cannot survive: the shutdown
+        // lands while the socket is listening but before `engine` is assigned — so it stops nothing
+        // — and a re-init then clears the latch under the binder. Only the monotonic epoch can tell
+        // the binder it has been superseded. Injected rather than raced, so there is no wall clock
+        // in this test.
+        val reachedRecheck = CountDownLatch(1)
+        SessionShareManager.afterBindBeforeRecheckForTest = {
+            SessionShareManager.afterBindBeforeRecheckForTest = null // fire once
+            SessionShareManager.shutdown()
+            setShuttingDown(false) // what a re-initialising embedder's start() does to the latch
+            // CIO binds its listening socket asynchronously, so block here until the port is
+            // demonstrably taken. Without this the end-state assertion below could be satisfied by
+            // the pre-bind state and pass whatever the guard does.
+            check(blockingAwaitUntil(SETTLE_MS) { !rangeIsFree() }) { "the listening socket never came up" }
+            reachedRecheck.countDown()
+        }
+        SessionShareManager.start()
+        awaitPrewarmLaunched()
+        McpTerminalRegistry.setRunning(mcpPort)
+
+        assertTrue(
+            reachedRecheck.await(SETTLE_MS, TimeUnit.MILLISECONDS),
+            "the pre-warm should have bound a server and reached the re-check"
+        )
+        // The port is bound as of this line. Only the guard can free it again.
+        assertTrue(
+            awaitUntil(SETTLE_MS) { engineIsNull() && rangeIsFree() },
+            "a server bound across a shutdown must be stopped again, not left running with no " +
+                "manager holding it"
+        )
+    }
+
+    @Test
+    fun `shutdown restores an active host fit and drops the embedder`() {
+        var restored: String? = null
+        SessionShareManager.fitHostEmbedder = object : SessionShareManager.FitHostEmbedder {
+            override fun onFitHost(tabId: String, deltaWidthPx: Float, deltaHeightPx: Float) = Unit
+            override fun onRestoreHostSize(tabId: String) { restored = tabId }
+        }
+        SessionShareManager.requestEmbeddedFit("fitted-tab", 120f, 80f)
+
+        SessionShareManager.shutdown()
+
+        assertEquals(
+            "fitted-tab", restored,
+            "shutdown must tell the embedder to undo a fit-resized host window"
+        )
+        assertNull(
+            SessionShareManager.fitHostEmbedder,
+            "shutdown must drop the embedder it was handed — holding it pins the host that is " +
+                "disposing us"
         )
     }
 
@@ -251,13 +311,14 @@ class SessionShareShutdownTest {
         )
     }
 
-    /** Active children of the manager's private scope. Reflection because the scope is an internal
+    /** Active children of the manager's lifecycle job. Reflection because the job is an internal
      *  implementation detail we nevertheless need to make an assertion about. */
-    private fun managerScopeChildren(): Int {
-        val scope = readPrivate("scope") as CoroutineScope
-        val job = scope.coroutineContext[Job] ?: return 0
-        return job.children.count { it.isActive }
-    }
+    private fun managerScopeChildren(): Int =
+        (readPrivate("lifecycle") as Job).children.count { it.isActive }
+
+    /** True when the manager holds no engine — the deterministic counterpart to [rangeIsFree],
+     *  which depends on nothing else on the machine grabbing one of the probed ports. */
+    private fun engineIsNull(): Boolean = readPrivate("engine") == null
 
     private fun readPrivate(name: String): Any? =
         SessionShareManager::class.java.getDeclaredField(name)
@@ -303,6 +364,17 @@ class SessionShareShutdownTest {
             candidate += portRange + 1
         }
         error("could not reserve $portRange consecutive free ports for the test")
+    }
+
+    /** [awaitUntil] for callers that cannot suspend — the production test seam runs on a plain
+     *  binder thread. */
+    private fun blockingAwaitUntil(timeoutMs: Long, predicate: () -> Boolean): Boolean {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000
+        while (System.nanoTime() < deadline) {
+            if (predicate()) return true
+            Thread.sleep(25)
+        }
+        return predicate()
     }
 
     private suspend fun awaitUntil(timeoutMs: Long, predicate: () -> Boolean): Boolean {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
@@ -68,8 +68,10 @@ class SessionShareShutdownTest {
         const val SETTLE_MS = 2_000L
 
         /** Active jobs under the manager's lifecycle once the pre-warm is in flight: the settings
-         *  watcher, plus the pre-warm nested inside it. */
-        const val SCOPE_CHILDREN_WITH_PREWARM = 2
+         *  watcher, the supervisorScope it collects inside, and the pre-warm nested in that. Counted
+         *  transitively — the point is that waiting on it proves the *pre-warm* exists, not just the
+         *  watcher, so this must track the real depth of the tree. */
+        const val SCOPE_CHILDREN_WITH_PREWARM = 3
     }
 
     /**

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/SessionShareShutdownTest.kt
@@ -49,8 +49,9 @@ import kotlin.test.assertTrue
  *   makes; `MirrorShare` still reads the process singleton directly, which no path here reaches
  *   because every share these tests attempt is refused before one is constructed.
  *
- * [SessionShareManager] is a singleton, so every test tears it back down in [tearDown]; the fact
- * that the tests pass in any order is itself coverage of `start()` re-arming after `shutdown()`.
+ * [SessionShareManager] is a singleton, so every test tears it back down in [tearDown] — including
+ * clearing the shutdown latch, which is why re-arming gets its own test rather than riding on test
+ * ordering.
  */
 class SessionShareShutdownTest {
 
@@ -197,6 +198,24 @@ class SessionShareShutdownTest {
     }
 
     @Test
+    fun `start re-arms the manager after shutdown`() = runBlocking {
+        SessionShareManager.start()
+        awaitPrewarmLaunched()
+        SessionShareManager.shutdown()
+
+        // The embedder loading BossTerm again — a plugin dispose/re-init cycle. If the latch stuck,
+        // sharing would be inert for the rest of the host process with nothing logged anywhere.
+        SessionShareManager.start()
+        awaitPrewarmLaunched()
+        McpTerminalRegistry.setRunning(mcpPort)
+
+        assertTrue(
+            awaitUntil(SETTLE_MS) { !rangeIsFree() },
+            "start() must clear the shutdown latch so the manager binds again"
+        )
+    }
+
+    @Test
     fun `shutdown with nothing started is safe`() {
         // No start(), no share, no engine — the state an embedder is in when it disposes BossTerm
         // without the user ever having enabled sharing.
@@ -264,7 +283,8 @@ class SessionShareShutdownTest {
      * reasons that have nothing to do with session sharing.
      */
     private fun reserveFreeRange(): Int {
-        var candidate = 20_000 + (System.nanoTime() % 10_000).toInt()
+        // floorMod, not %: nanoTime's origin is arbitrary and it is allowed to be negative.
+        var candidate = 20_000 + Math.floorMod(System.nanoTime(), 10_000L).toInt()
         repeat(200) {
             if ((candidate until candidate + PORT_RANGE).all { portIsFree(it) } &&
                 portIsFree(candidate + 100) // the stand-in MCP port


### PR DESCRIPTION
## The window

`SessionShareManager.shutdown()` cancelled **only its settings watcher**, never its own scope.

The settings watcher launches the pre-warm on the *manager* scope, not as a child of the watcher job:

```kotlin
watcherJob = scope.launch {
    …collect { (enabled, mode) ->
        if (mode != "off") scope.launch { prewarmRemote() }   // ← manager scope
    }
}
```

and `prewarmRemote()` parks for up to **5 seconds** waiting for the BossTerm MCP server to claim its port before it binds:

```kotlin
if (settings.mcpEnabled) {
    withTimeoutOrNull(5000) { McpTerminalRegistry.runningPort.first { it != null } }
}
mutex.withLock { ensureEngineLocked(settings) }   // ← binds a Ktor server
```

So `shutdown()` could run, tear everything down, and return — and then a pre-warm that had been parked in that wait would wake up and bind a **fresh Ktor server behind a manager that had already declared itself down**. When BossTerm is embedded in a plugin whose classloader is closing (the `terminal-tab` case), that late bind executes against dead classes.

The engine stop itself was never the problem: `shutdown()` already stops the engine inline and synchronously. This is about the work that was still in flight around it.

## Ordering: cancel *before* the engine stop

The guard block goes first, and the teardown proper follows:

```kotlin
shuttingDown = true                        // 1. refuse late binds
shutdownEpoch.incrementAndGet()            //    …monotonically, see below
claimRemoteOp()                            // 2. supersede any in-flight establish
lifecycle.cancel()                         // 3. cancel our own in-flight work
… // shares, grants, remote access, engine.stop(200, 800)
```

**Why first, not last.** The engine stop is the *widest* part of shutdown — up to 800 ms — and it ends with the port freed. Cancelling after it would leave precisely the window this PR closes wide open, and would leave it open at the exact moment the port becomes bindable again.

**Why nothing is lost by going first.** `shutdown()` exists specifically to do everything itself, inline, "without the coroutine scope (which would not drain at process exit)". Auditing what is actually queued on that scope:

| queued work | kind | cost of cancelling |
|---|---|---|
| `prewarmRemote` | setup | *the point* |
| `establishRemote` / `establishCloudflareVerified` | setup | none — op token already supersedes it |
| `registerRespawn` | setup | none |
| cloudflared prefetch | setup | none |
| `unshare` / `stopAll` bodies | cleanup | none — strict subsets of what `shutdown()` then does itself |

There is no cleanup on that scope that `shutdown()` does not already duplicate, so cancel-first abandons nothing.

**`claimRemoteOp()` moved up with it.** Cancellation is cooperative and cannot interrupt `CloudflaredExposer`'s `awaitUrl`/`awaitReady`, which are plain blocking calls. The op token is what makes a blocked establish bail and destroy its own tunnel rather than adopt one after we have torn down, so it must be bumped alongside the cancel, not after the teardown.

## Cancellation alone is not enough

`ensureEngineLocked()` contains **no suspension point**. A pre-warm already inside it runs to completion no matter what, and one that woke a moment before the cancel landed still arrives holding a live intent to bind. So a `@Volatile shuttingDown` latch backs the cancellation up in three places:

- checked at the top of `ensureEngineLocked()` — refuses to bind at all (this also covers a `share()` racing an embedder's `dispose()`);
- **re-checked after the engine is adopted**, since `shutdown()` is synchronous and therefore cannot take the mutex — it may have run its whole teardown while we were binding, read a still-null `engine`, and left ours alive behind it. Adopt-then-re-check is the same shape `establishCloudflareVerified` already uses for its tunnel;
- re-checked in `prewarmRemote()` after the MCP wait, so the "Pre-warming…" log stays honest.

The scope hangs off a **per-lifecycle `SupervisorJob`** that `shutdown()` cancels outright and `start()` replaces, so the singleton **re-arms**: both `bossterm-app` and the BossConsole terminal plugin call `start()`/`shutdown()`, and a shutdown must not leave sharing permanently inert. Cancelling a long-lived job's *children* would not be enough — the job stays `Active`, so a `scope.launch` already past its guard (the settings watcher's) can still add a live child after everything was cancelled. A cancelled job makes every later launch inert.

Because `start()` clears the latch, the re-checks go through a monotonic `shutdownEpoch` rather than the latch alone (`supersededByShutdown(epoch)`). Otherwise a dispose/re-init landing inside a single bind could clear the latch under the binder, and the worst interleaving leaves a **live bound server with `engine == null`** — unstoppable, and pushing the next bind to `port+1`. It is the same tool, for the same question, as the existing `remoteOp` token.

## The other straggler paths

Cancelling the scope handles work that is *on* it. Second commit closes the paths that aren't:

- **`share()` adopts, then re-checks** — the same shape `ensureEngineLocked` uses for the engine, not a pre-check. `shutdown()` deliberately does not take the mutex, so it can land anywhere in the registration block; a `MirrorShare` left behind runs observer coroutines on its *own* scope, which `cancelChildren()` never reaches. On losing that race the share is unregistered and stopped through the same path `unshare()` uses (extracted as `unregisterShareLocked`).
- **`start()` and `shutdown()`'s body are `@Synchronized`** so the pair is ordered — the embedder callbacks run *outside* the monitor, since a host that marshals them onto its UI thread would deadlock against a `start()` already running there. A shutdown racing a start could otherwise cancel the freshly-launched watcher and then null `watcherJob`, leaving the manager latch-clear with no settings observer: no pre-warm, no teardown on disable, nothing logged. Unreachable from bossterm-app's shape; the plugin dispose/re-init path is exactly where it would show up.
- **`unshare()`, `refreshRemoteLink()`, `applyRemoteMode()`** return early when latched rather than enqueuing onto a scope that was just cancelled.
- **`registerRespawn`'s `onExit` callback** checks the latch too: it runs on a ForkJoinPool thread *outside* the scope, so cancellation cannot reach it, and a cloudflared process exiting after dispose would otherwise schedule a fresh coroutine inside a classloader being unloaded.
- **The late-bind guard's `stop()` moved to a daemon thread.** `ensureEngineLocked` runs synchronously on the caller's thread, and `share()` reaches it from a `rememberCoroutineScope` — the Compose UI thread. That is precisely why the remote-establish kick below it is already pushed off this path; the new guard was blocking there for up to 1 s. It is also the one thing `shutdown()` can leave outstanding, which its KDoc now says.
- **The settings watcher launches the pre-warm on its own coroutine**, not through the `scope` property, which re-resolves `lifecycle` on each access — a shutdown/re-arm landing between the watcher's guard and its launch could otherwise attach the new coroutine to the fresh lifecycle and outlive the cancel.
- **`shutdown()` releases active host fits and drops `fitHostEmbedder`.** It stops shares inline rather than through `unregisterShareLocked` — the only caller of `releaseEmbeddedFit` — so an embedder that resized its pane for "Fit host to my screen" was never told to undo it when BossTerm unloaded, and the embedder reference itself was never cleared, pinning the host that was disposing us.
- `@Volatile` on `watcherJob`, `boundHost` and the test seam, all written and read across threads.

## Two fixes that fall out of introducing cancellation

This scope was never cancelled before, so nothing on it had to be cancellation-safe. Two spots now are:

- **`stopEngineLocked()` is `NonCancellable` end to end** — the remote teardown as well as the engine stop. Cancelled on the remote teardown it throws before entering the `try`, so the Tailscale mapping is never unmapped, cloudflared is never killed, *and* the `finally` never runs; cancelled on the stop, the `finally` clears `engine` while the server is still bound and `shutdown()` then finds nothing to stop. Everything in there is teardown already committed to, and it is bounded by the CLI timeouts plus the 300 ms / 1000 ms stop budget.
- Nothing on this scope logs a cancellation as a failure. A `CancellationException` under a `SupervisorJob` is never reported to a handler, and the one `catch` that would have swallowed one is now inside the `NonCancellable` fence.

`engine` becomes `@Volatile` — `shutdown()` reads it from a thread that is not the one holding the mutex when the binder writes it.

## What is tested, and the mutations that prove it

`SessionShareShutdownTest` drives the real path — settings watcher, parked pre-warm, real socket binds. It is kept honest by construction:

- every test reserves a run of **ten consecutive free ports** (the manager's `MAX_PORT_FALLBACK` scan) and asserts over the whole range, so "nothing bound" is a real observation. The window is clamped below 32768 so it can't overlap Linux's default ephemeral range;
- "free" is asserted by *probing*, never by holding the ports — a test cannot pass by making the bind impossible;
- no test shuts down on a timer: each waits until the pre-warm coroutine actually exists on the manager's scope, so "shutdown during an in-flight pre-warm" cannot quietly degrade into "shutdown before it started";
- the positive control (nothing bound while parked, something bound once the MCP port is published) fails if a fix over-reaches and leaves the manager inert;
- the remote mode is an unrecognised provider string: not `"off"`, so the pre-warm arms, but `establishRemote`'s `when` falls through to `null`, so no test ever shells out to `tailscale` or `cloudflared`;
- settings come from a throwaway `SettingsManager` injected through a test seam. `MirrorShare` still reads the process singleton directly, which no path here reaches because every share these tests attempt is refused before one is constructed;
- re-arming after shutdown gets its own test rather than riding on test ordering — `tearDown` clears the latch, so ordering proves nothing (M5 below);
- "nothing is bound" is asserted on *both* the port scan and the `engine` field: the field is deterministic, and the scan is what catches a bound server the manager has lost track of.

Not covered, deliberately: the `if (shuttingDown) return` short-circuits added to `unshare`, `applyRemoteMode`, `refreshRemoteLink` and the respawn callback. Each guards a path that already no-ops after shutdown for incidental reasons, so a test could only assert the absence of an unobservable side effect.

Mutation results — each mutation applied to the merged fix, full class re-run:

| mutation | result |
|---|---|
| **M1** — drop `cancelChildren()`, keep the latch | ❌ `shutdown cancels the manager's own in-flight work` (`expected:<0> but was:<1>`), plus the positive control as collateral |
| **M2** — drop the latch, keep `cancelChildren()` | ❌ `share is refused after shutdown` |
| **M3** — pre-fix behaviour: neither | ❌ 3 fail, including `shutdown during an in-flight pre-warm prevents a late re-bind` |
| **M4** — ordering reverted: guard block moved *after* `engine.stop()` | ✅ survives — see below |
| **M5** — drop `start()`'s re-arm | ❌ `start re-arms the manager after shutdown` |
| **M6** — drop `share()`'s adopt-then-re-check | ✅ survives — see below |
| **M7** — drop the epoch, re-check the clearable latch instead | ❌ `a bind that loses to a shutdown plus re-init is undone` |
| **M8** — drop the fit release + embedder drop | ❌ `shutdown restores an active host fit and drops the embedder` |

M3 is the one that matters for the finding: **the regression test reproduces the bug** and only passes with a fix in place.

M1's collateral kill is the bug escaping its own test case — the straggler it leaves alive binds the engine and survives into the next test. The `shutdown cancels the manager's own in-flight work` failure is the deterministic one.

M7 was originally in the surviving column. It is now killed by injecting the race through a production seam (`afterBindBeforeRecheckForTest`, fired between "socket is listening" and `engine = started`) instead of waiting for it: the seam blocks until the port is demonstrably taken, so the end-state assertion cannot be satisfied by the pre-bind state, and there is no wall clock in the test.

### Two mutations survive, and both for the same reason

**M4** (ordering) and **M6** (`share()`'s re-check) are not caught, and I would rather say so than imply otherwise. Both need `shutdown()` to land inside a specific non-suspending stretch on another thread. M4 has no injection point that would distinguish it — with the latch set first, the *observable* outcome is identical either way. M6 does, but exercising it means letting `share()` construct a real `MirrorShare`, which still resolves `SettingsManager.instance` directly (~10 sites, one a write) — so the test would touch a developer's real `~/.bossterm/settings.json` exactly when it fails. That is gated on extending the settings seam into `MirrorShare`, which is a reasonable follow-up but not this PR.

They still earn their place:

- **Ordering.** The latch prevents the *bind*; only cancellation prevents the coroutine from *executing at all*, and execution inside a closing classloader is the plugin-side hazard. Cancel-first bounds that exposure to zero suspension points instead of to the length of the engine stop. M1 is what pins the cancellation itself.
- **`share()`'s re-check.** The window is narrow but the consequence is durable: a `MirrorShare` observing terminal state forever, on a scope nothing will ever cancel.

## Verification

- `./gradlew :compose-ui:desktopTest` — **BUILD SUCCESSFUL**, full module suite green; the new class 9/9.
- `./gradlew :bossterm-app:compileKotlinDesktop` — **BUILD SUCCESSFUL**.
- CI green on macOS, Ubuntu and Windows.

Some intermediate local runs showed 9 failures in the PTY-backed daemon tests (`TerminalSessionCoreTest`, `DaemonAttachServerTest`, `DaemonMcpToolsTest`, `DaemonSessionHostTest`). Those reproduce on a **clean tree with these changes stashed** — environmental flakiness from spawning real PTYs, unrelated to this PR, and absent from both the final local run and CI.

## Relationship to the plugin-side fix

`risa-labs-inc/boss-plugin-terminal-tab#52` added a bounded re-check and a second stop after the MCP wait, and says in as many words that it **narrows rather than closes** the window — because a plugin cannot stop work that is in flight inside the library it is unloading. This closes it at the source. The plugin-side guard remains valid as defence in depth and needs no change.

No version bump — releases are handled separately.
