### PR TITLE
Make Boss Calling's in-app call label an embedder parameter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ Located in: `compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/shell/S
 - `VoiceCallService.kt` — share-viewer policy: control role, share scope, mint budget, call tokens
 - `HostVoiceCallController.kt` — the in-app call (JDK WebSocket + `javax.sound.sampled`, no WebRTC)
 - `VoiceAgentStorage.kt` — the chmod-600 key file
+- `VoiceAgentCustomization.kt` — the embedder seam for the agent's instructions (the button's label
+  is a `TabbedTerminal` parameter instead, alongside `contextMenuItems`)
 - Two surfaces, one tool set: the viewer path is browser↔OpenAI over WebRTC with an ephemeral secret;
   the in-app path is host↔OpenAI over WebSocket with the standard key. They key "agent is speaking"
   off *different* event families (`output_audio_buffer.*` vs `response.output_audio.*`), so a change
@@ -110,9 +112,11 @@ Located in: `compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/shell/S
 - **Clipboard**: Copy-on-select, middle-click paste
 - **Mouse**: vim/tmux support, Shift bypasses
 - **AI Menu**: Claude Code, Codex, Gemini, OpenCode
-- **Boss Calling**: voice-call the session's AI agent — "Call BossTerm" in the status strip (in-app)
-  or the share viewer's bottom bar (remote). Needs an OpenAI key in `~/.bossterm/voice.json`;
-  remote calls additionally require control of the share
+- **Boss Calling**: voice-call the session's AI agent — the status-strip pill (in-app) or the share
+  viewer's bottom bar (remote). "Boss Calling" is the FEATURE and is fixed; the in-app button's
+  label is `TabbedTerminal(callLabel = …)` — null renders "Call BossTerm", BossConsole passes
+  "Call Boss". The viewer's button is a static web asset and stays "Call BossTerm". Needs an OpenAI
+  key in `~/.bossterm/voice.json`; remote calls additionally require control of the share
 - **Debug**: Ctrl+Shift+D
 
 ## Programmatic API

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -163,6 +163,13 @@ import ai.rever.bossterm.compose.ui.ProperTerminal
  * @param hyperlinkRegistry Custom hyperlink pattern registry for per-instance hyperlink customization.
  *                          Use this to add custom patterns (e.g., JIRA ticket IDs, custom URLs).
  *                          Default: global HyperlinkDetector.registry
+ * @param callLabel What Boss Calling's in-app button is called: the status-strip pill, the key
+ *                  prompt behind it, and the settings copy that describes it. Null (the default)
+ *                  renders "Call BossTerm", so standalone output is unchanged.
+ *                  Use case: an embedder whose users have never heard of BossTerm —
+ *                  `callLabel = "Call Boss"` inside BossConsole. This renames the BUTTON only;
+ *                  "Boss Calling" is the feature's name and is fixed, as is the share viewer's own
+ *                  Call button (a static web asset, possibly served by the daemon).
  * @param modifier Compose modifier for the terminal container
  * @param platformServices Custom platform services
  */
@@ -188,6 +195,7 @@ fun TabbedTerminal(
     onContextMenuOpenAsync: (suspend () -> Unit)? = null,
     settingsOverride: TerminalSettingsOverride? = null,
     hyperlinkRegistry: HyperlinkRegistry = HyperlinkDetector.registry,
+    callLabel: String? = null,
     /**
      * Whether the terminal is currently "active" from the host's
      * perspective — i.e. the surrounding panel/tab is the one the user
@@ -937,6 +945,9 @@ fun TabbedTerminal(
     // Popup menu for the MCP status segment (same menu the old MCP pill showed).
     val mcpMenu = remember { ai.rever.bossterm.compose.features.ContextMenuController() }
     val mcpServerLabel = LocalBossTermMcpConfig.current?.displayName ?: "BossTerm"
+    // Resolved once here, not at each of the four sites that render it, so the pill, the key prompt
+    // it opens and the share windows' Boss Calling panel can never disagree about the name.
+    val resolvedCallLabel = ai.rever.bossterm.compose.share.resolveCallLabel(callLabel)
     var attachStatus by remember { mutableStateOf<AttachStatus?>(null) }
     var mcpAttaching by remember { mutableStateOf(false) }
     // Session sharing (issue #276): dialog state + live set of shared tab ids.
@@ -2114,8 +2125,9 @@ fun TabbedTerminal(
         // QR/links dialog if already shared). Shown per its own toggle.
         val showMcpStatus = settings.mcpShowStatusIndicator
         val showSharingStatus = settings.sessionSharingShowIndicator
-        // In-app voice call ("Call BossTerm"): the pill sits beside Sharing and drives the one call
-        // this app can have; the strip below it appears while that call is up.
+        // In-app voice call: the pill sits beside Sharing and drives the one call this app can
+        // have; the strip below it appears while that call is up. Its wording is the embedder's
+        // (the `callLabel` parameter) — "Call BossTerm" standalone.
         //
         // Subscribed as a DERIVED, distinct-until-changed flow rather than the raw call state: this
         // lambda owns the terminal rendering path, and the call state carries fields that change
@@ -2231,6 +2243,7 @@ fun TabbedTerminal(
                         }
                     },
                     call = callSegment,
+                    callLabel = resolvedCallLabel,
                     onCallClick = {
                         // One click is the whole interaction: ask for a key if there isn't one,
                         // start when idle, end when live, clear a failure when it failed.
@@ -2256,6 +2269,7 @@ fun TabbedTerminal(
                             voiceKeyPrompt = false
                             HostVoiceCall.start()
                         },
+                        callLabel = resolvedCallLabel,
                     )
                 }
                 attachStatus?.let { status ->
@@ -2359,6 +2373,7 @@ fun TabbedTerminal(
             onRefreshLink = { ai.rever.bossterm.compose.share.SessionShareManager.refreshRemoteLink() },
             sessionName = ai.rever.bossterm.compose.share.SessionShareManager.sessionNameFor(info.tabId) ?: "",
             onSessionNameChange = { ai.rever.bossterm.compose.share.SessionShareManager.setSessionName(info.tabId, it) },
+            callLabel = resolvedCallLabel,
         )
     }
 
@@ -2372,6 +2387,7 @@ fun TabbedTerminal(
             focusedSessionId = tabController.activeTab?.remotePaneId,
             onDismiss = { daemonShareOpen = false },
             focusTick = shareFocusTick,
+            callLabel = resolvedCallLabel,
         )
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareWindow.kt
@@ -14,6 +14,7 @@ import ai.rever.bossterm.compose.settings.components.SettingsSection
 import ai.rever.bossterm.compose.settings.components.SettingsTextField
 import ai.rever.bossterm.compose.settings.sections.BossCallingSection
 import ai.rever.bossterm.compose.settings.theme.BossUiTheme
+import ai.rever.bossterm.compose.share.DEFAULT_CALL_LABEL
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -83,6 +84,12 @@ fun DaemonShareWindow(
     focusedSessionId: String?,
     onDismiss: () -> Unit,
     focusTick: Int = 0,
+    /**
+     * What the IN-APP call button is called in the GUI hosting this window (`TabbedTerminal`'s
+     * `callLabel`, resolved). The daemon serving the share is a separate process and has no
+     * embedder, but this window is composed by the GUI, so its Boss Calling copy follows the GUI.
+     */
+    callLabel: String = DEFAULT_CALL_LABEL,
 ) {
     val clipboard = LocalClipboardManager.current
     val shareState by DaemonShareClient.state.collectAsState()
@@ -145,7 +152,7 @@ fun DaemonShareWindow(
                 if (share == null) {
                     StartSection(scope, focusedSessionId)
                 } else {
-                    ShareDetails(share, pending, clipboard)
+                    ShareDetails(share, pending, clipboard, callLabel)
                 }
             }
             // Pinned footer — always visible without scrolling.
@@ -227,6 +234,7 @@ private fun ShareDetails(
     share: DaemonAttachProtocol.ShareView,
     pending: List<DaemonAttachProtocol.PendingApproval>,
     clipboard: ClipboardManager,
+    callLabel: String,
 ) {
     // Viewer-facing label for this share (the remote group header). Defaults to username_machine on the
     // daemon side; editing it round-trips via SetShareName. (Parity with the non-daemon ShareWindow.)
@@ -302,7 +310,7 @@ private fun ShareDetails(
 
     // Same controls as the GUI share window: the daemon serves voice calls too (with the smaller
     // headless tool surface), and this is the window a daemon host is looking at.
-    BossCallingSection(showAgentOptions = false)
+    BossCallingSection(showAgentOptions = false, callLabel = callLabel)
     Spacer(Modifier.height(20.dp))
 
     RemoteAccessSection(share)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -1118,7 +1118,8 @@ data class TerminalSettings(
     val voiceExposeAllTools: Boolean = true,
 
     /**
-     * Show the "Call BossTerm" segment in the tab-bar status strip. Its own toggle, like
+     * Show the call segment ("Call BossTerm", or whatever an embedder passed as `TabbedTerminal`'s
+     * `callLabel`) in the tab-bar status strip. Its own toggle, like
      * [mcpShowStatusIndicator] and [sessionSharingShowIndicator]: because Boss Calling ships
      * enabled, without this a new pill would appear for everyone — including users who had
      * deliberately turned the other two off to reclaim that corner.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/BossCallingSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/BossCallingSection.kt
@@ -13,6 +13,7 @@ import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.settings.components.SettingsDropdown
 import ai.rever.bossterm.compose.settings.components.SettingsSection
 import ai.rever.bossterm.compose.settings.components.SettingsToggle
+import ai.rever.bossterm.compose.share.DEFAULT_CALL_LABEL
 import ai.rever.bossterm.compose.voice.StampCachedValue
 import ai.rever.bossterm.compose.voice.VoiceTurnDetection
 import ai.rever.bossterm.compose.voice.StoredVoiceConfig
@@ -56,6 +57,57 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
+ * The share viewer's Call button, spelled out.
+ *
+ * The three lines that talk about what a VIEWER sees name it literally, not through the embedder's
+ * `callLabel`: the viewer's button is a static web asset (`share-viewer/index.html`), possibly
+ * served by the daemon, and it does not follow the embedder. Under BossConsole the in-app pill says
+ * "Call Boss" and these still, correctly, say "Call BossTerm" — this panel's whole job is answering
+ * "why is there no Call button?", and it can only do that by naming the button the person is
+ * actually looking for.
+ */
+private const val VIEWER_CALL_LABEL = "Call BossTerm"
+
+/*
+ * The three strings below are the only settings copy that names the IN-APP call button, so they are
+ * functions of the label rather than literals: an embedder's rename has to reach the settings that
+ * describe the button, not just the button. They are separate from the composable so a test can
+ * assert both halves — that standalone reads exactly as it always did, and that a set label lands in
+ * all three.
+ */
+
+/**
+ * Why you would turn Boss Calling on at all, and what it costs.
+ *
+ * This is the one line that names BOTH call surfaces, and they can disagree — the embedder renames
+ * the in-app pill and the viewer's button stays [VIEWER_CALL_LABEL]. So it collapses to the shorter
+ * "in this window and in the share viewer" only when the two really are one name, which is every
+ * standalone build; an embedder gets both names instead of a sentence that is half wrong.
+ */
+internal fun bossCallingEnableDescription(callLabel: String): String =
+    (if (callLabel == VIEWER_CALL_LABEL) {
+        "Show a \"$callLabel\" button — in this window and in the share viewer — "
+    } else {
+        "Show a \"$callLabel\" button in this window, and a \"$VIEWER_CALL_LABEL\" button in the " +
+                "share viewer, "
+    }) +
+            "that starts a voice conversation with an AI agent (OpenAI Realtime) able to " +
+            "inspect this session and run commands. Starting a call sends your tab titles " +
+            "and working directories to OpenAI, and anything the agent then reads from the " +
+            "terminal goes with it. On, but idle until you set the API key below; calling " +
+            "from a share also requires control of it."
+
+/** The status-strip toggle. */
+internal fun bossCallingIndicatorLabel(callLabel: String): String = "Show the $callLabel indicator"
+
+/** …and what turning it off actually costs you. */
+internal fun bossCallingIndicatorDescription(callLabel: String): String =
+    "Show the \"$callLabel\" segment in the tab-bar status strip, " +
+            "alongside the MCP and Sharing indicators. It is also how you START a call " +
+            "from this window, so turning it off leaves calling available only to share " +
+            "viewers."
+
+/**
  * The "Boss Calling (voice)" controls, shared by Settings → Session Sharing and the Share window.
  *
  * It lives in both places on purpose: the Share window is where a host is actually handing out a
@@ -63,8 +115,14 @@ import kotlinx.coroutines.withContext
  * unavailable) is impossible to debug from the viewer's side. [showAgentOptions] drops the
  * model/voice pickers for the compact Share-window rendering.
  *
+ * The SECTION keeps its name ("Boss Calling") in every build — that is the feature. Only copy about
+ * the in-app button follows [callLabel].
+ *
  * @param statusLine rendered under the toggle — the Share window uses it to say, in the host's own
  *   words, whether viewers can call right now.
+ * @param callLabel what the in-app call button is called on this host, already resolved. Reaches
+ *   here from `TabbedTerminal`'s `callLabel` by way of the Share window; the standalone Settings
+ *   window leaves it at [DEFAULT_CALL_LABEL], which is what standalone renders anyway.
  */
 @Composable
 internal fun BossCallingSection(
@@ -78,18 +136,14 @@ internal fun BossCallingSection(
      * wrong in the daemon's share window.
      */
     keyPresentOverride: Boolean? = null,
+    callLabel: String = DEFAULT_CALL_LABEL,
 ) {
     SettingsSection(title = "Boss Calling (voice)") {
         SettingsToggle(
             label = "Enable Boss Calling",
             checked = settings.voiceCallEnabled,
             onCheckedChange = { onSettingsChange(settings.copy(voiceCallEnabled = it)) },
-            description = "Show a \"Call BossTerm\" button — in this window and in the share viewer — " +
-                    "that starts a voice conversation with an AI agent (OpenAI Realtime) able to " +
-                    "inspect this session and run commands. Starting a call sends your tab titles " +
-                    "and working directories to OpenAI, and anything the agent then reads from the " +
-                    "terminal goes with it. On, but idle until you set the API key below; calling " +
-                    "from a share also requires control of it."
+            description = bossCallingEnableDescription(callLabel)
         )
         SettingsToggle(
             label = "Allow calls from share viewers",
@@ -106,13 +160,10 @@ internal fun BossCallingSection(
         if (statusLine) VoiceAvailabilityLine(settings, keyPresentOverride)
         if (showAgentOptions) {
             SettingsToggle(
-                label = "Show the Call BossTerm indicator",
+                label = bossCallingIndicatorLabel(callLabel),
                 checked = settings.voiceShowStatusIndicator,
                 onCheckedChange = { onSettingsChange(settings.copy(voiceShowStatusIndicator = it)) },
-                description = "Show the \"Call BossTerm\" segment in the tab-bar status strip, " +
-                        "alongside the MCP and Sharing indicators. It is also how you START a call " +
-                        "from this window, so turning it off leaves calling available only to share " +
-                        "viewers."
+                description = bossCallingIndicatorDescription(callLabel)
             )
             SettingsDropdown(
                 label = "Model",
@@ -245,7 +296,11 @@ private fun VoiceAgentInstructionsField(value: String, onChange: (String) -> Uni
  *    would land in the one panel whose entire job is answering "why is there no Call button?".
  */
 @Composable
-internal fun BossCallingSection(showAgentOptions: Boolean = true, statusLine: Boolean = true) {
+internal fun BossCallingSection(
+    showAgentOptions: Boolean = true,
+    statusLine: Boolean = true,
+    callLabel: String = DEFAULT_CALL_LABEL,
+) {
     val inMemory by SettingsManager.instance.settings.collectAsState()
     val settingsCache = remember {
         StampCachedValue(
@@ -288,6 +343,7 @@ internal fun BossCallingSection(showAgentOptions: Boolean = true, statusLine: Bo
         showAgentOptions = showAgentOptions,
         statusLine = statusLine,
         keyPresentOverride = keyOnDisk,
+        callLabel = callLabel,
     )
 }
 
@@ -305,10 +361,10 @@ private fun VoiceAvailabilityLine(settings: TerminalSettings, keyPresentOverride
     val (text, color) = when {
         !settings.voiceCallEnabled -> "Off — no calls from this window or from viewers." to TextMuted
         !settings.voiceCallShareEnabled ->
-            "In-app only — viewers see no Call BossTerm button." to TextMuted
-        !keyPresent -> "No API key yet — viewers see no Call BossTerm button until you add one below." to Danger
+            "In-app only — viewers see no $VIEWER_CALL_LABEL button." to TextMuted
+        !keyPresent -> "No API key yet — viewers see no $VIEWER_CALL_LABEL button until you add one below." to Danger
         // The viewer shows the button to every device; control is enforced when they click it.
-        else -> "Ready — viewers see the Call BossTerm button (calling needs control)." to AccentColor
+        else -> "Ready — viewers see the $VIEWER_CALL_LABEL button (calling needs control)." to AccentColor
     }
     Text(text = text, color = color, fontSize = 11.sp, modifier = Modifier.padding(top = 2.dp))
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/ShareWindow.kt
@@ -101,6 +101,11 @@ fun ShareWindow(
     /** The share's name as viewers see it (default: the username). */
     sessionName: String = "",
     onSessionNameChange: (String) -> Unit = {},
+    /**
+     * What the IN-APP call button is called on this host (`TabbedTerminal`'s `callLabel`, resolved).
+     * The Boss Calling panel below names it; the viewer's own button is unaffected.
+     */
+    callLabel: String = DEFAULT_CALL_LABEL,
 ) {
     val clipboard = LocalClipboardManager.current
     val loopbackOnly = info.url.contains("://127.0.0.1") || info.url.contains("://localhost")
@@ -284,7 +289,7 @@ fun ShareWindow(
                 // to can do. Self-persisting (this window carries no settings snapshot), and it
                 // reports whether the Call button is actually reachable — without a key the
                 // viewer shows nothing at all, which is undebuggable from the far end.
-                BossCallingSection(showAgentOptions = false)
+                BossCallingSection(showAgentOptions = false, callLabel = callLabel)
                 Spacer(Modifier.height(20.dp))
 
                 RemoteAccessSetupSection(

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/StatusStrip.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/StatusStrip.kt
@@ -28,18 +28,57 @@ import androidx.compose.ui.unit.sp
  * `● MCP | ● Sharing | ● Call BossTerm`. Each segment's dot is color-coded (green = on/active,
  * amber = busy, gray = off/idle) and is clickable. Replaces the separate pills so status reads on
  * one line. Each segment is shown only when its own toggle is enabled.
+ *
+ * The call segment's wording is the embedder's — see `TabbedTerminal`'s `callLabel` parameter.
  */
 private val ON = Color(0xFF4CAF50)
 private val OFF = Color(0xFF6B6B6B)
 private val BUSY = Color(0xFFE5A54B)
 private val LIVE_TALK = Color(0xFF4A90E2)
 
-/** What the Call BossTerm segment should show — derived from the in-app call state. */
+/**
+ * What the in-app call button says when the embedder has not renamed it — i.e. always, in plain
+ * `bossterm-app`.
+ *
+ * "Boss Calling" is the FEATURE and is fixed everywhere (the settings section, the macOS microphone
+ * prompt, the docs). This is only what the button is CALLED, which is the one part an embedder is
+ * putting in front of users who have never heard of BossTerm.
+ */
+const val DEFAULT_CALL_LABEL: String = "Call BossTerm"
+
+/**
+ * The embedder's `callLabel` resolved for rendering — never blank.
+ *
+ * `null` means "standalone", matching `contextMenuItemsProvider` and friends. Blank is folded into
+ * the same case rather than rendering an empty pill: an embedder computing this from its own
+ * branding should get BossTerm's name back, not a dot with nothing after it.
+ */
+internal fun resolveCallLabel(callLabel: String?): String =
+    callLabel?.trim()?.takeUnless { it.isEmpty() } ?: DEFAULT_CALL_LABEL
+
+/** What the call segment should show — derived from the in-app call state. */
 enum class CallSegmentState {
     Hidden,
     /** Enabled but no API key yet — the pill still shows, and clicking it asks for one. */
     NeedsKey,
     Ready, Connecting, Live, Speaking, Working, Failed,
+}
+
+/**
+ * The call segment's text, all in one place so the label an embedder sets reaches every state and
+ * not just the idle one.
+ *
+ * [CallSegmentState.NeedsKey] deliberately reads the same as [CallSegmentState.Ready]: "set this up"
+ * is the click, not a warning to stare at. [CallSegmentState.Connecting] deliberately drops the
+ * label — "Calling…" is the whole story at that moment, and it is the one state that stays coherent
+ * whatever the product is called.
+ */
+internal fun callSegmentLabel(state: CallSegmentState, callLabel: String): String = when (state) {
+    CallSegmentState.Connecting -> "Calling…"
+    CallSegmentState.Working -> "$callLabel · working"
+    CallSegmentState.Speaking, CallSegmentState.Live -> "$callLabel · live"
+    CallSegmentState.Failed -> "$callLabel · failed"
+    else -> callLabel
 }
 
 @Composable
@@ -63,6 +102,11 @@ fun StatusStrip(
     modifier: Modifier = Modifier,
     call: CallSegmentState = CallSegmentState.Hidden,
     onCallClick: () -> Unit = {},
+    /**
+     * What the call segment is called. Already resolved — hosts pass `TabbedTerminal`'s `callLabel`
+     * through [resolveCallLabel], so this is never null and never blank.
+     */
+    callLabel: String = DEFAULT_CALL_LABEL,
 ) {
     val showCall = call != CallSegmentState.Hidden
     if (!showMcp && !showSharing && !showCall) return
@@ -131,15 +175,7 @@ fun StatusStrip(
                         CallSegmentState.Failed -> Color(0xFFD9534F)
                         else -> OFF
                     },
-                    // NeedsKey deliberately reads the same as Ready: "set this up" is the click,
-                    // not a warning to stare at.
-                    label = when (call) {
-                        CallSegmentState.Connecting -> "Calling…"
-                        CallSegmentState.Working -> "Call BossTerm · working"
-                        CallSegmentState.Speaking, CallSegmentState.Live -> "Call BossTerm · live"
-                        CallSegmentState.Failed -> "Call BossTerm · failed"
-                        else -> "Call BossTerm"
-                    },
+                    label = callSegmentLabel(call, callLabel),
                     onClick = onCallClick,
                 )
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/HostCallBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/HostCallBar.kt
@@ -32,8 +32,13 @@ private val Amber = Color(0xFFE5A54B)
 private val Danger = Color(0xFFD9534F)
 
 /**
- * The in-app call strip, shown under the status pills while a "Call BossTerm" call is up: a live
- * microphone level meter, what the agent is doing, Mute and End.
+ * The in-app call strip, shown under the status pills while a call is up: a live microphone level
+ * meter, what the agent is doing, Mute and End.
+ *
+ * Deliberately name-free — every string here is about the call in progress ("Listening…", "End
+ * call"), not about the product — so it reads the same whatever an embedder called the pill above
+ * it (`TabbedTerminal`'s `callLabel`). "Boss is speaking" names the AGENT, which is called Boss on
+ * both surfaces and in both builds.
  *
  * The meter is real mic loudness (from [HostVoiceCall.level]) rather than a canned animation — with
  * no browser tab to look at, it is the only way to tell "it can't hear me" from "it's thinking".
@@ -137,7 +142,7 @@ private fun BarButton(label: String, onClick: () -> Unit, tint: Color = Label) {
  * The two settings are separate parameters because they mean different things, and one combined
  * `pillEnabled` flag could not express both rules at once:
  *  - [featureEnabled] off (Boss Calling itself) hides everything except a call already in progress,
- *    so turning it off doesn't leave a "Call BossTerm · failed" pill with nothing behind it, and
+ *    so turning it off doesn't leave a "… · failed" pill with nothing behind it, and
  *    doesn't strand a live call with no way to end it;
  *  - [indicatorEnabled] off (just the pill) additionally keeps [CallSegmentState.Failed] visible —
  *    the error segment is the only place the failure can be dismissed, so hiding it left the call

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/VoiceKeyDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/VoiceKeyDialog.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.compose.voice
 
 import ai.rever.bossterm.compose.settings.SettingsTheme.AccentColor
+import ai.rever.bossterm.compose.share.DEFAULT_CALL_LABEL
 import ai.rever.bossterm.compose.settings.SettingsTheme.BackgroundColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.BorderColor
 import ai.rever.bossterm.compose.settings.SettingsTheme.Danger
@@ -43,15 +44,22 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
- * Asked for in place when someone clicks "Call BossTerm" with no key stored: sending them off to
+ * Asked for in place when someone clicks the call pill with no key stored: sending them off to
  * hunt through Settings for the one thing standing between them and a call is the wrong answer, so
  * the key is collected right here and the call starts as soon as it saves.
  *
  * Storage is the same chmod-600 `~/.bossterm/voice.json` the settings field writes, so a key added
  * here shows as set everywhere else too.
+ *
+ * The title is the pill's own wording (`TabbedTerminal`'s `callLabel`) — this dialog IS that click,
+ * and a prompt titled with a product name the user has never seen would not look like one.
  */
 @Composable
-internal fun VoiceKeyDialog(onDismiss: () -> Unit, onSaved: () -> Unit) {
+internal fun VoiceKeyDialog(
+    onDismiss: () -> Unit,
+    onSaved: () -> Unit,
+    callLabel: String = DEFAULT_CALL_LABEL,
+) {
     var input by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
     var saving by remember { mutableStateOf(false) }
@@ -82,7 +90,7 @@ internal fun VoiceKeyDialog(onDismiss: () -> Unit, onSaved: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
         containerColor = BackgroundColor,
-        title = { Text("Call BossTerm", color = TextPrimary, fontSize = 15.sp) },
+        title = { Text(callLabel, color = TextPrimary, fontSize = 15.sp) },
         text = {
             Column(modifier = Modifier.width(380.dp)) {
                 Text(

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/CallLabelTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/CallLabelTest.kt
@@ -1,0 +1,287 @@
+package ai.rever.bossterm.compose.share
+
+import ai.rever.bossterm.compose.settings.sections.bossCallingEnableDescription
+import ai.rever.bossterm.compose.settings.sections.bossCallingIndicatorDescription
+import ai.rever.bossterm.compose.settings.sections.bossCallingIndicatorLabel
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * `TabbedTerminal(callLabel = …)` renames Boss Calling's in-app button, and standalone BossTerm must
+ * not notice.
+ *
+ * Two halves, and the second is the one that rots: it is easy to make the pill configurable and
+ * leave the settings copy describing a button that no longer exists by that name. So every in-app
+ * site is asserted here against its exact pre-existing string, and a scan of the sources keeps a new
+ * one from being hardcoded past this test.
+ */
+class CallLabelTest {
+
+    private val embedder = "Call Boss"
+
+    // ---- resolving the parameter ----
+
+    /** Null is what `bossterm-app` passes, by never passing anything. */
+    @Test
+    fun `standalone renders Call BossTerm`() {
+        assertEquals("Call BossTerm", DEFAULT_CALL_LABEL)
+        assertEquals("Call BossTerm", resolveCallLabel(null))
+    }
+
+    @Test
+    fun `an embedder's label is what renders`() {
+        assertEquals(embedder, resolveCallLabel(embedder))
+    }
+
+    /** An embedder deriving this from its own branding must not be able to produce an empty pill. */
+    @Test
+    fun `blank is treated as unset`() {
+        for (blank in listOf("", "   ", "\t\n")) {
+            assertEquals("Call BossTerm", resolveCallLabel(blank), "for [$blank]")
+        }
+    }
+
+    @Test
+    fun `surrounding whitespace is trimmed`() {
+        assertEquals(embedder, resolveCallLabel("  Call Boss  "))
+    }
+
+    // ---- the status strip ----
+
+    /**
+     * Byte-for-byte what master rendered. The point of the change is that standalone output does not
+     * move, so these are spelled out rather than derived from the constant.
+     */
+    @Test
+    fun `every status segment reads exactly as it did before`() {
+        val default = resolveCallLabel(null)
+        assertEquals("Call BossTerm", callSegmentLabel(CallSegmentState.Ready, default))
+        assertEquals("Call BossTerm", callSegmentLabel(CallSegmentState.NeedsKey, default))
+        assertEquals("Call BossTerm", callSegmentLabel(CallSegmentState.Hidden, default))
+        assertEquals("Calling…", callSegmentLabel(CallSegmentState.Connecting, default))
+        assertEquals("Call BossTerm · working", callSegmentLabel(CallSegmentState.Working, default))
+        assertEquals("Call BossTerm · live", callSegmentLabel(CallSegmentState.Live, default))
+        assertEquals("Call BossTerm · live", callSegmentLabel(CallSegmentState.Speaking, default))
+        assertEquals("Call BossTerm · failed", callSegmentLabel(CallSegmentState.Failed, default))
+    }
+
+    /**
+     * The states are the part a rename misses: shipping "Call Boss" beside "Call BossTerm · live" is
+     * exactly the half-done rename this test exists to catch.
+     */
+    @Test
+    fun `the embedder's label reaches every state, not just the idle one`() {
+        for (state in CallSegmentState.entries) {
+            val label = callSegmentLabel(state, embedder)
+            assertFalse(label.contains("BossTerm"), "$state still says BossTerm: $label")
+            if (state != CallSegmentState.Connecting) {
+                assertTrue(label.startsWith(embedder), "$state does not lead with the label: $label")
+            }
+        }
+        assertEquals("Call Boss · live", callSegmentLabel(CallSegmentState.Live, embedder))
+        assertEquals("Call Boss · working", callSegmentLabel(CallSegmentState.Working, embedder))
+        assertEquals("Call Boss · failed", callSegmentLabel(CallSegmentState.Failed, embedder))
+    }
+
+    /** "Calling…" is about the call in flight, not the product — it must stay name-free. */
+    @Test
+    fun `connecting names nothing`() {
+        assertEquals("Calling…", callSegmentLabel(CallSegmentState.Connecting, embedder))
+    }
+
+    // ---- the settings copy ----
+
+    @Test
+    fun `settings copy is unchanged standalone`() {
+        val default = resolveCallLabel(null)
+        assertEquals("Show the Call BossTerm indicator", bossCallingIndicatorLabel(default))
+        assertEquals(
+            "Show the \"Call BossTerm\" segment in the tab-bar status strip, " +
+                "alongside the MCP and Sharing indicators. It is also how you START a call " +
+                "from this window, so turning it off leaves calling available only to share " +
+                "viewers.",
+            bossCallingIndicatorDescription(default),
+        )
+        assertEquals(
+            "Show a \"Call BossTerm\" button — in this window and in the share viewer — " +
+                "that starts a voice conversation with an AI agent (OpenAI Realtime) able to " +
+                "inspect this session and run commands. Starting a call sends your tab titles " +
+                "and working directories to OpenAI, and anything the agent then reads from the " +
+                "terminal goes with it. On, but idle until you set the API key below; calling " +
+                "from a share also requires control of it.",
+            bossCallingEnableDescription(default),
+        )
+    }
+
+    @Test
+    fun `settings copy about the in-app button follows the embedder`() {
+        assertEquals("Show the Call Boss indicator", bossCallingIndicatorLabel(embedder))
+        val indicator = bossCallingIndicatorDescription(embedder)
+        assertTrue(indicator.startsWith("Show the \"Call Boss\" segment"), indicator)
+        assertFalse(indicator.contains("BossTerm"), indicator)
+    }
+
+    /**
+     * The one sentence naming both surfaces. They genuinely differ under an embedder — the viewer's
+     * button is a static web asset that does not follow `callLabel` — so it must name both rather
+     * than claim one label covers both.
+     */
+    @Test
+    fun `the enable description names the viewer's own button when they differ`() {
+        val text = bossCallingEnableDescription(embedder)
+        assertTrue(text.contains("\"Call Boss\" button in this window"), text)
+        assertTrue(text.contains("\"Call BossTerm\" button in the share viewer"), text)
+        // The shared tail is untouched either way.
+        assertTrue(text.endsWith("from a share also requires control of it."), text)
+    }
+
+    // ---- no site left behind ----
+
+    /**
+     * Every in-app label site must render the resolved `callLabel`. A grep is a poor test of behavior
+     * and a good test of THIS: the failure mode is a new pill, tooltip or dialog title that hardcodes
+     * the string and is invisible to every assertion above.
+     *
+     * The literal is allowed only as a named constant — [DEFAULT_CALL_LABEL] (what standalone
+     * renders) and `BossCallingSection.VIEWER_CALL_LABEL` (the share viewer's fixed button,
+     * deliberately not the embedder's). Comments and KDoc are stripped: they discuss the label
+     * constantly and none of it renders.
+     */
+    @Test
+    fun `no source hardcodes the call label outside a named constant`() {
+        val root = desktopMainSources()
+        val offenders = root.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { file ->
+                stripComments(file.readText()).lineSequence()
+                    .withIndex()
+                    .filter { (_, line) -> line.contains("Call BossTerm") }
+                    .filterNot { (_, line) -> line.contains("const val") }
+                    .map { (i, line) -> "${file.relativeTo(root)}:${i + 1}: ${line.trim()}" }
+            }
+            .toList()
+        assertTrue(
+            offenders.isEmpty(),
+            "hardcoded call label — render TabbedTerminal's resolved callLabel instead:\n" +
+                offenders.joinToString("\n"),
+        )
+    }
+
+    /**
+     * The wiring, which no assertion above can see: every composable that renders the label has a
+     * `callLabel` parameter defaulting to [DEFAULT_CALL_LABEL], so a call site that simply forgets to
+     * pass it compiles, runs, and quietly renders "Call BossTerm" inside BossConsole. Dropping one
+     * argument is the whole failure mode, so the argument lists are checked directly.
+     */
+    @Test
+    fun `every host threads the label into the composables that render it`() {
+        val root = desktopMainSources()
+        val expected = mapOf(
+            "TabbedTerminal.kt" to
+                listOf("StatusStrip", "VoiceKeyDialog", "ShareWindow", "DaemonShareWindow"),
+            "share/ShareWindow.kt" to listOf("BossCallingSection"),
+            "daemon/DaemonShareWindow.kt" to listOf("BossCallingSection", "ShareDetails"),
+        )
+        for ((path, callees) in expected) {
+            val file = File(root, "ai/rever/bossterm/compose/$path")
+            assertTrue(file.isFile, "moved or renamed: $file")
+            val source = stripComments(file.readText())
+            for (callee in callees) {
+                val calls = invocationArguments(source, callee)
+                assertTrue(calls.isNotEmpty(), "no $callee( call left in $path — did it move?")
+                for (args in calls) {
+                    assertTrue(
+                        args.contains("callLabel"),
+                        "$path calls $callee(…) without passing callLabel, so it silently renders " +
+                            "the standalone name inside an embedder:\n$args",
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * The argument text of each `callee(...)` invocation in [source] — declarations excluded. Naive
+     * paren matching, which is enough: none of these argument lists contains a parenthesis inside a
+     * string literal.
+     */
+    private fun invocationArguments(source: String, callee: String): List<String> {
+        val call = Regex("(?<![A-Za-z0-9_])$callee\\s*\\(")
+        return call.findAll(source)
+            .filterNot { source.take(it.range.first).trimEnd().endsWith("fun") }
+            .mapNotNull { match ->
+                var depth = 0
+                var i = match.range.last
+                while (i < source.length) {
+                    when (source[i]) {
+                        '(' -> depth++
+                        ')' -> {
+                            depth--
+                            if (depth == 0) return@mapNotNull source.substring(match.range.last + 1, i)
+                        }
+                    }
+                    i++
+                }
+                null
+            }
+            .toList()
+    }
+
+    /**
+     * Both allowed constants still say what standalone has always said. Paired with the scan above,
+     * this is what pins "standalone output is unchanged" — the scan proves nothing else spells it
+     * out, these prove the two that do are right.
+     */
+    @Test
+    fun `the viewer's button and the standalone default agree with the shipped web asset`() {
+        assertEquals("Call BossTerm", DEFAULT_CALL_LABEL)
+        val html = CallLabelTest::class.java.classLoader
+            .getResourceAsStream("share-viewer/index.html")
+            ?.bufferedReader()?.readText()
+            ?: fail("share-viewer/index.html is not on the test classpath")
+        assertTrue(
+            html.contains("<span id=\"voicelabel\">Call BossTerm</span>"),
+            "the viewer's button was renamed — VIEWER_CALL_LABEL in BossCallingSection.kt is now a lie",
+        )
+    }
+
+    /** Gradle runs tests from the module directory; walk up in case something else does not. */
+    private fun desktopMainSources(): File {
+        var dir: File? = File("").absoluteFile
+        repeat(5) {
+            val here = dir ?: return@repeat
+            for (candidate in listOf("src/desktopMain/kotlin", "compose-ui/src/desktopMain/kotlin")) {
+                val f = File(here, candidate)
+                if (f.isDirectory) return f
+            }
+            dir = here.parentFile
+        }
+        fail("could not locate compose-ui/src/desktopMain/kotlin from ${File("").absolutePath}")
+    }
+
+    /**
+     * Crude but sufficient: drop `//` tails and block comments so KDoc discussing the label does not
+     * read as a site. Does not understand the string literal `"//"`, which no label site has.
+     */
+    private fun stripComments(source: String): String {
+        val out = StringBuilder(source.length)
+        var i = 0
+        var inBlock = false
+        while (i < source.length) {
+            val c = source[i]
+            val next = source.getOrNull(i + 1)
+            when {
+                inBlock && c == '*' && next == '/' -> { inBlock = false; i += 2 }
+                inBlock -> { if (c == '\n') out.append(c); i++ }
+                c == '/' && next == '*' -> { inBlock = true; i += 2 }
+                c == '/' && next == '/' -> { while (i < source.length && source[i] != '\n') i++ }
+                else -> { out.append(c); i++ }
+            }
+        }
+        return out.toString()
+    }
+}


### PR DESCRIPTION
## What

`"Boss Calling"` is the **feature**. `"Call BossTerm"` is what its **button** says. Only the second
is something an embedder should be able to change — BossConsole's users have never heard of
BossTerm, and the pill they click should say "Call Boss".

This makes the in-app call label a `TabbedTerminal` parameter. Standalone output is byte-identical.

```kotlin
TabbedTerminal(
    state = state,
    onExit = { … },
    callLabel = "Call Boss",   // null (default) → "Call BossTerm"
)
```

## Where the config lives, and why

`callLabel: String? = null` on **`TabbedTerminal`**, alongside `contextMenuItems` /
`contextMenuItemsProvider` — the house pattern for embedder customization: a composable parameter
whose null/empty default means "standalone behaviour, unchanged".

Deliberately **not** `BossTermMcpConfig`. The call label has nothing to do with MCP; it would have
been bolted onto that type only because it happens to be reachable.

Three judgement calls worth stating:

**A plain `String?`, not a provider lambda.** Context menus offer
`contextMenuItemsProvider` because their *content* is recomputed on every open (async assistant
status). A product name is fixed at embed time. A `String?` parameter already recomposes when the
embedder passes state-backed text, so a provider would buy nothing and add a per-composition call.

**Not added to `EmbeddableTerminal`.** It renders no call affordance at all — no `StatusStrip`,
`HostCallBar`, `VoiceKeyDialog` or `HostVoiceCall` reference anywhere in the file, and no `voice`
reference either. Adding the parameter there would be a public knob wired to nothing. The call pill
lives only in `TabbedTerminal`'s top-right overlay. (`terminal-tab`, the real embedder, composes
both — `TabbedTerminal` ×2 and `EmbeddableTerminal` ×1 — so this was worth checking rather than
assuming.)

**Resolved once.** `resolveCallLabel(callLabel)` runs in `TabbedTerminal` next to the existing
`mcpServerLabel` line, and the resolved non-null string is threaded outward, so the pill, the dialog
it opens and the share windows' settings panel cannot disagree. Blank is folded into the default —
an embedder computing the label from its own branding gets BossTerm's name back, not an empty pill.

## Every label site

Found by grepping the literal and near-variants (`Call BossTerm`, `Calling BossTerm`, `BossTerm
agent`, `voicelabel`, `Talk to`) across Kotlin, resources, HTML/JS and docs.

### Now driven by `callLabel`

| Site | What renders |
|---|---|
| `share/StatusStrip.kt` | the segment, **all six states** — `Call BossTerm`, `· working`, `· live` (×2 states), `· failed`, plus `Calling…` |
| `voice/VoiceKeyDialog.kt` | the `AlertDialog` **title** — it *is* the pill's click |
| `settings/…/BossCallingSection.kt` | "Enable Boss Calling" description |
| `settings/…/BossCallingSection.kt` | "Show the Call BossTerm indicator" — the toggle **label** |
| `settings/…/BossCallingSection.kt` | …and that toggle's description |

Threaded through `TabbedTerminal` → `StatusStrip` / `VoiceKeyDialog` / `ShareWindow` /
`DaemonShareWindow` → `BossCallingSection` (both overloads).

### Deliberately left literal

`BossCallingSection`'s three availability lines ("viewers see no Call BossTerm button…") describe
the **share viewer's** button, which does not follow the embedder — see below. They now go through a
named `VIEWER_CALL_LABEL` constant so the distinction is stated in code rather than implied.

### Surprises worth calling out

- **The settings copy outnumbered the UI.** Six of the eight in-app occurrences were in
  `BossCallingSection.kt`, not the pill — and three of those six are about the *viewer's* button, so
  a naive find-and-replace would have made them wrong rather than right.
- **No tooltip and no accessibility label exist on the call segment.** `StatusStrip.Segment`
  supports a tooltip, but only the Sharing segment sets one, and Compose Desktop sets no semantics
  here. Nothing was missed; there is nothing there yet. If a tooltip is ever added to the call
  segment it must take `callLabel` — the source scan below will catch it if it hardcodes instead.
- **No menu entry, action or keybinding** references the call — `BuiltinActions`/`KeymapActions` are
  clean. The pill is the only in-app entry point.

## Derived phrasings

Reported rather than silently reworded, as asked:

- **`HostCallBar` needed no change and reads correctly under substitution.** Every string is about
  the call in progress — "Connecting…", "Listening…", "Muted", "Mute"/"Unmute", "End call", "Call
  failed" — none names the product. Its KDoc now says so, so the next person does not "fix" it.
- **"Boss is speaking"** (`HostCallBar`) names the **agent**, not the product: both surfaces
  instruct the model with *"You are Boss, a voice assistant…"*. It reads correctly as "Call Boss" →
  "Boss is speaking", and stays correct standalone. Left alone.
- **`Calling…`** (the Connecting state) drops the label entirely. That is pre-existing and right —
  it is the one state that reads well under any name. Asserted so.
- **There is no "Calling BossTerm…" string** anywhere; it does not exist to fix.
- **The one sentence naming both surfaces** ("Show a "Call BossTerm" button — in this window and in
  the share viewer —") genuinely goes wrong under substitution, because the two surfaces really do
  differ. It now collapses to the original wording only when the labels match, and names both
  separately when they don't. Standalone bytes unchanged.

## Why the share viewer keeps "Call BossTerm"

Its Call button is a static web asset (`share-viewer/index.html`, `viewer.js`), and the server
serving it may be the BossTerm **daemon** — a separate process with no embedder in it. Propagating
the label there means putting it on the wire (`ShareProtocol.VoiceStatus`) *and* persisting it
somewhere the daemon can read, which is a settings-persistence design, not a rendering change. Out
of scope here and flagged as a follow-up decision.

Same reasoning for the standalone **Settings window**: `SettingsWindow` is composed by
`bossterm-app`, not by `TabbedTerminal`, and no embedder composes it (`terminal-tab` passes
`onShowSettings` to its own host and never calls it). Its window title is literally "BossTerm
Settings". Threading the label through `SettingsPanel` for a surface no embedder renders would be
speculative; it stays on the default, which is what it renders anyway.

## Standalone is unchanged

`CallLabelTest` asserts the exact pre-existing string for all six segment states and all six
settings strings, spelled out literally rather than derived from the constant. A source scan then
proves nothing else spells the label out: the literal `"Call BossTerm"` is permitted **only** as a
named constant (`DEFAULT_CALL_LABEL`, `VIEWER_CALL_LABEL`), with comments and KDoc stripped.

## Tests — 13 new, mutation-checked

`compose-ui/src/desktopTest/…/share/CallLabelTest.kt`. Every claim below was verified by breaking
the wiring and confirming the suite goes red:

| # | Mutation | Result |
|---|---|---|
| M1 | `StatusStrip` hardcodes the `Working` state again | ❌ 2 failed — *reaches every state*, *no source hardcodes* |
| M2 | `resolveCallLabel` ignores its argument | ❌ 2 failed — *embedder's label is what renders*, *whitespace trimmed* |
| M3 | `TabbedTerminal` stops passing `callLabel` to `StatusStrip` | ❌ 1 failed — *every host threads the label* |
| M4 | `bossCallingIndicatorLabel` hardcodes the string | ❌ 2 failed — *settings copy follows the embedder*, *no source hardcodes* |
| M5 | enable-description branch inverted | ❌ 2 failed — *settings copy unchanged standalone*, *names the viewer's own button* |
| M6 | `DEFAULT_CALL_LABEL` renamed to "Call Boss" | ❌ 5 failed |
| M7 | `ShareWindow` drops the argument | ❌ 1 failed — *every host threads the label* |
| M8 | `VoiceKeyDialog` hardcodes its title | ❌ 1 failed — *no source hardcodes* |
| M9 | `DaemonShareWindow` drops the argument | ❌ 1 failed — *every host threads the label* |

M3/M7/M9 are the reason the suite includes a wiring check: every renderer's `callLabel` **defaults**
to `DEFAULT_CALL_LABEL`, so a forgotten argument compiles, runs, and quietly shows the standalone
name inside an embedder. `every host threads the label into the composables that render it` parses
each invocation's argument list and requires `callLabel` in it — no pure assertion can see that.

## Verification

- `:compose-ui:compileKotlinDesktop` — BUILD SUCCESSFUL
- `:compose-ui:desktopTest` — **761 tests, 1 failure**: `DaemonAttachServerTest > attach survives
  malformed and unknown client frames`. **Pre-existing** — verified by restoring master's sources at
  `HEAD~1` and rerunning that class: same failure (a socket-timing test that is flaky in this
  sandboxed environment). Untouched by this change; the only daemon file here is the Compose
  `DaemonShareWindow.kt`.
- `:bossterm-app`, `:embedded-example`, `:tabbed-example` `compileKotlinDesktop` — BUILD SUCCESSFUL
  (the new parameter breaks no existing call site)
- `AGENTS.md` updated — the "Boss Calling" line now states feature-vs-button and where the label
  comes from.

## Follow-up for the maintainer

Should the **share viewer's** Call button follow the embedder too? It needs the label on the wire
plus a persisted setting the daemon can read. Happy to do it as its own PR if wanted.
