### PR TITLE
Finish BossTermMcpManager.stop() synchronously so a closing classloader can't outrun the teardown

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpManager.kt
@@ -22,19 +22,24 @@ import kotlinx.serialization.json.put
 import io.ktor.server.sse.SSE
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.IOException
@@ -46,6 +51,8 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Lifecycle wrapper that brings up the BossTerm in-process MCP server on a
@@ -62,8 +69,9 @@ import java.util.concurrent.ConcurrentHashMap
  *    pair. Toggling `mcpEnabled` brings the server up/down; changing
  *    `mcpPort` while enabled performs a stop-then-start.
  *  - On [stop] the watcher is cancelled and any running Ktor engine is
- *    stopped asynchronously on a background coroutine. Caller does not
- *    block.
+ *    stopped **before the call returns** — bounded by [STOP_BUDGET_MS], so an
+ *    embedder unloading this instance's classloader cannot outrun the
+ *    teardown. See [stop] for the ordering and the cost.
  *  - The server always binds to `127.0.0.1` — never `0.0.0.0`.
  *  - Every request must arrive with a `Host` header pointing at a loopback
  *    name (`127.0.0.1` or `localhost`, optionally with the bound port).
@@ -100,19 +108,61 @@ class BossTermMcpManager(
     // Null when no engine is running.
     private var runningServer: BossTermMcpServer? = null
 
+    /**
+     * Parent job for **everything this manager launches**, replaced by [start] and cancelled by
+     * [stop] — one job per embedder lifecycle. A child of [parentScope]'s job, so an embedder
+     * that cancels its own scope still tears us down (the behaviour we had when every coroutine
+     * was launched directly on [parentScope]).
+     *
+     * Not `parentScope` itself: [stop] must be able to cancel our in-flight work without
+     * cancelling an embedder scope it does not own — `bossterm-app` shares one `mcpScope` with
+     * its daemon-fallback wiring. And not a long-lived job plus `cancelChildren()`: that cancels
+     * the children that exist, but the job stays Active, so a `launch` already past its guard
+     * still produces a live child *after* [stop] cancelled everything. A cancelled job makes
+     * every later launch inert — the guarantee we actually want — and a fresh job in [start] is
+     * what lets a manager re-arm.
+     *
+     * Cancelling this also supersedes the mutex-guarded `reattachJob?.cancel()` that #331 added:
+     * cancelling the parent reaches the current fan-out *and* any that a straggler manages to
+     * launch afterwards, which no read-then-cancel of a single reference can do.
+     */
+    @Volatile private var lifecycle: CompletableJob = SupervisorJob(parentScope.coroutineContext[Job])
+
+    /** Everything this manager launches. Inherits [parentScope]'s dispatcher, not its job. */
+    private val scope: CoroutineScope get() = CoroutineScope(parentScope.coroutineContext + lifecycle)
+
+    /**
+     * Latched by [stop] before it tears anything down; cleared by [start].
+     *
+     * Cancelling [lifecycle] is what stops in-flight work, but it cannot stop *all* of it.
+     * [reconcile] reaches [startEngineLocked] through `mutex.withLock`, and `Mutex.lock()` has an
+     * uncontended fast path that returns without checking cancellation — so a cancelled collector
+     * can still take the lock, and [startEngineLocked] has no suspension point at all once it
+     * has. It would then bind a fresh engine behind a manager that has already declared itself
+     * down. This flag is the authority that binder checks: it is what makes "stopped" mean "no
+     * engine may be bound", not merely "no *waiting* coroutine may bind".
+     */
+    @Volatile private var stopping = false
+
+    /**
+     * Bumped by every [start] and every [stop]. [stopping] alone is not a sound basis for the
+     * teardown's re-check, because [start] clears it — and [stop]'s wait is *bounded*, so a
+     * teardown it gave up on can still be sitting on [mutex] when the embedder re-arms this
+     * manager. Without the epoch that teardown would wake up and stop the engine the new
+     * lifecycle had just bound. The counter only moves forward, so "am I still the current
+     * lifecycle's teardown" is a single comparison.
+     */
+    private val lifecycleEpoch = AtomicInteger(0)
+
     private var watcherJob: Job? = null
     private var disabledToolsWatcherJob: Job? = null
     private var preferredShellWatcherJob: Job? = null
 
-    // In-flight auto-reattach fan-out (see launchAutoReattach). Tracked so stop()
-    // can cancel it: when an embedding host unloads this instance's classloader
-    // (BOSS plugin hot-swap/update), an orphaned reattach coroutine that keeps
-    // running past dispose crashes with NoClassDefFoundError on its next lazy
-    // class load. Also cancelled by the next launchAutoReattach so two fan-outs
-    // never race each other's CLI-config rewrites. Unlike the watcher jobs above
-    // (written only from single-threaded start()), this is written under [mutex]
-    // from reconcile — so stop() cancels it inside the same lock, giving the
-    // read a happens-before edge and closing the assign-vs-cancel race.
+    // In-flight auto-reattach fan-out (see launchAutoReattach). Cancelled by the next
+    // launchAutoReattach so two fan-outs never race each other's CLI-config rewrites, and — as a
+    // child of [lifecycle] — by stop(): when an embedding host unloads this instance's
+    // classloader (BOSS plugin hot-swap/update), an orphaned reattach coroutine that keeps
+    // running past dispose crashes with NoClassDefFoundError on its next lazy class load (#331).
     // Internal (not private) for the lifecycle tests.
     internal var reattachJob: Job? = null
 
@@ -161,9 +211,21 @@ class BossTermMcpManager(
         registry.setMcpConfig(config)
     }
 
-    /** Begin observing settings. Idempotent. Safe to call multiple times. */
+    /**
+     * Begin observing settings. Idempotent. Safe to call multiple times.
+     *
+     * Also re-arms the manager after a [stop]: a cancelled [lifecycle] makes every later launch
+     * inert, so without a fresh job a restarted manager would observe nothing. `@Synchronized`
+     * with [stop] so the pair is ordered — otherwise a start racing a stop could install a fresh
+     * lifecycle only for the stop to cancel it, leaving a cleared latch and no watcher.
+     */
+    @Synchronized
     fun start() {
         if (watcherJob?.isActive == true) return
+
+        if (!lifecycle.isActive) lifecycle = SupervisorJob(parentScope.coroutineContext[Job])
+        stopping = false
+        lifecycleEpoch.incrementAndGet()
 
         // Hydrate the runtime attached-targets set from persisted settings so
         // the indicator/menu reflect prior-session state immediately, and
@@ -199,7 +261,7 @@ class BossTermMcpManager(
             }
         }
 
-        watcherJob = parentScope.launch {
+        watcherJob = scope.launch {
             // Before the first bind (and thus the first auto-reattach),
             // reconcile the persisted set against the CLIs' own config files
             // (adopt entries we're missing, prune ones the user removed) —
@@ -221,7 +283,7 @@ class BossTermMcpManager(
         // start/stop (which also holds the mutex). The actual SDK-mutation race is
         // serialized internally by BossTermMcpServer.applyDisabledSet via its own
         // toolsLock — that's what makes the concurrent manage_tools-handler path safe.
-        disabledToolsWatcherJob = parentScope.launch {
+        disabledToolsWatcherJob = scope.launch {
             settingsManager.settings
                 .map { it.disabledMcpTools }
                 .distinctUntilChanged()
@@ -238,7 +300,7 @@ class BossTermMcpManager(
         // setting changes — no client restart. Write when opted in AND an
         // engine is bound; delete otherwise. Also clears any stale marker left
         // by a prior kill -9 when the setting is (or has become) off.
-        preferredShellWatcherJob = parentScope.launch {
+        preferredShellWatcherJob = scope.launch {
             settingsManager.settings
                 .map { it.mcpRunCommandPreferredShell }
                 .distinctUntilChanged()
@@ -253,53 +315,145 @@ class BossTermMcpManager(
     }
 
     /**
-     * Cancel the watcher and stop the Ktor engine on a background coroutine.
-     * Returns immediately — does not block the caller's thread. Idempotent.
+     * Cancel the watchers, cancel in-flight work, and stop the Ktor engine —
+     * **synchronously**. Idempotent, and safe when nothing ever started.
+     *
+     * This used to fire the teardown onto [parentScope] and return. An embedder unloading
+     * BossTerm — the BossConsole `terminal-tab` plugin's `dispose()` — then closed this
+     * instance's classloader while that coroutine was still queued, and it died on its next
+     * first-time class load:
+     *
+     *     WARN PluginClassLoader: Attempt to load class from unloading classloader
+     *       {className=…BossTermMcpManager$stopRunningEngineLocked$1, state=UNLOADED}
+     *
+     * followed by LinkageErrors from Ktor classes resolving across two loaders. Nothing the
+     * teardown coroutine can do about it from the inside; the fix is for `dispose()` not to
+     * return until the teardown has happened. (`bossterm-app` had the same bug in a milder
+     * form: its shutdown hook calls `stop()` and then `mcpScope.cancel()` on the next line,
+     * which cancelled the teardown before it ran.)
+     *
+     * **Ordering: stop the manager before stopping the server, not after.** [beginStop] latches
+     * [stopping], bumps [lifecycleEpoch] and cancels [lifecycle] *before* the teardown proper
+     * runs. Doing it the other way round leaves the whole engine-stop window — up to
+     * [STOP_TIMEOUT_DISPOSE_MS], ending with the port freed — open for a straggler to reconcile
+     * its way into a fresh bind behind a manager that has already declared itself down. Nothing
+     * is lost by going first: everything queued on [lifecycle] is setup or upkeep (settings
+     * watchers, the CLI reattach fan-out, the streamable-session sweeper, the `closeAll`
+     * warm-up), never cleanup — the teardown below performs every cleanup step itself, inline.
+     *
+     * **Bounded, not blocking.** A hang here would be worse than the leak, so the teardown runs
+     * on a detached thread and this waits [STOP_BUDGET_MS] for it. Cancelling a `join` is
+     * instantaneous, which a `withTimeout` *around* the teardown would not be: `engine.stop` is
+     * a blocking JDK-level call, and a timeout wrapped around it cannot return until it does.
+     * On expiry we log at ERROR and abandon the teardown — strictly better than today's
+     * unconditional abandonment, but it is a real (rare) residual, hence the loud log.
+     *
+     * **Cost.** The embedder may call this on the EDT, so the budget is small and split:
+     *  - Engine stop: [STOP_GRACE_DISPOSE_MS]/[STOP_TIMEOUT_DISPOSE_MS], deliberately tighter
+     *    than the [STOP_GRACE_MS]/[STOP_TIMEOUT_MS] used by [reconcile]. A long-lived SSE client
+     *    (Claude Code holds one open continuously) counts as an in-flight call, so Ktor waits out
+     *    the full grace period every time — that grace is the dominant term. Draining it politely
+     *    is worth 500ms while the app keeps running and only the port is changing; on dispose
+     *    every client is about to lose the endpoint regardless, so 200ms is not just faster, it
+     *    is the right semantics.
+     *  - Drain: [STOP_DRAIN_MS] for the cancelled work to actually finish. Sized to let a
+     *    cancellation land at a suspension point, *not* to wait out `McpCliAttacher`'s 15s
+     *    uninterruptible `waitFor` — that stretch is covered by its eager class-preload (#331),
+     *    not by waiting.
+     *
+     * Typical: a few ms with no engine, ~200ms with an SSE client attached. Worst case: exactly
+     * [STOP_BUDGET_MS].
      */
     fun stop() {
-        watcherJob?.cancel()
+        val teardown = beginStop()
+        val drained = runBlocking {
+            withTimeoutOrNull(STOP_BUDGET_MS) { teardown.join() } != null
+        }
+        if (!drained) {
+            log.error(
+                "BossTerm MCP teardown did not finish within {}ms; abandoning it. If this instance " +
+                    "is being unloaded, the straggler may still fault on a closed classloader.",
+                STOP_BUDGET_MS
+            )
+        }
+    }
+
+    /**
+     * [stop]'s state transition, plus the detached teardown it returns for [stop] to wait on.
+     *
+     * `@Synchronized` with [start] only — deliberately not for the wait, which happens outside
+     * the monitor so a concurrent [start] is never blocked for the full budget. That interleaving
+     * is what [lifecycleEpoch] exists for.
+     */
+    @Synchronized
+    private fun beginStop(): Job {
+        // 1. Latch first, so an uninterruptible binder refuses (see [stopping]), and bump the
+        //    epoch so this teardown can tell whether it has been superseded by the time it runs.
+        stopping = true
+        val epoch = lifecycleEpoch.incrementAndGet()
+        // 2. Cancel our own in-flight work. Cancelling the job — not just its children — also
+        //    makes any launch that slips through afterwards inert; [start] installs a fresh one.
+        val cancelled = lifecycle
+        cancelled.cancel()
         watcherJob = null
-        disabledToolsWatcherJob?.cancel()
         disabledToolsWatcherJob = null
-        preferredShellWatcherJob?.cancel()
         preferredShellWatcherJob = null
-        // Async shutdown so callers (including Compose onDispose on the UI
-        // thread) don't block waiting for Ktor's grace period. The reattach
-        // fan-out is cancelled inside the lock — its writer (launchAutoReattach,
-        // reached from reconcile) assigns under the same mutex, so cancelling
-        // here can't race a concurrent assignment or read a stale reference.
-        // No new fan-out can start after this block: watcherJob (the only
-        // reconcile trigger) was cancelled synchronously above.
-        // Nothing in this coroutine may escape uncaught: it runs AFTER stop()
-        // (and, in an embedding host, dispose()) has returned, and a plugin
-        // hot-swap closes this instance's classloader at that point — so any
-        // first-time lazy class load in the teardown path throws
-        // NoClassDefFoundError from the closed loader and would crash the host
-        // (this killed BOSS via StreamableMcpSessions.closeAll's state-machine
-        // class; same failure mode as the #331 reattach orphan). Plain
-        // try/catch on purpose: it compiles inline and needs no class of its
-        // own. Cleanup past the failure point is forfeited, which is fine —
-        // the engine stop has already been requested and the instance is dying.
-        parentScope.launch(Dispatchers.IO) {
+
+        // 3. Teardown, off the caller's thread so [stop] can abandon it on expiry.
+        //
+        // A dedicated thread rather than Dispatchers.IO: IO is capped at 64 workers and BossTerm
+        // pins several per shell session, so a saturated pool would spend the entire budget
+        // never dispatching us. One short-lived daemon thread per manager lifecycle is cheap.
+        //
+        // Nothing in this coroutine may escape uncaught: in an embedding host it can outlive
+        // dispose() (on the abandon path), and a plugin hot-swap closes this instance's
+        // classloader at that point — so any first-time lazy class load in the teardown path
+        // throws NoClassDefFoundError from the closed loader and would crash the host (this
+        // killed BOSS via StreamableMcpSessions.closeAll's state-machine class; same failure mode
+        // as the #331 reattach orphan). Plain try/catch on purpose: it compiles inline and needs
+        // no class of its own. Cleanup past the failure point is forfeited, which is fine — the
+        // engine stop has already been requested and the instance is dying.
+        val dispatcher = Executors.newSingleThreadExecutor { r ->
+            Thread(r, "bossterm-mcp-stop").apply { isDaemon = true }
+        }.asCoroutineDispatcher()
+        val job = CoroutineScope(dispatcher).launch {
             try {
                 mutex.withLock {
-                    reattachJob?.cancel()
+                    if (lifecycleEpoch.get() != epoch) {
+                        // [stop] gave up on us and the embedder has since re-armed this manager.
+                        // The engine we can see now belongs to the new lifecycle; stopping it
+                        // would break a manager that is legitimately running.
+                        log.warn("MCP teardown superseded by a newer start()/stop(); leaving the engine alone")
+                        return@withLock
+                    }
                     reattachJob = null
-                    stopRunningEngineLocked()
+                    stopRunningEngineLocked(STOP_GRACE_DISPOSE_MS, STOP_TIMEOUT_DISPOSE_MS)
+                }
+                // Best-effort drain: the cancel above lands at the next suspension point, and
+                // this is what makes "stop() returned" mean "that already happened" for
+                // everything cancellable. Bounded and non-fatal — see [stop] for what is
+                // deliberately NOT waited out here.
+                if (withTimeoutOrNull(STOP_DRAIN_MS) { cancelled.join() } == null) {
+                    log.info(
+                        "MCP in-flight work still draining after {}ms (likely a CLI reattach inside " +
+                            "its uninterruptible process wait); continuing",
+                        STOP_DRAIN_MS
+                    )
                 }
             } catch (e: CancellationException) {
-                // parentScope cancellation, not a teardown failure — let the
-                // coroutine complete as cancelled rather than mis-logging it
-                // below. Rethrowing needs no lazy load: CancellationException
+                // Not a teardown failure — let the coroutine complete as cancelled rather than
+                // mis-logging it below. Rethrowing needs no lazy load: CancellationException
                 // aliases the (parent-loader) JDK class.
                 throw e
             } catch (t: Throwable) {
-                // Full stack on purpose: anything landing here is an unknown
-                // failure mode, and the trace is what identifies the next
-                // StreamableMcpSessions-style lazy-load site.
-                log.warn("MCP engine teardown after stop() failed (classloader likely closed)", t)
+                // Full stack on purpose: anything landing here is an unknown failure mode, and
+                // the trace is what identifies the next StreamableMcpSessions-style lazy-load
+                // site.
+                log.warn("MCP engine teardown during stop() failed (classloader likely closed)", t)
             }
         }
+        job.invokeOnCompletion { dispatcher.close() }
+        return job
     }
 
     private suspend fun reconcile(desired: McpRuntimeConfig) {
@@ -350,7 +504,18 @@ class BossTermMcpManager(
         HardFailed,
     }
 
-    private fun startEngineLocked(desiredPort: Int) {
+    // internal (not private) so McpEngineTeardownTest can drive the post-stop bind attempt that
+    // cancellation cannot reach; production callers hold [mutex].
+    internal fun startEngineLocked(desiredPort: Int) {
+        // Refuse outright once [stop] has latched. This function has no suspension point, so
+        // cancellation cannot reach a reconcile that is already inside it — and a reconcile that
+        // took [mutex]'s uncontended fast path after the cancel landed still arrives here holding
+        // a live intent to bind. The latch turns both into a no-op, which is what stops a bind
+        // from slipping into the window [stop]'s teardown is about to open by freeing the port.
+        if (stopping) {
+            log.info("BossTerm MCP bind refused: manager is stopping")
+            return
+        }
         // Try the user's configured port first, then walk sequential ports up to
         // MAX_PORT_FALLBACK_ATTEMPTS - 1 more. EADDRINUSE triggers fallback;
         // EACCES (permission denied — privileged ports on Linux/macOS), other
@@ -571,7 +736,7 @@ class BossTermMcpManager(
             // observe a freshly-minted session, closing it is the same benign
             // eviction the idle sweeper and session cap already impose — the
             // client sees 404 and re-initializes.
-            parentScope.launch {
+            scope.launch {
                 // On the fresh empty map closeAll cannot throw — this guard
                 // exists so no future change to closeAll can ever cancel
                 // parentScope (not guaranteed to be a SupervisorJob) from a
@@ -590,7 +755,7 @@ class BossTermMcpManager(
             // Streamable HTTP clients that vanish without DELETE (crashed or
             // just exited, as codex does per invocation) leave sessions behind;
             // sweep them so a long-running app doesn't accrete one per run.
-            streamableSweeperJob = parentScope.launch {
+            streamableSweeperJob = scope.launch {
                 while (true) {
                     delay(STREAMABLE_SWEEP_INTERVAL_MS)
                     // evictIdle contains its own per-transport failure handling;
@@ -734,7 +899,7 @@ class BossTermMcpManager(
         // A rebind supersedes any still-running fan-out from the previous bind —
         // let the newer port win instead of racing two writers over CLI configs.
         reattachJob?.cancel()
-        reattachJob = parentScope.launch(Dispatchers.IO) {
+        reattachJob = scope.launch(Dispatchers.IO) {
             reattachBodyOverrideForTest?.let { it(port); return@launch }
             // One identity probe per distinct registered port (several CLIs
             // usually point at the same default), before the fan-out.
@@ -785,14 +950,24 @@ class BossTermMcpManager(
         }
     }
 
-    // internal (not private) for McpEngineTeardownTest; production callers
-    // hold [mutex].
-    internal suspend fun stopRunningEngineLocked() {
+    /**
+     * Stop the running engine and clear every field that describes it.
+     *
+     * [graceMs]/[timeoutMs] default to the reconcile-path budget; [stop] passes a tighter one
+     * because it is synchronous and may be on the EDT — see [stop] for why a shorter grace is
+     * also the right semantics there.
+     *
+     * internal (not private) for McpEngineTeardownTest; production callers hold [mutex].
+     */
+    internal suspend fun stopRunningEngineLocked(
+        graceMs: Long = STOP_GRACE_MS,
+        timeoutMs: Long = STOP_TIMEOUT_MS
+    ) {
         val engine = runningEngine ?: return
         val port = runningPort
         try {
             withContext(Dispatchers.IO) {
-                engine.stop(STOP_GRACE_MS, STOP_TIMEOUT_MS)
+                engine.stop(graceMs, timeoutMs)
             }
             log.info("BossTerm MCP server stopped (port {})", port)
         } catch (e: Throwable) {
@@ -918,8 +1093,37 @@ class BossTermMcpManager(
          */
         private const val STREAMABLE_IDLE_TTL_MS = 2 * 60 * 60 * 1000L
         private const val STREAMABLE_SWEEP_INTERVAL_MS = 15 * 60 * 1000L
+        /**
+         * Engine-stop budget on the [reconcile] path (MCP toggled off, port changed). The app
+         * keeps running and a client may be mid-request, so draining politely is worth the wait.
+         */
         private const val STOP_GRACE_MS = 500L
         private const val STOP_TIMEOUT_MS = 1500L
+
+        /**
+         * Engine-stop budget on the [stop] path. Tighter because [stop] is synchronous and the
+         * embedder may call it on the EDT — and because on dispose every client is losing the
+         * endpoint anyway, so there is nothing to drain politely *for*. Same numbers
+         * `SessionShareManager.shutdown` settled on for its own synchronous teardown.
+         */
+        private const val STOP_GRACE_DISPOSE_MS = 200L
+        private const val STOP_TIMEOUT_DISPOSE_MS = 800L
+
+        /**
+         * How long [stop]'s teardown waits for cancelled in-flight work to finish. Enough for a
+         * cancellation to land at a suspension point on a loaded machine; deliberately far short
+         * of `McpCliAttacher`'s 15s process timeout, whose uninterruptible stretch is made safe
+         * by eager class-preloading (#331) rather than by waiting it out.
+         */
+        private const val STOP_DRAIN_MS = 250L
+
+        /**
+         * Hard ceiling on how long [stop] blocks its caller. Covers
+         * [STOP_TIMEOUT_DISPOSE_MS] + [STOP_DRAIN_MS] plus contention on [mutex] (an in-flight
+         * reconcile mid-port-walk), with headroom. On expiry the teardown is abandoned and
+         * logged at ERROR: a hang in dispose() would be worse than the leak it prevents.
+         */
+        private const val STOP_BUDGET_MS = 1_500L
 
         /**
          * How many sequential ports to try when the user's configured `mcpPort`

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpEngineTeardownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpEngineTeardownTest.kt
@@ -3,32 +3,41 @@ package ai.rever.bossterm.compose.mcp
 import ai.rever.bossterm.compose.settings.SettingsManager
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.embeddedServer
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 import kotlin.io.path.createTempDirectory
+import kotlin.system.measureTimeMillis
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
- * Pins the contract of the guarded closeAll step in
- * [BossTermMcpManager.stopRunningEngineLocked]: when closing the streamable
- * sessions blows up (in production: NoClassDefFoundError, because the engine
- * teardown runs on a background coroutine after an embedding host's plugin
- * hot-swap has closed this classloader — see [BossTermMcpManager.stop]), the
- * bookkeeping below the guard must still run, so the registry never keeps
- * reporting a running server that is gone.
+ * Pins two contracts of [BossTermMcpManager]'s engine teardown.
  *
- * The real failure (a closed classloader) can't be produced in a unit test,
- * so the close step is substituted via
- * [BossTermMcpManager.closeAllOverrideForTest], and the engine is a stub that
- * was never started so no port is bound. The port marker is redirected into
- * the temp settings dir ([BossTermMcpManager.portMarkerFileOverrideForTest])
- * so the teardown's marker delete can't touch a developer's real
- * `~/.bossterm/mcp.port`.
+ * **The guarded closeAll step in [BossTermMcpManager.stopRunningEngineLocked]**: when closing the
+ * streamable sessions blows up (in production: NoClassDefFoundError, because the manager is being
+ * torn down inside a classloader an embedding host is closing), the bookkeeping below the guard
+ * must still run, so the registry never keeps reporting a running server that is gone.
+ *
+ * **[BossTermMcpManager.stop] is synchronous and bounded**: it must not return until the engine is
+ * actually stopped — a fire-and-forget teardown is what let a `terminal-tab` hot-reload close the
+ * plugin classloader out from under it — but it must never hang, because it runs from an
+ * embedder's `dispose()`, possibly on the EDT.
+ *
+ * The real failure (a closed classloader) can't be produced in a unit test, so the close step is
+ * substituted via [BossTermMcpManager.closeAllOverrideForTest] — which doubles as the seam for
+ * making the teardown observably slow. The engine is a stub that was never started, so no port is
+ * bound. The port marker is redirected into the temp settings dir
+ * ([BossTermMcpManager.portMarkerFileOverrideForTest]) so the teardown's marker delete can't touch
+ * a developer's real `~/.bossterm/mcp.port`.
  */
 class McpEngineTeardownTest {
 
@@ -43,6 +52,9 @@ class McpEngineTeardownTest {
         portMarkerFileOverrideForTest = File(settingsDir, "mcp.port")
     }
 
+    /** A never-started CIO server: enough to drive the teardown without binding a port. */
+    private fun stubEngine() = embeddedServer(CIO, host = "127.0.0.1", port = 0) {}
+
     @AfterTest
     fun tearDown() {
         McpTerminalRegistry.setStopped()
@@ -52,7 +64,7 @@ class McpEngineTeardownTest {
     @Test
     fun `engine-stop bookkeeping survives a throwing closeAll`() = runBlocking {
         val manager = newManager()
-        manager.runningEngine = embeddedServer(CIO, host = "127.0.0.1", port = 0) {}
+        manager.runningEngine = stubEngine()
         McpTerminalRegistry.setRunning(7699)
         manager.closeAllOverrideForTest = {
             throw NoClassDefFoundError("ai/rever/bossterm/compose/mcp/StreamableMcpSessions\$closeAll\$1")
@@ -68,5 +80,155 @@ class McpEngineTeardownTest {
             McpTerminalRegistry.runningPort.value,
             "registry must report stopped even when closeAll throws"
         )
+    }
+
+    /**
+     * The regression. The override parks inside the teardown for [SLOW_TEARDOWN_MS]; a
+     * fire-and-forget `stop()` cannot possibly have got past it by the time it returns, so the
+     * flag is what distinguishes "teardown finished" from "teardown scheduled".
+     */
+    @Test
+    fun `stop does not return until the engine teardown has finished`() {
+        val manager = newManager()
+        manager.runningEngine = stubEngine()
+        McpTerminalRegistry.setRunning(7699)
+        val teardownFinished = AtomicBoolean(false)
+        manager.closeAllOverrideForTest = {
+            delay(SLOW_TEARDOWN_MS)
+            teardownFinished.set(true)
+        }
+
+        manager.stop()
+
+        assertTrue(
+            teardownFinished.get(),
+            "stop() returned before the teardown finished — the embedder's classloader can " +
+                "close under it"
+        )
+        assertNull(manager.runningEngine, "engine reference must be cleared by stop()")
+        assertNull(McpTerminalRegistry.runningPort.value, "registry must report stopped after stop()")
+    }
+
+    /**
+     * The other half of the contract: synchronous, but never a hang. A teardown that overruns is
+     * abandoned (and logged at ERROR), because freezing an embedder's `dispose()` — on the EDT —
+     * would be worse than the straggler it prevents.
+     *
+     * The teardown parks on a gate rather than a fixed `delay` for two reasons. The gate is
+     * released in the `finally`, so the abandoned teardown finishes with the test instead of
+     * lingering into the next class — this suite shares one JVM with PTY-backed daemon tests that
+     * assert on output arriving within a poll window, and a straggler still holding the mutex and
+     * doing registry/file bookkeeping several seconds later is enough to fail them. And the
+     * watchdog releases it too, so a regression that drops the bound *fails* here rather than
+     * hanging the build.
+     */
+    @Test
+    fun `stop abandons a teardown that overruns its budget`() {
+        val manager = newManager()
+        manager.runningEngine = stubEngine()
+        val release = CompletableDeferred<Unit>()
+        manager.closeAllOverrideForTest = { release.await() }
+        val watchdog = thread(isDaemon = true, name = "overrun-watchdog") {
+            try {
+                Thread.sleep(HANG_GUARD_MS)
+                release.complete(Unit)
+            } catch (_: InterruptedException) {
+                // Released by the test instead; nothing to do.
+            }
+        }
+
+        try {
+            val elapsed = measureTimeMillis { manager.stop() }
+
+            assertTrue(
+                elapsed < ABANDON_CEILING_MS,
+                "stop() must bound its wait, but blocked for ${elapsed}ms on a teardown that " +
+                    "does not finish on its own"
+            )
+        } finally {
+            release.complete(Unit)
+            watchdog.interrupt()
+        }
+    }
+
+    @Test
+    fun `stop is idempotent`() {
+        val manager = newManager()
+        manager.runningEngine = stubEngine()
+        McpTerminalRegistry.setRunning(7699)
+
+        manager.stop()
+        val secondCall = measureTimeMillis { manager.stop() } // must not throw
+
+        assertNull(manager.runningEngine, "a second stop() must leave the manager torn down")
+        assertNull(McpTerminalRegistry.runningPort.value, "a second stop() must leave the registry stopped")
+        assertTrue(
+            secondCall < IDLE_STOP_CEILING_MS,
+            "a second stop() has nothing to do and must not wait for a budget, took ${secondCall}ms"
+        )
+    }
+
+    @Test
+    fun `stop on a manager that never started is a cheap no-op`() {
+        val manager = newManager()
+
+        val elapsed = measureTimeMillis { manager.stop() } // must not throw
+
+        assertTrue(
+            elapsed < IDLE_STOP_CEILING_MS,
+            "stop() with nothing to tear down must not wait for a budget, took ${elapsed}ms"
+        )
+    }
+
+    /**
+     * Cancellation alone cannot close the window. `reconcile` reaches `startEngineLocked` through
+     * `mutex.withLock`, whose uncontended fast path returns without checking cancellation, and
+     * `startEngineLocked` then has no suspension point at all — so a cancelled collector can still
+     * arrive holding a live intent to bind, right as the teardown frees the port. The latch is
+     * what refuses it.
+     *
+     * Driven directly rather than through the settings watcher because that interleaving is a race
+     * a unit test cannot schedule. [LATCH_TEST_PORT] is high and unregistered: if the latch ever
+     * regresses, this binds a real loopback server there rather than colliding with a developer's
+     * live BossTerm on 7676.
+     */
+    @Test
+    fun `a bind is refused once stop has latched`() = runBlocking {
+        val manager = newManager()
+        manager.stop()
+
+        try {
+            manager.startEngineLocked(LATCH_TEST_PORT)
+
+            assertNull(manager.runningEngine, "no engine may be bound after stop() has latched")
+            assertNull(McpTerminalRegistry.runningPort.value, "a post-stop bind must not resurrect the registry")
+        } finally {
+            manager.stopRunningEngineLocked() // only reachable if the latch regressed
+        }
+    }
+
+    private companion object {
+        /** Long enough that a fire-and-forget teardown is unambiguously still in flight. */
+        private const val SLOW_TEARDOWN_MS = 200L
+
+        /**
+         * Ceiling for a `stop()` whose teardown never finishes on its own. Comfortably above
+         * `STOP_BUDGET_MS` so normal jitter can't fail it, and comfortably below [HANG_GUARD_MS]
+         * so a dropped bound is unambiguous.
+         */
+        private const val ABANDON_CEILING_MS = 3_000L
+
+        /** Backstop that releases a parked teardown, so a dropped bound fails instead of hanging. */
+        private const val HANG_GUARD_MS = 6_000L
+
+        /**
+         * Ceiling for a `stop()` with nothing to do. Well under `STOP_BUDGET_MS`, so a regression
+         * that makes the empty path wait out a budget fails; generous enough for a cold thread
+         * spawn on a loaded CI box.
+         */
+        private const val IDLE_STOP_CEILING_MS = 700L
+
+        /** Unassigned high port; only ever bound if the stop latch regresses. */
+        private const val LATCH_TEST_PORT = 47811
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpReattachLifecycleTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpReattachLifecycleTest.kt
@@ -98,9 +98,9 @@ class McpReattachLifecycleTest {
 
     /**
      * The tighter form of the first test: not just "gets cancelled eventually", but "is already
-     * cancelled AND finished unwinding by the time [BossTermMcpManager.stop] returns, and never
-     * resumes". That is the property an embedder needs — `dispose()` returning is the moment the
-     * host is free to close this classloader, and anything that wakes up afterwards faults on it.
+     * cancelled by the time [BossTermMcpManager.stop] returns, and never resumes". That is the
+     * property an embedder needs — `dispose()` returning is the moment the host is free to close
+     * this classloader, and anything that wakes up afterwards faults on it.
      *
      * Deliberately not wrapped in `runBlocking`: `stop()` is called from a plain thread, the way
      * an embedder's `dispose()` calls it.
@@ -124,12 +124,54 @@ class McpReattachLifecycleTest {
         manager.stop()
 
         assertTrue(job.isCancelled, "stop() must cancel the in-flight fan-out")
-        assertTrue(
-            job.isCompleted,
-            "stop() must not return while cancelled work is still unwinding — the host closes " +
-                "the classloader the moment dispose() returns"
-        )
         assertFalse(resumed.get(), "cancelled work must not resume after stop() returned")
+    }
+
+    /**
+     * Cancelling is not the same as having finished. Real in-flight work has something to unwind —
+     * `McpCliAttacher`'s fan-out holds process handles and half-written CLI configs — and until
+     * that unwinding is done the coroutine is still executing code out of this classloader. The
+     * host closes it the moment `dispose()` returns, so `stop()` drains before returning.
+     *
+     * The unwind is a blocking sleep in a `finally`, sized well inside `STOP_DRAIN_MS`: without the
+     * drain, `stop()` returns while the sleep is still going and the flag is unset.
+     *
+     * The drain is deliberately bounded and best-effort — it is sized to let a cancellation land,
+     * not to wait out `McpCliAttacher`'s 15s process timeout, whose uninterruptible stretch is made
+     * safe by eager class-preloading (#331) instead.
+     */
+    @Test
+    fun `stop waits for cancelled work to finish unwinding`() {
+        val manager = newManager()
+        McpTerminalRegistry.markAttached(McpAttachTarget.CLAUDE_CODE)
+        val entered = CountDownLatch(1)
+        val unwound = AtomicBoolean(false)
+        manager.reattachBodyOverrideForTest = {
+            try {
+                entered.countDown()
+                delay(30_000) // parked; cancellation lands here and runs the finally
+            } finally {
+                Thread.sleep(UNWIND_MS)
+                unwound.set(true)
+            }
+        }
+
+        manager.launchAutoReattach(port = 7699)
+        assertNotNull(manager.reattachJob)
+        assertTrue(entered.await(5, TimeUnit.SECONDS), "the fan-out never started")
+
+        manager.stop()
+
+        assertTrue(
+            unwound.get(),
+            "stop() returned while cancelled work was still unwinding — the host closes the " +
+                "classloader the moment dispose() returns"
+        )
+    }
+
+    private companion object {
+        /** Simulated unwind cost of a cancelled fan-out. Comfortably inside `STOP_DRAIN_MS`. */
+        private const val UNWIND_MS = 120L
     }
 
     /**

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpReattachLifecycleTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/McpReattachLifecycleTest.kt
@@ -1,16 +1,23 @@
 package ai.rever.bossterm.compose.mcp
 
 import ai.rever.bossterm.compose.settings.SettingsManager
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -35,7 +42,11 @@ class McpReattachLifecycleTest {
         registry = McpTerminalRegistry,
         settingsManager = SettingsManager(File(settingsDir, "settings.json").absolutePath),
         parentScope = scope,
-    )
+    ).apply {
+        // Redirected so a teardown that reaches the marker delete can't touch a developer's real
+        // `~/.bossterm/mcp.port`.
+        portMarkerFileOverrideForTest = File(settingsDir, "mcp.port")
+    }
 
     @AfterTest
     fun tearDown() {
@@ -83,5 +94,75 @@ class McpReattachLifecycleTest {
         manager.stop()
         withTimeout(5_000) { second.join() }
         assertTrue(second.isCancelled)
+    }
+
+    /**
+     * The tighter form of the first test: not just "gets cancelled eventually", but "is already
+     * cancelled AND finished unwinding by the time [BossTermMcpManager.stop] returns, and never
+     * resumes". That is the property an embedder needs — `dispose()` returning is the moment the
+     * host is free to close this classloader, and anything that wakes up afterwards faults on it.
+     *
+     * Deliberately not wrapped in `runBlocking`: `stop()` is called from a plain thread, the way
+     * an embedder's `dispose()` calls it.
+     */
+    @Test
+    fun `in-flight work is cancelled and cannot resume after stop returns`() {
+        val manager = newManager()
+        McpTerminalRegistry.markAttached(McpAttachTarget.CLAUDE_CODE)
+        val entered = CountDownLatch(1)
+        val resumed = AtomicBoolean(false)
+        manager.reattachBodyOverrideForTest = {
+            entered.countDown()
+            delay(30_000)     // parked; this is where cancellation lands
+            resumed.set(true) // must never run
+        }
+
+        manager.launchAutoReattach(port = 7699)
+        val job = assertNotNull(manager.reattachJob)
+        assertTrue(entered.await(5, TimeUnit.SECONDS), "the fan-out never started")
+
+        manager.stop()
+
+        assertTrue(job.isCancelled, "stop() must cancel the in-flight fan-out")
+        assertTrue(
+            job.isCompleted,
+            "stop() must not return while cancelled work is still unwinding — the host closes " +
+                "the classloader the moment dispose() returns"
+        )
+        assertFalse(resumed.get(), "cancelled work must not resume after stop() returned")
+    }
+
+    /**
+     * Pins the *ordering*, not just the fact: in-flight work is cancelled **before** the engine
+     * teardown, never after. The engine stop is the widest part of `stop()` and it ends by freeing
+     * the port, so cancelling after it would leave exactly the window being closed wide open — a
+     * straggler waking during the stop could reconcile its way into a fresh bind behind a manager
+     * that has already declared itself down.
+     *
+     * `closeAllOverrideForTest` is the observation point because it runs *inside*
+     * `stopRunningEngineLocked`: whatever it can see about the fan-out is what the teardown saw.
+     */
+    @Test
+    fun `in-flight work is cancelled before the engine teardown runs`() {
+        val manager = newManager()
+        McpTerminalRegistry.markAttached(McpAttachTarget.CLAUDE_CODE)
+        val entered = CountDownLatch(1)
+        val gate = CompletableDeferred<Unit>() // never completed — holds the fan-out open
+        manager.reattachBodyOverrideForTest = { entered.countDown(); gate.await() }
+
+        manager.launchAutoReattach(port = 7699)
+        val job = assertNotNull(manager.reattachJob)
+        assertTrue(entered.await(5, TimeUnit.SECONDS), "the fan-out never started")
+
+        val cancelledBeforeTeardown = AtomicBoolean(false)
+        manager.runningEngine = embeddedServer(CIO, host = "127.0.0.1", port = 0) {}
+        manager.closeAllOverrideForTest = { cancelledBeforeTeardown.set(job.isCancelled) }
+
+        manager.stop()
+
+        assertTrue(
+            cancelledBeforeTeardown.get(),
+            "the fan-out was still live when the engine teardown ran — cancellation must come first"
+        )
     }
 }


### PR DESCRIPTION
## The evidence

From a live BossConsole run, during a `terminal-tab` hot-reload — the plugin bundles BossTerm:

```
WARN PluginClassLoader: Attempt to load class from unloading classloader
  {pluginId=…terminaltab, className=ai.rever.bossterm.compose.mcp.BossTermMcpManager$stopRunningEngineLocked$1,
   state=UNLOADED}
```

followed by `IllegalAccessError` / `LinkageError` from Ktor classes resolving across two loaders.

`stop()` cancelled its watchers and then fired the engine teardown onto `parentScope` — fire-and-forget. The embedder's `dispose()` returned, the host closed the classloader, and the teardown coroutine then tried to load classes that no longer resolve. The diagnosis held exactly as described; nothing else was going on.

BossConsole#57 (merged) made a closing `PluginClassLoader` **throw** rather than silently resolve plugin classes against the host. That fixed the corruption and made this failure loud and correctly attributed — it did not fix the race. The fix has to be here: `dispose()` must not return until the teardown has happened.

**A second instance of the same bug, found while fixing this.** `bossterm-app`'s shutdown hook does:

```kotlin
synchronized(mcpLock) { mcpManager }?.stop()
…
mcpScope.cancel()
```

With a fire-and-forget `stop()`, that `mcpScope.cancel()` two lines later cancelled the teardown before it ran — so the standalone app has most likely never stopped its MCP engine cleanly at exit. Making `stop()` synchronous fixes that for free.

Same shape as #346 (`SessionShareManager.shutdown()`), and the same idiom: **latch + monotonic epoch + cancel-before-teardown**.

## Ordering

`beginStop()` latches `stopping`, bumps `lifecycleEpoch`, and cancels `lifecycle` **before** the teardown proper. The other way round leaves the whole engine-stop window — ending with the port freed — open for a straggler to reconcile its way into a fresh bind behind a manager that has already declared itself down. Nothing is lost by going first: everything on the scope is setup or upkeep (settings watchers, the CLI reattach fan-out, the sweeper, the `closeAll` warm-up), never cleanup — the teardown performs every cleanup step itself, inline.

**Cancellation alone cannot finish the job**, for a reason specific to this class: `reconcile()` reaches `startEngineLocked()` through `mutex.withLock`, and `Mutex.lock()`'s uncontended fast path returns *without checking cancellation*; `startEngineLocked()` then has no suspension point at all. So a cancelled collector can still take the lock and arrive holding a live intent to bind. The latch, checked there, is what makes "stopped" mean "no engine may be bound" rather than "no *waiting* coroutine may bind".

**The epoch earns its place for a different reason than in #346.** There, `shutdown()` deliberately does not take the mutex, so a bind can interleave with the teardown. Here `stop()` *does* take it, so the mutex already orders bind against teardown. What the epoch covers instead is that **`stop()`'s wait is bounded**: a teardown it gave up on can still be sitting on the mutex when the embedder re-arms the manager, and would then stop the engine the new lifecycle had just bound. Three abandon points, only two of which need the epoch:

| Abandoned while… | Guarded by |
|---|---|
| waiting for the teardown thread | epoch |
| waiting on `mutex` | epoch |
| already inside `stopRunningEngineLocked` | the mutex itself — it is held throughout, so a re-armed `reconcile` cannot bind until the teardown has finished and nulled the fields |

## Bounded, not blocking

The teardown runs on a **dedicated daemon thread** and `stop()` waits `STOP_BUDGET_MS` (1.5s) on `join`.

- **Why a join and not `withTimeout` around the teardown.** Cancelling a `join` is instantaneous. A `withTimeout` *wrapped around* the teardown is not: `engine.stop` is a blocking JDK-level call, and `withTimeout` does not return until the body actually finishes — so it would bound nothing in the one case that matters.
- **Why a dedicated thread and not `Dispatchers.IO`.** IO is capped at 64 workers and BossTerm pins several per shell session (the known exhaustion mode). A saturated pool would spend the entire budget never dispatching the teardown. One short-lived daemon thread per manager lifecycle is cheap and cannot be starved.
- **On expiry** the teardown is abandoned and logged at **ERROR**. That is a real residual — but strictly better than today, where it is abandoned unconditionally and silently. A hang in `dispose()` would be worse than the leak.

## The EDT cost

The embedder may call `stop()` from `dispose()` on the EDT, so the budget is small and split:

| Phase | Budget | Note |
|---|---|---|
| Engine stop | 200ms grace / 800ms timeout | vs. `reconcile`'s 500/1500 |
| Drain of cancelled work | 250ms | best-effort |
| **Total ceiling** | **1500ms** | hard; abandons past this |

The **grace period is the dominant term**: a long-lived SSE client (Claude Code holds one open continuously) counts as an in-flight call, so Ktor waits it out every time. Shortening it on this path is not just faster, it is the right semantics — draining politely is worth 500ms while the app keeps running and only the port is changing; on dispose every client is losing the endpoint regardless. `reconcile` keeps the longer budget.

- **Typical**: a few ms with no engine bound; **~200ms** with a client attached.
- **Worst case**: **1500ms**.

## Scope launches: cancelled vs. left alone

Every `parentScope.launch` moves onto a `lifecycle`-backed scope, so one cancel reaches all of them — *and* reaches any launch a straggler starts afterwards, which no read-then-cancel of a single reference can do. That supersedes the mutex-guarded `reattachJob?.cancel()` from #331.

| Site | Disposition |
|---|---|
| `watcherJob` (settings → reconcile) | **Cancelled + latched.** The only one that can bind an engine. |
| `disabledToolsWatcherJob` | **Cancelled.** A live collector; post-teardown its work is a no-op, but it would keep loading classes on each emission. |
| `preferredShellWatcherJob` | **Cancelled.** Same; also touches the port-marker file. |
| `reattachJob` (CLI fan-out) | **Cancelled.** #331's orphan. Its uninterruptible `Process.waitFor` stretch stays covered by `McpCliAttacher`'s eager class-preload — the drain is sized to let cancellation land, *not* to wait out a 15s shell-out. |
| `streamableSweeperJob` | **Cancelled** (already was, in the `finally`); now also a lifecycle child. Parked in `delay`, so cancellation lands instantly. |
| `closeAll` warm-up | **Cancelled** for uniformity. One-shot and effectively instant; it cannot meaningfully outlive anything. |
| Per-request caller-tab resolution (`ProcessAncestry` in the Ktor intercept) | **Deliberately NOT cancelled.** It runs on the *engine's* coroutine context, not ours — `lifecycle.cancel()` cannot reach it, and only `engine.stop()` ends it. This is precisely why the engine stop has to be *inside* the synchronous budget rather than merely requested. |

`lifecycle` is a child of `parentScope`'s job, so an embedder cancelling its own scope still tears us down — the behaviour we had when everything launched directly on `parentScope`. `start()` re-arms it and clears the latch; both are `@Synchronized` so a start racing a stop is ordered.

## Tests

`McpEngineTeardownTest` (+5) and `McpReattachLifecycleTest` (+3) — 11 tests over this contract. Full `:compose-ui:desktopTest` on the merged tree: **769/769 green**.

## Mutations

Every claim above was mutation-checked. **Five of six caught; one survivor, reported.**

| # | Mutation | Result |
|---|---|---|
| M1 | Restore the fire-and-forget launch | **Caught** — 4 tests |
| M2 | Drop the timeout (plain `join()`) | **Caught** — `stop abandons a teardown that overruns its budget` |
| M3 | Invert the ordering (cancel *after* the teardown) | **Caught** — `in-flight work is cancelled before the engine teardown runs` |
| M4 | Remove the bind latch | **Caught** — `a bind is refused once stop has latched` |
| M5 | Remove the drain | **Caught** — `stop waits for cancelled work to finish unwinding` |
| M6 | Remove the epoch guard | **SURVIVED** |

**M6 survives, and I do not think it should be forced.** The guard only fires when a teardown is abandoned *while still waiting for its thread or for the mutex*, and a `start()` then re-arms the manager underneath it. Reaching that state deterministically needs a seam that holds the private `mutex` open across an abandon — machinery that would exist only for this test, on a path already argued safe by the table above (the third, non-epoch abandon point is covered by the mutex itself). I left the guard in because it is four lines and the failure it prevents is stopping a live engine, but it is asserted by reasoning, not by test.

**M5 is worth flagging too**: it was "caught" on my first pass by `job.isCompleted` immediately after `stop()`, and then **survived a re-run** — that assertion is a race, not a check. Replaced with an explicit 120ms unwind in a `finally` (well inside `STOP_DRAIN_MS`), which is deterministic in both directions. Second commit here.

## One test-isolation finding

The overrun test originally parked its abandoned teardown on a fixed `delay`, which left it holding the mutex and doing registry/file bookkeeping ~4.5s into the *next* test class. That reproducibly failed 5–6 PTY-backed `Daemon*Test` cases, which assert on output arriving within a poll window. Bisected properly: production change alone was 748/748 green, so it was the test, not the fix. It now parks on a gate released in the `finally` (with a watchdog so a dropped bound *fails* rather than hangs), and the suite is clean.

---

Closes what boss-plugin-terminal-tab#52 attempted plugin-side — that PR made the plugin block waiting for this stop and was closed unmerged in favour of fixing it here.
