### PR TITLE
Reveal the collapsed sidebar on hover instead of only on a chevron click

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -64,6 +64,9 @@ import ai.rever.bossterm.compose.vcs.GitUtils
 import ai.rever.bossterm.compose.vcs.VersionControlMenuProvider
 import ai.rever.bossterm.compose.shell.ShellCustomizationMenuProvider
 import ai.rever.bossterm.compose.menu.MenuActions
+import ai.rever.bossterm.compose.tabs.SidebarRevealCloseDelayMs
+import ai.rever.bossterm.compose.tabs.SidebarRevealOpenDelayMs
+import ai.rever.bossterm.compose.tabs.hoverRevealTarget
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -186,6 +189,20 @@ import ai.rever.bossterm.compose.ui.ProperTerminal
  *                        Use case: a host whose own features (git, browser, plugins) should be
  *                        reachable by voice — see [ai.rever.bossterm.compose.voice.VoiceToolSource].
  */
+
+/**
+ * Wiring only the sidebar's overlay-drawer instance of the tab bar needs — the in-flow bar
+ * and the top bar pass null. See SidebarHoverReveal.kt for the reveal itself.
+ */
+private data class SidebarDrawerHooks(
+    /** Retract the drawer: picking a pane, or the chevron once the drawer is pinned. */
+    val onDismiss: () -> Unit,
+    /** Pin it open. Null once pinned, which is what puts the collapse chevron back. */
+    val onPin: (() -> Unit)?,
+    /** Menu / rename / drag in flight inside the drawer — blocks hover-driven retraction. */
+    val onBusyChange: (Boolean) -> Unit
+)
+
 @Composable
 fun TabbedTerminal(
     state: TabbedTerminalState? = null,
@@ -1209,15 +1226,12 @@ fun TabbedTerminal(
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
         val tabBarOnLeft = settings.tabBarPosition == "left"
         // collapsed renders the left bar as the slim icon rail; onToggleCollapse backs the
-        // chevron. onDrawerDismiss is non-null only for the overlay drawer instance —
-        // selecting a pane then also closes the drawer (share-viewer behavior). onPin is
-        // non-null only for a hover reveal, turning that chevron into a pin.
+        // chevron. `drawer` is non-null only for the overlay drawer instance.
         val tabBarComposable: @Composable (
             collapsed: Boolean,
             onToggleCollapse: () -> Unit,
-            onDrawerDismiss: (() -> Unit)?,
-            onPin: (() -> Unit)?
-        ) -> Unit = { collapsed, onToggleCollapse, onDrawerDismiss, onPin ->
+            drawer: SidebarDrawerHooks?
+        ) -> Unit = { collapsed, onToggleCollapse, drawer ->
             // Tab bar (show when multiple tabs or alwaysShowTabBar is set).
             if (tabBarVisible) {
             val summaryMode = settings.tabBarSummaryMode
@@ -1485,7 +1499,7 @@ fun TabbedTerminal(
                 activeTabIndex = tabController.activeTabIndex,
                 focusedPaneId = focusedPaneId,
                 onPaneSelected = { tabIndex, paneId ->
-                    onDrawerDismiss?.invoke()
+                    drawer?.onDismiss?.invoke()
                     tabController.switchToTab(tabIndex)
                     tabController.tabs.getOrNull(tabIndex)?.let { t -> splitStates[t.id]?.setFocusedPane(paneId) }
                 },
@@ -1605,7 +1619,8 @@ fun TabbedTerminal(
                 verticalWidth = settings.tabBarVerticalWidth.dp,
                 collapsed = collapsed,
                 onToggleCollapse = if (tabBarOnLeft) onToggleCollapse else null,
-                onPin = if (tabBarOnLeft) onPin else null
+                onPin = if (tabBarOnLeft) drawer?.onPin else null,
+                onTransientInteraction = drawer?.onBusyChange
             )
             }
         }
@@ -2086,32 +2101,33 @@ fun TabbedTerminal(
             // Dismissing a reveal (picking a pane, or the chevron once pinned) sticks until
             // the pointer leaves — otherwise it slides straight back in under the cursor.
             var revealSuppressed by remember { mutableStateOf(false) }
+            // The revealed bar has a menu, rename, or drag in flight; retracting would
+            // dispose the composition that owns it, so hover stops being the only vote.
+            var drawerBusy by remember { mutableStateOf(false) }
             val railHover = remember { MutableInteractionSource() }
             val drawerHover = remember { MutableInteractionSource() }
             val pointerOnRail by railHover.collectIsHoveredAsState()
             val pointerOnDrawer by drawerHover.collectIsHoveredAsState()
-            val revealTarget = ai.rever.bossterm.compose.tabs.hoverRevealTarget(
+            val revealTarget = hoverRevealTarget(
                 enabled = hoverExpand,
                 railShown = railShown,
                 pointerOnRail = pointerOnRail,
-                pointerOnDrawer = pointerOnDrawer
+                pointerOnDrawer = pointerOnDrawer,
+                drawerBusy = drawerBusy
             )
             LaunchedEffect(revealTarget, revealSuppressed) {
-                if (revealTarget && !revealSuppressed) {
-                    delay(ai.rever.bossterm.compose.tabs.SidebarRevealOpenDelayMs)
-                    hoverRevealed = true
-                } else {
-                    delay(ai.rever.bossterm.compose.tabs.SidebarRevealCloseDelayMs)
-                    hoverRevealed = false
-                }
+                val reveal = revealTarget && !revealSuppressed
+                if (reveal == hoverRevealed) return@LaunchedEffect
+                delay(if (reveal) SidebarRevealOpenDelayMs else SidebarRevealCloseDelayMs)
+                hoverRevealed = reveal
             }
             // Re-arm on the pointer-left edge, so a dismissal can't be undone by the very
             // hover that is still sitting on the strip.
             val pointerInSidebar = pointerOnRail || pointerOnDrawer
             LaunchedEffect(pointerInSidebar) { if (!pointerInSidebar) revealSuppressed = false }
             LaunchedEffect(narrow) { if (!narrow) drawerOpen = false }
-            LaunchedEffect(railShown) {
-                if (!railShown) {
+            LaunchedEffect(railShown, hoverExpand) {
+                if (!railShown || !hoverExpand) {
                     hoverRevealed = false
                     revealSuppressed = false
                 }
@@ -2124,7 +2140,6 @@ fun TabbedTerminal(
                             if (narrow) drawerOpen = true
                             else settingsManager.updateSetting { copy(tabBarCollapsed = !tabBarCollapsed) }
                         },
-                        null,
                         null
                     )
                 }
@@ -2157,14 +2172,22 @@ fun TabbedTerminal(
                     enter = slideInHorizontally(initialOffsetX = { -it }),
                     exit = slideOutHorizontally(targetOffsetX = { -it })
                 ) {
-                    Box(modifier = Modifier.hoverable(drawerHover, enabled = hoverExpand)) {
-                        tabBarComposable(false, dismissDrawer, dismissDrawer, pinDrawer)
+                    Box(modifier = Modifier.hoverable(drawerHover, enabled = hoverExpand && railShown)) {
+                        tabBarComposable(
+                            false,
+                            dismissDrawer,
+                            SidebarDrawerHooks(
+                                onDismiss = dismissDrawer,
+                                onPin = pinDrawer,
+                                onBusyChange = { drawerBusy = it }
+                            )
+                        )
                     }
                 }
             }
         } else {
             Column(modifier = Modifier.fillMaxSize()) {
-                tabBarComposable(false, {}, null, null)
+                tabBarComposable(false, {}, null)
                 mainContent()
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -7,6 +7,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -61,6 +64,7 @@ import ai.rever.bossterm.compose.vcs.GitUtils
 import ai.rever.bossterm.compose.vcs.VersionControlMenuProvider
 import ai.rever.bossterm.compose.shell.ShellCustomizationMenuProvider
 import ai.rever.bossterm.compose.menu.MenuActions
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -1205,9 +1209,15 @@ fun TabbedTerminal(
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
         val tabBarOnLeft = settings.tabBarPosition == "left"
         // collapsed renders the left bar as the slim icon rail; onToggleCollapse backs the
-        // chevron. onDrawerDismiss is non-null only for the narrow-window overlay drawer
-        // instance — selecting a pane then also closes the drawer (share-viewer behavior).
-        val tabBarComposable: @Composable (collapsed: Boolean, onToggleCollapse: () -> Unit, onDrawerDismiss: (() -> Unit)?) -> Unit = { collapsed, onToggleCollapse, onDrawerDismiss ->
+        // chevron. onDrawerDismiss is non-null only for the overlay drawer instance —
+        // selecting a pane then also closes the drawer (share-viewer behavior). onPin is
+        // non-null only for a hover reveal, turning that chevron into a pin.
+        val tabBarComposable: @Composable (
+            collapsed: Boolean,
+            onToggleCollapse: () -> Unit,
+            onDrawerDismiss: (() -> Unit)?,
+            onPin: (() -> Unit)?
+        ) -> Unit = { collapsed, onToggleCollapse, onDrawerDismiss, onPin ->
             // Tab bar (show when multiple tabs or alwaysShowTabBar is set).
             if (tabBarVisible) {
             val summaryMode = settings.tabBarSummaryMode
@@ -1594,7 +1604,8 @@ fun TabbedTerminal(
                               else ai.rever.bossterm.compose.tabs.TabBarOrientation.TOP,
                 verticalWidth = settings.tabBarVerticalWidth.dp,
                 collapsed = collapsed,
-                onToggleCollapse = if (tabBarOnLeft) onToggleCollapse else null
+                onToggleCollapse = if (tabBarOnLeft) onToggleCollapse else null,
+                onPin = if (tabBarOnLeft) onPin else null
             )
             }
         }
@@ -2060,18 +2071,63 @@ fun TabbedTerminal(
             // narrow window the bar is forced down to the icon rail and the expand chevron
             // opens the full bar as an overlay drawer instead of pushing the terminal; in a
             // wide window the chevron toggles a persisted in-flow collapse.
+            //
+            // Whichever way the rail was reached, hovering it reveals the full bar as the
+            // same overlay drawer (see SidebarHoverReveal.kt) so the terminal is never
+            // resized. `tabBarHoverExpand` off restores the chevron-only behavior.
             val narrow = maxWidth < ai.rever.bossterm.compose.tabs.TabBarAutoCollapseWidth
+            val railShown = narrow || settings.tabBarCollapsed
+            val hoverExpand = settings.tabBarHoverExpand
+            // Two independent reasons the drawer can be open, kept apart on purpose:
+            // only the chevron-opened one installs the click-catcher below, so a
+            // hover-revealed drawer never swallows the click that focuses the terminal.
             var drawerOpen by remember { mutableStateOf(false) }
+            var hoverRevealed by remember { mutableStateOf(false) }
+            // Dismissing a reveal (picking a pane, or the chevron once pinned) sticks until
+            // the pointer leaves — otherwise it slides straight back in under the cursor.
+            var revealSuppressed by remember { mutableStateOf(false) }
+            val railHover = remember { MutableInteractionSource() }
+            val drawerHover = remember { MutableInteractionSource() }
+            val pointerOnRail by railHover.collectIsHoveredAsState()
+            val pointerOnDrawer by drawerHover.collectIsHoveredAsState()
+            val revealTarget = ai.rever.bossterm.compose.tabs.hoverRevealTarget(
+                enabled = hoverExpand,
+                railShown = railShown,
+                pointerOnRail = pointerOnRail,
+                pointerOnDrawer = pointerOnDrawer
+            )
+            LaunchedEffect(revealTarget, revealSuppressed) {
+                if (revealTarget && !revealSuppressed) {
+                    delay(ai.rever.bossterm.compose.tabs.SidebarRevealOpenDelayMs)
+                    hoverRevealed = true
+                } else {
+                    delay(ai.rever.bossterm.compose.tabs.SidebarRevealCloseDelayMs)
+                    hoverRevealed = false
+                }
+            }
+            // Re-arm on the pointer-left edge, so a dismissal can't be undone by the very
+            // hover that is still sitting on the strip.
+            val pointerInSidebar = pointerOnRail || pointerOnDrawer
+            LaunchedEffect(pointerInSidebar) { if (!pointerInSidebar) revealSuppressed = false }
             LaunchedEffect(narrow) { if (!narrow) drawerOpen = false }
+            LaunchedEffect(railShown) {
+                if (!railShown) {
+                    hoverRevealed = false
+                    revealSuppressed = false
+                }
+            }
             Row(modifier = Modifier.fillMaxSize()) {
-                tabBarComposable(
-                    narrow || settings.tabBarCollapsed,
-                    {
-                        if (narrow) drawerOpen = true
-                        else settingsManager.updateSetting { copy(tabBarCollapsed = !tabBarCollapsed) }
-                    },
-                    null
-                )
+                Box(modifier = Modifier.hoverable(railHover, enabled = hoverExpand && railShown)) {
+                    tabBarComposable(
+                        railShown,
+                        {
+                            if (narrow) drawerOpen = true
+                            else settingsManager.updateSetting { copy(tabBarCollapsed = !tabBarCollapsed) }
+                        },
+                        null,
+                        null
+                    )
+                }
                 Box(modifier = Modifier.weight(1f).fillMaxHeight()) { mainContent() }
             }
             if (narrow && drawerOpen) {
@@ -2080,19 +2136,35 @@ fun TabbedTerminal(
                     detectTapGestures(onPress = { drawerOpen = false })
                 })
             }
-            if (narrow) {
+            if (railShown) {
+                val dismissDrawer = {
+                    drawerOpen = false
+                    hoverRevealed = false
+                    if (pointerInSidebar) revealSuppressed = true
+                }
+                // A drawer that only exists because the pointer is here offers a pin instead
+                // of the collapse chevron: pinning turns it into the real bar (wide) or makes
+                // it stay put until dismissed (narrow, where the rail is forced by width).
+                val pinDrawer: (() -> Unit)? = if (hoverRevealed && !drawerOpen) {
+                    {
+                        if (narrow) drawerOpen = true
+                        else settingsManager.updateSetting { copy(tabBarCollapsed = false) }
+                    }
+                } else null
                 AnimatedVisibility(
-                    visible = drawerOpen,
+                    visible = drawerOpen || hoverRevealed,
                     modifier = Modifier.align(Alignment.CenterStart).fillMaxHeight(),
                     enter = slideInHorizontally(initialOffsetX = { -it }),
                     exit = slideOutHorizontally(targetOffsetX = { -it })
                 ) {
-                    tabBarComposable(false, { drawerOpen = false }, { drawerOpen = false })
+                    Box(modifier = Modifier.hoverable(drawerHover, enabled = hoverExpand)) {
+                        tabBarComposable(false, dismissDrawer, dismissDrawer, pinDrawer)
+                    }
                 }
             }
         } else {
             Column(modifier = Modifier.fillMaxSize()) {
-                tabBarComposable(false, {}, null)
+                tabBarComposable(false, {}, null, null)
                 mainContent()
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/features/ContextMenuController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/features/ContextMenuController.kt
@@ -82,6 +82,16 @@ class ContextMenuController {
     private val _menuState = mutableStateOf(MenuState())
     val menuState: State<MenuState> = _menuState
 
+    private val _menuVisible = mutableStateOf(false)
+
+    /**
+     * True while a menu is on screen, native popup included — [menuState] only tracks the
+     * Compose fallback. A native popup swallows the pointer, so callers whose lifetime is
+     * driven by hover (the sidebar's hover reveal) need this to know not to disappear from
+     * under the menu they own.
+     */
+    val menuVisible: State<Boolean> = _menuVisible
+
     /**
      * Show context menu at screen coordinates using native AWT popup
      */
@@ -105,6 +115,7 @@ class ContextMenuController {
                 y = y,
                 items = items
             )
+            _menuVisible.value = true
         }
     }
 
@@ -132,6 +143,7 @@ class ContextMenuController {
             override fun popupMenuWillBecomeInvisible(e: javax.swing.event.PopupMenuEvent?) {
                 // Update state when popup is dismissed (by any means)
                 _menuState.value = MenuState()
+                _menuVisible.value = false
                 currentPopup = null
             }
             override fun popupMenuCanceled(e: javax.swing.event.PopupMenuEvent?) {}
@@ -139,6 +151,7 @@ class ContextMenuController {
 
         // Store reference for future dismissal
         currentPopup = popup
+        _menuVisible.value = true
 
         // Find the window to use as invoker - prefer focused window, but find window at mouse position if not focused
         var targetWindow: Window? = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
@@ -179,6 +192,7 @@ class ContextMenuController {
             currentPopup = null
         }
         _menuState.value = MenuState()
+        _menuVisible.value = false
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -467,6 +467,14 @@ data class TerminalSettings(
     val tabBarCollapsed: Boolean = false,
 
     /**
+     * Reveal the full vertical bar as an overlay drawer while the pointer rests on the
+     * collapsed rail — whether the rail was forced by a narrow window or collapsed with
+     * the chevron. The terminal is never resized; the bar floats over it and retracts
+     * when the pointer leaves. Off = the chevron is the only way to reveal it.
+     */
+    val tabBarHoverExpand: Boolean = true,
+
+    /**
      * Summary mode (Warp's VerticalTabsSummaryMode): show one chip per tab
      * (the active pane, labeled with the tab's title) instead of one chip per
      * split pane. Off = per-pane chips (default).

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/BehaviorSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/BehaviorSettingsSection.kt
@@ -103,6 +103,14 @@ fun BehaviorSettingsSection(
                 enabled = settings.tabBarPosition == "left"
             )
             SettingsToggle(
+                label = "Expand Sidebar on Hover",
+                checked = settings.tabBarHoverExpand,
+                onCheckedChange = { onSettingsChange(settings.copy(tabBarHoverExpand = it)) },
+                description = "Reveal the full sidebar while the pointer rests on the collapsed strip " +
+                    "(narrow window or manually collapsed). Off = use the chevron",
+                enabled = settings.tabBarPosition == "left"
+            )
+            SettingsToggle(
                 label = "Summary Mode",
                 checked = settings.tabBarSummaryMode,
                 onCheckedChange = { onSettingsChange(settings.copy(tabBarSummaryMode = it)) },

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/SidebarHoverReveal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/SidebarHoverReveal.kt
@@ -30,10 +30,14 @@ internal const val SidebarRevealCloseDelayMs = 250L
  * @param pointerOnRail pointer is over the rail.
  * @param pointerOnDrawer pointer is over the revealed drawer — true during the handoff,
  *   and what keeps the drawer open while the user reaches for a tab chip.
+ * @param drawerBusy the revealed bar has an interaction in flight that outlives a click —
+ *   a context menu, an inline rename, a tab drag. Retracting would dispose the composition
+ *   that owns it, so hover alone must not decide; see TabBar's onTransientInteraction.
  */
 internal fun hoverRevealTarget(
     enabled: Boolean,
     railShown: Boolean,
     pointerOnRail: Boolean,
-    pointerOnDrawer: Boolean
-): Boolean = enabled && railShown && (pointerOnRail || pointerOnDrawer)
+    pointerOnDrawer: Boolean,
+    drawerBusy: Boolean = false
+): Boolean = enabled && railShown && (pointerOnRail || pointerOnDrawer || drawerBusy)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/SidebarHoverReveal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/SidebarHoverReveal.kt
@@ -1,0 +1,39 @@
+package ai.rever.bossterm.compose.tabs
+
+/**
+ * Hover-reveal for the collapsed vertical [TabBar]: when the bar is down to its slim
+ * icon rail — either forced by a narrow window ([TabBarAutoCollapseWidth]) or collapsed
+ * with the chevron — resting the pointer on the rail slides the full bar in as an
+ * overlay drawer, which retracts once the pointer leaves. Gated by the
+ * `tabBarHoverExpand` setting (on by default).
+ *
+ * The timing lives in a `LaunchedEffect` in `TabbedTerminal`; the decision itself is
+ * kept pure here so it can be unit-tested.
+ */
+
+/** Pointer rest time before the collapsed rail reveals the full bar. */
+internal const val SidebarRevealOpenDelayMs = 150L
+
+/**
+ * Grace period after the pointer leaves before the reveal retracts. Must exceed
+ * [SidebarRevealOpenDelayMs]: it covers the rail → drawer handoff (the drawer slides
+ * over the rail, so hover moves between two different nodes) and brief excursions
+ * past the drawer's edge.
+ */
+internal const val SidebarRevealCloseDelayMs = 250L
+
+/**
+ * Whether the hover drawer should be revealed.
+ *
+ * @param enabled the `tabBarHoverExpand` setting.
+ * @param railShown true while the slim rail (not the full bar) is what's in the layout.
+ * @param pointerOnRail pointer is over the rail.
+ * @param pointerOnDrawer pointer is over the revealed drawer — true during the handoff,
+ *   and what keeps the drawer open while the user reaches for a tab chip.
+ */
+internal fun hoverRevealTarget(
+    enabled: Boolean,
+    railShown: Boolean,
+    pointerOnRail: Boolean,
+    pointerOnDrawer: Boolean
+): Boolean = enabled && railShown && (pointerOnRail || pointerOnDrawer)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -323,6 +323,14 @@ fun TabBar(
      * the bar open; once pinned the bar is the real one again and the chevron returns.
      */
     onPin: (() -> Unit)? = null,
+    /**
+     * Reports whether an interaction that outlives a single click is in flight: a context
+     * menu, an inline rename, or a tab drag. All of it is state owned by this composition,
+     * so an owner that disposes the bar on its own schedule (the hover reveal, which
+     * retracts when the pointer leaves) must keep it alive while this is true — otherwise
+     * "Rename…" silently does nothing and a drag past the edge is dropped.
+     */
+    onTransientInteraction: ((Boolean) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     // Context menu controller for chip right-click menu
@@ -455,6 +463,25 @@ fun TabBar(
 
     // Remote group box currently renaming its header inline (by RemoteTabGroup.id).
     var editingRemoteId by remember { mutableStateOf<String?>(null) }
+
+    // Everything above that survives past a single click, reported upward so a hover-driven
+    // owner doesn't dispose this composition mid-interaction. Disposal reports false —
+    // whoever is still listening must not be left holding a stale "busy".
+    val menuOnScreen by contextMenuController.menuVisible
+    val transientInteraction = menuOnScreen || editingPaneId != null ||
+        editingRemoteId != null || draggedTabIndex != null
+    // The callback arrives fresh on every recomposition, so hold it by reference rather than
+    // keying the effects on it — otherwise they restart constantly.
+    val reportInteraction by rememberUpdatedState(onTransientInteraction)
+    LaunchedEffect(transientInteraction) { reportInteraction?.invoke(transientInteraction) }
+    DisposableEffect(Unit) {
+        onDispose {
+            reportInteraction?.invoke(false)
+            // A native popup is a separate AWT window: nothing else takes it down when the
+            // bar it belongs to goes away, leaving a menu orphaned over the terminal.
+            contextMenuController.hideMenu()
+        }
+    }
 
     // Right-click menu on a remote group's HEADER — local customization of the box
     // (name + accent color) plus Disconnect. Nothing here touches the host.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.HorizontalSplit
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.QrCode2
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.VerticalSplit
@@ -316,6 +317,12 @@ fun TabBar(
     collapsed: Boolean = false,
     /** Vertical bar only: collapse/expand chevron next to "Add remote" (and atop the rail). Null hides it. */
     onToggleCollapse: (() -> Unit)? = null,
+    /**
+     * Vertical bar only: marks this instance as a transient hover reveal over the collapsed
+     * rail (see SidebarHoverReveal.kt). The bottom collapse chevron becomes a pin that keeps
+     * the bar open; once pinned the bar is the real one again and the chevron returns.
+     */
+    onPin: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     // Context menu controller for chip right-click menu
@@ -1060,15 +1067,19 @@ fun TabBar(
                         )
                         Text("Add remote", color = Color(0xFFB0B0B0), fontSize = 12.sp)
                     }
-                    onToggleCollapse?.let { toggle ->
+                    // A hover reveal pins itself open; the real bar collapses. Same slot, so
+                    // the icon is the state: pin = "this will go away", chevron = "it's mine".
+                    (onPin ?: onToggleCollapse)?.let { action ->
                         IconButton(
-                            onClick = toggle,
+                            onClick = action,
                             modifier = Modifier.size(28.dp)
                                 .consumeSecondaryPress()
                         ) {
                             Icon(
-                                imageVector = Icons.Default.ChevronLeft,
-                                contentDescription = "Collapse sidebar",
+                                imageVector = if (onPin != null) Icons.Default.PushPin
+                                              else Icons.Default.ChevronLeft,
+                                contentDescription = if (onPin != null) "Keep sidebar open"
+                                                     else "Collapse sidebar",
                                 tint = barMuted,
                                 modifier = Modifier.size(18.dp)
                             )

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/SidebarHoverRevealTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/SidebarHoverRevealTest.kt
@@ -1,0 +1,37 @@
+package ai.rever.bossterm.compose.tabs
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SidebarHoverRevealTest {
+
+    @Test
+    fun `reveal follows the pointer while the rail is shown`() {
+        // Rail hovered, drawer not yet under the pointer — the reveal starts here.
+        assertTrue(hoverRevealTarget(enabled = true, railShown = true, pointerOnRail = true, pointerOnDrawer = false))
+        // Handoff: the drawer slides over the rail, so both zones report a hover.
+        assertTrue(hoverRevealTarget(enabled = true, railShown = true, pointerOnRail = true, pointerOnDrawer = true))
+        // Pointer moved onto the drawer proper (reaching for a tab chip).
+        assertTrue(hoverRevealTarget(enabled = true, railShown = true, pointerOnRail = false, pointerOnDrawer = true))
+        // Pointer left both zones.
+        assertFalse(hoverRevealTarget(enabled = true, railShown = true, pointerOnRail = false, pointerOnDrawer = false))
+    }
+
+    @Test
+    fun `setting off keeps the chevron as the only way in`() {
+        assertFalse(hoverRevealTarget(enabled = false, railShown = true, pointerOnRail = true, pointerOnDrawer = false))
+        assertFalse(hoverRevealTarget(enabled = false, railShown = true, pointerOnRail = true, pointerOnDrawer = true))
+    }
+
+    @Test
+    fun `an expanded in-flow bar never reveals a drawer`() {
+        assertFalse(hoverRevealTarget(enabled = true, railShown = false, pointerOnRail = true, pointerOnDrawer = false))
+        assertFalse(hoverRevealTarget(enabled = true, railShown = false, pointerOnRail = true, pointerOnDrawer = true))
+    }
+
+    @Test
+    fun `retract is slower than reveal so the rail to drawer handoff survives`() {
+        assertTrue(SidebarRevealCloseDelayMs > SidebarRevealOpenDelayMs)
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/SidebarHoverRevealTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/SidebarHoverRevealTest.kt
@@ -31,6 +31,31 @@ class SidebarHoverRevealTest {
     }
 
     @Test
+    fun `an interaction in flight holds the drawer open with the pointer gone`() {
+        // Context menu, inline rename, or a tab drag: the drawer owns that state, so
+        // retracting would silently discard it.
+        assertTrue(
+            hoverRevealTarget(
+                enabled = true, railShown = true,
+                pointerOnRail = false, pointerOnDrawer = false, drawerBusy = true
+            )
+        )
+        // Not a way around the other two gates, though.
+        assertFalse(
+            hoverRevealTarget(
+                enabled = false, railShown = true,
+                pointerOnRail = false, pointerOnDrawer = false, drawerBusy = true
+            )
+        )
+        assertFalse(
+            hoverRevealTarget(
+                enabled = true, railShown = false,
+                pointerOnRail = false, pointerOnDrawer = false, drawerBusy = true
+            )
+        )
+    }
+
+    @Test
     fun `retract is slower than reveal so the rail to drawer handoff survives`() {
         assertTrue(SidebarRevealCloseDelayMs > SidebarRevealOpenDelayMs)
     }

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -77,6 +77,10 @@ Location: `~/.bossterm/settings.json`
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `alwaysShowTabBar` | Boolean | `false` | Show tab bar even with single tab |
+| `tabBarPosition` | String | `"left"` | `"left"` (vertical) or `"top"` |
+| `tabBarVerticalWidth` | Float | `180` | Width (dp) of the left tab bar |
+| `tabBarCollapsed` | Boolean | `false` | Left tab bar collapsed to the slim icon strip |
+| `tabBarHoverExpand` | Boolean | `true` | Hovering the collapsed strip reveals the full bar as an overlay drawer |
 
 ### Performance Settings
 

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -81,6 +81,7 @@ Location: `~/.bossterm/settings.json`
 | `tabBarVerticalWidth` | Float | `180` | Width (dp) of the left tab bar |
 | `tabBarCollapsed` | Boolean | `false` | Left tab bar collapsed to the slim icon strip |
 | `tabBarHoverExpand` | Boolean | `true` | Hovering the collapsed strip reveals the full bar as an overlay drawer |
+| `tabBarSummaryMode` | Boolean | `false` | One chip per tab instead of one per split pane |
 
 ### Performance Settings
 


### PR DESCRIPTION
## Why

The left tab bar drops to a 44dp icon strip in two ways: a window narrower than `TabBarAutoCollapseWidth` (700dp) forces it, or the user collapses it with the `‹` chevron. Either way, getting the full bar back needed a deliberate click — a poor fit for a strip you brush past constantly, and in the manually-collapsed case there was no drawer at all, just an in-flow rail with no way to peek at tab titles.

## What

Resting the pointer on the strip slides the full bar in as an overlay drawer after 150ms; it retracts 250ms after the pointer leaves. Works whichever way the strip was reached.

- **Overlay, not push.** The drawer floats over the terminal, so hovering never resizes the PTY or reflows output. Reuses the existing narrow-window drawer treatment (`slideInHorizontally` / `slideOutHorizontally`, `CenterStart`).
- **Retract is slower than reveal** (250 vs 150ms) because the drawer slides *over* the strip: hover hands off between two different nodes mid-reveal, so the grace period is what keeps it from flickering. Two `MutableInteractionSource`s (strip zone, drawer zone) OR'd together, following the `AlwaysVisibleScrollbar` pattern.
- **The bottom button's icon is the state.** A hover-revealed drawer shows a 📌 instead of the collapse chevron; the real in-flow bar keeps `‹`.
  - Pin in a wide window → persists `tabBarCollapsed = false`, so the drawer *becomes* the real bar and the icon flips back to `‹`.
  - Pin in a narrow window (where width forces the strip regardless) → the drawer stays put until dismissed.
- **Dismissal sticks.** Picking a pane — or the chevron once pinned — suppresses the reveal until the pointer actually leaves the sidebar, so it can't slide straight back in under the cursor.
- **No stolen clicks.** Only the chevron-opened drawer keeps its full-screen click-catcher; a hover-revealed drawer never swallows the click that focuses the terminal.

New setting `tabBarHoverExpand` (Settings ▸ Behavior ▸ Tab Bar → "Expand Sidebar on Hover"), **on by default**. Off restores today's chevron-only behavior exactly. No persistence work needed — `SettingsManager`'s `ignoreUnknownKeys` + `encodeDefaults` migrate the new key on next launch.

## Changes

| File | What |
|---|---|
| `tabs/SidebarHoverReveal.kt` (new) | Delay constants + the pure `hoverRevealTarget(...)` decision |
| `TabbedTerminal.kt` | Hover tracking + debounce; the drawer now renders whenever the strip is shown, not only in narrow windows; `tabBarComposable` grew an `onPin` argument |
| `tabs/TabBar.kt` | New optional `onPin` param; the bottom slot renders `(onPin ?: onToggleCollapse)` with pin vs chevron |
| `settings/TerminalSettings.kt`, `sections/BehaviorSettingsSection.kt` | The setting and its toggle |
| `docs/wiki/Configuration.md` | New key, plus the three tab-bar keys that table was missing |

`TabBar`'s new param is optional and there is one call site, so no other caller changes.

## Testing

- `SidebarHoverRevealTest` (new, 4 cases) covers the reveal decision including the strip→drawer handoff moment.
- `./gradlew :compose-ui:compileKotlinDesktop` — green, no new warnings.
- `:compose-ui:desktopTest` for the `tabs` + `settings` packages — 18 tests, 0 failures.
- `:bossterm-app:run` off this branch boots clean; interactive pass done in that build.

Worth a second look when reviewing: right-clicking a chip inside a revealed drawer (native `JPopupMenu`, so it should outlive the drawer retracting) and tab drag-reorder (#342) inside a revealed drawer.
