### PR TITLE
Stop rewriting the bundled fonts on every launch (window-never-appears hang)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,9 @@ Skiko can't read a typeface out of the jar (classloader issues), so bundled font
 disk first. Extract via `extractBundledFont()` in `compose-ui/.../util/FontUtils.kt` — do NOT go
 back to a per-launch `File.createTempFile`:
 
-- `classLoader.getResourceAsStream("fonts/…​.ttf")` → `~/.bossterm/fonts/<name>-<sha256-12>.ttf`
-  (content-addressed, written once per font per upgrade, atomic temp+rename) → `Font(file = …)`
+- `classLoader.getResourceAsStream("fonts/….ttf")` → `~/.bossterm/fonts/<name>-<sha256-12>.ttf`
+  (content-addressed, written once per font per upgrade, fsync + atomic rename, superseded copies
+  pruned on the write path so a warm launch stays zero-I/O) → `Font(file = …)`
 - A fresh multi-megabyte file per launch is the worst case for endpoint-security scanning, and
   Skia's font path calls `dlsym` (CoreText weight mapping) — see the deadlock note below
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,40 @@ Do NOT include AI co-author attribution in commits unless the user explicitly re
 ## Critical Technical Patterns
 
 ### Font Loading
-Skiko has classloader issues. Use InputStream + temp file:
-- `classLoader.getResourceAsStream("fonts/MesloLGSNF-Regular.ttf")` → temp file → `Font(file = tempFile)`
+Skiko can't read a typeface out of the jar (classloader issues), so bundled fonts must land on
+disk first. Extract via `extractBundledFont()` in `compose-ui/.../util/FontUtils.kt` — do NOT go
+back to a per-launch `File.createTempFile`:
+
+- `classLoader.getResourceAsStream("fonts/…​.ttf")` → `~/.bossterm/fonts/<name>-<sha256-12>.ttf`
+  (content-addressed, written once per font per upgrade, atomic temp+rename) → `Font(file = …)`
+- A fresh multi-megabyte file per launch is the worst case for endpoint-security scanning, and
+  Skia's font path calls `dlsym` (CoreText weight mapping) — see the deadlock note below
+
+### Launch hangs with a window that never appears (macOS)
+Symptom: the process is alive, logs look healthy (MCP bound, settings saved), but no window paints,
+and the JVM sits near 0% CPU. This is not Gatekeeper, MDM policy, or a failed launch — it is
+**dyld loader-lock contention**:
+
+```
+AWT-EventQueue-0  Skia font load → SkCTFontGetNSFontWeightMapping → dlsym
+                  → withLoadersReadLock → __ulock_wait2        (blocked)
+other thread      dlopen → Loader::mapSegments → fcntl          (holds the WRITE lock,
+                  ^ code-signature validation on first map       stalled in the kernel)
+```
+
+Anything that stalls that first-map signature check — an EDR/endpoint-security extension scanning
+a newly written file is the common one — blocks the event thread before the first frame.
+
+Diagnose (do not guess at MDM):
+```bash
+jcmd <pid> Thread.print | grep -A4 '"AWT-EventQueue-0"'   # _nMakeFromFile / dlsym at the top?
+sample <pid> 3 -file /tmp/s.txt                           # native leaf: __ulock_wait2 under dyld?
+ps -p <pid> -o %cpu=,time=,etime=                         # blocked (low CPU, high elapsed) vs spinning
+```
+It clears itself once the scan returns; signature results are cached per file, so warm launches are
+fine and a clean build re-arms it. Note that querying windows via `osascript`/System Events makes
+macOS `dlopen` the accessibility bundles into the target — that adds a waiter on the very same lock
+and reports `0 windows` as a false negative. Use `jcmd`/`sample` instead.
 
 ### Emoji Rendering
 Skia ignores variation selectors (U+FE0F). Peek-ahead to detect, switch to `FontFamily.Default`, render as unit.
@@ -145,4 +177,4 @@ state.write("cmd\n", tabId = "id")   // Target tab by ID
 See `.claude/rules/shell-integration.md` for OSC 7/133 setup.
 
 ---
-*Last Updated: January 12, 2026*
+*Last Updated: July 28, 2026*

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/FontUtils.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/FontUtils.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.util
 
+import ai.rever.bossterm.compose.daemon.BossTermPaths
 import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -149,25 +150,89 @@ val cachedSTIXMathFont: FontFamily? by lazy {
 }
 
 /**
+ * Extract a bundled font resource to a file Skia can open, reusing the previous launch's copy.
+ *
+ * Skiko can't read a typeface straight out of the jar (classloader issues), so the bytes have to
+ * land on disk first. Doing that with [java.io.File.createTempFile] means every launch hands the
+ * OS a brand-new multi-megabyte file — the worst case for an endpoint-security agent, which scans
+ * it on first map. That scan happens inside dyld's loader lock (Skia's font path calls `dlsym`
+ * for the CoreText weight mapping), so a slow scan doesn't just delay the font: it blocks the AWT
+ * event thread before the window ever paints. Observed in the wild as a launch that shows no
+ * window for minutes while the process sits at ~0% CPU.
+ *
+ * So the copy is content-addressed and persistent: `~/.bossterm/fonts/<name>-<sha256-12>.ttf`.
+ * Same bytes, same path, so the scanner sees a familiar file and the write only happens once per
+ * font per upgrade. The hash in the name is what makes a new bundled font invalidate the old copy
+ * without needing a version check.
+ *
+ * @return the on-disk font file, or null if the resource is missing.
+ */
+internal fun extractBundledFont(resourcePath: String): java.io.File? {
+    val bytes = object {}.javaClass.classLoader
+        ?.getResourceAsStream(resourcePath)
+        ?.use { it.readBytes() }
+        ?: return null
+
+    val baseName = resourcePath.substringAfterLast('/').substringBeforeLast('.')
+    val digest = java.security.MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .take(6)
+        .joinToString("") { "%02x".format(it) }
+
+    // Cache under the BossTerm dir. If anything about it is unusable (read-only home, sandbox),
+    // fall back to the old per-launch temp file rather than failing to load a font at all.
+    val cached = runCatching {
+        val dir = java.io.File(BossTermPaths.dir(), "fonts").apply { mkdirs() }
+        java.io.File(dir, "$baseName-$digest.ttf").takeIf { it.parentFile?.isDirectory == true }
+    }.getOrNull()
+
+    if (cached != null) {
+        // Size check, not a re-hash: a partial file from a killed write is the failure mode worth
+        // catching, and the name already pins the content.
+        if (cached.isFile && cached.length() == bytes.size.toLong()) return cached
+        // Unique temp + atomic rename, so two BossTerm launches racing here can't publish a torn
+        // file to the shared path (same rationale as SettingsManager.writeToFileLocked).
+        val published = runCatching {
+            val tmp = java.io.File.createTempFile(".$baseName", ".tmp", cached.parentFile)
+            try {
+                tmp.writeBytes(bytes)
+                runCatching {
+                    java.nio.file.Files.move(
+                        tmp.toPath(), cached.toPath(),
+                        java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                    )
+                }.getOrElse {
+                    java.nio.file.Files.move(
+                        tmp.toPath(), cached.toPath(),
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                    )
+                }
+                cached
+            } finally {
+                runCatching { if (tmp.exists()) tmp.delete() }
+            }
+        }.getOrNull()
+        if (published != null) return published
+    }
+
+    return java.io.File.createTempFile(baseName, ".ttf").also { temp ->
+        temp.deleteOnExit()
+        temp.writeBytes(bytes)
+    }
+}
+
+/**
  * Load the bundled Noto Sans Symbols 2 font for symbol fallback.
  */
 private fun loadBundledSymbolFont(): FontFamily {
     return try {
-        val fontStream = object {}.javaClass.classLoader
-            ?.getResourceAsStream("fonts/NotoSansSymbols2-Regular.ttf")
+        val fontFile = extractBundledFont("fonts/NotoSansSymbols2-Regular.ttf")
             ?: return FontFamily.Default
-
-        val tempFile = java.io.File.createTempFile("NotoSansSymbols2", ".ttf")
-        tempFile.deleteOnExit()
-        fontStream.use { input ->
-            tempFile.outputStream().use { output ->
-                input.copyTo(output)
-            }
-        }
 
         FontFamily(
             androidx.compose.ui.text.platform.Font(
-                file = tempFile,
+                file = fontFile,
                 weight = FontWeight.Normal
             )
         )
@@ -182,21 +247,12 @@ private fun loadBundledSymbolFont(): FontFamily {
  */
 private fun loadBundledFont(): FontFamily {
     return try {
-        val fontStream = object {}.javaClass.classLoader
-            ?.getResourceAsStream("fonts/MesloLGSNF-Regular.ttf")
+        val fontFile = extractBundledFont("fonts/MesloLGSNF-Regular.ttf")
             ?: return FontFamily.Monospace
-
-        val tempFile = java.io.File.createTempFile("MesloLGSNF", ".ttf")
-        tempFile.deleteOnExit()
-        fontStream.use { input ->
-            tempFile.outputStream().use { output ->
-                input.copyTo(output)
-            }
-        }
 
         FontFamily(
             androidx.compose.ui.text.platform.Font(
-                file = tempFile,
+                file = fontFile,
                 weight = FontWeight.Normal
             )
         )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/FontUtils.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/FontUtils.kt
@@ -173,7 +173,9 @@ internal fun extractBundledFont(resourcePath: String): java.io.File? {
         ?.use { it.readBytes() }
         ?: return null
 
-    val baseName = resourcePath.substringAfterLast('/').substringBeforeLast('.')
+    val fileName = resourcePath.substringAfterLast('/')
+    val baseName = fileName.substringBeforeLast('.')
+    val extension = fileName.substringAfterLast('.', missingDelimiterValue = "ttf")
     val digest = java.security.MessageDigest.getInstance("SHA-256")
         .digest(bytes)
         .take(6)
@@ -183,19 +185,28 @@ internal fun extractBundledFont(resourcePath: String): java.io.File? {
     // fall back to the old per-launch temp file rather than failing to load a font at all.
     val cached = runCatching {
         val dir = java.io.File(BossTermPaths.dir(), "fonts").apply { mkdirs() }
-        java.io.File(dir, "$baseName-$digest.ttf").takeIf { it.parentFile?.isDirectory == true }
+        java.io.File(dir, "$baseName-$digest.$extension").takeIf { it.parentFile?.isDirectory == true }
     }.getOrNull()
 
     if (cached != null) {
-        // Size check, not a re-hash: a partial file from a killed write is the failure mode worth
-        // catching, and the name already pins the content.
+        // Catches a truncated copy (a write killed partway). Deliberately NOT a corruption check:
+        // the name states the intended content, nothing here verifies the bytes match it. The
+        // durable write below is what keeps a same-length-but-garbage file from happening, since
+        // such a file would pass this check on every later launch.
         if (cached.isFile && cached.length() == bytes.size.toLong()) return cached
         // Unique temp + atomic rename, so two BossTerm launches racing here can't publish a torn
         // file to the shared path (same rationale as SettingsManager.writeToFileLocked).
         val published = runCatching {
             val tmp = java.io.File.createTempFile(".$baseName", ".tmp", cached.parentFile)
             try {
-                tmp.writeBytes(bytes)
+                // fsync before the rename: a rename is atomic for *ordering*, not durability, and
+                // delayed allocation can otherwise publish a correctly-sized file with unwritten
+                // extents after a power loss. Truncation self-heals via the length check above;
+                // same-length garbage would be sticky until the bundled font itself changes.
+                java.io.FileOutputStream(tmp).use { out ->
+                    out.write(bytes)
+                    out.fd.sync()
+                }
                 runCatching {
                     java.nio.file.Files.move(
                         tmp.toPath(), cached.toPath(),
@@ -208,6 +219,25 @@ internal fun extractBundledFont(resourcePath: String): java.io.File? {
                         java.nio.file.StandardCopyOption.REPLACE_EXISTING,
                     )
                 }
+                // Write path only, so a warm launch stays zero-I/O: drop the previous version's
+                // copy and any orphaned temp. The hash in the name invalidates for *lookup* but
+                // never evicts, and `finally` below can't run if the JVM is SIGKILLed mid-write —
+                // which is exactly what someone does to a launch that shows no window.
+                runCatching {
+                    // An orphan is only orphaned if nobody is mid-write: another launch racing us
+                    // has a temp of its own in here, so temps are pruned by age, superseded copies
+                    // immediately. Deleting a file Skia has mapped is safe on POSIX (unlink) and
+                    // simply fails on Windows, which the per-file runCatching absorbs.
+                    val tempCutoff = System.currentTimeMillis() - 3_600_000
+                    cached.parentFile?.listFiles { f ->
+                        f != cached && f.isFile && when {
+                            f.name.startsWith("$baseName-") && f.name.endsWith(".$extension") -> true
+                            f.name.startsWith(".$baseName") && f.name.endsWith(".tmp") ->
+                                f.lastModified() < tempCutoff
+                            else -> false
+                        }
+                    }?.forEach { stale -> runCatching { stale.delete() } }
+                }
                 cached
             } finally {
                 runCatching { if (tmp.exists()) tmp.delete() }
@@ -216,7 +246,7 @@ internal fun extractBundledFont(resourcePath: String): java.io.File? {
         if (published != null) return published
     }
 
-    return java.io.File.createTempFile(baseName, ".ttf").also { temp ->
+    return java.io.File.createTempFile(baseName, ".$extension").also { temp ->
         temp.deleteOnExit()
         temp.writeBytes(bytes)
     }
@@ -243,12 +273,18 @@ private fun loadBundledSymbolFont(): FontFamily {
 }
 
 /**
+ * The bundled terminal font, resolved once. [loadTerminalFont] falls back here on every system-font
+ * miss and is itself behind `remember(settings.fontName)`, so without this the 2.5 MB inflate + hash
+ * would be re-paid on the composition thread each time the font setting changes.
+ */
+private val bundledFontFile: java.io.File? by lazy { extractBundledFont("fonts/MesloLGSNF-Regular.ttf") }
+
+/**
  * Load the bundled MesloLGS Nerd Font.
  */
 private fun loadBundledFont(): FontFamily {
     return try {
-        val fontFile = extractBundledFont("fonts/MesloLGSNF-Regular.ttf")
-            ?: return FontFamily.Monospace
+        val fontFile = bundledFontFile ?: return FontFamily.Monospace
 
         FontFamily(
             androidx.compose.ui.text.platform.Font(

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/BundledFontExtractionTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/BundledFontExtractionTest.kt
@@ -1,0 +1,89 @@
+package ai.rever.bossterm.compose.util
+
+import ai.rever.bossterm.compose.daemon.BossTermPaths
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The point of the cache is that a launch does NOT hand the OS a brand-new multi-megabyte file
+ * (see the dyld loader-lock note in AGENTS.md), so "the second launch writes nothing" is the
+ * behavior worth pinning down.
+ */
+class BundledFontExtractionTest {
+
+    private val resource = "fonts/MesloLGSNF-Regular.ttf"
+    private lateinit var dir: File
+    private var previousDir: String? = null
+
+    @BeforeTest
+    fun redirectBossTermDir() {
+        previousDir = System.getProperty(BossTermPaths.SETTINGS_DIR_PROPERTY)
+        dir = File.createTempFile("bossterm-font-test", "").let {
+            it.delete()
+            it.mkdirs()
+            it
+        }
+        System.setProperty(BossTermPaths.SETTINGS_DIR_PROPERTY, dir.absolutePath)
+    }
+
+    @AfterTest
+    fun restore() {
+        previousDir?.let { System.setProperty(BossTermPaths.SETTINGS_DIR_PROPERTY, it) }
+            ?: System.clearProperty(BossTermPaths.SETTINGS_DIR_PROPERTY)
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `extracts into the bossterm dir under a content-addressed name`() {
+        val file = assertNotNull(extractBundledFont(resource))
+
+        assertEquals(File(dir, "fonts").absolutePath, file.parentFile.absolutePath)
+        assertTrue(file.isFile && file.length() > 0)
+        // <base>-<12 hex>.ttf — the hash is what invalidates the copy when the bundled font changes.
+        assertTrue(
+            Regex("""^MesloLGSNF-Regular-[0-9a-f]{12}\.ttf$""").matches(file.name),
+            "unexpected cache file name: ${file.name}"
+        )
+    }
+
+    @Test
+    fun `second launch reuses the file instead of rewriting it`() {
+        val first = assertNotNull(extractBundledFont(resource))
+        val stamp = first.lastModified()
+        val bytes = first.readBytes()
+
+        val second = assertNotNull(extractBundledFont(resource))
+
+        assertEquals(first.absolutePath, second.absolutePath)
+        assertEquals(stamp, second.lastModified(), "cache was rewritten on the second call")
+        assertTrue(bytes.contentEquals(second.readBytes()))
+        // Exactly one copy, and no temp left behind by the publish.
+        assertEquals(
+            listOf(first.name),
+            File(dir, "fonts").listFiles()!!.map { it.name }.sorted()
+        )
+    }
+
+    @Test
+    fun `a truncated copy is republished rather than handed to Skia`() {
+        val original = assertNotNull(extractBundledFont(resource))
+        val full = original.readBytes()
+        original.writeBytes(full.copyOfRange(0, full.size / 3))
+
+        val repaired = assertNotNull(extractBundledFont(resource))
+
+        assertEquals(original.absolutePath, repaired.absolutePath)
+        assertTrue(full.contentEquals(repaired.readBytes()), "truncated cache was not repaired")
+    }
+
+    @Test
+    fun `a missing resource reports null rather than an empty font file`() {
+        assertNull(extractBundledFont("fonts/DefinitelyNotBundled-Regular.ttf"))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/BundledFontExtractionTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/BundledFontExtractionTest.kt
@@ -24,11 +24,7 @@ class BundledFontExtractionTest {
     @BeforeTest
     fun redirectBossTermDir() {
         previousDir = System.getProperty(BossTermPaths.SETTINGS_DIR_PROPERTY)
-        dir = File.createTempFile("bossterm-font-test", "").let {
-            it.delete()
-            it.mkdirs()
-            it
-        }
+        dir = java.nio.file.Files.createTempDirectory("bossterm-font-test").toFile()
         System.setProperty(BossTermPaths.SETTINGS_DIR_PROPERTY, dir.absolutePath)
     }
 
@@ -55,19 +51,61 @@ class BundledFontExtractionTest {
     @Test
     fun `second launch reuses the file instead of rewriting it`() {
         val first = assertNotNull(extractBundledFont(resource))
-        val stamp = first.lastModified()
         val bytes = first.readBytes()
+        // Back-date well past any filesystem timestamp granularity: at 1-second resolution a
+        // same-second rewrite would compare equal and pass while doing exactly what we forbid.
+        val backdated = System.currentTimeMillis() - 60_000
+        assertTrue(first.setLastModified(backdated), "could not back-date the cache file")
 
         val second = assertNotNull(extractBundledFont(resource))
 
         assertEquals(first.absolutePath, second.absolutePath)
-        assertEquals(stamp, second.lastModified(), "cache was rewritten on the second call")
+        assertEquals(backdated, second.lastModified(), "cache was rewritten on the second call")
         assertTrue(bytes.contentEquals(second.readBytes()))
         // Exactly one copy, and no temp left behind by the publish.
         assertEquals(
             listOf(first.name),
             File(dir, "fonts").listFiles()!!.map { it.name }.sorted()
         )
+    }
+
+    @Test
+    fun `publishing prunes a superseded copy and an orphaned temp`() {
+        val current = assertNotNull(extractBundledFont(resource))
+        val fonts = File(dir, "fonts")
+        // A previous version's copy, and a temp orphaned by a killed write (back-dated past the
+        // age guard that protects a concurrent launch's in-flight temp).
+        val superseded = File(fonts, "MesloLGSNF-Regular-000000000000.ttf").apply { writeBytes(ByteArray(16)) }
+        val orphanTemp = File(fonts, ".MesloLGSNF-Regular999.tmp").apply {
+            writeBytes(ByteArray(16))
+            setLastModified(System.currentTimeMillis() - 7_200_000)
+        }
+        val freshTemp = File(fonts, ".MesloLGSNF-Regular111.tmp").apply { writeBytes(ByteArray(16)) }
+        // Force a republish: truncating is what makes the length check miss.
+        current.writeBytes(ByteArray(8))
+
+        assertNotNull(extractBundledFont(resource))
+
+        assertTrue(!superseded.exists(), "old-hash copy was left behind")
+        assertTrue(!orphanTemp.exists(), "orphaned temp was left behind")
+        assertTrue(freshTemp.exists(), "a concurrent launch's in-flight temp must not be deleted")
+    }
+
+    @Test
+    fun `an unusable cache dir still yields a font file`() {
+        // Point the store at a regular file so mkdirs() cannot succeed.
+        val notADir = File.createTempFile("bossterm-not-a-dir", "")
+        System.setProperty(BossTermPaths.SETTINGS_DIR_PROPERTY, notADir.absolutePath)
+        try {
+            val file = assertNotNull(extractBundledFont(resource), "fallback must still produce a font")
+            assertTrue(file.isFile && file.length() > 0)
+            assertTrue(
+                file.parentFile.absolutePath != File(notADir, "fonts").absolutePath,
+                "expected the temp fallback, not the unusable cache path"
+            )
+        } finally {
+            notADir.delete()
+        }
     }
 
     @Test


### PR DESCRIPTION
## The symptom

A launch where **no window ever appears**. The process is alive, the logs look completely healthy (MCP server bound, share server bound, settings saved), and the JVM sits near 0% CPU. It reads exactly like a launch blocked by Gatekeeper or MDM policy. It isn't.

Caught live on a run of `:bossterm-app:run` — 17 minutes, no window, 719 ms of CPU across 1006 s elapsed.

## What it actually is

```
AWT-EventQueue-0   Skia font load → SkCTFontGetNSFontWeightMapping → dlsym
                   → dyld4::RuntimeLocks::withLoadersReadLock → __ulock_wait2   ← blocked
other thread       dlopen → Loader::mapSegments → SyscallDelegate::fcntl → __fcntl
                   ↑ first-map code-signature validation, holding the dyld
                     loader WRITE lock, stalled in the kernel
```

Skia's `makeFromFile` needs `dlsym` to resolve the CoreText `NSFontWeight*` mapping, so it wants dyld's loader **read** lock. Anything that stalls a first-map signature check holds the **write** lock, and the event thread never reaches the first frame.

An endpoint-security agent scanning a newly written file is the usual cause — and `loadBundledFont` was handing it the ideal input. `File.createTempFile` wrote a **fresh 2.5 MB `MesloLGSNF*.ttf`** (plus `NotoSansSymbols2`) into the temp dir on *every launch*, under a random name, so a scanner never got to reuse a verdict from last time.

## The fix

Extraction is now content-addressed and persistent: `~/.bossterm/fonts/<name>-<sha256-12>.ttf`.

- Bytes are written **once per font per upgrade**; every later launch opens a path the scanner has already cleared.
- The hash in the filename *is* the invalidation — a new bundled font resolves to a new path, no version field to maintain.
- Publishing uses a unique temp + `ATOMIC_MOVE` (same rationale as `SettingsManager.writeToFileLocked`), so two launches racing can't expose a torn file.
- A short-read copy is republished rather than handed to Skia.
- An unusable cache dir (read-only home, sandbox) falls back to the old per-launch temp, so a font always loads.

Both bundled-font call sites now go through one `extractBundledFont(resourcePath)`. Fonts were the only multi-megabyte per-launch extraction in the tree — the other `createTempFile` uses are small temp+rename writes (settings, port files, auth) or on-demand user actions (CLI installer, debug dump, share sheet).

## Docs

`AGENTS.md`'s "Font Loading" note is what pointed at `createTempFile` in the first place, so it now documents `extractBundledFont` and says explicitly not to go back. Added a **"Launch hangs with a window that never appears"** section with the lock diagram and the commands to tell this apart from a real launch block, rather than guessing at MDM:

```bash
jcmd <pid> Thread.print | grep -A4 '"AWT-EventQueue-0"'   # _nMakeFromFile / dlsym on top?
sample <pid> 3 -file /tmp/s.txt                           # native leaf __ulock_wait2 under dyld?
ps -p <pid> -o %cpu=,time=,etime=                         # blocked (low CPU, high elapsed) vs spinning
```

It also records a trap worth knowing: inspecting windows with `osascript`/System Events makes macOS `dlopen` the accessibility bundles **into the target process**, which piles a third waiter onto the same loader lock and reports `0 windows` as a false negative. That cost me a wrong turn during diagnosis.

## Testing

`BundledFontExtractionTest` (4 cases, redirects the store with `-Dbossterm.settings.dir`):

- extracts under `<dir>/fonts/` with a `<base>-<12 hex>.ttf` name
- **second call reuses the file and does not rewrite it** (asserts `lastModified` is unchanged and exactly one file exists) — the property this whole change is about
- a truncated copy is republished, not handed to Skia
- a missing resource returns null rather than an empty font file

`./gradlew :compose-ui:compileKotlinDesktop` green; the 4 tests pass.

Worth noting what this does and does not fix: it removes BossTerm's contribution (a new file every launch). A first-ever launch after an upgrade still writes once and can still hit a slow scan, and a stall originating in some other library's first map is unaffected — hence the diagnostic section rather than a claim that the hang is gone for good.
