### PR TITLE
Fix WebViewer bottom controls and cursor snapshots

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonAttachServer.kt
@@ -223,7 +223,13 @@ class DaemonAttachServer(
             try {
                 send(DaemonAttachProtocol.Server.Snapshot(
                     core.id,
-                    TerminalSnapshotEncoder.encode(core.textBuffer.createSnapshot(), core.terminal.cursorX, core.terminal.cursorY),
+                    TerminalSnapshotEncoder.encode(
+                        snapshot = core.textBuffer.createSnapshot(),
+                        cursorX = core.terminal.cursorX,
+                        cursorY = core.terminal.cursorY,
+                        cursorVisible = core.display.cursorVisible,
+                        cursorShape = core.display.cursorShape,
+                    ),
                     sz.columns, sz.rows,
                 ))
                 synchronized(preludeLock) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonShareServer.kt
@@ -810,9 +810,11 @@ class DaemonShareServer(
                             // ordered with PTY output without rebuilding retained browser history.
                             attachment.repaintSender.offer {
                                 TerminalSnapshotEncoder.encodeScreenRepaint(
-                                    core.textBuffer.createSnapshot(),
-                                    core.terminal.cursorX,
-                                    core.terminal.cursorY,
+                                    snapshot = core.textBuffer.createSnapshot(),
+                                    cursorX = core.terminal.cursorX,
+                                    cursorY = core.terminal.cursorY,
+                                    cursorVisible = core.display.cursorVisible,
+                                    cursorShape = core.display.cursorShape,
                                 )
                             }
                         }
@@ -906,10 +908,12 @@ class DaemonShareServer(
             vc.outbox.sendSnapshot(core.id, FrameOutbox.Frame.Text(ShareProtocol.encodeServer(ServerMessage.PaneSnapshot(
                 core.id,
                 TerminalSnapshotEncoder.encode(
-                    core.textBuffer.createSnapshot(),
-                    core.terminal.cursorX,
-                    core.terminal.cursorY,
-                    webViewerScrollbackLines(core.textBuffer),
+                    snapshot = core.textBuffer.createSnapshot(),
+                    cursorX = core.terminal.cursorX,
+                    cursorY = core.terminal.cursorY,
+                    maxHistoryLines = webViewerScrollbackLines(core.textBuffer),
+                    cursorVisible = core.display.cursorVisible,
+                    cursorShape = core.display.cursorShape,
                 ),
                 sz.columns, sz.rows,
                 webViewerScrollbackLines(core.textBuffer),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -919,9 +919,11 @@ class MirrorShare(
                         // and the payload remains bounded by the pane dimensions.
                         entry.repaintSender.offer {
                             TerminalSnapshotEncoder.encodeScreenRepaint(
-                                entry.tab.textBuffer.createSnapshot(),
-                                entry.tab.terminal.cursorX,
-                                entry.tab.terminal.cursorY,
+                                snapshot = entry.tab.textBuffer.createSnapshot(),
+                                cursorX = entry.tab.terminal.cursorX,
+                                cursorY = entry.tab.terminal.cursorY,
+                                cursorVisible = entry.tab.display.cursorVisibleSnapshot,
+                                cursorShape = entry.tab.display.cursorShapeSnapshot,
                             )
                         }
                     }
@@ -1099,16 +1101,18 @@ class MirrorShare(
     /**
      * Build the initial-paint blob for a pane as **styled** text: each cell run is
      * prefixed with its SGR escape so the viewer's xterm.js paints the scrollback in
-     * color, exactly like live output. (Previously this sent `line.text` — plain chars
-     * with no styling — so the very first render was monochrome until new output arrived.)
+     * color, exactly like live output. The suffix also restores cursor visibility and shape,
+     * which xterm loses when the viewer resets it before applying a snapshot.
      */
     private fun snapshotText(tab: TerminalTab): String {
         val snap = tab.textBuffer.createSnapshot()
         return TerminalSnapshotEncoder.encode(
-            snap,
-            tab.terminal.cursorX,
-            tab.terminal.cursorY,
-            webViewerScrollbackLines(tab.textBuffer),
+            snapshot = snap,
+            cursorX = tab.terminal.cursorX,
+            cursorY = tab.terminal.cursorY,
+            maxHistoryLines = webViewerScrollbackLines(tab.textBuffer),
+            cursorVisible = tab.display.cursorVisibleSnapshot,
+            cursorShape = tab.display.cursorShapeSnapshot,
         )
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoder.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoder.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.share
 
+import ai.rever.bossterm.terminal.CursorShape
 import ai.rever.bossterm.terminal.TerminalColor
 import ai.rever.bossterm.terminal.TextStyle
 import ai.rever.bossterm.terminal.model.BufferSnapshot
@@ -19,6 +20,8 @@ object TerminalSnapshotEncoder {
         cursorX: Int,
         cursorY: Int,
         maxHistoryLines: Int = Int.MAX_VALUE,
+        cursorVisible: Boolean = true,
+        cursorShape: CursorShape? = null,
     ): String {
         val sb = StringBuilder()
         var row = -snapshot.historyLinesCount.coerceAtMost(maxHistoryLines.coerceAtLeast(0))
@@ -28,6 +31,7 @@ object TerminalSnapshotEncoder {
             row++
         }
         sb.append("[0m") // reset trailing style
+        appendCursorState(sb, cursorVisible, cursorShape)
         // Park the cursor at its real screen position (1-based row;col) — otherwise the viewer
         // leaves it on the bottom row after the full-height blob (scrollback + screen).
         val cy = cursorY.coerceIn(1, snapshot.height)
@@ -47,6 +51,8 @@ object TerminalSnapshotEncoder {
         snapshot: BufferSnapshot,
         cursorX: Int,
         cursorY: Int,
+        cursorVisible: Boolean = true,
+        cursorShape: CursorShape? = null,
     ): String {
         val sb = StringBuilder()
         for (row in 0 until snapshot.height) {
@@ -55,8 +61,24 @@ object TerminalSnapshotEncoder {
         }
         val cy = cursorY.coerceIn(1, snapshot.height)
         val cx = cursorX.coerceAtLeast(1)
-        sb.append("\u001b[0m\u001b[$cy;${cx}H")
+        sb.append("\u001b[0m")
+        appendCursorState(sb, cursorVisible, cursorShape)
+        sb.append("\u001b[$cy;${cx}H")
         return sb.toString()
+    }
+
+    /** Restore host cursor modes lost when viewer.js resets xterm before applying a snapshot. */
+    private fun appendCursorState(sb: StringBuilder, visible: Boolean, shape: CursorShape?) {
+        sb.append(if (visible) "\u001b[?25h" else "\u001b[?25l")
+        val decscusr = when (shape) {
+            CursorShape.BLINK_BLOCK -> 1
+            CursorShape.STEADY_BLOCK, null -> 2
+            CursorShape.BLINK_UNDERLINE -> 3
+            CursorShape.STEADY_UNDERLINE -> 4
+            CursorShape.BLINK_VERTICAL_BAR -> 5
+            CursorShape.STEADY_VERTICAL_BAR -> 6
+        }
+        sb.append("\u001b[").append(decscusr).append(" q")
     }
 
     /** Append one buffer line as SGR-prefixed styled runs, trimming invisible trailing padding. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoder.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoder.kt
@@ -20,8 +20,8 @@ object TerminalSnapshotEncoder {
         cursorX: Int,
         cursorY: Int,
         maxHistoryLines: Int = Int.MAX_VALUE,
-        cursorVisible: Boolean = true,
-        cursorShape: CursorShape? = null,
+        cursorVisible: Boolean,
+        cursorShape: CursorShape?,
     ): String {
         val sb = StringBuilder()
         var row = -snapshot.historyLinesCount.coerceAtMost(maxHistoryLines.coerceAtLeast(0))
@@ -30,13 +30,13 @@ object TerminalSnapshotEncoder {
             if (row < snapshot.height - 1) sb.append("\r\n")
             row++
         }
-        sb.append("[0m") // reset trailing style
+        sb.append("\u001b[0m") // reset trailing style
         appendCursorState(sb, cursorVisible, cursorShape)
         // Park the cursor at its real screen position (1-based row;col) — otherwise the viewer
         // leaves it on the bottom row after the full-height blob (scrollback + screen).
         val cy = cursorY.coerceIn(1, snapshot.height)
         val cx = cursorX.coerceAtLeast(1)
-        sb.append("[$cy;${cx}H")
+        sb.append("\u001b[$cy;${cx}H")
         return sb.toString()
     }
 
@@ -51,8 +51,8 @@ object TerminalSnapshotEncoder {
         snapshot: BufferSnapshot,
         cursorX: Int,
         cursorY: Int,
-        cursorVisible: Boolean = true,
-        cursorShape: CursorShape? = null,
+        cursorVisible: Boolean,
+        cursorShape: CursorShape?,
     ): String {
         val sb = StringBuilder()
         for (row in 0 until snapshot.height) {
@@ -110,7 +110,7 @@ object TerminalSnapshotEncoder {
         if (style.hasOption(TextStyle.Option.HIDDEN)) codes.add("8")
         style.foreground?.let { codes.add(sgrColor(it, fg = true)) }
         style.background?.let { codes.add(sgrColor(it, fg = false)) }
-        return "[" + codes.joinToString(";") + "m"
+        return "\u001b[" + codes.joinToString(";") + "m"
     }
 
     private fun sgrColor(c: TerminalColor, fg: Boolean): String {

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -53,13 +53,15 @@
     #mcppill { cursor: pointer; display: inline-flex; align-items: center; gap: 5px; }
     #mcppill .dot { width: 7px; height: 7px; border-radius: 50%; background: #6b6b6b; display: inline-block; }
     #mcppill.on .dot { background: #4caf50; }
-    /* Boss Calling (voice agent) — a bottom bar, because calling is a mode you're IN, not a
-       toolbar toggle: idle it shows one Call button; on a call it becomes a strip with a live
-       level meter, what the agent is doing, Mute and End. Rides above #keybar (see
-       layoutForKeyboard) so the on-screen keys and the call controls never overlap. */
-    #voicebar { display: none; position: fixed; left: 0; right: 0; bottom: 0; z-index: 29;
-                align-items: center; justify-content: center; gap: 8px; padding: 7px 10px;
-                background: #2b2b2b; border-top: 1px solid #404040; }
+    /* Boss Calling and the mobile keystrokes share ONE bottom strip. Either group may be
+       present by itself; when both are available they sit beside each other in the same
+       horizontally scrollable row. viewer.js positions and reserves this wrapper once. */
+    #bottomstrip { display: none; position: fixed; left: 0; right: 0; bottom: 0; z-index: 30;
+                   align-items: center; gap: 8px; padding: 6px 8px; box-sizing: border-box;
+                   background: #2b2b2b; border-top: 1px solid #404040;
+                   overflow-x: auto; overflow-y: hidden; -webkit-overflow-scrolling: touch; }
+    #bottomstrip.on { display: flex; }
+    #voicebar { display: none; flex: 0 0 auto; align-items: center; justify-content: center; }
     #voicebar.on { display: flex; }
     #voicecallbtn { display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
                     padding: 6px 16px; border-radius: 16px; border: 1px solid #4caf50;
@@ -69,12 +71,12 @@
     #voicecallbtn.disabled { opacity: .5; cursor: default; border-color: #505050; }
     #voicecallbtn .dot { width: 8px; height: 8px; border-radius: 50%; background: #4caf50; display: inline-block; }
     /* in-call strip */
-    #voicecall { display: none; align-items: center; gap: 12px; width: 100%; max-width: 640px; }
+    #voicecall { display: none; align-items: center; gap: 12px; flex: 0 0 auto; }
     #voicecall.on { display: flex; }
     /* listening/speaking meter: bars driven by a WebAudio analyser (mic while you talk, the
        agent's track while it answers), so silence is visibly different from a stalled call. */
-    #voicelevel { display: flex; align-items: center; gap: 3px; height: 24px; flex: 1 1 auto;
-                  min-width: 80px; }
+    #voicelevel { display: flex; align-items: center; gap: 3px; height: 24px; flex: 0 0 80px;
+                  width: 80px; min-width: 80px; }
     #voicelevel i { flex: 1 1 0; max-width: 5px; min-height: 3px; height: 3px; border-radius: 2px;
                     background: #4caf50; transition: height 70ms linear, background 200ms linear; }
     #voicecall.speaking #voicelevel i { background: #4a90e2; }
@@ -124,10 +126,9 @@
     #stage { flex: 1 1 auto; display: flex; min-width: 0; min-height: 0;
              overflow: auto; -webkit-overflow-scrolling: touch; }
 
-    /* on-screen key bar (mobile): Esc / Tab / Ctrl-combos / arrows. Fixed so viewer.js can
-       pin it just above the soft keyboard (via the VisualViewport API). */
-    #keybar { display: none; position: fixed; left: 0; right: 0; bottom: 0; z-index: 30; gap: 6px; padding: 6px 8px;
-              background: #2b2b2b; border-top: 1px solid #404040; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    /* on-screen key group (mobile): Esc / Tab / Ctrl-combos / arrows. #bottomstrip
+       owns fixed positioning and scrolling so voice and keys can never form two rows. */
+    #keybar { display: none; flex: 0 0 auto; align-items: center; gap: 6px; }
     /* divs (not buttons) so tapping never blurs the terminal textarea / drops the iOS
        keyboard; flex-centered since divs don't center text like a <button>. */
     .keybtn { flex: 0 0 auto; min-width: 42px; box-sizing: border-box; display: inline-flex;
@@ -260,17 +261,19 @@
     <div id="stage"></div>
   </div>
   <div id="viewpill"></div>
-  <!-- Boss Calling: idle = the Call button; on a call = level meter + status + Mute/End. -->
-  <div id="voicebar">
-    <span id="voicecallbtn" title="Talk to this session's BossTerm agent"><span class="dot"></span><span id="voicelabel">Call BossTerm</span></span>
-    <span id="voicecall">
-      <span id="voicelevel"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></span>
-      <span id="voicestate">Connecting…</span>
-      <button id="voicemute" title="Mute your microphone">Mute</button>
-      <button id="voicehang" title="End the call">End call</button>
-    </span>
+  <div id="bottomstrip">
+    <!-- Boss Calling: idle = the Call button; on a call = level meter + status + Mute/End. -->
+    <div id="voicebar">
+      <span id="voicecallbtn" title="Talk to this session's BossTerm agent"><span class="dot"></span><span id="voicelabel">Call BossTerm</span></span>
+      <span id="voicecall">
+        <span id="voicelevel"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></span>
+        <span id="voicestate">Connecting…</span>
+        <button id="voicemute" title="Mute your microphone">Mute</button>
+        <button id="voicehang" title="End the call">End call</button>
+      </span>
+    </div>
+    <div id="keybar"></div>
   </div>
-  <div id="keybar"></div>
   <div id="ctxmenu"></div>
   <div id="voicetoast"></div>
 

--- a/compose-ui/src/desktopMain/resources/share-viewer/index.html
+++ b/compose-ui/src/desktopMain/resources/share-viewer/index.html
@@ -54,13 +54,15 @@
     #mcppill .dot { width: 7px; height: 7px; border-radius: 50%; background: #6b6b6b; display: inline-block; }
     #mcppill.on .dot { background: #4caf50; }
     /* Boss Calling and the mobile keystrokes share ONE bottom strip. Either group may be
-       present by itself; when both are available they sit beside each other in the same
-       horizontally scrollable row. viewer.js positions and reserves this wrapper once. */
+       present by itself; when both are available they wrap within the same scroller so the
+       first keystrokes stay reachable on narrow phones. viewer.js reserves this wrapper once. */
     #bottomstrip { display: none; position: fixed; left: 0; right: 0; bottom: 0; z-index: 30;
-                   align-items: center; gap: 8px; padding: 6px 8px; box-sizing: border-box;
+                   align-items: center; flex-wrap: wrap; justify-content: center; gap: 8px;
+                   padding: 6px 8px; box-sizing: border-box;
                    background: #2b2b2b; border-top: 1px solid #404040;
                    overflow-x: auto; overflow-y: hidden; -webkit-overflow-scrolling: touch; }
     #bottomstrip.on { display: flex; }
+    #bottomstrip.has-keys { justify-content: flex-start; }
     #voicebar { display: none; flex: 0 0 auto; align-items: center; justify-content: center; }
     #voicebar.on { display: flex; }
     #voicecallbtn { display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
@@ -127,7 +129,7 @@
              overflow: auto; -webkit-overflow-scrolling: touch; }
 
     /* on-screen key group (mobile): Esc / Tab / Ctrl-combos / arrows. #bottomstrip
-       owns fixed positioning and scrolling so voice and keys can never form two rows. */
+       owns fixed positioning and scrolling so voice and keys never become separate strips. */
     #keybar { display: none; flex: 0 0 auto; align-items: center; gap: 6px; }
     /* divs (not buttons) so tapping never blurs the terminal textarea / drops the iOS
        keyboard; flex-centered since divs don't center text like a <button>. */

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -261,13 +261,19 @@
   var voiceAudioEl = null; // hidden <audio> for the agent's voice, created on first call
   var voiceToastTimer = null;
   function syncBottomStrip() {
-    var visible = voiceBarEl.classList.contains("on") || keybarEl.style.display === "flex";
+    var keysVisible = !!controlGranted;
+    bottomStripEl.classList.toggle("has-keys", keysVisible);
+    var visible = voiceBarEl.classList.contains("on") || keysVisible;
     bottomStripEl.classList.toggle("on", visible);
   }
   function toast(text, ms) {
     voiceToastEl.textContent = text;
-    // Sit above the shared bottom strip rather than under it.
-    voiceToastEl.style.bottom = (bottomStripEl.classList.contains("on") ? bottomStripEl.offsetHeight + 12 : 18) + "px";
+    // getBoundingClientRect includes the strip's keyboard offset, unlike offsetHeight alone.
+    var toastBottom = 18;
+    if (bottomStripEl.classList.contains("on")) {
+      toastBottom = Math.max(18, Math.round(window.innerHeight - bottomStripEl.getBoundingClientRect().top + 12));
+    }
+    voiceToastEl.style.bottom = toastBottom + "px";
     voiceToastEl.style.display = "block";
     if (voiceToastTimer) clearTimeout(voiceToastTimer);
     voiceToastTimer = setTimeout(function () { voiceToastEl.style.display = "none"; }, ms || 4000);
@@ -902,8 +908,8 @@
     // run on every event — including output-driven scroll events.
     positionBottomStrip(Math.max(0, Math.round(kbH) - appliedShiftPx));
   }
-  // Voice controls and on-screen keys are one fixed row. Position that row once at the
-  // keyboard edge and reserve its height once so opening the keyboard cannot double-push the UI.
+  // Voice controls and on-screen keys are one fixed strip. Position that wrapper once at the
+  // keyboard edge and reserve its measured height so wrapping cannot double-push the UI.
   function positionBottomStrip(kbBottomPx) {
     bottomStripEl.style.bottom = kbBottomPx + "px";
     var stripH = bottomStripEl.classList.contains("on") ? bottomStripEl.offsetHeight : 0;
@@ -978,8 +984,8 @@
     var sx = 0, sy = 0, moved = false, touched = false;
     // The keys are <div>s, NOT <button>s: a non-focusable element doesn't steal focus from
     // the terminal's hidden textarea on iOS, so the soft keyboard stays up WITHOUT a
-    // touchstart preventDefault — which means a horizontal swipe still scrolls the key bar
-    // natively (overflow-x). A 10px move-guard tells a swipe from a tap.
+    // touchstart preventDefault — which means a horizontal swipe still scrolls the shared bottom
+    // strip natively (overflow-x). A 10px move-guard tells a swipe from a tap.
     b.addEventListener("touchstart", function (e) {
       touched = true; moved = false;
       var t = e.touches[0]; if (t) { sx = t.clientX; sy = t.clientY; }

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -247,7 +247,9 @@
   // The meter's bars are static markup — query once instead of every animation frame.
   var voiceBars = null;
   var voiceMicOk = !!(window.isSecureContext && navigator.mediaDevices && navigator.mediaDevices.getUserMedia);
+  var bottomStripEl = document.getElementById("bottomstrip");
   var voiceBarEl = document.getElementById("voicebar");
+  var keybarEl = document.getElementById("keybar");
   var voiceCallBtnEl = document.getElementById("voicecallbtn");
   var voiceLabelEl = document.getElementById("voicelabel");
   var voiceCallEl = document.getElementById("voicecall");
@@ -258,10 +260,14 @@
   var voiceToastEl = document.getElementById("voicetoast");
   var voiceAudioEl = null; // hidden <audio> for the agent's voice, created on first call
   var voiceToastTimer = null;
+  function syncBottomStrip() {
+    var visible = voiceBarEl.classList.contains("on") || keybarEl.style.display === "flex";
+    bottomStripEl.classList.toggle("on", visible);
+  }
   function toast(text, ms) {
     voiceToastEl.textContent = text;
-    // Sit above the call bar rather than under it.
-    voiceToastEl.style.bottom = (voiceBarEl.classList.contains("on") ? voiceBarEl.offsetHeight + 12 : 18) + "px";
+    // Sit above the shared bottom strip rather than under it.
+    voiceToastEl.style.bottom = (bottomStripEl.classList.contains("on") ? bottomStripEl.offsetHeight + 12 : 18) + "px";
     voiceToastEl.style.display = "block";
     if (voiceToastTimer) clearTimeout(voiceToastTimer);
     voiceToastTimer = setTimeout(function () { voiceToastEl.style.display = "none"; }, ms || 4000);
@@ -294,6 +300,7 @@
       } else {
         voiceBarEl.classList.remove("on");
       }
+      syncBottomStrip();
       layoutForKeyboard();
       return;
     }
@@ -322,7 +329,8 @@
       voiceStateEl.title = voice.model ? "In a call with " + voice.model : "";
       voiceMuteEl.textContent = voice.muted ? "Unmute" : "Mute";
     }
-    layoutForKeyboard(); // the bar changed height → re-reserve space at the bottom
+    syncBottomStrip();
+    layoutForKeyboard(); // the shared strip changed height → re-reserve space at the bottom
   }
   voiceCallBtnEl.onclick = function () {
     if (!voice.status || !voice.status.available || voice.state !== "idle") return;
@@ -750,7 +758,6 @@
     }
   }
 
-  var keybarEl = document.getElementById("keybar");
   var menubtnEl = document.getElementById("menubtn");
   var bodyEl = document.getElementById("body");
   var ctxEl = document.getElementById("ctxmenu");
@@ -872,7 +879,7 @@
       var shift = 0;
       if (open) {
         var visibleBottom = vv.offsetTop + vv.height;
-        var clear = (keybarEl.style.display !== "none" ? keybarEl.offsetHeight : 0) + 8;
+        var clear = (bottomStripEl.classList.contains("on") ? bottomStripEl.offsetHeight : 0) + 8;
         var cb = cursorBottomPx();
         // Unknown cursor → fall back to the full push (old behavior).
         shift = cb === null ? Math.round(kbH)
@@ -890,19 +897,17 @@
       // Keyboard just closed → apply any auto-fit we deferred while it was up.
       if (!open) maybeAutoFit();
     }
-    // Blur-safe (touches no textarea ancestor): keep the key bar riding the keyboard top and
-    // reserve body padding. Uses the scroll-invariant kbH so it doesn't jitter, and is safe to
+    // Blur-safe (touches no textarea ancestor): keep the shared bottom strip riding the keyboard
+    // top and reserve body padding. Uses the scroll-invariant kbH so it doesn't jitter, and is safe to
     // run on every event — including output-driven scroll events.
-    positionBottomBars(Math.max(0, Math.round(kbH) - appliedShiftPx));
+    positionBottomStrip(Math.max(0, Math.round(kbH) - appliedShiftPx));
   }
-  // The two fixed bars stack: #keybar rides the keyboard top, the Boss Calling bar sits on top of
-  // it, and #body reserves both so the terminal is never hidden behind them.
-  function positionBottomBars(kbBottomPx) {
-    keybarEl.style.bottom = kbBottomPx + "px";
-    var keyH = (keybarEl.style.display !== "none" && keybarEl.offsetHeight) ? keybarEl.offsetHeight : 0;
-    voiceBarEl.style.bottom = (kbBottomPx + keyH) + "px";
-    var voiceH = voiceBarEl.classList.contains("on") ? voiceBarEl.offsetHeight : 0;
-    bodyEl.style.paddingBottom = (keyH + voiceH) + "px";
+  // Voice controls and on-screen keys are one fixed row. Position that row once at the
+  // keyboard edge and reserve its height once so opening the keyboard cannot double-push the UI.
+  function positionBottomStrip(kbBottomPx) {
+    bottomStripEl.style.bottom = kbBottomPx + "px";
+    var stripH = bottomStripEl.classList.contains("on") ? bottomStripEl.offsetHeight : 0;
+    bodyEl.style.paddingBottom = stripH + "px";
   }
   // While the keyboard is up, keep the cursor visible above it. Only pushes FURTHER up (never
   // reduces the shift) and only when the cursor sits below the visible fold — so the common
@@ -915,14 +920,14 @@
     var cb = cursorBottomPx(); if (cb === null) return;
     var kbH = Math.max(0, window.innerHeight - vv.height);
     var visibleBottom = vv.offsetTop + vv.height;
-    var clear = (keybarEl.style.display !== "none" ? keybarEl.offsetHeight : 0) + 8;
+    var clear = (bottomStripEl.classList.contains("on") ? bottomStripEl.offsetHeight : 0) + 8;
     var want = Math.round(Math.max(0, Math.min(kbH, cb - visibleBottom + clear)));
     if (want <= appliedShiftPx) return; // cursor already clear of the keyboard — don't churn
     appliedShiftPx = want;
     var wasFocused = document.activeElement === activeTextarea();
     document.body.style.transform = "translateY(-" + want + "px)";
     if (wasFocused) { var ta = activeTextarea(); if (ta) try { ta.focus({ preventScroll: true }); } catch (e) {} }
-    positionBottomBars(Math.max(0, Math.round(kbH) - appliedShiftPx));
+    positionBottomStrip(Math.max(0, Math.round(kbH) - appliedShiftPx));
   }
   if (window.visualViewport) {
     window.visualViewport.addEventListener("resize", layoutForKeyboard);
@@ -999,7 +1004,12 @@
   }
   function buildKeybar() {
     keybarEl.innerHTML = "";
-    if (!controlGranted) { keybarEl.style.display = "none"; layoutForKeyboard(); return; }
+    if (!controlGranted) {
+      keybarEl.style.display = "none";
+      syncBottomStrip();
+      layoutForKeyboard();
+      return;
+    }
     keybarEl.style.display = "flex";
     var kb = document.createElement("div");
     kb.className = "keybtn"; kb.textContent = "⌨"; kb.title = "Show / hide keyboard";
@@ -1011,7 +1021,8 @@
       wireKeyButton(b, k[1]);
       keybarEl.appendChild(b);
     });
-    layoutForKeyboard(); // reserve space + position above the keyboard
+    syncBottomStrip();
+    layoutForKeyboard(); // reserve one strip height + position above the keyboard
   }
   // The first pane of [node]'s tree (tree order) — the client's default focus / key-bar
   // target. Host focus is intentionally NOT reflected on the client; the client picks its own.

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/ShareViewerAssetTest.kt
@@ -61,4 +61,19 @@ class ShareViewerAssetTest {
             assertEquals(digest.take(token.length), token, "stale immutable cache token for $font")
         }
     }
+
+    @Test
+    fun `shared bottom strip wraps mobile controls and centers voice-only state`() {
+        val html = resource("share-viewer/index.html")
+        val rule = checkNotNull(Regex("""#bottomstrip \{([^}]*)}""").find(html)) {
+            "missing #bottomstrip CSS rule"
+        }.groupValues[1]
+
+        assertTrue(rule.contains("flex-wrap: wrap"), "voice controls must not push every key off-screen")
+        assertTrue(rule.contains("justify-content: center"), "a voice-only pill stays centered")
+        assertTrue(
+            html.contains("#bottomstrip.has-keys { justify-content: flex-start; }"),
+            "keystrokes keep a stable left edge when present",
+        )
+    }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoderTest.kt
@@ -23,6 +23,8 @@ class TerminalSnapshotEncoderTest {
             snapshot = snapshot,
             cursorX = 3,
             cursorY = 2,
+            cursorVisible = true,
+            cursorShape = null,
         )
 
         assertEquals(1, snapshot.historyLinesCount)
@@ -66,6 +68,7 @@ class TerminalSnapshotEncoderTest {
                 snapshot = snapshot,
                 cursorX = 1,
                 cursorY = 1,
+                cursorVisible = true,
                 cursorShape = shape,
             )
             assertTrue(

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/share/TerminalSnapshotEncoderTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.share
 
+import ai.rever.bossterm.terminal.CursorShape
 import ai.rever.bossterm.terminal.model.CharBuffer
 import ai.rever.bossterm.terminal.model.StyleState
 import ai.rever.bossterm.terminal.model.TerminalTextBuffer
@@ -29,6 +30,48 @@ class TerminalSnapshotEncoderTest {
         assertFalse(repaint.contains("history"))
         assertFalse(repaint.contains("\u001bc"), "screen repaint must not reset or clear scrollback")
         assertTrue(repaint.contains("\u001b[1;1H\u001b[2K"))
-        assertTrue(repaint.endsWith("\u001b[0m\u001b[2;3H"))
+        assertTrue(repaint.endsWith("\u001b[0m\u001b[?25h\u001b[2 q\u001b[2;3H"))
+    }
+
+    @Test
+    fun `initial snapshot restores a hidden cursor instead of showing xterm default`() {
+        val snapshot = TerminalTextBuffer(4, 1, StyleState()).createSnapshot()
+
+        val encoded = TerminalSnapshotEncoder.encode(
+            snapshot = snapshot,
+            cursorX = 2,
+            cursorY = 1,
+            cursorVisible = false,
+            cursorShape = CursorShape.BLINK_VERTICAL_BAR,
+        )
+
+        assertTrue(encoded.endsWith("\u001b[0m\u001b[?25l\u001b[5 q\u001b[1;2H"))
+    }
+
+    @Test
+    fun `snapshot maps every host cursor shape to DECSCUSR`() {
+        val snapshot = TerminalTextBuffer(2, 1, StyleState()).createSnapshot()
+        val expected: Map<CursorShape?, Int> = mapOf(
+            null to 2,
+            CursorShape.BLINK_BLOCK to 1,
+            CursorShape.STEADY_BLOCK to 2,
+            CursorShape.BLINK_UNDERLINE to 3,
+            CursorShape.STEADY_UNDERLINE to 4,
+            CursorShape.BLINK_VERTICAL_BAR to 5,
+            CursorShape.STEADY_VERTICAL_BAR to 6,
+        )
+
+        for ((shape, decscusr) in expected) {
+            val encoded = TerminalSnapshotEncoder.encode(
+                snapshot = snapshot,
+                cursorX = 1,
+                cursorY = 1,
+                cursorShape = shape,
+            )
+            assertTrue(
+                encoded.endsWith("\u001b[0m\u001b[?25h\u001b[$decscusr q\u001b[1;1H"),
+                "wrong DECSCUSR sequence for $shape",
+            )
+        }
     }
 }

--- a/compose-ui/src/desktopTest/resources/share-viewer-harness/viewer-harness.cjs
+++ b/compose-ui/src/desktopTest/resources/share-viewer-harness/viewer-harness.cjs
@@ -629,7 +629,7 @@ function loadViewer(options) {
   define("devicePixelRatio", 2);
   define("innerWidth", 390);
   define("innerHeight", 780);
-  define("visualViewport", undefined);
+  define("visualViewport", opts.visualViewport);
   define("matchMedia", () => ({
     matches: false,
     addEventListener() {},
@@ -976,7 +976,43 @@ const scenarios = {
     assert.strictEqual(lastTerminal().options.scrollback, 20000, "the viewer cap must win over a huge host cap");
   },
 
-  async "Boss Calling lives in the bottom bar: Call → live strip with meter, Mute, End"() {
+  "Boss Calling and keystrokes share one keyboard-aware bottom strip"() {
+    const viewportListeners = {};
+    const viewport = {
+      height: 780,
+      offsetTop: 0,
+      addEventListener(type, fn) { viewportListeners[type] = fn; },
+    };
+    loadViewer({ voiceCapable: true, visualViewport: viewport });
+    const socket = connectPanes(["pane-1"]);
+    const strip = el("bottomstrip");
+    strip.offsetHeight = 52;
+    el("voicebar").offsetHeight = 44;
+    el("keybar").offsetHeight = 48;
+
+    socket.deliver({ t: "control", granted: true });
+    assert.ok(strip.classList.contains("on"), "keystrokes alone show the shared strip");
+    assert.strictEqual(el("keybar").style.display, "flex");
+
+    socket.deliver({ t: "voiceStatus", available: true });
+    assert.ok(el("voicebar").classList.contains("on"), "voice joins the same strip");
+    assert.ok(strip.classList.contains("on"));
+    assert.strictEqual(el("body").style.paddingBottom, "52px", "reserve the shared row once");
+    assert.strictEqual(el("voicebar").style.bottom, undefined, "voice is not a separately positioned row");
+    assert.strictEqual(el("keybar").style.bottom, undefined, "keys are not a separately positioned row");
+
+    viewport.height = 480;
+    viewportListeners.resize();
+    assert.strictEqual(strip.style.bottom, "300px", "the one strip rides the keyboard edge");
+    assert.strictEqual(el("body").style.paddingBottom, "52px", "keyboard-open layout still reserves one row");
+
+    socket.deliver({ t: "voiceStatus", available: false });
+    assert.ok(strip.classList.contains("on"), "keystrokes keep the strip visible when voice leaves");
+    socket.deliver({ t: "control", granted: false });
+    assert.ok(!strip.classList.contains("on"), "the strip hides when neither group is available");
+  },
+
+  async "Boss Calling lives in the shared bottom strip: Call → live controls with meter, Mute, End"() {
     loadViewer({ voiceCapable: true });
     const socket = connectPanes(["pane-1"]);
     socket.deliver({ t: "control", granted: true });

--- a/compose-ui/src/desktopTest/resources/share-viewer-harness/viewer-harness.cjs
+++ b/compose-ui/src/desktopTest/resources/share-viewer-harness/viewer-harness.cjs
@@ -992,23 +992,37 @@ const scenarios = {
 
     socket.deliver({ t: "control", granted: true });
     assert.ok(strip.classList.contains("on"), "keystrokes alone show the shared strip");
+    assert.ok(strip.classList.contains("has-keys"), "control state marks the strip as key-bearing");
     assert.strictEqual(el("keybar").style.display, "flex");
 
+    // Visibility follows controlGranted, not the exact spelling of an inline display value.
+    el("keybar").style.display = "inline-flex";
+    socket.deliver({ t: "voiceStatus", available: false });
+    assert.ok(strip.classList.contains("on"), "keystrokes keep the strip visible for any flex display");
+
+    // A narrow phone wraps voice and keys inside this ONE wrapper; reserve its measured height once.
+    strip.offsetHeight = 104;
     socket.deliver({ t: "voiceStatus", available: true });
     assert.ok(el("voicebar").classList.contains("on"), "voice joins the same strip");
     assert.ok(strip.classList.contains("on"));
-    assert.strictEqual(el("body").style.paddingBottom, "52px", "reserve the shared row once");
+    assert.strictEqual(el("body").style.paddingBottom, "104px", "reserve the wrapped shared strip once");
     assert.strictEqual(el("voicebar").style.bottom, undefined, "voice is not a separately positioned row");
     assert.strictEqual(el("keybar").style.bottom, undefined, "keys are not a separately positioned row");
 
     viewport.height = 480;
     viewportListeners.resize();
     assert.strictEqual(strip.style.bottom, "300px", "the one strip rides the keyboard edge");
-    assert.strictEqual(el("body").style.paddingBottom, "52px", "keyboard-open layout still reserves one row");
+    assert.strictEqual(el("body").style.paddingBottom, "104px", "keyboard-open layout reserves the wrapped strip once");
 
-    socket.deliver({ t: "voiceStatus", available: false });
-    assert.ok(strip.classList.contains("on"), "keystrokes keep the strip visible when voice leaves");
+    // The strip spans y=376..480 after wrapping and riding the 300px keyboard inset.
+    strip.rect = { left: 0, top: 376, width: 390, height: 104, right: 390, bottom: 480 };
+    socket.deliver({ t: "voiceError", code: "rate_limited" });
+    assert.strictEqual(el("voicetoast").style.bottom, "416px", "toast sits above keyboard and strip");
+
     socket.deliver({ t: "control", granted: false });
+    assert.ok(strip.classList.contains("on"), "voice keeps the strip visible when keystrokes leave");
+    assert.ok(!strip.classList.contains("has-keys"), "a voice-only strip returns to centered layout");
+    socket.deliver({ t: "voiceStatus", available: false });
     assert.ok(!strip.classList.contains("on"), "the strip hides when neither group is available");
   },
 


### PR DESCRIPTION
## Summary

- place Boss Calling and mobile keystrokes in one keyboard-aware bottom strip
- restore host cursor visibility and shape in WebViewer snapshots and resyncs
- cover keyboard layout and cursor state with regression tests

## Root cause

The viewer positioned `#voicebar` and `#keybar` as separate fixed rows and reserved both heights, so opening the mobile keyboard double-pushed the terminal.

Separately, `paneSnapshot` resets xterm before replaying styled cells and cursor position, but the snapshot omitted the host cursor visibility and DECSCUSR shape. TUIs that hide the hardware cursor and paint their own block therefore showed that block alongside xterm's reset cursor.

## Impact

Call controls now share the keystroke row, and the terminal reserves only one row around the soft keyboard. Initial connects and text/graphics resyncs now preserve hidden, block, underline, and vertical-bar cursor modes for GUI and daemon shares.

## Validation

- `ANDROID_HOME=/Users/kshivang/Library/Android/sdk ./gradlew :compose-ui:desktopTest --tests "ai.rever.bossterm.compose.share.TerminalSnapshotEncoderTest" --console=plain`
- `ANDROID_HOME=/Users/kshivang/Library/Android/sdk ./gradlew :compose-ui:desktopTest --tests "ai.rever.bossterm.compose.share.ShareViewerScriptTest" --console=plain`
- `ANDROID_HOME=/Users/kshivang/Library/Android/sdk ./gradlew :compose-ui:desktopTest --tests "ai.rever.bossterm.compose.share.ShareViewerAssetTest" --tests "ai.rever.bossterm.compose.share.CallLabelTest" --console=plain`
- `ANDROID_HOME=/Users/kshivang/Library/Android/sdk ./gradlew build --console=plain`
