### PR TITLE
chore: point publish metadata at risalabs.ai and drop bot CI identities

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Risa Labs"
+          git config user.email "enterprise@risalabs.ai"
 
       - name: Get release info
         id: release_info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Commit Version Bump
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version_bump != 'none' && github.event.inputs.version_bump != 'patch'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Risa Labs"
+          git config user.email "enterprise@risalabs.ai"
 
           if ! git diff --quiet VERSION; then
             git add VERSION
@@ -454,8 +454,8 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           VERSION="${{ needs.prepare-version.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Risa Labs"
+          git config user.email "enterprise@risalabs.ai"
           # Idempotent so a rerun of a partially-failed release (tag pushed, later
           # step failed) can proceed instead of dying on "tag already exists".
           if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null; then
@@ -609,8 +609,8 @@ jobs:
       - name: Commit and Push
         run: |
           cd homebrew-tap
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Risa Labs"
+          git config user.email "enterprise@risalabs.ai"
           git add Casks/bossterm.rb
           git commit -m "Update BossTerm to ${{ needs.prepare-version.outputs.version }}"
           git push

--- a/README.md
+++ b/README.md
@@ -751,4 +751,4 @@ BossTerm has since been completely rewritten from the ground up in Kotlin with C
 
 ---
 
-**Built by [Risa Labs Inc](https://risalabs.ai)**
+**Built by [Risa Labs Inc](https://www.risalabs.ai)**

--- a/bossterm-app/build.gradle.kts
+++ b/bossterm-app/build.gradle.kts
@@ -157,7 +157,7 @@ compose.desktop {
 
             linux {
                 iconFile.set(rootProject.file("BossTerm.png"))
-                debMaintainer = "shivang.risa@gmail.com"
+                debMaintainer = "support@risalabs.ai"
                 menuGroup = "System;TerminalEmulator"
                 appCategory = "Utility"
                 shortcut = true

--- a/bossterm-core-mpp/build.gradle.kts
+++ b/bossterm-core-mpp/build.gradle.kts
@@ -102,7 +102,7 @@ mavenPublishing {
             developer {
                 id.set("kshivang")
                 name.set("Shivang")
-                email.set("shivang.risa@gmail.com")
+                email.set("enterprise@risalabs.ai")
             }
         }
         scm {

--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -203,7 +203,7 @@ mavenPublishing {
             developer {
                 id.set("kshivang")
                 name.set("Shivang")
-                email.set("shivang.risa@gmail.com")
+                email.set("enterprise@risalabs.ai")
             }
         }
         scm {

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -58,4 +58,4 @@ BossTerm is dual-licensed under [LGPLv3](https://github.com/kshivang/BossTerm/bl
 
 ---
 
-**Built by [Risa Labs Inc](https://risalabs.ai)**
+**Built by [Risa Labs Inc](https://www.risalabs.ai)**


### PR DESCRIPTION
## Why

The Maven Central POMs and the `.deb` `Maintainer` field carried a personal gmail address. Since these are published artifact metadata, they should name a company mailbox that will still be read years from now.

## What changed

| Area | Before | After |
|---|---|---|
| `compose-ui`, `bossterm-core-mpp` POMs | `shivang.risa@gmail.com` | `enterprise@risalabs.ai` |
| `bossterm-app` `debMaintainer` | `shivang.risa@gmail.com` | `support@risalabs.ai` |
| `release.yml`, `release-notes.yml` | `github-actions[bot]` | `Risa Labs <enterprise@risalabs.ai>` |
| `README.md`, `docs/wiki/Home.md` | `https://risalabs.ai` | `https://www.risalabs.ai` |

### Why two different addresses

Deliberate. The Debian `Maintainer` field is a *support* contact, and `support@risalabs.ai` is already what BossConsole's `debMaintainer` and the published apt metadata (`apt/dists/stable/main/binary-amd64/Packages`) advertise — using `enterprise@` here would have made this the only package disagreeing with the repo it ships alongside. POM `developers.email` is not a support channel, so `enterprise@` fits there.

## Verification

All 9 workflow YAML files parse. The apex domain 301-redirects to `www`, hence the canonical form in docs. Bot CI identities removed per our rule that automated commits carry a plain project identity.

## Note for reviewers

This repo lives under a personal account (`kshivang/BossTerm`), so the personal address was arguably intentional. Flagging in case you'd rather keep it — the POM change is easy to drop while keeping the rest.
