### PR TITLE
feat(voice): let an embedder supply Boss Calling's OpenAI key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,20 @@ Located in: `compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/shell/S
 - `VoiceCallService.kt` - share-viewer policy: control role, share scope, mint budget, call tokens
 - `HostVoiceCallController.kt` - the in-app call (JDK WebSocket + `javax.sound.sampled`, no WebRTC)
 - `VoiceAgentStorage.kt` - the chmod-600 key file
+- `VoiceKeySource.kt` - **where the key comes from**: an embedder-supplied source first, then
+  `voice.json`. Read `resolve()`, never `VoiceAgentStorage.load()` directly, on any path that needs
+  a usable key. BossTerm can't depend on `boss-plugin-api`, so the seam is a plain lambda that
+  `terminal-tab` fills from BOSS's `Settings → AI Providers` (its **OpenAI** provider specifically -
+  Realtime is OpenAI's, so handing over whatever provider is merely *active* would send an
+  `sk-ant-…` key to `api.openai.com`). Only the credential is shared: the Realtime model stays
+  `TerminalSettings.voiceCallModel`, because an `LlmConfig.modelId` is a *chat* model.
+  Process-wide rather than a `TabbedTerminal` parameter because three unrelated paths read the key
+  (in-app call, share mint, share advertisement). A throwing embedder falls through to the file
+  rather than taking a call down - it runs host code across a plugin classloader.
+  The daemon is deliberately excluded: it is headless with no embedder in the process.
+  `keyStamp()` still only sees file edits, so an embedder key is noticed on the next read rather
+  than pushed - which is why `MirrorShare`'s presence check calls it per read alongside its two
+  file-backed caches.
 - `VoiceAgentCustomization.kt` - the embedder seam for the agent's instructions (the button's label
   is a `TabbedTerminal` parameter instead, alongside `contextMenuItems`)
 - `VoiceToolSource.kt` - the EMBEDDER's tool surface (`TabbedTerminal(voiceToolSource = …)`), merged
@@ -160,7 +174,8 @@ Located in: `compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/shell/S
   viewer's bottom bar (remote). "Boss Calling" is the FEATURE and is fixed; the in-app button's
   label is `TabbedTerminal(callLabel = …)` - null renders "Call BossTerm", BossConsole passes
   "Call Boss". The viewer's button is a static web asset and stays "Call BossTerm". Needs an OpenAI
-  key in `~/.bossterm/voice.json`; remote calls additionally require control of the share
+  key - from an embedder-registered source if there is one, else `~/.bossterm/voice.json` (see
+  `VoiceKeySource.kt`); remote calls additionally require control of the share
 - **Debug**: Ctrl+Shift+D
 
 ## Programmatic API

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/MirrorShare.kt
@@ -15,6 +15,7 @@ import ai.rever.bossterm.compose.voice.VoiceAgentStorage
 import ai.rever.bossterm.compose.voice.RemoteVoiceCalls
 import ai.rever.bossterm.compose.voice.StampCachedValue
 import ai.rever.bossterm.compose.voice.VoiceCallService
+import ai.rever.bossterm.compose.voice.VoiceKeySource
 import ai.rever.bossterm.compose.voice.voiceCallTokenMatches
 import ai.rever.bossterm.compose.window.WindowManager
 import ai.rever.bossterm.terminal.model.TerminalModelListener
@@ -153,7 +154,13 @@ class MirrorShare(
             // round-trip: the same undiagnosable-from-the-far-end failure `reason` exists to stop.
             // Either source saying yes is enough. The flow is instant after an in-process save; the
             // stamp cache catches everything else for two stats.
-            keyPresent = { VoiceAgentStorage.keyPresentFlow.value || keyOnDisk.get() == true },
+            keyPresent = {
+                // Three sources, any one is enough. The embedder's is checked per read because
+                // it has no stamp and moves no flow, so neither cache below can see it change.
+                VoiceKeySource.embedderKeyPresent() ||
+                    VoiceAgentStorage.keyPresentFlow.value ||
+                    keyOnDisk.get() == true
+            },
             // Reads voice.json when its stamp moved. The FLOW answer is free and usually enough;
             // this is the cross-process half — see keyOnDisk.
             sessionName = { sessionName.value },

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/HostVoiceCallController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/HostVoiceCallController.kt
@@ -76,7 +76,7 @@ internal class HostVoiceCallController(
      */
     private val newAudio: () -> VoiceAudioIo = { JavaSoundVoiceAudioIo() },
     private val settings: () -> TerminalSettings = { SettingsManager.instance.settings.value },
-    private val loadKey: () -> String? = { VoiceAgentStorage.load()?.openaiApiKey?.takeIf { it.isNotBlank() } },
+    private val loadKey: () -> String? = { VoiceKeySource.resolve() },
     /** Injected in tests so the ceilings can be exercised without waiting them out. */
     private val nowMs: () -> Long = { System.currentTimeMillis() },
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/VoiceCallService.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/VoiceCallService.kt
@@ -46,7 +46,7 @@ internal class VoiceCallService(
     private val scope: CoroutineScope,
     private val broker: VoiceSessionBroker = VoiceSessionBroker(),
     private val settings: () -> TerminalSettings = { SettingsManager.instance.settings.value },
-    private val loadKey: () -> String? = { VoiceAgentStorage.load()?.openaiApiKey?.takeIf { it.isNotBlank() } },
+    private val loadKey: () -> String? = { VoiceKeySource.resolve() },
     /**
      * Whether a key exists, for [status] only — separate from [loadKey] because status is
      * recomputed on every settings emission per share, and the GUI can answer from the in-process

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/VoiceKeySource.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/VoiceKeySource.kt
@@ -1,0 +1,89 @@
+package ai.rever.bossterm.compose.voice
+
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * Where Boss Calling's OpenAI key comes from: an embedder-supplied source if one is registered,
+ * otherwise `~/.bossterm/voice.json`.
+ *
+ * BossTerm ships as a standalone app as well as a library, so the file stays the fallback and the
+ * settings UI that writes it stays exactly as it was. The override exists for an embedder that
+ * already asks its users for AI credentials somewhere else and should not ask twice: BOSS keeps
+ * them in the secret-manager plugin's `Settings → AI Providers`, and `terminal-tab` registers a
+ * source that reads the user's **OpenAI** provider from there.
+ *
+ * BossTerm cannot depend on `boss-plugin-api` to do that itself — hence a plain lambda.
+ *
+ * ## Registration
+ *
+ * ```kotlin
+ * VoiceKeySource.setEmbedderSource { context.llmProvider?.configuredProviders()
+ *     ?.firstOrNull { it.providerId == "OPENAI" }?.apiKey }
+ * ```
+ *
+ * Process-wide rather than a `TabbedTerminal` parameter because the key is read on three
+ * unrelated paths — the in-app call ([HostVoiceCallController]), the share server's ephemeral
+ * mint ([VoiceCallService] → [VoiceSessionBroker]), and share advertisement — and threading a
+ * composable parameter to all of them would put the seam in the wrong place. Pass null to
+ * deregister, which an embedder must do when it unloads.
+ *
+ * ## What this deliberately does not cover
+ *
+ * - **The Realtime model stays BossTerm's** (`TerminalSettings.voiceCallModel`). An
+ *   `LlmConfig.modelId` is a *chat* model; Realtime needs a `gpt-realtime-*`. Only the credential
+ *   is shared.
+ * - **An OpenAI key specifically.** Realtime is OpenAI's; an embedder must not hand over whatever
+ *   provider happens to be active, or a `sk-ant-…` key ends up at `api.openai.com`.
+ * - **The daemon.** [ai.rever.bossterm.compose.daemon.DaemonShareServer] runs headless with no
+ *   embedder in the process and keeps reading `voice.json` directly.
+ * - **Change notification.** [VoiceAgentStorage.keyStamp] detects an edit to the file; an embedder
+ *   source has no equivalent, so a key that appears in the embedder is noticed the next time
+ *   something asks rather than pushed. Presence checks call [resolve] per read for that reason.
+ */
+object VoiceKeySource {
+    private val log = LoggerFactory.getLogger(VoiceKeySource::class.java)
+
+    @Volatile
+    private var embedder: (() -> String?)? = null
+
+    /** Register (or, with null, remove) the embedder's key source. */
+    fun setEmbedderSource(source: (() -> String?)?) {
+        embedder = source
+        log.info("Boss Calling key source: {}", if (source == null) "voice.json" else "embedder")
+    }
+
+    /**
+     * The key to use, embedder first, or null when neither source has one.
+     *
+     * The embedder's lambda reaches into host code — a plugin classloader in BOSS's case — so a
+     * throw here must not take a voice call or a share advertisement down with it; it falls
+     * through to the file instead. Logged without the throwable: nothing in this path should be
+     * able to print a credential.
+     */
+    internal fun resolve(file: File = VoiceAgentStorage.defaultFile()): String? {
+        val fromEmbedder = try {
+            embedder?.invoke()
+        } catch (t: Throwable) {
+            log.warn("Embedder key source failed ({}); falling back to voice.json", t::class.simpleName)
+            null
+        }
+        return fromEmbedder?.takeIf { it.isNotBlank() }
+            ?: VoiceAgentStorage.load(file)?.openaiApiKey?.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Whether the *embedder* can supply a key, ignoring the file.
+     *
+     * Separate from [resolve] because the share server's presence check is already a careful
+     * two-source affair (an in-process flow plus a stamp-cached disk read) and this is a third
+     * source to OR in, not a replacement for either.
+     */
+    internal fun embedderKeyPresent(): Boolean =
+        try {
+            !embedder?.invoke().isNullOrBlank()
+        } catch (t: Throwable) {
+            log.warn("Embedder key source failed ({}) during presence check", t::class.simpleName)
+            false
+        }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceKeySourceTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceKeySourceTest.kt
@@ -1,0 +1,121 @@
+package ai.rever.bossterm.compose.voice
+
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Precedence and failure isolation for Boss Calling's key: an embedder-supplied source wins over
+ * `voice.json`, but must never be able to break the call if it throws.
+ *
+ * BossTerm ships standalone as well as embedded, so the file has to keep working untouched when
+ * nothing is registered — that is what most of these assert.
+ */
+class VoiceKeySourceTest {
+
+    private fun tempFile() = createTempDirectory("voice-key-src").resolve("voice.json").toFile()
+
+    @AfterTest
+    fun deregister() {
+        // The source is process-wide; leaving one registered would leak into every other suite.
+        VoiceKeySource.setEmbedderSource(null)
+    }
+
+    @Test
+    fun `with no embedder registered the file is used`() {
+        val file = tempFile()
+        VoiceAgentStorage.save(StoredVoiceConfig(openaiApiKey = "sk-from-file"), file)
+
+        assertEquals("sk-from-file", VoiceKeySource.resolve(file))
+        assertFalse(VoiceKeySource.embedderKeyPresent())
+    }
+
+    @Test
+    fun `the embedder source wins over the file`() {
+        val file = tempFile()
+        VoiceAgentStorage.save(StoredVoiceConfig(openaiApiKey = "sk-from-file"), file)
+        VoiceKeySource.setEmbedderSource { "sk-from-embedder" }
+
+        assertEquals("sk-from-embedder", VoiceKeySource.resolve(file))
+        assertTrue(VoiceKeySource.embedderKeyPresent())
+    }
+
+    /**
+     * The BOSS case: the user has no OpenAI provider configured, so the plugin's lambda returns
+     * null. That must fall through to the file rather than reporting "no key" — an embedded user
+     * who pasted a key into BossTerm's own settings keeps working.
+     */
+    @Test
+    fun `an embedder returning null falls through to the file`() {
+        val file = tempFile()
+        VoiceAgentStorage.save(StoredVoiceConfig(openaiApiKey = "sk-from-file"), file)
+        VoiceKeySource.setEmbedderSource { null }
+
+        assertEquals("sk-from-file", VoiceKeySource.resolve(file))
+        assertFalse(VoiceKeySource.embedderKeyPresent())
+    }
+
+    @Test
+    fun `an embedder returning blank falls through to the file`() {
+        val file = tempFile()
+        VoiceAgentStorage.save(StoredVoiceConfig(openaiApiKey = "sk-from-file"), file)
+        VoiceKeySource.setEmbedderSource { "   " }
+
+        assertEquals("sk-from-file", VoiceKeySource.resolve(file))
+        assertFalse(VoiceKeySource.embedderKeyPresent())
+    }
+
+    /**
+     * The embedder's lambda runs host code across a plugin classloader. A `LinkageError` there —
+     * an api symbol the host does not serve, say — must not take a voice call or a share
+     * advertisement down with it.
+     */
+    @Test
+    fun `a throwing embedder falls through instead of propagating`() {
+        val file = tempFile()
+        VoiceAgentStorage.save(StoredVoiceConfig(openaiApiKey = "sk-from-file"), file)
+        VoiceKeySource.setEmbedderSource { throw NoSuchMethodError("getLlmProvider") }
+
+        assertEquals("sk-from-file", VoiceKeySource.resolve(file))
+        assertFalse(VoiceKeySource.embedderKeyPresent())
+    }
+
+    @Test
+    fun `no key anywhere resolves to null`() {
+        val file = tempFile() // never written
+        VoiceKeySource.setEmbedderSource { null }
+        assertNull(VoiceKeySource.resolve(file))
+    }
+
+    @Test
+    fun `deregistering restores the file as the only source`() {
+        val file = tempFile()
+        VoiceAgentStorage.save(StoredVoiceConfig(openaiApiKey = "sk-from-file"), file)
+        VoiceKeySource.setEmbedderSource { "sk-from-embedder" }
+        assertEquals("sk-from-embedder", VoiceKeySource.resolve(file))
+
+        // An embedder must deregister when it unloads, or its dead classloader stays reachable.
+        VoiceKeySource.setEmbedderSource(null)
+
+        assertEquals("sk-from-file", VoiceKeySource.resolve(file))
+        assertFalse(VoiceKeySource.embedderKeyPresent())
+    }
+
+    /**
+     * `embedderKeyPresent` reports on the embedder alone — the share server ORs it with two
+     * separate file-backed checks, so answering true for a file-only key would make one of those
+     * redundant and hide a regression in it.
+     */
+    @Test
+    fun `embedderKeyPresent ignores a key that only exists in the file`() {
+        val file = tempFile()
+        VoiceAgentStorage.save(StoredVoiceConfig(openaiApiKey = "sk-from-file"), file)
+
+        assertFalse(VoiceKeySource.embedderKeyPresent())
+        assertEquals("sk-from-file", VoiceKeySource.resolve(file))
+    }
+}


### PR DESCRIPTION
## Why

BossTerm asked for an OpenAI key in `~/.bossterm/voice.json` even when its embedder had already
collected AI credentials elsewhere. In BOSS those live in the secret-manager plugin's
`Settings → AI Providers`, so a user pasted the same key twice.

## What changed

`VoiceKeySource` is the seam: an embedder-registered lambda, consulted before the file. A plain
lambda rather than a typed provider because BossTerm also ships standalone and cannot depend on
`boss-plugin-api`. The file, the chmod-600 storage and the settings UI that writes it are untouched,
and remain the only source for the standalone app.

Process-wide rather than a `TabbedTerminal` parameter because three unrelated paths read the key —
the in-app call (`HostVoiceCallController`), the share server's ephemeral mint
(`VoiceCallService` → `VoiceSessionBroker`), and share advertisement (`MirrorShare`) — and threading
a composable parameter to all three would put the seam in the wrong place.

`MirrorShare`'s presence check gains the embedder as a third source, ORed in alongside the
in-process flow and the stamp-cached disk read. Without that, a share would advertise `no_key` while
the in-app call worked: `keyStamp()` only sees file edits, and an embedder key moves no flow, so it
must be asked per read.

**Failure isolation matters here:** the lambda runs host code across a plugin classloader, so a
`LinkageError` from an api symbol the host does not serve must not take a voice call or a share
advertisement down. It falls through to the file, and logs the exception type only — nothing on this
path should be able to print a credential.

## Deliberately not covered

- **the Realtime model stays `TerminalSettings.voiceCallModel`** — an `LlmConfig.modelId` is a
  *chat* model; Realtime needs `gpt-realtime-*`. Only the credential is shared.
- **an OpenAI key specifically.** The embedder must not hand over whatever provider happens to be
  active, or an `sk-ant-…` key ends up at `api.openai.com`.
- **the daemon** keeps reading `voice.json` directly — it is headless with no embedder in the
  process.

## Tests

8 new cases. **Mutation-verified twice**: inverting the precedence fails two by name, and removing
the `try/catch` fails the throwing-embedder case. Full `compose-ui` suite green at **907**.

## Follow-up (not in this PR)

`terminal-tab` does the actual wiring —
`{ context.llmProvider?.configuredProviders()?.firstOrNull { it.providerId == "OPENAI" }?.apiKey }`.
It pins a published `bossterm-compose` and its release auto-triggers on BossTerm releases, so this
must merge and release first; the pin is never hand-bumped.