### PR TITLE
fix(theme): draw the search highlight before text, like selection

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -552,7 +552,15 @@ object TerminalCanvasRenderer {
         // over the thin left-edge bar (it shows through the column's left bearing).
         renderCommandBlockGutter(ctx)
 
-        // Pass 1.5: Draw selection highlight BEFORE text (so text renders on top)
+        // Pass 1.5: search and selection, both BEFORE text so glyphs stay crisp.
+        // Search first, so that if the mutual exclusion below is ever lifted,
+        // selection (the user's live gesture) wins the overlap.
+        if (ctx.searchVisible && ctx.searchMatches.isNotEmpty()) {
+            renderSearchHighlight(ctx)
+        }
+        // Still mutually exclusive with an active search. That predates this change;
+        // it is now a choice made in one phase rather than a side effect of the two
+        // highlights living in different ones.
         if (ctx.selectionStart != null && ctx.selectionEnd != null &&
             !(ctx.searchVisible && ctx.searchMatches.isNotEmpty())) {
             renderSelectionHighlight(ctx)
@@ -1132,7 +1140,43 @@ object TerminalCanvasRenderer {
             }
         }
 
-        // Search match highlights
+        // Search highlighting now happens in Pass 1.5, BEFORE text, so the wash is
+        // a background rather than a tint on the glyphs. See renderSearchHighlight.
+        // Selection is likewise Pass 1.5, and the cursor has its own overlay Canvas.
+
+        // Cursor is intentionally NOT drawn here. It lives in its own overlay Canvas
+        // (see ProperTerminal) so its blink only repaints a single small layer instead of
+        // re-running this whole text pass twice a second. See [renderCursorOverlay].
+    }
+
+    /**
+     * Pass 1.5: search match backgrounds, drawn BEFORE text.
+     *
+     * This used to run in Pass 3, painting a translucent wash ON TOP of the glyphs
+     * it highlighted - so alpha had to serve two masters at once: emphasis (which
+     * match am I on) and legibility (can I still read through it). Selection was
+     * moved before text for exactly this reason; search had not followed.
+     *
+     * Measured across all twelve builtins, worst case, as a fraction of each
+     * theme's own foreground-on-background contrast:
+     *
+     *     over the glyphs, current match @0.65   1.71:1   11.6% of baseline
+     *     over the glyphs, other matches @0.32   2.78:1   37.2%
+     *     behind the glyphs, one fill    @0.35   2.92:1   34.8%
+     *
+     * So a single fill behind the text beats BOTH previous states, and the glyphs
+     * stay crisp instead of being tinted. Which is also why the current match no
+     * longer gets a heavier fill: at 0.65 it was the worst-reading state in the
+     * whole terminal. Its outline carries the distinction on its own now.
+     *
+     * A stronger fill is not available by tuning: in several themes `searchMatch`
+     * sits close in luminance to the foreground (one-dark, both Solarizeds), so no
+     * alpha reaches the 4.5:1 text floor - a couple of those themes do not reach it
+     * unhighlighted either. Flipping the glyphs to the background colour measures
+     * WORSE (2.98:1 worst), so it is not the answer here.
+     */
+    private fun DrawScope.renderSearchHighlight(ctx: RenderingContext) {
+        val snapshot = ctx.bufferSnapshot
         if (ctx.searchVisible && ctx.searchMatches.isNotEmpty()) {
             val matchLength = ctx.searchQuery.length
             ctx.searchMatches.forEachIndexed { index, (matchCol, matchRow) ->
@@ -1150,11 +1194,9 @@ object TerminalCanvasRenderer {
                     // colour the theme never defined.
                     val matchBase = ctx.settings.foundPatternColorValue
                     val isCurrentMatch = index == ctx.currentMatchIndex
-                    val matchColor = if (isCurrentMatch) {
-                        matchBase.copy(alpha = 0.65f)
-                    } else {
-                        matchBase.copy(alpha = 0.32f)
-                    }
+                    // One fill for every match; the outline below marks the current
+                    // one. See this function's KDoc for the measurements.
+                    val matchColor = matchBase.copy(alpha = SEARCH_FILL_ALPHA)
 
                     for (charOffset in 0 until matchLength) {
                         val col = matchCol + charOffset
@@ -1208,11 +1250,6 @@ object TerminalCanvasRenderer {
             }
         }
 
-        // Selection highlight is now rendered in Pass 1.5 (before text) so text is visible on top
-
-        // Cursor is intentionally NOT drawn here. It lives in its own overlay Canvas
-        // (see ProperTerminal) so its blink only repaints a single small layer instead of
-        // re-running this whole text pass twice a second. See [renderCursorOverlay].
     }
 
     /**
@@ -1380,7 +1417,18 @@ object TerminalCanvasRenderer {
      * Cursor is rendered at its buffer position - when scrolled into history,
      * cursor will be below the visible area and won't be rendered.
      */
-        /**
+            /**
+     * Opacity of a search match's background fill.
+     *
+     * Chosen by measurement, not taste: see [renderSearchHighlight]. At 0.35 the
+     * worst builtin retains 34.8% of its own foreground contrast, which beats both
+     * states of the previous over-the-glyph wash (37.2% and 11.6%) while keeping
+     * the glyphs untinted. Raising it trades legibility for prominence in exactly
+     * the themes that can least afford it.
+     */
+    private const val SEARCH_FILL_ALPHA = 0.35f
+
+/**
      * How opaque a block must be before the covered glyph is repainted on top.
      *
      * Below this the original glyph shows THROUGH the block, so a repaint doubles

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/SearchHighlightContrastTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/SearchHighlightContrastTest.kt
@@ -1,0 +1,137 @@
+package ai.rever.bossterm.compose.theme
+
+import ai.rever.bossterm.compose.settings.theme.BuiltinThemes
+import androidx.compose.ui.graphics.Color
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Why the search highlight is a background at [SEARCH_FILL_ALPHA] rather than a
+ * heavier wash over the glyphs.
+ *
+ * The old arrangement drew the wash in Pass 3, on top of the text, so alpha served
+ * emphasis and legibility at once. Moving it to Pass 1.5 (as selection already
+ * was) makes it a true background - but a background still has to leave the text
+ * readable, and in several builtins `searchMatch` sits close in luminance to the
+ * foreground, so "just use it at full strength" does not work.
+ *
+ * These are the numbers that picked 0.35. They are asserted rather than written in
+ * a comment because the constant is exactly the kind of thing that gets nudged up
+ * for prominence, and the themes that suffer most are the ones nobody is looking
+ * at when they nudge it.
+ */
+class SearchHighlightContrastTest {
+    /** Mirrors `TerminalCanvasRenderer.SEARCH_FILL_ALPHA` (private). */
+    private val fillAlpha = 0.35f
+
+    /** The two alphas the old over-the-glyph wash used. */
+    private val oldOtherAlpha = 0.32f
+    private val oldCurrentAlpha = 0.65f
+
+    private fun luminance(c: Color): Double {
+        fun ch(v: Float): Double {
+            val s = v.toDouble()
+            return if (s <= 0.03928) s / 12.92 else ((s + 0.055) / 1.055).pow(2.4)
+        }
+        return 0.2126 * ch(c.red) + 0.7152 * ch(c.green) + 0.0722 * ch(c.blue)
+    }
+
+    private fun contrast(
+        a: Color,
+        b: Color,
+    ): Double {
+        val la = luminance(a)
+        val lb = luminance(b)
+        return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+    }
+
+    private fun over(
+        top: Color,
+        bottom: Color,
+        alpha: Float,
+    ): Color =
+        Color(
+            red = top.red * alpha + bottom.red * (1 - alpha),
+            green = top.green * alpha + bottom.green * (1 - alpha),
+            blue = top.blue * alpha + bottom.blue * (1 - alpha),
+        )
+
+    /**
+     * A fill BEHIND the glyphs must leave every theme a usable fraction of its own
+     * foreground contrast. Expressed as a fraction, not an absolute floor: a couple
+     * of builtins (both Solarizeds) do not clear 4.5:1 even unhighlighted, so an
+     * absolute floor would be unreachable rather than informative.
+     */
+    @Test
+    fun `the search fill keeps a third of every theme's own contrast`() {
+        val worst =
+            BuiltinThemes.ALL.minOf { theme ->
+                val fg = theme.foregroundColor
+                val bg = theme.backgroundColorValue
+                contrast(fg, over(theme.searchMatchColor, bg, fillAlpha)) / contrast(fg, bg)
+            }
+        assertTrue(
+            worst >= 0.33,
+            "the search fill leaves the worst theme only ${(worst * 100).toInt()}% of its own " +
+                "contrast; lower SEARCH_FILL_ALPHA or pick a different searchMatch",
+        )
+    }
+
+    /**
+     * The strong guarantee: a background fill beats the CURRENT-match wash it
+     * replaced, on every theme. That wash was the worst-reading state in the
+     * terminal - at 0.65 it left one builtin 11.6% of its own contrast.
+     *
+     * Against the old OTHER-match wash (0.32) the comparison is closer, and
+     * measured honestly it is not a clean win everywhere: the ratio runs 0.87
+     * (one-dark) to 1.05 (solarized-light). The number cannot express what
+     * actually improved - the old wash tinted the GLYPH toward the highlight
+     * colour, and a background does not - so this pins a floor rather than
+     * claiming a gain.
+     */
+    @Test
+    fun `a background fill beats the current-match wash and holds against the other`() {
+        for (theme in BuiltinThemes.ALL) {
+            val fg = theme.foregroundColor
+            val bg = theme.backgroundColorValue
+            val match = theme.searchMatchColor
+
+            val behind = contrast(fg, over(match, bg, fillAlpha))
+            // The old wash tinted the glyph AND the cell behind it.
+            val oldOther = contrast(over(match, fg, oldOtherAlpha), over(match, bg, oldOtherAlpha))
+            val oldCurrent = contrast(over(match, fg, oldCurrentAlpha), over(match, bg, oldCurrentAlpha))
+
+            assertTrue(
+                behind > oldCurrent,
+                "${theme.id}: behind-text ($behind) must beat the old current-match wash ($oldCurrent)",
+            )
+            assertTrue(
+                behind >= oldOther * 0.85,
+                "${theme.id}: behind-text ($behind) fell more than 15% below the old " +
+                    "other-match wash ($oldOther); measured worst is 0.87 on one-dark",
+            )
+        }
+    }
+
+    /**
+     * The reason the current match no longer gets a heavier fill: a heavier one is
+     * not available. Pins that raising the alpha makes the worst theme worse, so
+     * the outline really does have to carry the distinction.
+     */
+    @Test
+    fun `a heavier fill would degrade the worst theme further`() {
+        fun worstRetention(alpha: Float) =
+            BuiltinThemes.ALL.minOf { theme ->
+                val fg = theme.foregroundColor
+                val bg = theme.backgroundColorValue
+                contrast(fg, over(theme.searchMatchColor, bg, alpha)) / contrast(fg, bg)
+            }
+        assertTrue(
+            worstRetention(0.5f) < worstRetention(fillAlpha),
+            "if a heavier fill did not cost contrast, the current match should use one",
+        )
+    }
+}


### PR DESCRIPTION
## Why

Search highlighting ran in **Pass 3**, painting a translucent wash *on top of* the glyphs it highlighted. That made alpha serve two masters at once: emphasis (which match am I on) and legibility (can I still read through it). Selection was moved to Pass 1.5 for exactly this reason - `renderOverlays` still carried the note *"Selection highlight is now rendered in Pass 1.5 (before text) so text is visible on top"* - and search never followed. This finishes it.

## The numbers decided the design

Worst case across all twelve builtins, as a fraction of each theme's **own** foreground-on-background contrast:

| arrangement | worst contrast | % of theme's baseline |
|---|---|---|
| over the glyphs, current match @0.65 | 1.71:1 | **11.6%** |
| over the glyphs, other matches @0.32 | 2.78:1 | 37.2% |
| behind the glyphs, one fill @0.35 | 2.92:1 | 34.8% |

The current match's heavier wash was the worst-reading state in the terminal. A single fill behind the text beats it on **every** theme, and leaves the glyphs untinted.

That is why every match now gets the same fill, and the outline carries the distinction alone: a heavier fill for the current match is not available, only more damaging. A test pins that raising the alpha makes the worst theme worse.

## Two things I expected and measured false

Both changed the design, so they are worth stating:

- **A full-strength fill is impossible.** In `one-dark` and both Solarizeds, `searchMatch` sits close in luminance to the foreground, so no alpha reaches the 4.5:1 text floor. Those themes do not reach it unhighlighted either - which is why the guard asserts a fraction of each theme's own baseline rather than an absolute floor that would be unreachable and uninformative.
- **Flipping the glyphs to the background colour measures worse** (2.98:1 worst), not better. That is the standard move for a background highlight, and here it is the wrong one - so the text pass's batching hot loop stays untouched.

Against the old *other-match* wash the comparison is closer and not a clean win everywhere: the ratio runs 0.87 (`one-dark`) to 1.05 (`solarized-light`). `SearchHighlightContrastTest` pins that as a floor rather than claiming a gain, because the number cannot express what actually improved - the old wash tinted the glyph itself, and a background does not.

## Scope

Selection and search remain mutually exclusive. That predates this change; it is now a choice made in one phase rather than a side effect of the two highlights living in different ones. Worth revisiting separately if you want them to coexist.

**930 tests, 0 failures.**
