### PR TITLE
fix(emulator): contain scroll-region rotation inside its margins

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/BossTerminal.kt
@@ -1234,9 +1234,20 @@ class BossTerminal(
         myTabulator.setTabStop(myCursorX)
     }
 
+    /**
+     * IL/DL are ignored when the cursor sits outside the scrolling region (DEC VT510). Without this
+     * the region's TOP margin is unguarded: with `ESC[2;9r` and the cursor on row 1, the rotation
+     * would run from row 1 and pan a row the region does not own. The bottom margin is contained
+     * inside [LinesStorage.rotateRegion]; this is the mirror of it, and it has to live here because
+     * only the terminal knows where the cursor is.
+     */
+    private fun cursorIsOutsideScrollRegion(): Boolean =
+        myCursorY < myScrollRegionTop || myCursorY > myScrollRegionBottom
+
     override fun insertLines(count: Int) {
         terminalTextBuffer.lock()
         try {
+            if (cursorIsOutsideScrollRegion()) return
             terminalTextBuffer.insertLines(myCursorY - 1, count, myScrollRegionBottom)
         } finally {
             terminalTextBuffer.unlock()
@@ -1246,6 +1257,7 @@ class BossTerminal(
     override fun deleteLines(count: Int) {
         terminalTextBuffer.lock()
         try {
+            if (cursorIsOutsideScrollRegion()) return
             terminalTextBuffer.deleteLines(myCursorY - 1, count, myScrollRegionBottom)
         } finally {
             terminalTextBuffer.unlock()

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/LinesStorage.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/LinesStorage.kt
@@ -1,6 +1,7 @@
 package ai.rever.bossterm.terminal.model
 
 import ai.rever.bossterm.terminal.StyledTextConsumer
+import kotlin.math.abs
 import kotlin.math.min
 
 /**
@@ -153,40 +154,39 @@ fun LinesStorage.processLines(yStart: Int, count: Int, consumer: StyledTextConsu
  * @param lastLine last row of the region; rows after it are unaffected.
  */
 fun LinesStorage.insertLines(y: Int, count: Int, lastLine: Int, filler: TerminalLine.TextEntry) {
+  if (count <= 0) return
   rotateRegion(y, lastLine, delta = count, filler = filler)
 }
 
 /**
  * Rotate the rows of a scrolling region by [delta], filling the vacated end with blanks.
  *
- * Positive [delta] pans content DOWN (SD / IL): the bottom [delta] rows fall out past the bottom
- * margin and blanks appear at [y]. Negative pans UP (SU / DL / line feed): the top rows leave and
- * blanks appear at the bottom margin. Rows outside `[y, lastLine]` are PINNED and never move.
+ * Positive [delta] pans content DOWN (SD / IL): the bottom rows fall out past the bottom margin and
+ * blanks appear at [y]. Negative pans UP (SU / DL / line feed): the top rows leave and blanks appear
+ * at the bottom margin. Rows outside `[y, lastLine]` are PINNED and never move.
  *
- * This exists as one function because the two directions are the same rotation with opposite
- * signs, and keeping them as two hand-written index computations is exactly how they came to
- * disagree. The down direction removed at a per-iteration `lastLine.coerceAtMost(size - 1)`, which
- * walks past the margin as each removal shifts the rows above it up — with rows r1..r10, a region
- * of 2..9 and count 3 it deleted r9, then the PINNED r10, then r8, leaving r7 in row 10. Claude
- * Code drives precisely this (`ESC[2;Nr` + `ESC[nT`) and pins its prompt box below the region, so
- * the rows it never repaints were being corrupted underneath it. The up direction bounded its loop
- * by `y < size` rather than by the region, so any count past the region height destroyed the rows
- * below the bottom margin too, and fed them to scrollback on a top-anchored region.
+ * One function rather than two because the directions are the same rotation with opposite signs.
+ * They were previously two hand-written index computations, and each reached past a margin in its
+ * own way - see the commit that introduced this for the exact index math that failed. Three bounds
+ * keep both honest:
  *
- * Two bounds keep both honest:
- *  - the region is materialized up to [lastLine] first. Clamping the region to `size - 1` instead
- *    makes the PAINTED row count define the margin, so on a partly painted screen the rows that
- *    should have shifted down into the unpainted part are dropped instead. Rendering never
- *    materializes trailing rows ([ai.rever.bossterm.terminal.model.pool.IncrementalSnapshotBuilder]
- *    iterates `0 until size`), so a short screen stays short and this is reachable, not theoretical.
- *  - the move is clamped to the region height, so an oversized count blanks the region and nothing
- *    else. Moving `count` rows while removing fewer changed the screen's height.
+ *  - the region is materialized up to [lastLine] before it is measured. Clamping to `size - 1`
+ *    instead lets the PAINTED row count define the margin, so rows that should shift into the
+ *    unpainted part are dropped. Rendering never materializes trailing rows
+ *    ([ai.rever.bossterm.terminal.model.pool.IncrementalSnapshotBuilder] iterates `0 until size`),
+ *    so a short screen stays short: reachable, not theoretical. Note this makes the first scroll
+ *    grow `size` to the region bottom permanently, and on a partly painted MAIN screen the rows
+ *    handed back for scrollback then include the blanks a full-height screen really has.
+ *  - the move is clamped to the region height, so an oversized count blanks the region and touches
+ *    nothing outside it. Moving `count` rows while removing fewer changed the screen's height.
+ *  - `lastLine < y` is a no-op. Callers reach this with a cursor-derived [y] (IL/DL), which can sit
+ *    outside the region entirely.
  *
  * @param y first row of the region.
  * @param lastLine last row of the region; rows after it are unaffected.
  * @param delta signed number of rows to move; clamped to the region height.
- * @return the rows that left the region, in top-to-bottom order. Only meaningful for a negative
- *   [delta], where the caller may hand them to scrollback.
+ * @return the rows that left the region, top-to-bottom, for a negative [delta]. Always empty for a
+ *   positive [delta]: nothing downstream consumes it, and SD is a scroll hot path.
  */
 private fun LinesStorage.rotateRegion(
   y: Int,
@@ -200,16 +200,20 @@ private fun LinesStorage.rotateRegion(
   // rather than however far painting happens to have reached.
   if (lastLine >= size) get(lastLine)
   val regionBottom = lastLine.coerceAtMost(size - 1)
-  val moved = kotlin.math.abs(delta).coerceAtMost(regionBottom - y + 1)
+  val moved = abs(delta).coerceAtMost(regionBottom - y + 1)
   if (moved <= 0) return emptyList()
 
-  val removeAt = if (delta > 0) regionBottom - moved + 1 else y
-  val insertAt = if (delta > 0) y else regionBottom - moved + 1
+  val panDown = delta > 0
+  val removeIndex = if (panDown) regionBottom - moved + 1 else y
+  val insertIndex = if (panDown) y else regionBottom - moved + 1
 
-  val removed = ArrayList<TerminalLine>(moved)
-  repeat(moved) { removed.add(removeAt(removeAt)) }
-  repeat(moved) { insertAt(insertAt, TerminalLine(filler)) }
-  return removed
+  val removed = if (panDown) null else ArrayList<TerminalLine>(moved)
+  repeat(moved) {
+    val line = removeAt(removeIndex)
+    removed?.add(line)
+  }
+  repeat(moved) { insertAt(insertIndex, TerminalLine(filler)) }
+  return removed ?: emptyList()
 }
 
 /**

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/LinesStorage.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/LinesStorage.kt
@@ -1,7 +1,6 @@
 package ai.rever.bossterm.terminal.model
 
 import ai.rever.bossterm.terminal.StyledTextConsumer
-import kotlin.math.abs
 import kotlin.math.min
 
 /**
@@ -154,58 +153,66 @@ fun LinesStorage.processLines(yStart: Int, count: Int, consumer: StyledTextConsu
  * @param lastLine last row of the region; rows after it are unaffected.
  */
 fun LinesStorage.insertLines(y: Int, count: Int, lastLine: Int, filler: TerminalLine.TextEntry) {
-  if (count <= 0) return
-  rotateRegion(y, lastLine, delta = count, filler = filler)
+  rotateRegion(y, lastLine, panDown = true, magnitude = count, filler = filler)
 }
 
 /**
- * Rotate the rows of a scrolling region by [delta], filling the vacated end with blanks.
+ * Rotate the rows of a scrolling region, filling the vacated end with blanks.
  *
- * Positive [delta] pans content DOWN (SD / IL): the bottom rows fall out past the bottom margin and
- * blanks appear at [y]. Negative pans UP (SU / DL / line feed): the top rows leave and blanks appear
- * at the bottom margin. Rows outside `[y, lastLine]` are PINNED and never move.
+ * [panDown] moves content toward the bottom margin (SD / IL): the bottom rows fall out past
+ * [lastLine] and blanks appear at [y]. Otherwise it moves toward the top (SU / DL / line feed): the
+ * top rows leave and blanks appear at the bottom margin. Rows outside `[y, lastLine]` are PINNED and
+ * never move.
  *
- * One function rather than two because the directions are the same rotation with opposite signs.
- * They were previously two hand-written index computations, and each reached past a margin in its
- * own way - see the commit that introduced this for the exact index math that failed. Three bounds
- * keep both honest:
+ * One function rather than two because the directions are the same rotation mirrored. They were
+ * previously two hand-written index computations, and each reached past a margin in its own way -
+ * see the commit that introduced this for the index math that failed. Three bounds keep both
+ * honest:
  *
- *  - the region is materialized up to [lastLine] before it is measured. Clamping to `size - 1`
- *    instead lets the PAINTED row count define the margin, so rows that should shift into the
- *    unpainted part are dropped. Rendering never materializes trailing rows
- *    ([ai.rever.bossterm.terminal.model.pool.IncrementalSnapshotBuilder] iterates `0 until size`),
- *    so a short screen stays short: reachable, not theoretical. Note this makes the first scroll
- *    grow `size` to the region bottom permanently, and on a partly painted MAIN screen the rows
- *    handed back for scrollback then include the blanks a full-height screen really has.
- *  - the move is clamped to the region height, so an oversized count blanks the region and touches
- *    nothing outside it. Moving `count` rows while removing fewer changed the screen's height.
+ *  - the region is materialized up to [lastLine] before anything is measured, so the bottom margin
+ *    is the REGION's, never however far painting has reached. Letting the painted row count define
+ *    it drops the rows that should shift into the unpainted part, and rendering never materializes
+ *    trailing rows ([ai.rever.bossterm.terminal.model.pool.IncrementalSnapshotBuilder] iterates
+ *    `0 until size`), so a short screen stays short: reachable, not theoretical. Two consequences
+ *    worth knowing - the first scroll grows `size` to the region bottom permanently, and on a
+ *    partly painted MAIN screen the rows handed back for scrollback then include the blanks a
+ *    full-height screen really has.
+ *  - [magnitude] is clamped to the region height, so an oversized count blanks the region and
+ *    touches nothing outside it. Moving `count` rows while removing fewer changed the screen height.
  *  - `lastLine < y` is a no-op. Callers reach this with a cursor-derived [y] (IL/DL), which can sit
  *    outside the region entirely.
  *
+ * Direction is a flag rather than a signed count so there is no sign to get wrong, and so the
+ * accumulator below can be allocated only on the side that returns it.
+ *
  * @param y first row of the region.
  * @param lastLine last row of the region; rows after it are unaffected.
- * @param delta signed number of rows to move; clamped to the region height.
- * @return the rows that left the region, top-to-bottom, for a negative [delta]. Always empty for a
- *   positive [delta]: nothing downstream consumes it, and SD is a scroll hot path.
+ * @param panDown true to move content toward [lastLine] (SD / IL), false toward [y] (SU / DL).
+ * @param magnitude rows to move; clamped to the region height, ignored at zero or below.
+ * @return the rows that left the region, top-to-bottom, when [panDown] is false. Empty when it is
+ *   true: nothing downstream consumes those, and SD is a scroll hot path.
  */
 private fun LinesStorage.rotateRegion(
   y: Int,
   lastLine: Int,
-  delta: Int,
+  panDown: Boolean,
+  magnitude: Int,
   filler: TerminalLine.TextEntry,
 ): List<TerminalLine> {
-  if (delta == 0 || y < 0 || lastLine < y) return emptyList()
+  if (magnitude <= 0 || y < 0 || lastLine < y) return emptyList()
 
-  // Materialize the region before measuring it, so the margin is the region's real bottom
-  // rather than however far painting happens to have reached.
+  // `get` fills the storage up to the index, so after this the region's bottom margin IS
+  // `lastLine`. Deliberately not re-clamped to `size - 1` afterwards: that clamp is what let the
+  // painted row count define the margin. The second check covers a capacity-limited storage that
+  // cannot grow that far, where a no-op beats an out-of-bounds removal.
   if (lastLine >= size) get(lastLine)
-  val regionBottom = lastLine.coerceAtMost(size - 1)
-  val moved = abs(delta).coerceAtMost(regionBottom - y + 1)
-  if (moved <= 0) return emptyList()
+  if (lastLine >= size) return emptyList()
 
-  val panDown = delta > 0
-  val removeIndex = if (panDown) regionBottom - moved + 1 else y
-  val insertIndex = if (panDown) y else regionBottom - moved + 1
+  val moved = magnitude.coerceAtMost(lastLine - y + 1)
+  // The rotation takes rows from one end of the region and opens the same number at the other.
+  val bottomStart = lastLine - moved + 1
+  val removeIndex = if (panDown) bottomStart else y
+  val insertIndex = if (panDown) y else bottomStart
 
   val removed = if (panDown) null else ArrayList<TerminalLine>(moved)
   repeat(moved) {
@@ -229,7 +236,7 @@ private fun LinesStorage.rotateRegion(
  */
 fun LinesStorage.deleteLines(y: Int, count: Int, lastLine: Int, filler: TerminalLine.TextEntry): List<TerminalLine> {
   if (count <= 0) return emptyList()
-  return rotateRegion(y, lastLine, delta = -count, filler = filler)
+  return rotateRegion(y, lastLine, panDown = false, magnitude = count, filler = filler)
 }
 
 /**

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/LinesStorage.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/LinesStorage.kt
@@ -144,67 +144,88 @@ fun LinesStorage.processLines(yStart: Int, count: Int, consumer: StyledTextConsu
 }
 
 /**
- * Performs a cyclic shift:
- * adds [count] of lines at the position [y], then removes [count] of lines from the end of [y, lastLine] range.
+ * Pans the `[y, lastLine]` region DOWN by [count]: the bottom rows fall out past `lastLine` and
+ * blanks appear at [y]. Rows outside the region are pinned. See [rotateRegion] - [count] is clamped
+ * to the region height, so fewer than [count] blanks appear when the region is shorter than that.
  *
- * Optimized to use direct index operations instead of multiple list shuffles.
- * Before: O(m + n + count) where m = lines before y, n = lines after lastLine
- * After: O(count) direct index operations
- *
- * @param y        index of the insertion point, the operation does not affect all lines before this line.
- * @param count    number of lines to insert.
- * @param lastLine the operation does not affect all lines after this line.
+ * @param y        first row of the region; rows before it are unaffected.
+ * @param count    rows to pan down, clamped to the region height.
+ * @param lastLine last row of the region; rows after it are unaffected.
  */
 fun LinesStorage.insertLines(y: Int, count: Int, lastLine: Int, filler: TerminalLine.TextEntry) {
-  if (count <= 0) return
-
-  // First, remove count lines from the end of the scroll region (they scroll off)
-  repeat(count) {
-    val removeIndex = lastLine.coerceAtMost(size - 1)
-    if (removeIndex >= y && size > 0) {
-      removeAt(removeIndex)
-    }
-  }
-
-  // Then, insert count blank lines at position y
-  repeat(count) {
-    insertAt(y, TerminalLine(filler))
-  }
+  rotateRegion(y, lastLine, delta = count, filler = filler)
 }
 
 /**
- * Performs a cyclic shift:
- * removes [count] of lines after the position [y], then adds [count] of lines after the [lastLine].
+ * Rotate the rows of a scrolling region by [delta], filling the vacated end with blanks.
  *
- * Optimized to use direct index operations instead of multiple list shuffles.
- * Before: O(m + n + count) where m = lines before y, n = lines after lastLine
- * After: O(count) direct index operations
+ * Positive [delta] pans content DOWN (SD / IL): the bottom [delta] rows fall out past the bottom
+ * margin and blanks appear at [y]. Negative pans UP (SU / DL / line feed): the top rows leave and
+ * blanks appear at the bottom margin. Rows outside `[y, lastLine]` are PINNED and never move.
  *
- * @param y        first index if the line to delete, the operation does not affect all lines before this line.
- * @param count    number of lines to delete.
- * @param lastLine the operation does not affect all lines after this line.
+ * This exists as one function because the two directions are the same rotation with opposite
+ * signs, and keeping them as two hand-written index computations is exactly how they came to
+ * disagree. The down direction removed at a per-iteration `lastLine.coerceAtMost(size - 1)`, which
+ * walks past the margin as each removal shifts the rows above it up — with rows r1..r10, a region
+ * of 2..9 and count 3 it deleted r9, then the PINNED r10, then r8, leaving r7 in row 10. Claude
+ * Code drives precisely this (`ESC[2;Nr` + `ESC[nT`) and pins its prompt box below the region, so
+ * the rows it never repaints were being corrupted underneath it. The up direction bounded its loop
+ * by `y < size` rather than by the region, so any count past the region height destroyed the rows
+ * below the bottom margin too, and fed them to scrollback on a top-anchored region.
+ *
+ * Two bounds keep both honest:
+ *  - the region is materialized up to [lastLine] first. Clamping the region to `size - 1` instead
+ *    makes the PAINTED row count define the margin, so on a partly painted screen the rows that
+ *    should have shifted down into the unpainted part are dropped instead. Rendering never
+ *    materializes trailing rows ([ai.rever.bossterm.terminal.model.pool.IncrementalSnapshotBuilder]
+ *    iterates `0 until size`), so a short screen stays short and this is reachable, not theoretical.
+ *  - the move is clamped to the region height, so an oversized count blanks the region and nothing
+ *    else. Moving `count` rows while removing fewer changed the screen's height.
+ *
+ * @param y first row of the region.
+ * @param lastLine last row of the region; rows after it are unaffected.
+ * @param delta signed number of rows to move; clamped to the region height.
+ * @return the rows that left the region, in top-to-bottom order. Only meaningful for a negative
+ *   [delta], where the caller may hand them to scrollback.
+ */
+private fun LinesStorage.rotateRegion(
+  y: Int,
+  lastLine: Int,
+  delta: Int,
+  filler: TerminalLine.TextEntry,
+): List<TerminalLine> {
+  if (delta == 0 || y < 0 || lastLine < y) return emptyList()
+
+  // Materialize the region before measuring it, so the margin is the region's real bottom
+  // rather than however far painting happens to have reached.
+  if (lastLine >= size) get(lastLine)
+  val regionBottom = lastLine.coerceAtMost(size - 1)
+  val moved = kotlin.math.abs(delta).coerceAtMost(regionBottom - y + 1)
+  if (moved <= 0) return emptyList()
+
+  val removeAt = if (delta > 0) regionBottom - moved + 1 else y
+  val insertAt = if (delta > 0) y else regionBottom - moved + 1
+
+  val removed = ArrayList<TerminalLine>(moved)
+  repeat(moved) { removed.add(removeAt(removeAt)) }
+  repeat(moved) { insertAt(insertAt, TerminalLine(filler)) }
+  return removed
+}
+
+/**
+ * Pans the `[y, lastLine]` region UP by [count]: the top rows leave the region and blanks appear at
+ * the bottom margin. Rows outside the region are pinned. See [rotateRegion] - [count] is clamped to
+ * the region height, so a larger count blanks the region rather than reaching past `lastLine`.
+ *
+ * @param y        first row of the region; rows before it are unaffected.
+ * @param count    rows to pan up, clamped to the region height.
+ * @param lastLine last row of the region; rows after it are unaffected.
+ * @return the rows that left the region, top-to-bottom. The caller appends these to scrollback when
+ *   the region starts at the top of the screen.
  */
 fun LinesStorage.deleteLines(y: Int, count: Int, lastLine: Int, filler: TerminalLine.TextEntry): List<TerminalLine> {
   if (count <= 0) return emptyList()
-
-  val removed = mutableListOf<TerminalLine>()
-
-  // Remove count lines starting at position y
-  repeat(count) {
-    if (y < size && y <= lastLine) {
-      removed.add(removeAt(y))
-    }
-  }
-
-  // Insert count blank lines at the end of the scroll region
-  // The insert position is (lastLine - count + 1) since we've already removed lines
-  val actualRemoved = removed.size
-  repeat(actualRemoved) { i ->
-    val insertIndex = (lastLine - count + 1 + i).coerceIn(0, size)
-    insertAt(insertIndex, TerminalLine(filler))
-  }
-
-  return removed
+  return rotateRegion(y, lastLine, delta = -count, filler = filler)
 }
 
 /**

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/BossTerminalCharacterWidthTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/BossTerminalCharacterWidthTest.kt
@@ -51,19 +51,4 @@ class BossTerminalCharacterWidthTest {
         return BossTerminal(NoopTerminalDisplay(), textBuffer, styleState)
     }
 
-    private class NoopTerminalDisplay : TerminalDisplay {
-        override var windowTitle: String? = null
-        override var iconTitle: String? = null
-        override val selection: TerminalSelection? = null
-
-        override fun setCursor(x: Int, y: Int) = Unit
-        override fun setCursorShape(cursorShape: CursorShape?) = Unit
-        override fun beep() = Unit
-        override fun scrollArea(scrollRegionTop: Int, scrollRegionSize: Int, dy: Int) = Unit
-        override fun setCursorVisible(isCursorVisible: Boolean) = Unit
-        override fun useAlternateScreenBuffer(useAlternateScreenBuffer: Boolean) = Unit
-        override fun terminalMouseModeSet(mouseMode: MouseMode) = Unit
-        override fun setMouseFormat(mouseFormat: MouseFormat) = Unit
-        override fun ambiguousCharsAreDoubleWidth(): Boolean = false
-    }
 }

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/BossTerminalImageSizingTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/BossTerminalImageSizingTest.kt
@@ -115,19 +115,4 @@ class BossTerminalImageSizingTest {
         intrinsicHeight = height
     )
 
-    private class NoopTerminalDisplay : TerminalDisplay {
-        override var windowTitle: String? = null
-        override var iconTitle: String? = null
-        override val selection: TerminalSelection? = null
-
-        override fun setCursor(x: Int, y: Int) = Unit
-        override fun setCursorShape(cursorShape: CursorShape?) = Unit
-        override fun beep() = Unit
-        override fun scrollArea(scrollRegionTop: Int, scrollRegionSize: Int, dy: Int) = Unit
-        override fun setCursorVisible(isCursorVisible: Boolean) = Unit
-        override fun useAlternateScreenBuffer(useAlternateScreenBuffer: Boolean) = Unit
-        override fun terminalMouseModeSet(mouseMode: MouseMode) = Unit
-        override fun setMouseFormat(mouseFormat: MouseFormat) = Unit
-        override fun ambiguousCharsAreDoubleWidth(): Boolean = false
-    }
 }

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/CursorRowDriftTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/CursorRowDriftTest.kt
@@ -1,12 +1,8 @@
-package ai.rever.bossterm.compose.terminal
+package ai.rever.bossterm.terminal.model
 
-import ai.rever.bossterm.compose.ComposeTerminalDisplay
 import ai.rever.bossterm.terminal.ArrayTerminalDataStream
 import ai.rever.bossterm.terminal.TerminalMode
 import ai.rever.bossterm.terminal.emulator.BossEmulator
-import ai.rever.bossterm.terminal.model.BossTerminal
-import ai.rever.bossterm.terminal.model.StyleState
-import ai.rever.bossterm.terminal.model.TerminalTextBuffer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -41,20 +37,14 @@ class CursorRowDriftTest {
     private val height = 10
 
     private fun feed(sequence: String, assertions: (TerminalTextBuffer) -> Unit) {
-        val display = ComposeTerminalDisplay()
-        try {
-            val styleState = StyleState()
-            val buffer = TerminalTextBuffer(width = width, height = height, styleState = styleState)
-            val terminal = BossTerminal(display, buffer, styleState)
-            terminal.setModeEnabled(TerminalMode.AlternateBuffer, true)
-            buffer.getLine(height - 1) // materialize the lazily allocated screen rows
-            val stream = ArrayTerminalDataStream(sequence.toCharArray())
-            val emulator = BossEmulator(stream, terminal)
-            while (emulator.hasNext()) emulator.next()
-            assertions(buffer)
-        } finally {
-            display.dispose()
-        }
+        val styleState = StyleState()
+        val buffer = TerminalTextBuffer(width = width, height = height, styleState = styleState)
+        val terminal = BossTerminal(NoopTerminalDisplay(), buffer, styleState)
+        terminal.setModeEnabled(TerminalMode.AlternateBuffer, true)
+        buffer.getLine(height - 1) // materialize the lazily allocated screen rows
+        val emulator = BossEmulator(ArrayTerminalDataStream(sequence.toCharArray()), terminal)
+        while (emulator.hasNext()) emulator.next()
+        assertions(buffer)
     }
 
     private fun TerminalTextBuffer.rowText(row: Int) = getLine(row).text.trimEnd()

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/LinesStorageRotationTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/LinesStorageRotationTest.kt
@@ -1,0 +1,98 @@
+package ai.rever.bossterm.terminal.model
+
+import ai.rever.bossterm.terminal.TextStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The [insertLines] / [deleteLines] contract, exercised on the storage directly.
+ *
+ * `ScrollRegionContainmentTest` drives the same code through `BossEmulator`, which is the right
+ * level for "does a Claude Code frame corrupt the screen". This one holds the clamp contract itself:
+ * the region bottom is [lastLine] and never a `size`-derived value, the move is bounded by the
+ * region height, and a region that does not exist is a no-op. Those are the properties someone
+ * reintroducing a `size - 1` margin would break, and they should fail here without an emulator in
+ * the way.
+ */
+class LinesStorageRotationTest {
+
+    private val filler = TerminalLine.TextEntry(TextStyle.EMPTY, CharBuffer(' ', 4))
+
+    private fun storage(rows: Int): LinesStorage {
+        val storage = CyclicBufferLinesStorage(maxCapacity = -1)
+        repeat(rows) { i ->
+            storage.addToBottom(TerminalLine(TerminalLine.TextEntry(TextStyle.EMPTY, CharBuffer("r${i + 1}"))))
+        }
+        return storage
+    }
+
+    private fun LinesStorage.labels() = (0 until size).map { this[it].text.trimEnd() }
+
+    @Test
+    fun panDownTakesFromTheBottomOfTheRegionAndOpensTheTop() {
+        val s = storage(6)
+        s.insertLines(y = 1, count = 2, lastLine = 4, filler = filler)
+        assertEquals(listOf("r1", "", "", "r2", "r3", "r6"), s.labels())
+    }
+
+    @Test
+    fun panUpTakesFromTheTopOfTheRegionAndOpensTheBottom() {
+        val s = storage(6)
+        s.deleteLines(y = 1, count = 2, lastLine = 4, filler = filler)
+        assertEquals(listOf("r1", "r4", "r5", "", "", "r6"), s.labels())
+    }
+
+    @Test
+    fun aMoveOfExactlyTheRegionHeightBlanksIt() {
+        val s = storage(6)
+        s.insertLines(y = 1, count = 4, lastLine = 4, filler = filler)
+        assertEquals(listOf("r1", "", "", "", "", "r6"), s.labels())
+    }
+
+    @Test
+    fun anOversizedMoveIsClampedToTheRegion() {
+        val s = storage(6)
+        s.deleteLines(y = 1, count = 999, lastLine = 4, filler = filler)
+        assertEquals(listOf("r1", "", "", "", "", "r6"), s.labels())
+        assertEquals(6, s.size, "the screen height must not change")
+    }
+
+    @Test
+    fun aSingleRowRegionRotatesInPlace() {
+        val s = storage(3)
+        s.insertLines(y = 1, count = 1, lastLine = 1, filler = filler)
+        assertEquals(listOf("r1", "", "r3"), s.labels())
+    }
+
+    /** The bottom margin comes from `lastLine`, not from how many rows have been materialized. */
+    @Test
+    fun theRegionBottomIsMaterializedRatherThanClampedToSize() {
+        val s = storage(3)
+        s.insertLines(y = 0, count = 5, lastLine = 9, filler = filler)
+        assertEquals(10, s.size, "the region is materialized to its bottom margin")
+        assertEquals(
+            listOf("", "", "", "", "", "r1", "r2", "r3", "", ""),
+            s.labels(),
+            "the painted rows shift down instead of being dropped",
+        )
+    }
+
+    @Test
+    fun aDegenerateOrEmptyRegionIsANoOp() {
+        for (args in listOf(Triple(3, 2, 1), Triple(1, 0, 4), Triple(-1, 2, 4))) {
+            val (y, count, lastLine) = args
+            val s = storage(4)
+            s.insertLines(y = y, count = count, lastLine = lastLine, filler = filler)
+            s.deleteLines(y = y, count = count, lastLine = lastLine, filler = filler)
+            assertEquals(listOf("r1", "r2", "r3", "r4"), s.labels(), "no-op for y=$y count=$count last=$lastLine")
+        }
+    }
+
+    /** Panning down discards the rows that leave; only panning up hands them back for scrollback. */
+    @Test
+    fun onlyPanningUpReturnsTheRowsThatLeft() {
+        val s = storage(6)
+        val removed = s.deleteLines(y = 0, count = 2, lastLine = 5, filler = filler)
+        assertEquals(listOf("r1", "r2"), removed.map { it.text.trimEnd() })
+    }
+}

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/NoopTerminalDisplay.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/NoopTerminalDisplay.kt
@@ -1,0 +1,29 @@
+package ai.rever.bossterm.terminal.model
+
+import ai.rever.bossterm.terminal.CursorShape
+import ai.rever.bossterm.terminal.TerminalDisplay
+import ai.rever.bossterm.terminal.emulator.mouse.MouseFormat
+import ai.rever.bossterm.terminal.emulator.mouse.MouseMode
+
+/**
+ * A [TerminalDisplay] that records nothing, for tests that only care about the buffer.
+ *
+ * Shared because this had been copied privately into four test classes, which means adding a member
+ * to [TerminalDisplay] costs four identical edits. Tests needing to observe display calls should
+ * still keep their own local stub - this one deliberately has no state to assert on.
+ */
+internal open class NoopTerminalDisplay : TerminalDisplay {
+    override var windowTitle: String? = null
+    override var iconTitle: String? = null
+    override val selection: TerminalSelection? = null
+
+    override fun setCursor(x: Int, y: Int) = Unit
+    override fun setCursorShape(cursorShape: CursorShape?) = Unit
+    override fun beep() = Unit
+    override fun scrollArea(scrollRegionTop: Int, scrollRegionSize: Int, dy: Int) = Unit
+    override fun setCursorVisible(isCursorVisible: Boolean) = Unit
+    override fun useAlternateScreenBuffer(useAlternateScreenBuffer: Boolean) = Unit
+    override fun terminalMouseModeSet(mouseMode: MouseMode) = Unit
+    override fun setMouseFormat(mouseFormat: MouseFormat) = Unit
+    override fun ambiguousCharsAreDoubleWidth(): Boolean = false
+}

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/ScrollRegionContainmentTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/ScrollRegionContainmentTest.kt
@@ -1,12 +1,8 @@
 package ai.rever.bossterm.terminal.model
 
 import ai.rever.bossterm.terminal.ArrayTerminalDataStream
-import ai.rever.bossterm.terminal.CursorShape
-import ai.rever.bossterm.terminal.TerminalDisplay
 import ai.rever.bossterm.terminal.TerminalMode
 import ai.rever.bossterm.terminal.emulator.BossEmulator
-import ai.rever.bossterm.terminal.emulator.mouse.MouseFormat
-import ai.rever.bossterm.terminal.emulator.mouse.MouseMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -20,10 +16,15 @@ import kotlin.test.assertEquals
  *
  * where `g-pages/supabase/functions` should have been.
  *
- * Both directions are covered here because they were separately wrong: SD walked past the bottom
- * margin on ANY count, and SU reached past it on any count larger than the region. The oversized
- * and partly painted cases each hid behind a test that only used a small count on a fully painted
- * screen, so they are pinned explicitly.
+ * Both directions are covered because they were separately wrong: SD walked past the bottom margin
+ * on ANY count, and SU reached past it on any count larger than the region. The oversized and
+ * partly painted cases each hid behind a test that used a small count on a fully painted screen, so
+ * they are pinned explicitly. IL/DL reach the same code with a CURSOR-derived top, a materially
+ * different input space, so they get their own cases.
+ *
+ * Assertions are on ROWS wherever possible. A history assertion under a region that does not start
+ * at row 1 proves nothing: `TerminalTextBuffer.scrollArea` only feeds scrollback when
+ * `scrollRegionTop == 1`, so such a test passes with the rotation completely broken.
  */
 class ScrollRegionContainmentTest {
 
@@ -34,13 +35,14 @@ class ScrollRegionContainmentTest {
     private fun replay(
         sequence: String,
         screenHeight: Int = height,
+        alternateScreen: Boolean = true,
         materializeAll: Boolean = true,
         assertions: (TerminalTextBuffer) -> Unit,
     ) {
         val styleState = StyleState()
         val buffer = TerminalTextBuffer(width, screenHeight, styleState)
         val terminal = BossTerminal(NoopTerminalDisplay(), buffer, styleState)
-        terminal.setModeEnabled(TerminalMode.AlternateBuffer, true)
+        if (alternateScreen) terminal.setModeEnabled(TerminalMode.AlternateBuffer, true)
         if (materializeAll) buffer.getLine(screenHeight - 1)
         val emulator = BossEmulator(ArrayTerminalDataStream(sequence.toCharArray()), terminal)
         while (emulator.hasNext()) emulator.next()
@@ -104,10 +106,10 @@ class ScrollRegionContainmentTest {
     }
 
     /**
-     * The region's bottom margin is a property of the REGION, not of how far painting has reached.
-     * Rendering never materializes trailing rows (`IncrementalSnapshotBuilder` iterates
-     * `0 until size`), so a screen can stay short indefinitely; clamping the margin to `size - 1`
-     * silently dropped the rows that should have moved into the unpainted part.
+     * The bottom margin is a property of the REGION, not of how far painting has reached. Rendering
+     * never materializes trailing rows (`IncrementalSnapshotBuilder` iterates `0 until size`), so a
+     * screen can stay short indefinitely; clamping the margin to `size - 1` silently dropped the
+     * rows that should have moved into the unpainted part.
      */
     @Test
     fun scrollDownOnAPartlyPaintedScreenKeepsEveryRow() {
@@ -124,57 +126,94 @@ class ScrollRegionContainmentTest {
     }
 
     /**
-     * Scrolling a region that does NOT start at row 1 is not scrollback. Uses SU with an oversized
-     * count, because that is the combination that used to push rows from below the bottom margin
-     * into history.
+     * The same containment, measured on rows rather than on history: a region below row 1 cannot
+     * feed scrollback anyway, so asserting `historyLinesCount == 0` there proves nothing.
      */
     @Test
-    fun aRegionBelowTheTopAddsNoScrollback() {
+    fun aRegionBelowTheTopLeavesThePinnedRowsAlone() {
         replay(fillRows() + "$esc[2;9r$esc[40S") { buffer ->
-            assertEquals(0, buffer.historyLinesCount, "a region below row 1 must not feed scrollback")
+            val rows = buffer.rows()
+            assertEquals("r1", rows[0], "row 1 is pinned above the region")
+            assertEquals("r10", rows[9], "row 10 is pinned below the region")
         }
     }
 
     /**
-     * A top-anchored region DOES feed scrollback, but only with the rows that actually left the
-     * region - never the rows pinned below its bottom margin. This ran on the main screen because
-     * the alternate screen suppresses scrollback entirely, which would mask the assertion.
+     * A top-anchored region DOES feed scrollback, but only with the rows that actually left it -
+     * never the rows pinned below its bottom margin. On the MAIN screen, because the alternate
+     * screen suppresses scrollback entirely and would mask this.
      */
     @Test
     fun aTopAnchoredRegionScrollsOnlyItsOwnRowsIntoHistory() {
-        val styleState = StyleState()
-        val buffer = TerminalTextBuffer(width, height, styleState)
-        val terminal = BossTerminal(NoopTerminalDisplay(), buffer, styleState)
-        buffer.getLine(height - 1)
-        val sequence = fillRows() + "$esc[1;5r$esc[40S"
-        val emulator = BossEmulator(ArrayTerminalDataStream(sequence.toCharArray()), terminal)
-        while (emulator.hasNext()) emulator.next()
-
-        assertEquals(
-            listOf("r6", "r7", "r8", "r9", "r10"),
-            (5 until height).map { buffer.getLine(it).text.trimEnd() },
-            "rows below the bottom margin are pinned and must stay on screen",
-        )
-        assertEquals(
-            5,
-            buffer.historyLinesCount,
-            "only the region's own 5 rows reach history, not the 5 pinned below it",
-        )
+        replay(fillRows() + "$esc[1;5r$esc[40S", alternateScreen = false) { buffer ->
+            assertEquals(
+                listOf("r6", "r7", "r8", "r9", "r10"),
+                buffer.rows().subList(5, 10),
+                "rows below the bottom margin are pinned and must stay on screen",
+            )
+            assertEquals(
+                5,
+                buffer.historyLinesCount,
+                "only the region's own 5 rows reach history, not the 5 pinned below it",
+            )
+        }
     }
 
-    private class NoopTerminalDisplay : TerminalDisplay {
-        override var windowTitle: String? = null
-        override var iconTitle: String? = null
-        override val selection: TerminalSelection? = null
+    /**
+     * Materializing the region to its bottom margin also decides what a partly painted MAIN screen
+     * hands to scrollback. A real 24-row screen genuinely has blank rows to scroll away, so a
+     * 5-row scroll moves 5 rows even when only 3 have ever been painted. Pinned because this is a
+     * scrollback-content change, not merely an internal one.
+     */
+    @Test
+    fun aPartlyPaintedScreenScrollsItsBlankRowsIntoHistoryToo() {
+        replay(
+            fillRows(n = 3) + "$esc[1;24r$esc[5S",
+            screenHeight = 24,
+            alternateScreen = false,
+            materializeAll = false,
+        ) { buffer ->
+            assertEquals(5, buffer.historyLinesCount, "a 5-row scroll moves 5 rows, painted or not")
+            assertEquals(
+                listOf("r1", "r2", "r3", "", ""),
+                (-5..-1).map { buffer.getLine(it).text.trimEnd() },
+                "the three painted rows, then the blanks a full-height screen really has",
+            )
+        }
+    }
 
-        override fun setCursor(x: Int, y: Int) = Unit
-        override fun setCursorShape(cursorShape: CursorShape?) = Unit
-        override fun beep() = Unit
-        override fun scrollArea(scrollRegionTop: Int, scrollRegionSize: Int, dy: Int) = Unit
-        override fun setCursorVisible(isCursorVisible: Boolean) = Unit
-        override fun useAlternateScreenBuffer(useAlternateScreenBuffer: Boolean) = Unit
-        override fun terminalMouseModeSet(mouseMode: MouseMode) = Unit
-        override fun setMouseFormat(mouseFormat: MouseFormat) = Unit
-        override fun ambiguousCharsAreDoubleWidth(): Boolean = false
+    /**
+     * IL (`CSI L`) reaches the same rotation with a CURSOR-derived top. Inside the region it must
+     * still respect the bottom margin.
+     */
+    @Test
+    fun insertLineWithTheCursorInsideTheRegionKeepsPinnedRows() {
+        replay(fillRows() + "$esc[2;9r$esc[3;1H$esc[3L") { buffer ->
+            val rows = buffer.rows()
+            assertEquals("r1", rows[0], "row 1 is pinned above the region")
+            assertEquals("r10", rows[9], "row 10 is pinned below the region")
+            assertEquals("r2", rows[1], "rows above the cursor do not move")
+            assertEquals(listOf("", "", ""), rows.subList(2, 5), "three blanks open at the cursor")
+        }
+    }
+
+    /**
+     * IL with the cursor BELOW the bottom margin is a no-op. The old code skipped the removal but
+     * still inserted, growing the screen past the terminal height.
+     */
+    @Test
+    fun insertLineWithTheCursorBelowTheMarginChangesNothing() {
+        replay(fillRows() + "$esc[2;5r$esc[8;1H$esc[3L") { buffer ->
+            assertEquals(
+                (1..height).map { "r$it" },
+                buffer.rows(),
+                "IL outside the region must not move any row",
+            )
+            assertEquals(
+                height,
+                buffer.screenLinesCount,
+                "and must not grow the screen past the terminal height",
+            )
+        }
     }
 }

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/ScrollRegionContainmentTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/ScrollRegionContainmentTest.kt
@@ -91,15 +91,15 @@ class ScrollRegionContainmentTest {
      */
     @Test
     fun anOversizedScrollBlanksOnlyTheRegion() {
-        for (op in listOf("T", "S")) {
-            replay(fillRows() + "$esc[2;9r$esc[40$op") { buffer ->
+        for (op in listOf("T", "S")) for (count in listOf(9, 40)) {
+            replay(fillRows() + "$esc[2;9r$esc[$count$op") { buffer ->
                 val rows = buffer.rows()
-                assertEquals("r1", rows[0], "row 1 must survive an oversized $op")
-                assertEquals("r10", rows[9], "row 10 must survive an oversized $op")
+                assertEquals("r1", rows[0], "row 1 must survive $op x$count")
+                assertEquals("r10", rows[9], "row 10 must survive $op x$count")
                 assertEquals(
                     List(8) { "" },
                     rows.subList(1, 9),
-                    "an oversized $op blanks the region and nothing outside it",
+                    "$op x$count blanks the region and nothing outside it",
                 )
             }
         }
@@ -214,6 +214,24 @@ class ScrollRegionContainmentTest {
                 buffer.screenLinesCount,
                 "and must not grow the screen past the terminal height",
             )
+        }
+    }
+
+    /**
+     * The mirror of the case above, on the TOP margin. Both directions, because DL reaches the same
+     * guard. Containment is only meaningfully "pinned" if both margins are covered - a suite with
+     * just the bottom case advertises symmetry it does not have.
+     */
+    @Test
+    fun insertOrDeleteLineAboveTheTopMarginChangesNothing() {
+        for (op in listOf("L", "M")) {
+            replay(fillRows() + "$esc[5;10r$esc[1;1H$esc[3$op") { buffer ->
+                assertEquals(
+                    (1..height).map { "r$it" },
+                    buffer.rows(),
+                    "$op above the region's top margin must not move any row",
+                )
+            }
         }
     }
 }

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/ScrollRegionContainmentTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/ScrollRegionContainmentTest.kt
@@ -1,0 +1,180 @@
+package ai.rever.bossterm.terminal.model
+
+import ai.rever.bossterm.terminal.ArrayTerminalDataStream
+import ai.rever.bossterm.terminal.CursorShape
+import ai.rever.bossterm.terminal.TerminalDisplay
+import ai.rever.bossterm.terminal.TerminalMode
+import ai.rever.bossterm.terminal.emulator.BossEmulator
+import ai.rever.bossterm.terminal.emulator.mouse.MouseFormat
+import ai.rever.bossterm.terminal.emulator.mouse.MouseMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * A scrolling region pins every row outside it. Claude Code scrolls its transcript with `ESC[2;Nr`
+ * plus SD/SU and keeps its prompt box and "Jump to bottom" affordance in the pinned band below, so
+ * a scroll that reaches past a margin corrupts rows the app believes it owns - and it never repaints
+ * them, because from its model nothing there changed. That is how a live session ended up with
+ *
+ *     Update(.worktrees/bossconsole-or Jump to bottom (click) v /organisation/views/layout.ts)
+ *
+ * where `g-pages/supabase/functions` should have been.
+ *
+ * Both directions are covered here because they were separately wrong: SD walked past the bottom
+ * margin on ANY count, and SU reached past it on any count larger than the region. The oversized
+ * and partly painted cases each hid behind a test that only used a small count on a fully painted
+ * screen, so they are pinned explicitly.
+ */
+class ScrollRegionContainmentTest {
+
+    private val esc = "\u001b"
+    private val width = 8
+    private val height = 10
+
+    private fun replay(
+        sequence: String,
+        screenHeight: Int = height,
+        materializeAll: Boolean = true,
+        assertions: (TerminalTextBuffer) -> Unit,
+    ) {
+        val styleState = StyleState()
+        val buffer = TerminalTextBuffer(width, screenHeight, styleState)
+        val terminal = BossTerminal(NoopTerminalDisplay(), buffer, styleState)
+        terminal.setModeEnabled(TerminalMode.AlternateBuffer, true)
+        if (materializeAll) buffer.getLine(screenHeight - 1)
+        val emulator = BossEmulator(ArrayTerminalDataStream(sequence.toCharArray()), terminal)
+        while (emulator.hasNext()) emulator.next()
+        assertions(buffer)
+    }
+
+    /** Label every row with its own 1-based name so any movement is identifiable. */
+    private fun fillRows(n: Int = height) = (1..n).joinToString("") { "$esc[$it;1Hr$it" }
+
+    private fun TerminalTextBuffer.rows(n: Int = height) =
+        (0 until n).map { getLine(it).text.trimEnd() }
+
+    @Test
+    fun scrollDownKeepsContentInsideTheRegion() {
+        replay(fillRows() + "$esc[2;9r$esc[3T") { buffer ->
+            val rows = buffer.rows()
+            assertEquals("r1", rows[0], "row 1 is above the region and must not move")
+            assertEquals("r10", rows[9], "row 10 is below the region and must not move")
+            assertEquals(listOf("", "", ""), rows.subList(1, 4), "region top is exposed as blank")
+            assertEquals(
+                listOf("r2", "r3", "r4", "r5", "r6"),
+                rows.subList(4, 9),
+                "region content shifts down by 3 and clips at the bottom margin",
+            )
+        }
+    }
+
+    @Test
+    fun scrollUpKeepsContentInsideTheRegion() {
+        replay(fillRows() + "$esc[2;9r$esc[3S") { buffer ->
+            val rows = buffer.rows()
+            assertEquals("r1", rows[0], "row 1 is above the region and must not move")
+            assertEquals("r10", rows[9], "row 10 is below the region and must not move")
+            assertEquals(
+                listOf("r5", "r6", "r7", "r8", "r9"),
+                rows.subList(1, 6),
+                "region content shifts up by 3",
+            )
+            assertEquals(listOf("", "", ""), rows.subList(6, 9), "region bottom is exposed as blank")
+        }
+    }
+
+    /**
+     * A count past the region height blanks the region and touches nothing else. The region here is
+     * 8 rows; at exactly 8 both directions were already correct, so the bug only showed from 9 up.
+     */
+    @Test
+    fun anOversizedScrollBlanksOnlyTheRegion() {
+        for (op in listOf("T", "S")) {
+            replay(fillRows() + "$esc[2;9r$esc[40$op") { buffer ->
+                val rows = buffer.rows()
+                assertEquals("r1", rows[0], "row 1 must survive an oversized $op")
+                assertEquals("r10", rows[9], "row 10 must survive an oversized $op")
+                assertEquals(
+                    List(8) { "" },
+                    rows.subList(1, 9),
+                    "an oversized $op blanks the region and nothing outside it",
+                )
+            }
+        }
+    }
+
+    /**
+     * The region's bottom margin is a property of the REGION, not of how far painting has reached.
+     * Rendering never materializes trailing rows (`IncrementalSnapshotBuilder` iterates
+     * `0 until size`), so a screen can stay short indefinitely; clamping the margin to `size - 1`
+     * silently dropped the rows that should have moved into the unpainted part.
+     */
+    @Test
+    fun scrollDownOnAPartlyPaintedScreenKeepsEveryRow() {
+        replay(fillRows(n = 12) + "$esc[2;23r$esc[1T", screenHeight = 24, materializeAll = false) { buffer ->
+            val rows = buffer.rows(n = 24)
+            assertEquals("r1", rows[0], "row 1 is pinned above the region")
+            assertEquals("", rows[1], "the region top is exposed as blank")
+            assertEquals(
+                (2..12).map { "r$it" },
+                rows.subList(2, 13),
+                "every painted row shifts down one, including the last one painted",
+            )
+        }
+    }
+
+    /**
+     * Scrolling a region that does NOT start at row 1 is not scrollback. Uses SU with an oversized
+     * count, because that is the combination that used to push rows from below the bottom margin
+     * into history.
+     */
+    @Test
+    fun aRegionBelowTheTopAddsNoScrollback() {
+        replay(fillRows() + "$esc[2;9r$esc[40S") { buffer ->
+            assertEquals(0, buffer.historyLinesCount, "a region below row 1 must not feed scrollback")
+        }
+    }
+
+    /**
+     * A top-anchored region DOES feed scrollback, but only with the rows that actually left the
+     * region - never the rows pinned below its bottom margin. This ran on the main screen because
+     * the alternate screen suppresses scrollback entirely, which would mask the assertion.
+     */
+    @Test
+    fun aTopAnchoredRegionScrollsOnlyItsOwnRowsIntoHistory() {
+        val styleState = StyleState()
+        val buffer = TerminalTextBuffer(width, height, styleState)
+        val terminal = BossTerminal(NoopTerminalDisplay(), buffer, styleState)
+        buffer.getLine(height - 1)
+        val sequence = fillRows() + "$esc[1;5r$esc[40S"
+        val emulator = BossEmulator(ArrayTerminalDataStream(sequence.toCharArray()), terminal)
+        while (emulator.hasNext()) emulator.next()
+
+        assertEquals(
+            listOf("r6", "r7", "r8", "r9", "r10"),
+            (5 until height).map { buffer.getLine(it).text.trimEnd() },
+            "rows below the bottom margin are pinned and must stay on screen",
+        )
+        assertEquals(
+            5,
+            buffer.historyLinesCount,
+            "only the region's own 5 rows reach history, not the 5 pinned below it",
+        )
+    }
+
+    private class NoopTerminalDisplay : TerminalDisplay {
+        override var windowTitle: String? = null
+        override var iconTitle: String? = null
+        override val selection: TerminalSelection? = null
+
+        override fun setCursor(x: Int, y: Int) = Unit
+        override fun setCursorShape(cursorShape: CursorShape?) = Unit
+        override fun beep() = Unit
+        override fun scrollArea(scrollRegionTop: Int, scrollRegionSize: Int, dy: Int) = Unit
+        override fun setCursorVisible(isCursorVisible: Boolean) = Unit
+        override fun useAlternateScreenBuffer(useAlternateScreenBuffer: Boolean) = Unit
+        override fun terminalMouseModeSet(mouseMode: MouseMode) = Unit
+        override fun setMouseFormat(mouseFormat: MouseFormat) = Unit
+        override fun ambiguousCharsAreDoubleWidth(): Boolean = false
+    }
+}

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBufferBatchTest.kt
@@ -113,7 +113,7 @@ class TerminalTextBufferBatchTest {
     fun snapshotsStayResponsiveAndDisconnectClearsAbandonedBatch() {
         val styleState = StyleState()
         val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = styleState)
-        val display = NoopTerminalDisplay()
+        val display = RecordingTerminalDisplay()
         val terminal = BossTerminal(display, buffer, styleState)
         buffer.getLine(0) // Materialize the lazily allocated first screen row.
         val modelChanges = AtomicInteger()
@@ -166,7 +166,7 @@ class TerminalTextBufferBatchTest {
     fun disconnectClearsNestedBatchAndPublishesOnce() {
         val styleState = StyleState()
         val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = styleState)
-        val terminal = BossTerminal(NoopTerminalDisplay(), buffer, styleState)
+        val terminal = BossTerminal(RecordingTerminalDisplay(), buffer, styleState)
         val modelChanges = AtomicInteger()
         buffer.addModelListener(object : TerminalModelListener {
             override fun modelChanged() {
@@ -197,7 +197,7 @@ class TerminalTextBufferBatchTest {
     fun mismatchedTeardownThreadStillClearsBatchAndSynchronizedUpdate() {
         val styleState = StyleState()
         val buffer = TerminalTextBuffer(width = 8, height = 2, styleState = styleState)
-        val display = NoopTerminalDisplay()
+        val display = RecordingTerminalDisplay()
         val terminal = BossTerminal(display, buffer, styleState)
         val executor = Executors.newSingleThreadExecutor()
 
@@ -224,7 +224,7 @@ class TerminalTextBufferBatchTest {
         }
     }
 
-    private class NoopTerminalDisplay : TerminalDisplay {
+    private class RecordingTerminalDisplay : TerminalDisplay {
         var synchronizedUpdateEnabled: Boolean? = null
         override var windowTitle: String? = null
         override var iconTitle: String? = null

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/terminal/CursorRowDriftTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/terminal/CursorRowDriftTest.kt
@@ -1,0 +1,128 @@
+package ai.rever.bossterm.compose.terminal
+
+import ai.rever.bossterm.compose.ComposeTerminalDisplay
+import ai.rever.bossterm.terminal.ArrayTerminalDataStream
+import ai.rever.bossterm.terminal.TerminalMode
+import ai.rever.bossterm.terminal.emulator.BossEmulator
+import ai.rever.bossterm.terminal.model.BossTerminal
+import ai.rever.bossterm.terminal.model.StyleState
+import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Claude Code positions everything on its scrolled viewport with CURSOR-RELATIVE moves. A live
+ * capture shows one frame as:
+ *
+ * ```
+ * ESC[?2026h ESC[?25l ESC[H ESC[2;26r ESC[6T ESC[r ESC[H
+ *   per row:   CR ESC[5C ESC[1B <text>
+ *   indicator: CR ESC[24C ESC[18B " Jump to bottom (click) v "
+ * ESC[32;1H ESC[28;3H ESC[?25h ESC[?2026l
+ * ```
+ *
+ * Every position is counted from wherever the previous write left the cursor, so the app's layout
+ * only holds while its cursor model and the emulator's agree. These tests pin that arithmetic.
+ *
+ * They are NOT regression coverage for the scroll-region corruption that prompted them - that was
+ * `LinesStorage` moving rows past a margin, and it is covered by `ScrollRegionContainmentTest` in
+ * `bossterm-core-mpp`, where the defect lives. Cursor drift was one of several hypotheses for that
+ * artifact and was ruled out by these very tests: deferred wrap is correct, and full-width rows
+ * accumulate no drift. They are kept because that arithmetic had no coverage at all and a
+ * regression in it would corrupt every relative-positioned TUI.
+ *
+ * Each assertion is on where a marker actually LANDS in the buffer. Asserting a cursor field would
+ * only prove the emulator agrees with itself, not that an app's model of it holds.
+ */
+class CursorRowDriftTest {
+
+    private val esc = "\u001b"
+    private val width = 20
+    private val height = 10
+
+    private fun feed(sequence: String, assertions: (TerminalTextBuffer) -> Unit) {
+        val display = ComposeTerminalDisplay()
+        try {
+            val styleState = StyleState()
+            val buffer = TerminalTextBuffer(width = width, height = height, styleState = styleState)
+            val terminal = BossTerminal(display, buffer, styleState)
+            terminal.setModeEnabled(TerminalMode.AlternateBuffer, true)
+            buffer.getLine(height - 1) // materialize the lazily allocated screen rows
+            val stream = ArrayTerminalDataStream(sequence.toCharArray())
+            val emulator = BossEmulator(stream, terminal)
+            while (emulator.hasNext()) emulator.next()
+            assertions(buffer)
+        } finally {
+            display.dispose()
+        }
+    }
+
+    private fun TerminalTextBuffer.rowText(row: Int) = getLine(row).text.trimEnd()
+
+    /**
+     * The DEC deferred-wrap rule: writing the LAST column leaves the cursor on that column with a
+     * pending-wrap flag set, not on the next row. A `CUD 1` afterwards therefore moves exactly one
+     * row. Advancing eagerly instead costs one extra row per full-width line, and Claude Code pads
+     * every diff row to the full width.
+     */
+    @Test
+    fun writingTheLastColumnDefersTheWrapInsteadOfAdvancingTheRow() {
+        feed("$esc[H" + "X".repeat(width) + "\r$esc[1BMARK") { buffer ->
+            assertEquals("X".repeat(width), buffer.rowText(0), "row 1 holds the full-width write")
+            assertEquals(
+                "MARK",
+                buffer.rowText(1),
+                "a pending wrap must not have consumed a row before CUD",
+            )
+        }
+    }
+
+    /**
+     * The same rule across several full-width rows, which is what a real frame sends. Drift is
+     * cumulative, so this is the shape that would make the artifact worse the more rows a frame
+     * repaints - the reported "worse the faster you scroll".
+     */
+    @Test
+    fun fullWidthRowsDoNotAccumulateDrift() {
+        val rows = 4
+        val writes = (0 until rows).joinToString("") { "\r$esc[1B" + "%-${width}d".format(it) }
+        feed("$esc[H" + writes + "\r$esc[1BMARK") { buffer ->
+            for (i in 0 until rows) {
+                assertEquals(
+                    "$i",
+                    buffer.rowText(i + 1),
+                    "row ${i + 2} should hold full-width write $i",
+                )
+            }
+            assertEquals(
+                "MARK",
+                buffer.rowText(rows + 1),
+                "after $rows full-width rows the cursor must be exactly $rows rows down",
+            )
+        }
+    }
+
+    /**
+     * SD (`CSI n T`) pans the region's content down and, per DEC, does NOT move the cursor.
+     *
+     * The cursor is placed AFTER the region is set, because DECSTBM homes the cursor - so a
+     * sequence that set the region between positioning and scrolling would be measuring DECSTBM's
+     * homing rather than SD. Claude Code does not depend on the cursor surviving DECSTBM either;
+     * it re-homes with an explicit `ESC[H` before counting rows downward.
+     */
+    @Test
+    fun scrollDownLeavesTheCursorWhereItWas() {
+        feed("$esc[2;9r" + "$esc[4;1HROW4" + "$esc[3T" + "\rAFTER") { buffer ->
+            assertEquals(
+                "AFTER",
+                buffer.rowText(3),
+                "SD must not move the cursor, so row 4 receives AFTER",
+            )
+            assertEquals(
+                "ROW4",
+                buffer.rowText(6),
+                "the panned content should have moved down 3 rows, not vanished",
+            )
+        }
+    }
+}


### PR DESCRIPTION
Scrolling up in a Claude Code session left rows holding characters that did not belong there, worse the faster you scrolled. The corruption was in the **buffer**, not the renderer - a live session held

```
Update(.worktrees/bossconsole-or Jump to bottom (click) ↓ /organisation/views/layout.ts)
```

where `g-pages/supabase/functions` should have been: the app's own indicator overwritten into the middle of a transcript line.

## Cause

Claude Code owns the wheel (`?1000/?1002/?1003`) and scrolls its transcript itself with `ESC[2;Nr` plus SD/SU, keeping its prompt box and "Jump to bottom" affordance **pinned below** the region. Both directions could reach past a margin and corrupt that band, and the app never repaints it because from its model nothing there changed - so the damage persists.

- **`insertLines` (SD, `CSI nT`)** resolved its removal index inside the removal loop, so each removal shifted the rows above `lastLine` up while `lastLine` stayed put, and the second removal took the row *below* the margin. Rows r1..r10, region 2..9, count 3 deleted r9, then the pinned r10, then r8, leaving r7 in row 10. A bigger count damaged more rows, which is why a fast flick looked far worse than a slow scroll.
- **`deleteLines` (SU, `CSI nS`)** bounded its loop by `y < size` rather than by the region, so any count past the region height destroyed the rows below the bottom margin too, and on a top-anchored region pushed them into scrollback. It also derived its blank-insertion index from the requested count rather than the number actually removed, so blanks landed above the region top.

## Change

Both are the same rotation mirrored, which is how they came to disagree, so they now share one `rotateRegion` taking a `panDown` flag and a non-negative magnitude. It bounds the move to the region height and materializes the region before measuring it - deriving the margin from `size` let the *painted* row count define it, dropping rows that should have shifted into the unpainted part. That is reachable rather than theoretical: `IncrementalSnapshotBuilder` iterates `0 until size`, so a short screen stays short.

`CSI L` / `CSI M` (IL/DL) share this code and are contained with it, **including at the region's top margin** - `BossTerminal` now makes them a no-op when the cursor sits outside the region, per DEC VT510. That check lives in the terminal because only it knows the cursor position.

### Known consequences

- The first scroll grows `screenLinesStorage.size` to the region bottom permanently, so `IncrementalSnapshotBuilder` maps the full height from then on. Bounded by `height`, per-line results still cached, and correctness wins - but it partly gives back the lazy-materialization win, so noted here rather than left to a bisect.
- On a partly painted **main** screen, scrollback now receives the blank rows a full-height screen really has. Only bites when the count exceeds the painted row count; ordinary line-feed scrolling (`count == 1`) is unchanged.

## Testing

`ScrollRegionContainmentTest` and `LinesStorageRotationTest` live in `bossterm-core-mpp`, where the defect is - that module's own suite previously went green while this code was broken. They cover containment in both directions, oversized and boundary counts, a partly painted screen, IL/DL at both margins, and which rows a top-anchored region may put in scrollback.

**9 of 10 containment cases and 5 of 8 storage cases fail against pre-fix code**, verified by reverting `LinesStorage.kt` and `BossTerminal.kt` to `master` and re-running.

`CursorRowDriftTest` pins the cursor arithmetic Claude Code's relative positioning depends on (deferred wrap at the last column, no cumulative drift across full-width rows, SD not moving the cursor). It is not regression coverage for this bug and says so.

Full suites green: **1015 tests, 0 failures** across 117 classes.

App-verified: a build carrying the original one-direction fix resolved the reported artifact. SU containment, the IL/DL guards and the partly-painted fixes landed after that verification and are covered by tests only.