### PR TITLE
fix(scroll): keep a scrolled-up viewport on the same content as history grows

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
@@ -1013,11 +1013,13 @@ class TerminalTextBuffer internal constructor(
   }
 
   private fun addLinesToHistory(linesToAdd: List<TerminalLine>) {
+    if (linesToAdd.isEmpty()) return
     val totalAfterAdd = historyLinesStorage.size + linesToAdd.size
 
     // Fast path: no lines need to be discarded (most common case)
     if (totalAfterAdd <= maxHistoryLinesCount) {
       historyLinesStorage.addAllToBottom(linesToAdd)
+      changesMulticaster.linesAddedToHistory(linesToAdd.size)
       return
     }
 
@@ -1042,6 +1044,7 @@ class TerminalTextBuffer internal constructor(
     historyLinesStorage.addAllToBottom(linesToAdd)
     imageCellHistoryTrimCounter.addAndGet(discardedLinesCount.toLong())
 
+    changesMulticaster.linesAddedToHistory(linesToAdd.size)
     if (linesToDiscard.isNotEmpty()) {
       changesMulticaster.linesDiscardedFromHistory(linesToDiscard)
     }

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TerminalTextBuffer.kt
@@ -1044,10 +1044,12 @@ class TerminalTextBuffer internal constructor(
     historyLinesStorage.addAllToBottom(linesToAdd)
     imageCellHistoryTrimCounter.addAndGet(discardedLinesCount.toLong())
 
-    changesMulticaster.linesAddedToHistory(linesToAdd.size)
+    // Discards physically happened first, so report them first: a listener reconstructing the
+    // history index space would be misled by the reverse order.
     if (linesToDiscard.isNotEmpty()) {
       changesMulticaster.linesDiscardedFromHistory(linesToDiscard)
     }
+    changesMulticaster.linesAddedToHistory(linesToAdd.size)
   }
 
   private fun fireHistoryBufferLineCountChanged() {

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TextBufferChangesListener.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TextBufferChangesListener.kt
@@ -28,6 +28,12 @@ interface TextBufferChangesListener {
    * screen too, so a consumer anchoring a viewport must decide for itself whether an alt-screen
    * append is meaningful to it. The case this was added for is an ordinary shell streaming output.
    *
+   * NOT a complete account of history movement. `resize` fires this when a height shrink pushes
+   * lines into history, but a height GROWTH pulls lines back out with no event, so a consumer that
+   * only adds up these counts will over-count across a shrink/grow cycle. Anything reconstructing
+   * the history index space needs to handle resize itself rather than treating this as the sole
+   * source of truth.
+   *
    * Fired for every append, including the `scrollArea` hot path that a streaming process drives
    * once per output line — keep implementations cheap.
    *

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TextBufferChangesListener.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TextBufferChangesListener.kt
@@ -16,6 +16,22 @@ interface TextBufferChangesListener {
   fun linesChanged(fromIndex: Int) {}
 
   /**
+   * Lines scrolled off the top of the screen and were appended to the history buffer.
+   *
+   * A viewport anchored to the BOTTOM of the buffer (offset counted back from the live screen)
+   * addresses different content after this: everything the user is looking at moved [count]
+   * lines further from the bottom. Such a viewport has to add [count] to its offset to stay on
+   * the same content, which is the dual of what a top-anchored viewport does for
+   * [linesDiscardedFromHistory] (compare iTerm2's `PTYTextView.handleScrollbackOverflow:`).
+   *
+   * Fired for every append, including the `scrollArea` hot path that a full-screen TUI drives
+   * once per output line — keep implementations cheap.
+   *
+   * @param count number of lines appended to the end of the history.
+   */
+  fun linesAddedToHistory(count: Int) {}
+
+  /**
    * History buffer capacity was exceeded, so the Text Buffer had to discard some lines from the start of the history.
    *
    * @param lines discarded lines.

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TextBufferChangesListener.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TextBufferChangesListener.kt
@@ -24,7 +24,11 @@ interface TextBufferChangesListener {
    * the same content, which is the dual of what a top-anchored viewport does for
    * [linesDiscardedFromHistory] (compare iTerm2's `PTYTextView.handleScrollbackOverflow:`).
    *
-   * Fired for every append, including the `scrollArea` hot path that a full-screen TUI drives
+   * Fired for every append on BOTH screens - this buffer accumulates scrollback on the alternate
+   * screen too, so a consumer anchoring a viewport must decide for itself whether an alt-screen
+   * append is meaningful to it. The case this was added for is an ordinary shell streaming output.
+   *
+   * Fired for every append, including the `scrollArea` hot path that a streaming process drives
    * once per output line — keep implementations cheap.
    *
    * @param count number of lines appended to the end of the history.

--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TextBufferChangesMulticaster.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/terminal/model/TextBufferChangesMulticaster.kt
@@ -19,6 +19,12 @@ internal class TextBufferChangesMulticaster : TextBufferChangesListener {
     }
   }
 
+  override fun linesAddedToHistory(count: Int) {
+    forEachListeners {
+      it.linesAddedToHistory(count)
+    }
+  }
+
   override fun linesDiscardedFromHistory(lines: List<TerminalLine>) {
     forEachListeners {
       it.linesDiscardedFromHistory(lines)

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/HistoryAppendAnchorTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/HistoryAppendAnchorTest.kt
@@ -12,8 +12,11 @@ import kotlin.test.assertTrue
  * iTerm2 has the mirror-image problem — its viewport is anchored to the top, so lines evicted
  * from the head move it — and compensates in `PTYTextView.handleScrollbackOverflow:` using a
  * count accumulated since the last sync. Doing the same here requires the buffer to actually
- * report appends, and the `scrollArea` path a full-screen TUI drives (DECSTBM with top == 1)
+ * report appends, and the `scrollArea` path a streaming process drives (DECSTBM with top == 1)
  * previously reported nothing at all.
+ *
+ * Note this buffer accumulates scrollback on the ALTERNATE screen too, so appends are reported
+ * there as well; the consumer decides what to do with those. See [theAlternateScreenAlsoReportsItsAppends].
  */
 class HistoryAppendAnchorTest {
 
@@ -126,8 +129,6 @@ class HistoryAppendAnchorTest {
         )
     }
 
-
-
     @Test
     fun cappedHistoryStillReportsAppendsWhileDiscarding() {
         val buffer = buffer(maxHistory = 3)
@@ -138,7 +139,67 @@ class HistoryAppendAnchorTest {
         repeat(5) { buffer.scrollArea(1, -1, 4) }
 
         assertEquals(5, listener.appended, "appends must be reported even once history is capped")
-        assertTrue(listener.discarded > 0, "a capped history must also report its discards")
+        // Exact, not `> 0`: five appends into a 3-line history discards exactly 2, and a loose
+        // assertion would not notice an off-by-one in the discard path.
+        assertEquals(2, listener.discarded, "a capped history discards exactly the overflow")
         assertEquals(3, buffer.historyLinesCount)
+    }
+
+    /**
+     * The alternate screen accumulates scrollback in this buffer - `useAlternateBuffer` swaps in a
+     * live storage and `scrollArea` has no alt guard - so appends are reported there too. Pinned
+     * because a consumer anchoring a viewport has to know this: folding alt-screen appends walks
+     * the offset against a history that is discarded when the TUI exits.
+     */
+    @Test
+    fun theAlternateScreenAlsoReportsItsAppends() {
+        val buffer = buffer()
+        buffer.useAlternateBuffer(true)
+        val listener = RecordingListener()
+        buffer.addChangesListener(listener)
+        for (row in 1..4) buffer.write(row, "A$row")
+
+        repeat(3) { buffer.scrollArea(1, -1, 4) }
+
+        assertEquals(3, listener.appended, "alt-screen appends are reported like any other")
+        assertEquals(3, buffer.historyLinesCount, "and they really do land in a history buffer")
+    }
+
+    /** `moveScreenLinesToHistory` also routes through `addLinesToHistory`, so it must report too. */
+    @Test
+    fun movingScreenLinesToHistoryReportsTheAppend() {
+        val buffer = buffer()
+        val listener = RecordingListener()
+        buffer.addChangesListener(listener)
+        for (row in 1..4) buffer.write(row, "M$row")
+
+        buffer.moveScreenLinesToHistory()
+
+        assertEquals(
+            buffer.historyLinesCount,
+            listener.appended,
+            "every line moved into history must be reported",
+        )
+        assertTrue(listener.appended > 0, "the move must have produced at least one append")
+    }
+
+    /**
+     * An empty append must not wake listeners with a zero count.
+     *
+     * Deliberately NOT `scrollArea(1, 0, 4)`: `dy == 0` returns at the top of `scrollArea` and
+     * never reaches `addLinesToHistory`, so that would pass with the guard deleted. A degenerate
+     * region does reach it - the rotation yields no rows, and the top-anchored branch then calls
+     * `addLinesToHistory` with an empty list.
+     */
+    @Test
+    fun anEmptyAppendReportsNothing() {
+        val buffer = buffer()
+        val listener = RecordingListener()
+        buffer.addChangesListener(listener)
+        for (row in 1..4) buffer.write(row, "L$row")
+
+        buffer.scrollArea(1, -1, 0)
+
+        assertEquals(0, listener.appendCallbacks, "no callback at all for an empty append")
     }
 }

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/HistoryAppendAnchorTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/HistoryAppendAnchorTest.kt
@@ -1,5 +1,7 @@
 package ai.rever.bossterm.terminal.model
 
+import ai.rever.bossterm.core.util.CellPosition
+import ai.rever.bossterm.core.util.TermSize
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -181,6 +183,32 @@ class HistoryAppendAnchorTest {
             "every line moved into history must be reported",
         )
         assertTrue(listener.appended > 0, "the move must have produced at least one append")
+    }
+
+    /**
+     * The third caller of `addLinesToHistory`: a height SHRINK pushes the rows that no longer fit
+     * into history, and reports them like any other append.
+     *
+     * Pinned because it is the caller with the documented asymmetry - a height GROWTH pulls lines
+     * back out of history with no corresponding event - so a consumer that only sums these counts
+     * over-counts across a shrink/grow cycle. Inert in the app today, where the layout callback
+     * resets the offset on any resize, but the event contract is what is being asserted here.
+     */
+    @Test
+    fun aHeightShrinkReportsTheRowsItPushesIntoHistory() {
+        val buffer = buffer(height = 4)
+        val listener = RecordingListener()
+        buffer.addChangesListener(listener)
+        for (row in 1..4) buffer.write(row, "L$row")
+
+        buffer.resize(TermSize(20, 2), CellPosition(1, 4), selection = null)
+
+        assertEquals(
+            buffer.historyLinesCount,
+            listener.appended,
+            "the rows that no longer fit are reported as appends",
+        )
+        assertTrue(listener.appended > 0, "a shrink from 4 rows to 2 must push something down")
     }
 
     /**

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/HistoryAppendAnchorTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/terminal/model/HistoryAppendAnchorTest.kt
@@ -1,0 +1,144 @@
+package ai.rever.bossterm.terminal.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A viewport anchored to the bottom of the buffer addresses different content every time lines
+ * are appended to history: `bufferLine = screenRow - scrollOffset`, so growing the history moves
+ * the user's content one row further from the anchor per appended line.
+ *
+ * iTerm2 has the mirror-image problem — its viewport is anchored to the top, so lines evicted
+ * from the head move it — and compensates in `PTYTextView.handleScrollbackOverflow:` using a
+ * count accumulated since the last sync. Doing the same here requires the buffer to actually
+ * report appends, and the `scrollArea` path a full-screen TUI drives (DECSTBM with top == 1)
+ * previously reported nothing at all.
+ */
+class HistoryAppendAnchorTest {
+
+    private class RecordingListener : TextBufferChangesListener {
+        var appended = 0
+        var appendCallbacks = 0
+        var discarded = 0
+
+        override fun linesAddedToHistory(count: Int) {
+            appended += count
+            appendCallbacks++
+        }
+
+        override fun linesDiscardedFromHistory(lines: List<TerminalLine>) {
+            discarded += lines.size
+        }
+    }
+
+    private fun buffer(width: Int = 20, height: Int = 4, maxHistory: Int = 100) =
+        TerminalTextBuffer(width, height, StyleState(), maxHistory)
+
+    private fun TerminalTextBuffer.write(row: Int, text: String) {
+        val chars = text.toCharArray()
+        writeString(0, row, CharBuffer(chars, 0, chars.size))
+    }
+
+    /** Text of the line at a bottom-anchored viewport position, via the render snapshot. */
+    private fun TerminalTextBuffer.lineAt(screenRow: Int, scrollOffset: Int): String =
+        createIncrementalSnapshot().getLine(screenRow - scrollOffset).text.trimEnd()
+
+    @Test
+    fun scrollAreaReportsLinesItAppendsToHistory() {
+        val buffer = buffer()
+        val listener = RecordingListener()
+        buffer.addChangesListener(listener)
+        for (row in 1..4) buffer.write(row, "L$row")
+
+        // DECSTBM region starting at row 1 — what a full-screen TUI scrolls content inside.
+        buffer.scrollArea(1, -2, 4)
+
+        assertEquals(2, listener.appended, "the two lines that scrolled off must be reported")
+        assertEquals(2, buffer.historyLinesCount)
+    }
+
+    @Test
+    fun everyAppendIsReportedNotJustTheFirst() {
+        val buffer = buffer()
+        val listener = RecordingListener()
+        buffer.addChangesListener(listener)
+        for (row in 1..4) buffer.write(row, "L$row")
+
+        repeat(3) { buffer.scrollArea(1, -1, 4) }
+
+        assertEquals(3, listener.appendCallbacks)
+        assertEquals(3, listener.appended)
+    }
+
+    @Test
+    fun regionNotStartingAtTheTopAppendsNothing() {
+        val buffer = buffer()
+        val listener = RecordingListener()
+        buffer.addChangesListener(listener)
+        for (row in 1..4) buffer.write(row, "L$row")
+
+        // Content scrolled inside a region below row 1 never reaches history.
+        buffer.scrollArea(2, -1, 4)
+
+        assertEquals(0, listener.appended)
+        assertEquals(0, buffer.historyLinesCount)
+    }
+
+    @Test
+    fun uncompensatedBottomAnchorDriftsWhenHistoryGrows() {
+        val buffer = buffer()
+        for (row in 1..4) buffer.write(row, "L$row")
+        val offset = 2
+        buffer.scrollArea(1, -2, 4)
+        for (row in 3..4) buffer.write(row, "N$row")
+
+        val before = buffer.lineAt(screenRow = 0, scrollOffset = offset)
+        buffer.scrollArea(1, -1, 4)
+        val after = buffer.lineAt(screenRow = 0, scrollOffset = offset)
+
+        assertTrue(
+            before != after,
+            "holding the offset fixed must drift — this is the bug being compensated " +
+                "(row 0 showed '$before', now shows '$after')",
+        )
+    }
+
+    @Test
+    fun addingTheReportedCountKeepsTheViewportOnTheSameContent() {
+        val buffer = buffer()
+        val listener = RecordingListener()
+        buffer.addChangesListener(listener)
+        for (row in 1..4) buffer.write(row, "L$row")
+        var offset = 2
+        buffer.scrollArea(1, -2, 4)
+        for (row in 3..4) buffer.write(row, "N$row")
+
+        val before = buffer.lineAt(screenRow = 0, scrollOffset = offset)
+        listener.appended = 0
+        buffer.scrollArea(1, -1, 4)
+        offset += listener.appended // what ProperTerminal folds in per frame
+
+        assertEquals(
+            before,
+            buffer.lineAt(screenRow = 0, scrollOffset = offset),
+            "compensating by the reported append count must re-address the same line",
+        )
+    }
+
+
+
+    @Test
+    fun cappedHistoryStillReportsAppendsWhileDiscarding() {
+        val buffer = buffer(maxHistory = 3)
+        val listener = RecordingListener()
+        buffer.addChangesListener(listener)
+        for (row in 1..4) buffer.write(row, "L$row")
+
+        repeat(5) { buffer.scrollArea(1, -1, 4) }
+
+        assertEquals(5, listener.appended, "appends must be reported even once history is capped")
+        assertTrue(listener.discarded > 0, "a capped history must also report its discards")
+        assertEquals(3, buffer.historyLinesCount)
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -697,7 +697,7 @@ class EmbeddableTerminalState {
      * Scroll to the bottom of the terminal (most recent output).
      */
     fun scrollToBottom() {
-        session?.scrollOffset?.value = 0
+        session?.scrollTo(0)
     }
 
     /**
@@ -706,11 +706,7 @@ class EmbeddableTerminalState {
      * @param lines Number of lines to scroll (positive = up into history, negative = down)
      */
     fun scrollBy(lines: Int) {
-        session?.let { s ->
-            val maxScroll = s.textBuffer.historyLinesCount
-            val newOffset = (s.scrollOffset.value + lines).coerceIn(0, maxScroll)
-            s.scrollOffset.value = newOffset
-        }
+        session?.let { s -> s.scrollTo(s.scrollOffset.value + lines) }
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSession.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSession.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose
 
+import ai.rever.bossterm.compose.ui.HistoryAppendBank
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import ai.rever.bossterm.core.typeahead.TerminalTypeAheadManager
@@ -91,6 +92,17 @@ interface TerminalSession {
      * Current scroll offset in lines from the bottom of the buffer.
      */
     val scrollOffset: MutableState<Int>
+
+    /**
+     * Lines appended to history since the viewport last took a frame.
+     *
+     * Lives beside [scrollOffset] and shares its lifetime deliberately: the offset is measured
+     * back from the live bottom, so this is the correction that keeps it addressing the same
+     * content. A composition-scoped counter would be dropped whenever a tab goes to the
+     * background while the offset it corrects survives, so the tab would drift unnoticed and
+     * land somewhere else when reselected.
+     */
+    val historyAppendBank: HistoryAppendBank
 
     // === Search State ===
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSession.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TerminalSession.kt
@@ -104,6 +104,20 @@ interface TerminalSession {
      */
     val historyAppendBank: HistoryAppendBank
 
+    /**
+     * Move the viewport, clamped to the available history.
+     *
+     * The only supported way to write [scrollOffset]. Leaving the live bottom must also discard
+     * anything [historyAppendBank] has banked: those appends arrived while the view was following
+     * the bottom, so they are not compensation for a scrolled viewport, and folding them makes the
+     * first scrolled frame jump. Writing the state directly silently skips that, which is why this
+     * lives beside the state rather than in whichever composable happens to be driving.
+     */
+    fun scrollTo(target: Int) {
+        if (scrollOffset.value == 0) historyAppendBank.clear()
+        scrollOffset.value = target.coerceIn(0, textBuffer.historyLinesCount)
+    }
+
     // === Search State ===
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/blocks/CommandBlockActions.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/blocks/CommandBlockActions.kt
@@ -49,7 +49,7 @@ object CommandBlockActions {
         /** Scroll so [row] sits near the top of the viewport. */
         fun jumpToRow(row: Int) {
             val historySize = session.textBuffer.historyLinesCount
-            session.scrollOffset.value = (-row + 2).coerceIn(0, historySize)
+            session.scrollTo(-row + 2)
             session.display.requestImmediateRedraw()
         }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.tabs
 
+import ai.rever.bossterm.compose.ui.HistoryAppendBank
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import kotlinx.coroutines.CoroutineScope
@@ -379,6 +380,17 @@ data class TerminalTab(
     }
 
     /**
+     * Lines appended to history since the viewport last took a frame.
+     *
+     * Registered for the TAB's lifetime rather than a composition's, so a backgrounded tab keeps
+     * being compensated. A composition-scoped listener is removed when the tab stops being
+     * composed while [scrollOffset] survives, which is how a background tab drifts and then lands
+     * somewhere else when you switch back to it.
+     */
+    override val historyAppendBank: HistoryAppendBank =
+        HistoryAppendBank(textBuffer).also { textBuffer.addChangesListener(it) }
+
+    /**
      * Channel for queuing user input writes to the PTY.
      * Capacity of 256 provides reasonable buffer for burst input (e.g., paste operations).
      * Uses WriteOperation sealed class to handle both text and raw bytes in FIFO order.
@@ -466,6 +478,14 @@ data class TerminalTab(
      * displays can cause exceptions that crash the rendering pipeline.
      */
     override fun dispose() {
+        // Registered for this tab's lifetime, so it is unregistered here rather than by a
+        // composition leaving the tree.
+        try {
+            textBuffer.removeChangesListener(historyAppendBank)
+        } catch (e: Exception) {
+            System.err.println("WARN: Failed to remove history append bank: ${e.message}")
+        }
+
         // Remove model listener to prevent memory leak
         // This is CRITICAL - without cleanup, listeners accumulate and can crash
         // the rendering pipeline when they reference disposed displays

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBank.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBank.kt
@@ -61,13 +61,26 @@ class HistoryAppendBank(private val buffer: TerminalTextBuffer) : TextBufferChan
         pending.set(0)
     }
 
-    /** Everything that happened to history since the last drain, taken atomically together. */
-    fun drain(): HistoryDelta = HistoryDelta(
-        // Order matters: take the flag first, so an append racing in between is kept rather than
-        // silently dropped by the reset that follows it.
-        cleared = cleared.getAndSet(false),
-        appended = pending.getAndSet(0),
-    )
+    /**
+     * What has accumulated so far, WITHOUT taking it.
+     *
+     * Split from [consume] because the reader computes during composition, and a composition can
+     * be discarded before it applies. Taking the count there would silently swallow those appends
+     * on a discarded frame and leave exactly the permanent drift this class exists to prevent.
+     * `StableRenderFrameHolder` guards the frame capture against the same hazard.
+     */
+    fun peek(): HistoryDelta = HistoryDelta(cleared = cleared.get(), appended = pending.get())
+
+    /**
+     * Take back exactly what [peek] reported, once it has actually been applied.
+     *
+     * Subtracts rather than zeroing, so appends that landed between the peek and the commit stay
+     * banked for the next frame instead of being lost.
+     */
+    fun consume(delta: HistoryDelta) {
+        if (delta.appended != 0) pending.addAndGet(-delta.appended)
+        if (delta.cleared) cleared.set(false)
+    }
 
     /**
      * Forget anything banked.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBank.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBank.kt
@@ -1,0 +1,65 @@
+package ai.rever.bossterm.compose.ui
+
+import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import ai.rever.bossterm.terminal.model.TextBufferChangesListener
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Counts lines appended to history since the viewport last took a frame.
+ *
+ * The scroll offset is measured back from the LIVE BOTTOM of the buffer, so appending to history
+ * moves the content the user is reading that many rows further from the anchor. Compensating means
+ * knowing how many lines arrived between frames, and this is where that count lives.
+ *
+ * Deliberately an object rather than a counter inside the composable:
+ *
+ *  - its lifetime matches `scrollOffset`, which is session-scoped. A composition-scoped bank is
+ *    dropped when a tab goes to the background while the offset it corrects survives, so a
+ *    backgrounded tab drifts and lands somewhere else when you switch back.
+ *  - the two decisions worth getting right - the alternate-screen exclusion and when the bank is
+ *    cleared - become ordinary assertions instead of logic buried in a composable.
+ *
+ * Counting happens on the emulator thread inside the buffer lock; [drain] happens on the UI thread.
+ * An atomic is the whole synchronisation: the listener must never touch Compose state, because
+ * taking the snapshot lock under the buffer lock is the inversion `ComposeTerminalDisplay` warns
+ * about.
+ */
+class HistoryAppendBank(private val buffer: TerminalTextBuffer) : TextBufferChangesListener {
+
+    private val pending = AtomicInteger(0)
+
+    /**
+     * Alternate-screen appends are excluded HERE, at fire time, not when the count is drained.
+     *
+     * This runs synchronously inside the append, so `isUsingAlternateBuffer` describes the very
+     * lines being reported. Deciding on the UI thread a frame later races both ways: main-screen
+     * appends banked just before a TUI starts would be dropped, and alt-screen appends banked just
+     * before it exits would be folded into the main-screen offset - the exact thing the exclusion
+     * exists to prevent.
+     *
+     * The alternate screen really does accumulate scrollback in this buffer (`useAlternateBuffer`
+     * swaps in a live storage and `scrollArea` has no alt guard), but it is discarded when the TUI
+     * exits, so an offset derived from it would address a buffer that no longer exists.
+     */
+    override fun linesAddedToHistory(count: Int) {
+        if (!buffer.isUsingAlternateBuffer) pending.addAndGet(count)
+    }
+
+    override fun historyCleared() {
+        clear()
+    }
+
+    /** Take the count accumulated since the last call, resetting to zero. */
+    fun drain(): Int = pending.getAndSet(0)
+
+    /**
+     * Forget anything banked.
+     *
+     * Called when the viewport leaves the live bottom: appends that arrived while following the
+     * bottom are not compensation for a scrolled viewport, and folding them makes the first
+     * scrolled frame jump.
+     */
+    fun clear() {
+        pending.set(0)
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBank.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBank.kt
@@ -2,6 +2,7 @@ package ai.rever.bossterm.compose.ui
 
 import ai.rever.bossterm.terminal.model.TerminalTextBuffer
 import ai.rever.bossterm.terminal.model.TextBufferChangesListener
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -27,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class HistoryAppendBank(private val buffer: TerminalTextBuffer) : TextBufferChangesListener {
 
     private val pending = AtomicInteger(0)
+    private val cleared = AtomicBoolean(false)
 
     /**
      * Alternate-screen appends are excluded HERE, at fire time, not when the count is drained.
@@ -45,12 +47,27 @@ class HistoryAppendBank(private val buffer: TerminalTextBuffer) : TextBufferChan
         if (!buffer.isUsingAlternateBuffer) pending.addAndGet(count)
     }
 
+    /**
+     * History went away entirely - `CSI 3 J`, which is what plain `clear` emits, reaches this.
+     *
+     * Recorded rather than just zeroing the count, because a viewport scrolled up is now pointing
+     * into a history of size 0 and would render blank until the user scrolled again. The offset
+     * itself cannot be written from here: this runs on the emulator thread inside the buffer lock,
+     * and touching Compose state there is the lock inversion this class exists to avoid. So the
+     * fact is banked and the UI thread acts on it in the same drain as the counts.
+     */
     override fun historyCleared() {
-        clear()
+        cleared.set(true)
+        pending.set(0)
     }
 
-    /** Take the count accumulated since the last call, resetting to zero. */
-    fun drain(): Int = pending.getAndSet(0)
+    /** Everything that happened to history since the last drain, taken atomically together. */
+    fun drain(): HistoryDelta = HistoryDelta(
+        // Order matters: take the flag first, so an append racing in between is kept rather than
+        // silently dropped by the reset that follows it.
+        cleared = cleared.getAndSet(false),
+        appended = pending.getAndSet(0),
+    )
 
     /**
      * Forget anything banked.
@@ -63,3 +80,12 @@ class HistoryAppendBank(private val buffer: TerminalTextBuffer) : TextBufferChan
         pending.set(0)
     }
 }
+
+/**
+ * What happened to history between two frames.
+ *
+ * @param cleared history was emptied, so a scrolled-up viewport is addressing lines that no longer
+ *   exist and must return to the live bottom.
+ * @param appended lines added since the last drain, excluding the alternate screen.
+ */
+data class HistoryDelta(val cleared: Boolean, val appended: Int)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -232,6 +232,31 @@ fun ProperTerminal(
     onDispose { gridStabilityTracker.job?.cancel() }
   }
 
+  // Lines appended to history since the last frame the UI took. Our scroll offset is counted back
+  // from the LIVE BOTTOM, so every appended line moves the content the user is looking at one row
+  // further from that anchor - sit scrolled up while a build streams and the viewport slides out
+  // from under you. iTerm2 has the mirror-image problem (its viewport is top-anchored, so head
+  // eviction moves it) and fixes it the same way: accumulate a count, apply it when the view takes
+  // a frame (`syncResult.overflow` -> `PTYTextView.refreshAfterSync` -> `handleScrollbackOverflow:`).
+  //
+  // Accumulate lock-free on the emulator thread, apply on the UI thread. Deliberately NOT written
+  // straight from the listener - that fires inside the buffer lock on the hottest path, and taking
+  // Compose's snapshot lock under it is the lock inversion ComposeTerminalDisplay warns about.
+  val pendingHistoryAppends = remember(textBuffer) { java.util.concurrent.atomic.AtomicInteger(0) }
+  DisposableEffect(textBuffer) {
+    val anchor = object : ai.rever.bossterm.terminal.model.TextBufferChangesListener {
+      override fun linesAddedToHistory(count: Int) {
+        pendingHistoryAppends.addAndGet(count)
+      }
+
+      override fun historyCleared() {
+        pendingHistoryAppends.set(0)
+      }
+    }
+    textBuffer.addChangesListener(anchor)
+    onDispose { textBuffer.removeChangesListener(anchor) }
+  }
+
   // Command blocks captured for this session (OSC 133). Collected so the gutter
   // and scrollbar markers repaint as commands start and finish. Falls back to a
   // stable empty flow when this session does not track blocks.
@@ -1699,6 +1724,11 @@ fun ProperTerminal(
           accumulatedScrollDelta += delta * settings.scrollMultiplier
           val scrollLines = accumulatedScrollDelta.toInt()
           if (scrollLines != 0) {
+            if (scrollOffset == 0) {
+              // Leaving the bottom: appends banked while we were following it must not be folded
+              // into the offset we are about to take, or the first frame jumps.
+              pendingHistoryAppends.set(0)
+            }
             scrollOffset = (scrollOffset - scrollLines).coerceIn(0, historySize)
             accumulatedScrollDelta -= scrollLines.toFloat()
             userScrollTrigger++  // Mark as user-initiated scroll for scrollbar visibility
@@ -1869,6 +1899,18 @@ fun ProperTerminal(
         // Snapshot cached by Compose - recreated when display triggers redraw OR buffer dimensions change
         // Buffer, images, and cursor state are retained as one accepted render frame.
         val currentTrigger = display.redrawTrigger.value
+        // iTerm2's refreshAfterSync equivalent: fold the appends that landed since the last frame
+        // into the scroll offset so a scrolled-up viewport stays on the same content. Only while
+        // the user is actually scrolled up - at offset 0 we keep following the bottom, which is
+        // what iTerm2 does with `if (!userScroll) [self scrollEnd]`.
+        LaunchedEffect(currentTrigger) {
+          val appended = pendingHistoryAppends.getAndSet(0)
+          if (appended > 0 && scrollOffset > 0) {
+            // Clamping at historyLinesCount pins the view to the oldest surviving line once capped
+            // history starts evicting, mirroring iTerm2 clamping its scroll rect at 0.
+            scrollOffset = (scrollOffset + appended).coerceAtMost(textBuffer.historyLinesCount)
+          }
+        }
         val imageDataCache = terminal.getImageDataCache()
         val stableFrameHolder = remember(textBuffer, display) {
           StableRenderFrameHolder<StableTerminalRenderFrame>()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -151,22 +151,25 @@ internal class StableRenderFrameHolder<T : Any> {
 }
 
 /**
- * The offset a bottom-anchored viewport needs after [appended] lines were appended to history.
+ * The offset a bottom-anchored viewport needs after [change] happened to history.
  *
  * `scrollOffset` counts back from the LIVE BOTTOM, so appending moves the user's content that many
  * rows further from the anchor; adding the count re-addresses the same lines. Extracted from the
- * composable so the edges are unit-testable: following the bottom is left alone, and a capped
- * history pins the view to its oldest surviving line rather than running off the end.
+ * composable so the edges are unit-testable.
  *
  * @param current the offset now; 0 means following the live bottom.
- * @param appended lines added to history since the last fold.
- * @param historyCount history size after the append, the furthest back the viewport can address.
+ * @param change what happened to history since the last fold.
+ * @param historyCount history size after the change - the furthest back the viewport can address.
  */
-internal fun foldHistoryAppends(current: Int, appended: Int, historyCount: Int): Int = when {
-  appended <= 0 -> current
+internal fun foldHistoryAppends(current: Int, change: HistoryDelta, historyCount: Int): Int = when {
+  // History was emptied under a scrolled-up viewport: every line it addressed is gone, so the only
+  // sensible position left is the live bottom. Staying put would render blank until the user
+  // scrolled again.
+  change.cleared -> 0
+  change.appended <= 0 -> current
   // Following the bottom is a position, not a pin: keep following it.
   current <= 0 -> current
-  else -> (current + appended).coerceAtMost(historyCount)
+  else -> (current + change.appended).coerceAtMost(historyCount)
 }
 
 /**
@@ -1921,12 +1924,7 @@ fun ProperTerminal(
         // streamed output, and still a frame late. The SideEffect only commits what was already
         // rendered, and re-runs a fold that no-ops.
         val effectiveScrollOffset = remember(currentTrigger) {
-          val appended = historyAppendBank.drain()
-          if (appended > 0) {
-            foldHistoryAppends(scrollOffset, appended, textBuffer.historyLinesCount)
-          } else {
-            scrollOffset
-          }
+          foldHistoryAppends(scrollOffset, historyAppendBank.drain(), textBuffer.historyLinesCount)
         }
         SideEffect {
           if (scrollOffset != effectiveScrollOffset) scrollOffset = effectiveScrollOffset

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.*
+import java.util.concurrent.atomic.AtomicInteger
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -69,6 +70,7 @@ import ai.rever.bossterm.compose.actions.createBuiltinActions
 import ai.rever.bossterm.compose.splits.NavigationDirection
 import ai.rever.bossterm.compose.menu.MenuActions
 import ai.rever.bossterm.compose.debug.DebugWindow
+import ai.rever.bossterm.terminal.model.TextBufferChangesListener
 import ai.rever.bossterm.compose.features.ContextMenuController
 import ai.rever.bossterm.compose.features.ContextMenuPopup
 import ai.rever.bossterm.compose.features.showHyperlinkContextMenu
@@ -140,6 +142,25 @@ private data class StableTerminalRenderFrame(
 )
 
 /** UI-thread-confined retention committed only after an accepted composition applies. */
+/**
+ * The offset a bottom-anchored viewport needs after [appended] lines were appended to history.
+ *
+ * `scrollOffset` counts back from the LIVE BOTTOM, so appending moves the user's content that many
+ * rows further from the anchor; adding the count re-addresses the same lines. Extracted from the
+ * composable so the edges are unit-testable: following the bottom is left alone, and a capped
+ * history pins the view to its oldest surviving line rather than running off the end.
+ *
+ * @param current the offset now; 0 means following the live bottom.
+ * @param appended lines added to history since the last fold.
+ * @param historyCount history size after the append, the furthest back the viewport can address.
+ */
+internal fun foldHistoryAppends(current: Int, appended: Int, historyCount: Int): Int = when {
+  appended <= 0 -> current
+  // Following the bottom is a position, not a pin: keep following it.
+  current <= 0 -> current
+  else -> (current + appended).coerceAtMost(historyCount)
+}
+
 internal class StableRenderFrameHolder<T : Any> {
   private var frame: T? = null
 
@@ -242,11 +263,20 @@ fun ProperTerminal(
   // Accumulate lock-free on the emulator thread, apply on the UI thread. Deliberately NOT written
   // straight from the listener - that fires inside the buffer lock on the hottest path, and taking
   // Compose's snapshot lock under it is the lock inversion ComposeTerminalDisplay warns about.
-  val pendingHistoryAppends = remember(textBuffer) { java.util.concurrent.atomic.AtomicInteger(0) }
+  val pendingHistoryAppends = remember(textBuffer) { AtomicInteger(0) }
   DisposableEffect(textBuffer) {
-    val anchor = object : ai.rever.bossterm.terminal.model.TextBufferChangesListener {
+    val anchor = object : TextBufferChangesListener {
       override fun linesAddedToHistory(count: Int) {
-        pendingHistoryAppends.addAndGet(count)
+        // Decide here, not at drain time. This fires synchronously inside the append, so
+        // `isUsingAlternateBuffer` is consistent with the lines being reported. Testing it on the
+        // UI thread a frame later races both ways: main-screen appends banked before the app
+        // enters the alt screen would be dropped, and alt-screen appends banked before the TUI
+        // exits would be folded into the main-screen offset - exactly what the check prevents.
+        //
+        // The alternate screen really does accumulate scrollback here (`useAlternateBuffer` swaps
+        // in a live storage and `scrollArea` has no alt guard), but it is thrown away when the TUI
+        // exits, so an offset derived from it would address a buffer that no longer exists.
+        if (!textBuffer.isUsingAlternateBuffer) pendingHistoryAppends.addAndGet(count)
       }
 
       override fun historyCleared() {
@@ -255,6 +285,18 @@ fun ProperTerminal(
     }
     textBuffer.addChangesListener(anchor)
     onDispose { textBuffer.removeChangesListener(anchor) }
+  }
+
+  /**
+   * Move the viewport, clearing any banked appends when leaving the live bottom.
+   *
+   * Every path that takes the offset off 0 must go through this: appends banked while following
+   * the bottom are not compensation for a scrolled viewport, and folding them makes the first
+   * scrolled frame jump.
+   */
+  fun setScrollOffset(target: Int) {
+    if (scrollOffset == 0) pendingHistoryAppends.set(0)
+    scrollOffset = target.coerceIn(0, textBuffer.historyLinesCount)
   }
 
   // Command blocks captured for this session (OSC 133). Collected so the gutter
@@ -321,11 +363,11 @@ fun ProperTerminal(
     if (matchRow < visibleRowStart) {
       // Match is above visible area, scroll up to show it (with 2-line margin from top)
       val targetOffset = -matchRow + 2
-      scrollOffset = targetOffset.coerceIn(0, historySize)
+      setScrollOffset(targetOffset)
     } else if (matchRow > visibleRowEnd) {
       // Match is below visible area, scroll down to show it (with 2-line margin from bottom)
       val targetOffset = -(matchRow - screenHeight + 3)
-      scrollOffset = targetOffset.coerceIn(0, historySize)
+      setScrollOffset(targetOffset)
     }
     // If match is already visible, don't scroll
 
@@ -496,13 +538,13 @@ fun ProperTerminal(
           position.y < 0 -> {
             // Dragging above canvas - scroll up into history
             val scrollDelta = (-position.y * AUTO_SCROLL_SPEED).toInt().coerceAtLeast(1)
-            scrollOffset = (scrollOffset + scrollDelta).coerceIn(0, historySize)
+            setScrollOffset(scrollOffset + scrollDelta)
             true
           }
           position.y > height -> {
             // Dragging below canvas - scroll down toward current
             val scrollDelta = ((position.y - height) * AUTO_SCROLL_SPEED).toInt().coerceAtLeast(1)
-            scrollOffset = (scrollOffset - scrollDelta).coerceIn(0, historySize)
+            setScrollOffset(scrollOffset - scrollDelta)
             true
           }
           else -> false  // Back in bounds
@@ -881,7 +923,7 @@ fun ProperTerminal(
     screenHeight = { textBuffer.height },
     cellHeight = { cellHeight },
     onScroll = { newOffset ->
-      scrollOffset = newOffset
+      setScrollOffset(newOffset)
       display.requestImmediateRedraw() // Immediate redraw for responsive scrolling
     }
   )
@@ -1724,12 +1766,7 @@ fun ProperTerminal(
           accumulatedScrollDelta += delta * settings.scrollMultiplier
           val scrollLines = accumulatedScrollDelta.toInt()
           if (scrollLines != 0) {
-            if (scrollOffset == 0) {
-              // Leaving the bottom: appends banked while we were following it must not be folded
-              // into the offset we are about to take, or the first frame jumps.
-              pendingHistoryAppends.set(0)
-            }
-            scrollOffset = (scrollOffset - scrollLines).coerceIn(0, historySize)
+            setScrollOffset(scrollOffset - scrollLines)
             accumulatedScrollDelta -= scrollLines.toFloat()
             userScrollTrigger++  // Mark as user-initiated scroll for scrollbar visibility
           }
@@ -1899,24 +1936,20 @@ fun ProperTerminal(
         // Snapshot cached by Compose - recreated when display triggers redraw OR buffer dimensions change
         // Buffer, images, and cursor state are retained as one accepted render frame.
         val currentTrigger = display.redrawTrigger.value
-        // iTerm2's refreshAfterSync equivalent: fold the appends that landed since the last frame
-        // into the scroll offset so a scrolled-up viewport stays on the same content. Only while
-        // the user is actually scrolled up - at offset 0 we keep following the bottom, which is
-        // what iTerm2 does with `if (!userScroll) [self scrollEnd]`.
+        // iTerm2's refreshAfterSync equivalent: fold the appends banked since the last frame into
+        // the offset, so a scrolled-up viewport keeps addressing the same content. See
+        // [foldHistoryAppends] for the edges and the listener above for why alt-screen appends
+        // never reach the bank.
         //
-        // Never on the ALTERNATE screen. This buffer really does accumulate scrollback there
-        // (`useAlternateBuffer` swaps in a live CyclicBufferLinesStorage, and `scrollArea` has no
-        // alt guard), so a full-screen TUI scrolling with DECSTBM top == 1, or plain line feeds,
-        // appends and reports just like the main screen. Folding those would walk the offset
-        // against a history that is thrown away when the TUI exits, leaving the restored main view
-        // at an offset derived from a buffer that no longer exists. The bank is still drained, so
-        // alt-screen appends are discarded rather than applied late.
-        LaunchedEffect(currentTrigger) {
+        // SideEffect, not LaunchedEffect: this runs synchronously after apply, so the resulting
+        // recomposition lands in the same frame loop instead of the next one. A frame late would
+        // draw the post-append snapshot at the pre-append offset and then snap, which under
+        // sustained output trades a steady drift for a per-frame jitter. It also avoids allocating
+        // and cancelling a coroutine per redraw on the hottest composable in the app.
+        SideEffect {
           val appended = pendingHistoryAppends.getAndSet(0)
-          if (appended > 0 && scrollOffset > 0 && !textBuffer.isUsingAlternateBuffer) {
-            // Clamping at historyLinesCount pins the view to the oldest surviving line once capped
-            // history starts evicting, mirroring iTerm2 clamping its scroll rect at 0.
-            scrollOffset = (scrollOffset + appended).coerceAtMost(textBuffer.historyLinesCount)
+          if (appended > 0) {
+            scrollOffset = foldHistoryAppends(scrollOffset, appended, textBuffer.historyLinesCount)
           }
         }
         val imageDataCache = terminal.getImageDataCache()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -1903,9 +1903,17 @@ fun ProperTerminal(
         // into the scroll offset so a scrolled-up viewport stays on the same content. Only while
         // the user is actually scrolled up - at offset 0 we keep following the bottom, which is
         // what iTerm2 does with `if (!userScroll) [self scrollEnd]`.
+        //
+        // Never on the ALTERNATE screen. This buffer really does accumulate scrollback there
+        // (`useAlternateBuffer` swaps in a live CyclicBufferLinesStorage, and `scrollArea` has no
+        // alt guard), so a full-screen TUI scrolling with DECSTBM top == 1, or plain line feeds,
+        // appends and reports just like the main screen. Folding those would walk the offset
+        // against a history that is thrown away when the TUI exits, leaving the restored main view
+        // at an offset derived from a buffer that no longer exists. The bank is still drained, so
+        // alt-screen appends are discarded rather than applied late.
         LaunchedEffect(currentTrigger) {
           val appended = pendingHistoryAppends.getAndSet(0)
-          if (appended > 0 && scrollOffset > 0) {
+          if (appended > 0 && scrollOffset > 0 && !textBuffer.isUsingAlternateBuffer) {
             // Clamping at historyLinesCount pins the view to the oldest surviving line once capped
             // history starts evicting, mirroring iTerm2 clamping its scroll rect at 0.
             scrollOffset = (scrollOffset + appended).coerceAtMost(textBuffer.historyLinesCount)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -161,6 +161,16 @@ internal class StableRenderFrameHolder<T : Any> {
  * @param change what happened to history since the last fold.
  * @param historyCount history size after the change - the furthest back the viewport can address.
  */
+/**
+ * A fold computed during composition, waiting to be committed once that composition applies.
+ *
+ * Mutable and deliberately not Compose state: marking it consumed must not invalidate anything,
+ * and a composition that is discarded simply never marks it, so the bank keeps its count.
+ */
+internal class PendingFold(val delta: HistoryDelta, val offset: Int) {
+  var consumed: Boolean = false
+}
+
 internal fun foldHistoryAppends(current: Int, change: HistoryDelta, historyCount: Int): Int = when {
   // History was emptied under a scrolled-up viewport: every line it addressed is gone, so the only
   // sensible position left is the live bottom. Staying put would render blank until the user
@@ -274,10 +284,7 @@ fun ProperTerminal(
    * the bottom are not compensation for a scrolled viewport, and folding them makes the first
    * scrolled frame jump.
    */
-  fun setScrollOffset(target: Int) {
-    if (scrollOffset == 0) historyAppendBank.clear()
-    scrollOffset = target.coerceIn(0, textBuffer.historyLinesCount)
-  }
+  fun setScrollOffset(target: Int) = tab.scrollTo(target)
 
   // Command blocks captured for this session (OSC 133). Collected so the gutter
   // and scrollbar markers repaint as commands start and finish. Falls back to a
@@ -1932,21 +1939,33 @@ fun ProperTerminal(
         // A plain holder rather than Compose state on purpose: consuming it must not invalidate
         // the composition. Once consumed, every later recomposition renders straight from
         // `scrollOffset`, so user scrolling behaves exactly as it did before this change.
+        // Skipped entirely while the alternate screen is up. The fire-time gate keeps alt appends
+        // out of the bank, but a MAIN-screen append banked just before a TUI starts would still be
+        // folded here and clamped against `historyLinesCount` - which on the alt screen is the ALT
+        // history, typically 0. That collapses the offset and loses the main-screen position for
+        // good. Leaving it banked applies it correctly once the TUI exits.
         val pendingFold = remember(currentTrigger) {
-          val folded = foldHistoryAppends(
-            scrollOffset,
-            historyAppendBank.drain(),
-            textBuffer.historyLinesCount,
-          )
-          arrayOf<Int?>(if (folded != scrollOffset) folded else null)
+          if (textBuffer.isUsingAlternateBuffer) {
+            null
+          } else {
+            // peek, not drain: this runs during composition, and a composition that never applies
+            // must not swallow the count. Taken for real in the SideEffect below.
+            val delta = historyAppendBank.peek()
+            val folded = foldHistoryAppends(scrollOffset, delta, textBuffer.historyLinesCount)
+            if (delta.cleared || delta.appended > 0) PendingFold(delta, folded) else null
+          }
         }
         // The frame that first shows the appended lines is rendered at the corrected offset, so
-        // there is no shift-and-snap; the SideEffect only commits what was already drawn.
-        val effectiveScrollOffset = pendingFold[0] ?: scrollOffset
+        // there is no shift-and-snap; the SideEffect only commits what was already drawn. Once
+        // consumed, later recompositions render straight from `scrollOffset`, so user scrolling -
+        // which moves the offset without advancing the redraw trigger - is never clobbered.
+        val effectiveScrollOffset = pendingFold?.takeIf { !it.consumed }?.offset ?: scrollOffset
         SideEffect {
-          pendingFold[0]?.let { target ->
-            pendingFold[0] = null
-            if (scrollOffset != target) scrollOffset = target
+          pendingFold?.let { fold ->
+            if (fold.consumed) return@let
+            fold.consumed = true
+            historyAppendBank.consume(fold.delta)
+            if (scrollOffset != fold.offset) scrollOffset = fold.offset
           }
         }
         val imageDataCache = terminal.getImageDataCache()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -1740,7 +1740,7 @@ fun ProperTerminal(
           // Local scroll (main buffer or Shift+Wheel override)
           // Accumulate fractional deltas for smooth scrolling
           // Windows trackpads send small fractional values, so multiplier helps
-                accumulatedScrollDelta += delta * settings.scrollMultiplier
+          accumulatedScrollDelta += delta * settings.scrollMultiplier
           val scrollLines = accumulatedScrollDelta.toInt()
           if (scrollLines != 0) {
             setScrollOffset(scrollOffset - scrollLines)
@@ -1923,11 +1923,31 @@ fun ProperTerminal(
         // frame - a full extra recomposition of the largest composable in the app, per frame of
         // streamed output, and still a frame late. The SideEffect only commits what was already
         // rendered, and re-runs a fold that no-ops.
-        val effectiveScrollOffset = remember(currentTrigger) {
-          foldHistoryAppends(scrollOffset, historyAppendBank.drain(), textBuffer.historyLinesCount)
+        // Drained once per redraw trigger, then CONSUMED. Holding the folded value across
+        // recompositions instead would clobber the user: `scrollOffset` changes without the
+        // trigger advancing (the wheel writes it and never calls requestImmediateRedraw, and
+        // `redrawTrigger` only moves in ComposeTerminalDisplay.actualRedraw), so a cached value
+        // would both freeze the view mid-scroll and then get written back over the new offset.
+        //
+        // A plain holder rather than Compose state on purpose: consuming it must not invalidate
+        // the composition. Once consumed, every later recomposition renders straight from
+        // `scrollOffset`, so user scrolling behaves exactly as it did before this change.
+        val pendingFold = remember(currentTrigger) {
+          val folded = foldHistoryAppends(
+            scrollOffset,
+            historyAppendBank.drain(),
+            textBuffer.historyLinesCount,
+          )
+          arrayOf<Int?>(if (folded != scrollOffset) folded else null)
         }
+        // The frame that first shows the appended lines is rendered at the corrected offset, so
+        // there is no shift-and-snap; the SideEffect only commits what was already drawn.
+        val effectiveScrollOffset = pendingFold[0] ?: scrollOffset
         SideEffect {
-          if (scrollOffset != effectiveScrollOffset) scrollOffset = effectiveScrollOffset
+          pendingFold[0]?.let { target ->
+            pendingFold[0] = null
+            if (scrollOffset != target) scrollOffset = target
+          }
         }
         val imageDataCache = terminal.getImageDataCache()
         val stableFrameHolder = remember(textBuffer, display) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -132,6 +132,12 @@ private class GridStabilityTracker {
 /** A complete immutable frame retained while an application performs ?2026 updates. */
 private data class StableTerminalRenderFrame(
   val buffer: VersionedBufferSnapshot,
+  /**
+   * History appends peeked in the same breath as [buffer], so the fold describes exactly the
+   * lines this snapshot contains. Peeking outside the capture leaves a frame of residue when an
+   * append lands between the two.
+   */
+  val historyDelta: HistoryDelta,
   val imagesById: Map<Long, TerminalImage>,
   val cursorX: Int,
   val cursorY: Int,
@@ -1939,35 +1945,6 @@ fun ProperTerminal(
         // A plain holder rather than Compose state on purpose: consuming it must not invalidate
         // the composition. Once consumed, every later recomposition renders straight from
         // `scrollOffset`, so user scrolling behaves exactly as it did before this change.
-        // Skipped entirely while the alternate screen is up. The fire-time gate keeps alt appends
-        // out of the bank, but a MAIN-screen append banked just before a TUI starts would still be
-        // folded here and clamped against `historyLinesCount` - which on the alt screen is the ALT
-        // history, typically 0. That collapses the offset and loses the main-screen position for
-        // good. Leaving it banked applies it correctly once the TUI exits.
-        val pendingFold = remember(currentTrigger) {
-          if (textBuffer.isUsingAlternateBuffer) {
-            null
-          } else {
-            // peek, not drain: this runs during composition, and a composition that never applies
-            // must not swallow the count. Taken for real in the SideEffect below.
-            val delta = historyAppendBank.peek()
-            val folded = foldHistoryAppends(scrollOffset, delta, textBuffer.historyLinesCount)
-            if (delta.cleared || delta.appended > 0) PendingFold(delta, folded) else null
-          }
-        }
-        // The frame that first shows the appended lines is rendered at the corrected offset, so
-        // there is no shift-and-snap; the SideEffect only commits what was already drawn. Once
-        // consumed, later recompositions render straight from `scrollOffset`, so user scrolling -
-        // which moves the offset without advancing the redraw trigger - is never clobbered.
-        val effectiveScrollOffset = pendingFold?.takeIf { !it.consumed }?.offset ?: scrollOffset
-        SideEffect {
-          pendingFold?.let { fold ->
-            if (fold.consumed) return@let
-            fold.consumed = true
-            historyAppendBank.consume(fold.delta)
-            if (scrollOffset != fold.offset) scrollOffset = fold.offset
-          }
-        }
         val imageDataCache = terminal.getImageDataCache()
         val stableFrameHolder = remember(textBuffer, display) {
           StableRenderFrameHolder<StableTerminalRenderFrame>()
@@ -1976,6 +1953,7 @@ fun ProperTerminal(
           display.captureStableRenderFrame {
             StableTerminalRenderFrame(
               buffer = textBuffer.createIncrementalSnapshot(),
+              historyDelta = historyAppendBank.peek(),
               imagesById = imageDataCache.snapshotImages(),
               cursorX = display.cursorXSnapshot,
               cursorY = display.cursorYSnapshot,
@@ -1985,6 +1963,37 @@ fun ProperTerminal(
           }
         }
         val renderFrame = stableFrameHolder.frameFor(capturedFrame)
+        // Folded only for a capture that was ACCEPTED. `captureStableRenderFrame` returns null
+        // when the composition overlaps a DEC 2026 synchronized update, and `frameFor` then paints
+        // the previously retained snapshot - which does not contain the appended lines. Advancing
+        // the offset for it would jump the retained frame N rows and jump back when the real one
+        // lands: the shift-and-snap this exists to avoid, relocated into the ?2026 window.
+        //
+        // Skipped entirely on the alternate screen too: the fire-time gate keeps ALT appends out of
+        // the bank, and this keeps a banked MAIN-screen append from being clamped against the alt
+        // history (typically 0), which would collapse the offset and lose the position for good.
+        // The bank keeps its count either way, so skipping costs nothing but a frame.
+        val pendingFold = remember(capturedFrame) {
+          val delta = capturedFrame?.historyDelta
+          if (delta == null || textBuffer.isUsingAlternateBuffer || (!delta.cleared && delta.appended <= 0)) {
+            null
+          } else {
+            PendingFold(delta, foldHistoryAppends(scrollOffset, delta, textBuffer.historyLinesCount))
+          }
+        }
+        // The frame that first shows the appended lines renders at the corrected offset, so there
+        // is no shift-and-snap; the SideEffect only commits what was already drawn. Once consumed,
+        // later recompositions render straight from `scrollOffset`, so a user scroll - which moves
+        // the offset without advancing the redraw trigger - is never clobbered.
+        val effectiveScrollOffset = pendingFold?.takeIf { !it.consumed }?.offset ?: scrollOffset
+        SideEffect {
+          pendingFold?.let { fold ->
+            if (fold.consumed) return@let
+            fold.consumed = true
+            historyAppendBank.consume(fold.delta)
+            if (scrollOffset != fold.offset) scrollOffset = fold.offset
+          }
+        }
         SideEffect {
           // Only frames from a composition that reached apply become future fallbacks.
           capturedFrame?.let(stableFrameHolder::commit)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.*
-import java.util.concurrent.atomic.AtomicInteger
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -70,7 +69,6 @@ import ai.rever.bossterm.compose.actions.createBuiltinActions
 import ai.rever.bossterm.compose.splits.NavigationDirection
 import ai.rever.bossterm.compose.menu.MenuActions
 import ai.rever.bossterm.compose.debug.DebugWindow
-import ai.rever.bossterm.terminal.model.TextBufferChangesListener
 import ai.rever.bossterm.compose.features.ContextMenuController
 import ai.rever.bossterm.compose.features.ContextMenuPopup
 import ai.rever.bossterm.compose.features.showHyperlinkContextMenu
@@ -142,6 +140,16 @@ private data class StableTerminalRenderFrame(
 )
 
 /** UI-thread-confined retention committed only after an accepted composition applies. */
+internal class StableRenderFrameHolder<T : Any> {
+  private var frame: T? = null
+
+  fun frameFor(candidate: T?): T? = candidate ?: frame
+
+  fun commit(candidate: T) {
+    frame = candidate
+  }
+}
+
 /**
  * The offset a bottom-anchored viewport needs after [appended] lines were appended to history.
  *
@@ -159,16 +167,6 @@ internal fun foldHistoryAppends(current: Int, appended: Int, historyCount: Int):
   // Following the bottom is a position, not a pin: keep following it.
   current <= 0 -> current
   else -> (current + appended).coerceAtMost(historyCount)
-}
-
-internal class StableRenderFrameHolder<T : Any> {
-  private var frame: T? = null
-
-  fun frameFor(candidate: T?): T? = candidate ?: frame
-
-  fun commit(candidate: T) {
-    frame = candidate
-  }
 }
 
 /**
@@ -263,29 +261,8 @@ fun ProperTerminal(
   // Accumulate lock-free on the emulator thread, apply on the UI thread. Deliberately NOT written
   // straight from the listener - that fires inside the buffer lock on the hottest path, and taking
   // Compose's snapshot lock under it is the lock inversion ComposeTerminalDisplay warns about.
-  val pendingHistoryAppends = remember(textBuffer) { AtomicInteger(0) }
-  DisposableEffect(textBuffer) {
-    val anchor = object : TextBufferChangesListener {
-      override fun linesAddedToHistory(count: Int) {
-        // Decide here, not at drain time. This fires synchronously inside the append, so
-        // `isUsingAlternateBuffer` is consistent with the lines being reported. Testing it on the
-        // UI thread a frame later races both ways: main-screen appends banked before the app
-        // enters the alt screen would be dropped, and alt-screen appends banked before the TUI
-        // exits would be folded into the main-screen offset - exactly what the check prevents.
-        //
-        // The alternate screen really does accumulate scrollback here (`useAlternateBuffer` swaps
-        // in a live storage and `scrollArea` has no alt guard), but it is thrown away when the TUI
-        // exits, so an offset derived from it would address a buffer that no longer exists.
-        if (!textBuffer.isUsingAlternateBuffer) pendingHistoryAppends.addAndGet(count)
-      }
-
-      override fun historyCleared() {
-        pendingHistoryAppends.set(0)
-      }
-    }
-    textBuffer.addChangesListener(anchor)
-    onDispose { textBuffer.removeChangesListener(anchor) }
-  }
+  // Session-scoped, registered for the tab's lifetime: see TerminalSession.historyAppendBank.
+  val historyAppendBank = tab.historyAppendBank
 
   /**
    * Move the viewport, clearing any banked appends when leaving the live bottom.
@@ -295,7 +272,7 @@ fun ProperTerminal(
    * scrolled frame jump.
    */
   fun setScrollOffset(target: Int) {
-    if (scrollOffset == 0) pendingHistoryAppends.set(0)
+    if (scrollOffset == 0) historyAppendBank.clear()
     scrollOffset = target.coerceIn(0, textBuffer.historyLinesCount)
   }
 
@@ -351,7 +328,6 @@ fun ProperTerminal(
   // Scroll terminal to show a search match (only scroll if match not already visible)
   fun scrollToMatch(matchRow: Int) {
     val screenHeight = textBuffer.height
-    val historySize = textBuffer.historyLinesCount
 
     // Calculate currently visible rows (in buffer coordinates)
     // scrollOffset=0 means viewing current screen (rows 0 to screenHeight-1)
@@ -530,8 +506,7 @@ fun ProperTerminal(
     autoScrollJob?.cancel()
     autoScrollJob = scope.launch {
       while (isActive && isDragging) {
-        val historySize = textBuffer.historyLinesCount
-        val height = canvasSize.height
+            val height = canvasSize.height
 
         // Calculate scroll amount based on distance from bounds
         val scrolled = when {
@@ -1762,8 +1737,7 @@ fun ProperTerminal(
           // Local scroll (main buffer or Shift+Wheel override)
           // Accumulate fractional deltas for smooth scrolling
           // Windows trackpads send small fractional values, so multiplier helps
-          val historySize = textBuffer.historyLinesCount
-          accumulatedScrollDelta += delta * settings.scrollMultiplier
+                accumulatedScrollDelta += delta * settings.scrollMultiplier
           val scrollLines = accumulatedScrollDelta.toInt()
           if (scrollLines != 0) {
             setScrollOffset(scrollOffset - scrollLines)
@@ -1937,20 +1911,25 @@ fun ProperTerminal(
         // Buffer, images, and cursor state are retained as one accepted render frame.
         val currentTrigger = display.redrawTrigger.value
         // iTerm2's refreshAfterSync equivalent: fold the appends banked since the last frame into
-        // the offset, so a scrolled-up viewport keeps addressing the same content. See
-        // [foldHistoryAppends] for the edges and the listener above for why alt-screen appends
-        // never reach the bank.
+        // the offset, so a scrolled-up viewport keeps addressing the same content.
         //
-        // SideEffect, not LaunchedEffect: this runs synchronously after apply, so the resulting
-        // recomposition lands in the same frame loop instead of the next one. A frame late would
-        // draw the post-append snapshot at the pre-append offset and then snap, which under
-        // sustained output trades a steady drift for a per-frame jitter. It also avoids allocating
-        // and cancelling a coroutine per redraw on the hottest composable in the app.
-        SideEffect {
-          val appended = pendingHistoryAppends.getAndSet(0)
+        // Computed HERE, during composition and beside the frame capture, so THIS frame draws the
+        // new snapshot at the corrected offset. Writing it from an effect instead does not work:
+        // `scrollOffset` is read at composable scope (`rememberUpdatedState` below), so a write
+        // during apply invalidates the whole composable and schedules the correction for the NEXT
+        // frame - a full extra recomposition of the largest composable in the app, per frame of
+        // streamed output, and still a frame late. The SideEffect only commits what was already
+        // rendered, and re-runs a fold that no-ops.
+        val effectiveScrollOffset = remember(currentTrigger) {
+          val appended = historyAppendBank.drain()
           if (appended > 0) {
-            scrollOffset = foldHistoryAppends(scrollOffset, appended, textBuffer.historyLinesCount)
+            foldHistoryAppends(scrollOffset, appended, textBuffer.historyLinesCount)
+          } else {
+            scrollOffset
           }
+        }
+        SideEffect {
+          if (scrollOffset != effectiveScrollOffset) scrollOffset = effectiveScrollOffset
         }
         val imageDataCache = terminal.getImageDataCache()
         val stableFrameHolder = remember(textBuffer, display) {
@@ -2009,7 +1988,7 @@ fun ProperTerminal(
 
             // Version-based hyperlink caching: compute hash including scroll position
             // since visible content changes with scroll even if buffer content is same
-            val currentVersionHash = bufferSnapshot.computeVersionHash() * 31 + scrollOffset
+            val currentVersionHash = bufferSnapshot.computeVersionHash() * 31 + effectiveScrollOffset
 
             // Reuse cached hyperlinks if buffer content and scroll position unchanged
             val precomputedHyperlinks = if (currentVersionHash == lastHyperlinkVersionHash &&
@@ -2035,8 +2014,8 @@ fun ProperTerminal(
                 val startBuf = selectionTracker.resolveAnchorRow(block.startAnchor, bufferSnapshot)
                   ?: return@mapNotNull null
                 val endBuf = block.endAnchor?.let { selectionTracker.resolveAnchorRow(it, bufferSnapshot) }
-                val startScreen = startBuf + scrollOffset
-                val endScreen = endBuf?.let { it + scrollOffset } ?: visibleRows
+                val startScreen = startBuf + effectiveScrollOffset
+                val endScreen = endBuf?.let { it + effectiveScrollOffset } ?: visibleRows
                 if (endScreen < 0 || startScreen > visibleRows) return@mapNotNull null
                 val color = when (block.state) {
                   BlockState.SUCCESS -> settings.commandBlockSuccessColorValue
@@ -2066,7 +2045,7 @@ fun ProperTerminal(
               cellHeight = cellHeight,
               baseCellHeight = baseCellHeight,
               cellBaseline = cellMetrics.third,
-              scrollOffset = scrollOffset,
+              scrollOffset = effectiveScrollOffset,
               visibleCols = visibleCols,
               visibleRows = visibleRows,
               textMeasurer = textMeasurer,
@@ -2137,7 +2116,7 @@ fun ProperTerminal(
             } else activeTheme.cursorColor
             with(TerminalCanvasRenderer) {
               val bufferCursorRow = (cursorY - 1).coerceAtLeast(0)
-              val cursorScreenRow = bufferCursorRow + scrollOffset
+              val cursorScreenRow = bufferCursorRow + effectiveScrollOffset
               val cursorImageCell = bufferSnapshot.getLine(bufferCursorRow).getImageCellAt(effectiveCursorX)
               val cursorImageSlice = cursorImageCell?.let { imageCell ->
                 renderFrame.imagesById[imageCell.imageId]?.let { image ->
@@ -2160,7 +2139,7 @@ fun ProperTerminal(
                 cursorShape = cursorShape,
                 cursorX = effectiveCursorX,
                 cursorY = cursorY,
-                scrollOffset = scrollOffset,
+                scrollOffset = effectiveScrollOffset,
                 cellWidth = cellWidth,
                 cellHeight = cellHeight,
                 isFocused = isFocused,

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/FoldHistoryAppendsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/FoldHistoryAppendsTest.kt
@@ -1,0 +1,59 @@
+package ai.rever.bossterm.compose.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The arithmetic behind keeping a bottom-anchored viewport on the same content as history grows.
+ *
+ * This is the half with the edges - the buffer-side notification is covered by
+ * `HistoryAppendAnchorTest` in bossterm-core-mpp. It lives outside the composable precisely so
+ * these cases are ordinary assertions rather than something needing a Compose harness.
+ */
+class FoldHistoryAppendsTest {
+
+    @Test
+    fun addingTheAppendCountReAddressesTheSameContent() {
+        // Scrolled 10 back, 3 lines appended: the content is now 13 rows from the live bottom.
+        assertEquals(13, foldHistoryAppends(current = 10, appended = 3, historyCount = 500))
+    }
+
+    @Test
+    fun followingTheBottomKeepsFollowingIt() {
+        assertEquals(
+            0,
+            foldHistoryAppends(current = 0, appended = 40, historyCount = 500),
+            "offset 0 is 'follow the live bottom', not a pinned position",
+        )
+    }
+
+    @Test
+    fun aCappedHistoryPinsTheViewToItsOldestSurvivingLine() {
+        // History is full at 100, so the content the user was reading has been evicted; the
+        // viewport stops at the oldest line that still exists instead of running off the end.
+        assertEquals(100, foldHistoryAppends(current = 98, appended = 20, historyCount = 100))
+    }
+
+    @Test
+    fun anOffsetAlreadyPastTheHistoryIsBroughtBackToTheOldestLine() {
+        assertEquals(50, foldHistoryAppends(current = 80, appended = 5, historyCount = 50))
+    }
+
+    @Test
+    fun nothingAppendedLeavesTheOffsetExactlyWhereItWas() {
+        assertEquals(42, foldHistoryAppends(current = 42, appended = 0, historyCount = 500))
+        assertEquals(
+            42,
+            foldHistoryAppends(current = 42, appended = -3, historyCount = 500),
+            "a negative count must never walk the viewport backwards",
+        )
+    }
+
+    @Test
+    fun aSingleLineAppendMovesTheViewportOneRow() {
+        // The steady case: one line of streaming output, one row of compensation.
+        var offset = 7
+        repeat(5) { offset = foldHistoryAppends(offset, appended = 1, historyCount = 500) }
+        assertEquals(12, offset, "five appended lines move the viewport five rows")
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/FoldHistoryAppendsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/FoldHistoryAppendsTest.kt
@@ -12,17 +12,20 @@ import kotlin.test.assertEquals
  */
 class FoldHistoryAppendsTest {
 
+    private fun appended(n: Int) = HistoryDelta(cleared = false, appended = n)
+
+
     @Test
     fun addingTheAppendCountReAddressesTheSameContent() {
         // Scrolled 10 back, 3 lines appended: the content is now 13 rows from the live bottom.
-        assertEquals(13, foldHistoryAppends(current = 10, appended = 3, historyCount = 500))
+        assertEquals(13, foldHistoryAppends(current = 10, change = appended(3), historyCount = 500))
     }
 
     @Test
     fun followingTheBottomKeepsFollowingIt() {
         assertEquals(
             0,
-            foldHistoryAppends(current = 0, appended = 40, historyCount = 500),
+            foldHistoryAppends(current = 0, change = appended(40), historyCount = 500),
             "offset 0 is 'follow the live bottom', not a pinned position",
         )
     }
@@ -31,20 +34,20 @@ class FoldHistoryAppendsTest {
     fun aCappedHistoryPinsTheViewToItsOldestSurvivingLine() {
         // History is full at 100, so the content the user was reading has been evicted; the
         // viewport stops at the oldest line that still exists instead of running off the end.
-        assertEquals(100, foldHistoryAppends(current = 98, appended = 20, historyCount = 100))
+        assertEquals(100, foldHistoryAppends(current = 98, change = appended(20), historyCount = 100))
     }
 
     @Test
     fun anOffsetAlreadyPastTheHistoryIsBroughtBackToTheOldestLine() {
-        assertEquals(50, foldHistoryAppends(current = 80, appended = 5, historyCount = 50))
+        assertEquals(50, foldHistoryAppends(current = 80, change = appended(5), historyCount = 50))
     }
 
     @Test
     fun nothingAppendedLeavesTheOffsetExactlyWhereItWas() {
-        assertEquals(42, foldHistoryAppends(current = 42, appended = 0, historyCount = 500))
+        assertEquals(42, foldHistoryAppends(current = 42, change = appended(0), historyCount = 500))
         assertEquals(
             42,
-            foldHistoryAppends(current = 42, appended = -3, historyCount = 500),
+            foldHistoryAppends(current = 42, change = appended(-3), historyCount = 500),
             "a negative count must never walk the viewport backwards",
         )
     }
@@ -53,7 +56,29 @@ class FoldHistoryAppendsTest {
     fun aSingleLineAppendMovesTheViewportOneRow() {
         // The steady case: one line of streaming output, one row of compensation.
         var offset = 7
-        repeat(5) { offset = foldHistoryAppends(offset, appended = 1, historyCount = 500) }
+        repeat(5) { offset = foldHistoryAppends(offset, appended(1), 500) }
         assertEquals(12, offset, "five appended lines move the viewport five rows")
+    }
+
+    /**
+     * History emptied under a scrolled-up viewport - `CSI 3 J`, what plain `clear` emits. Every
+     * line the viewport addressed is gone, so staying put would render blank until the user
+     * scrolled again.
+     */
+    @Test
+    fun clearingHistoryReturnsTheViewportToTheLiveBottom() {
+        assertEquals(
+            0,
+            foldHistoryAppends(current = 40, change = HistoryDelta(cleared = true, appended = 0), historyCount = 0),
+        )
+    }
+
+    @Test
+    fun aClearWinsOverAnyAppendsInTheSameFrame() {
+        assertEquals(
+            0,
+            foldHistoryAppends(current = 40, change = HistoryDelta(cleared = true, appended = 7), historyCount = 0),
+            "the appended lines were cleared away too; there is nothing left to compensate",
+        )
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBankTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBankTest.kt
@@ -28,7 +28,7 @@ class HistoryAppendBankTest {
 
         repeat(3) { buffer.scrollArea(1, -1, 4) }
 
-        assertEquals(3, bank.drain())
+        assertEquals(3, bank.drain().appended)
     }
 
     /**
@@ -44,7 +44,7 @@ class HistoryAppendBankTest {
 
         repeat(3) { buffer.scrollArea(1, -1, 4) }
 
-        assertEquals(0, bank.drain(), "alt-screen appends must never reach the bank")
+        assertEquals(0, bank.drain().appended, "alt-screen appends must never reach the bank")
     }
 
     /**
@@ -64,7 +64,7 @@ class HistoryAppendBankTest {
 
         assertEquals(
             2,
-            bank.drain(),
+            bank.drain().appended,
             "the 2 main-screen lines survive, the 5 alt-screen ones were never banked",
         )
     }
@@ -75,8 +75,8 @@ class HistoryAppendBankTest {
         buffer.getLine(3)
         buffer.scrollArea(1, -1, 4)
 
-        assertEquals(1, bank.drain())
-        assertEquals(0, bank.drain(), "a second drain sees nothing new")
+        assertEquals(1, bank.drain().appended)
+        assertEquals(0, bank.drain().appended, "a second drain sees nothing new")
     }
 
     /** Leaving the live bottom discards the bank: those appends were not a scrolled viewport's. */
@@ -88,18 +88,34 @@ class HistoryAppendBankTest {
 
         bank.clear()
 
-        assertEquals(0, bank.drain())
+        assertEquals(0, bank.drain().appended)
     }
 
-    /** A cleared history leaves nothing to compensate for. */
+    /**
+     * A cleared history is reported as such, not merely as "no appends". A viewport scrolled up
+     * when `CSI 3 J` lands is addressing lines that no longer exist, so the fold needs to know the
+     * difference between "nothing happened" and "everything went away".
+     */
     @Test
-    fun clearingHistoryEmptiesTheBank() {
+    fun clearingHistoryIsReportedAndEmptiesTheBank() {
         val (buffer, bank) = buffer().bankWiredUp()
         buffer.getLine(3)
         repeat(4) { buffer.scrollArea(1, -1, 4) }
 
         buffer.clearHistory()
+        val delta = bank.drain()
 
-        assertEquals(0, bank.drain())
+        assertEquals(true, delta.cleared, "the clear must be reported, not just counted away")
+        assertEquals(0, delta.appended)
+        assertEquals(false, bank.drain().cleared, "and taken only once")
+    }
+
+    @Test
+    fun anOrdinaryAppendIsNotReportedAsAClear() {
+        val (buffer, bank) = buffer().bankWiredUp()
+        buffer.getLine(3)
+        buffer.scrollArea(1, -1, 4)
+
+        assertEquals(false, bank.drain().cleared)
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBankTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBankTest.kt
@@ -1,0 +1,105 @@
+package ai.rever.bossterm.compose.ui
+
+import ai.rever.bossterm.terminal.model.StyleState
+import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The two decisions that decide whether the viewport ends up somewhere sensible. Neither is
+ * arithmetic - [FoldHistoryAppendsTest] covers that - and neither was reachable from a test while
+ * they lived inside the composable.
+ */
+class HistoryAppendBankTest {
+
+    private fun buffer() = TerminalTextBuffer(20, 4, StyleState(), 100)
+
+    private fun TerminalTextBuffer.bankWiredUp(): Pair<TerminalTextBuffer, HistoryAppendBank> {
+        val bank = HistoryAppendBank(this)
+        addChangesListener(bank)
+        return this to bank
+    }
+
+    /** One line of streaming output, one line banked. */
+    @Test
+    fun mainScreenAppendsAreCounted() {
+        val (buffer, bank) = buffer().bankWiredUp()
+        buffer.getLine(3)
+
+        repeat(3) { buffer.scrollArea(1, -1, 4) }
+
+        assertEquals(3, bank.drain())
+    }
+
+    /**
+     * The alternate screen accumulates scrollback in this buffer, but it is discarded when the TUI
+     * exits - so folding those appends would leave the restored main view at an offset derived
+     * from a buffer that no longer exists.
+     */
+    @Test
+    fun alternateScreenAppendsAreNotCounted() {
+        val (buffer, bank) = buffer().bankWiredUp()
+        buffer.useAlternateBuffer(true)
+        buffer.getLine(3)
+
+        repeat(3) { buffer.scrollArea(1, -1, 4) }
+
+        assertEquals(0, bank.drain(), "alt-screen appends must never reach the bank")
+    }
+
+    /**
+     * The exclusion is decided when the append fires, not when the count is drained. Draining on
+     * the UI thread a frame later would race: these main-screen lines arrived before the TUI
+     * started, and must survive the switch.
+     */
+    @Test
+    fun appendsKeepTheScreenTheyArrivedOn() {
+        val (buffer, bank) = buffer().bankWiredUp()
+        buffer.getLine(3)
+        repeat(2) { buffer.scrollArea(1, -1, 4) }
+
+        // A TUI starts before the viewport takes its next frame.
+        buffer.useAlternateBuffer(true)
+        repeat(5) { buffer.scrollArea(1, -1, 4) }
+
+        assertEquals(
+            2,
+            bank.drain(),
+            "the 2 main-screen lines survive, the 5 alt-screen ones were never banked",
+        )
+    }
+
+    @Test
+    fun drainingEmptiesTheBank() {
+        val (buffer, bank) = buffer().bankWiredUp()
+        buffer.getLine(3)
+        buffer.scrollArea(1, -1, 4)
+
+        assertEquals(1, bank.drain())
+        assertEquals(0, bank.drain(), "a second drain sees nothing new")
+    }
+
+    /** Leaving the live bottom discards the bank: those appends were not a scrolled viewport's. */
+    @Test
+    fun clearForgetsWhatWasBanked() {
+        val (buffer, bank) = buffer().bankWiredUp()
+        buffer.getLine(3)
+        repeat(4) { buffer.scrollArea(1, -1, 4) }
+
+        bank.clear()
+
+        assertEquals(0, bank.drain())
+    }
+
+    /** A cleared history leaves nothing to compensate for. */
+    @Test
+    fun clearingHistoryEmptiesTheBank() {
+        val (buffer, bank) = buffer().bankWiredUp()
+        buffer.getLine(3)
+        repeat(4) { buffer.scrollArea(1, -1, 4) }
+
+        buffer.clearHistory()
+
+        assertEquals(0, bank.drain())
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBankTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/HistoryAppendBankTest.kt
@@ -28,7 +28,7 @@ class HistoryAppendBankTest {
 
         repeat(3) { buffer.scrollArea(1, -1, 4) }
 
-        assertEquals(3, bank.drain().appended)
+        assertEquals(3, bank.peek().appended)
     }
 
     /**
@@ -44,7 +44,7 @@ class HistoryAppendBankTest {
 
         repeat(3) { buffer.scrollArea(1, -1, 4) }
 
-        assertEquals(0, bank.drain().appended, "alt-screen appends must never reach the bank")
+        assertEquals(0, bank.peek().appended, "alt-screen appends must never reach the bank")
     }
 
     /**
@@ -64,19 +64,21 @@ class HistoryAppendBankTest {
 
         assertEquals(
             2,
-            bank.drain().appended,
+            bank.peek().appended,
             "the 2 main-screen lines survive, the 5 alt-screen ones were never banked",
         )
     }
 
     @Test
-    fun drainingEmptiesTheBank() {
+    fun consumingTakesExactlyWhatWasPeeked() {
         val (buffer, bank) = buffer().bankWiredUp()
         buffer.getLine(3)
         buffer.scrollArea(1, -1, 4)
 
-        assertEquals(1, bank.drain().appended)
-        assertEquals(0, bank.drain().appended, "a second drain sees nothing new")
+        val delta = bank.peek()
+        assertEquals(1, delta.appended)
+        bank.consume(delta)
+        assertEquals(0, bank.peek().appended, "consuming takes exactly what was peeked")
     }
 
     /** Leaving the live bottom discards the bank: those appends were not a scrolled viewport's. */
@@ -88,7 +90,7 @@ class HistoryAppendBankTest {
 
         bank.clear()
 
-        assertEquals(0, bank.drain().appended)
+        assertEquals(0, bank.peek().appended)
     }
 
     /**
@@ -103,11 +105,12 @@ class HistoryAppendBankTest {
         repeat(4) { buffer.scrollArea(1, -1, 4) }
 
         buffer.clearHistory()
-        val delta = bank.drain()
+        val delta = bank.peek()
 
         assertEquals(true, delta.cleared, "the clear must be reported, not just counted away")
         assertEquals(0, delta.appended)
-        assertEquals(false, bank.drain().cleared, "and taken only once")
+        bank.consume(delta)
+        assertEquals(false, bank.peek().cleared, "and taken only once")
     }
 
     @Test
@@ -116,6 +119,35 @@ class HistoryAppendBankTest {
         buffer.getLine(3)
         buffer.scrollArea(1, -1, 4)
 
-        assertEquals(false, bank.drain().cleared)
+        assertEquals(false, bank.peek().cleared)
+    }
+
+    /**
+     * A composition can be discarded before it applies. Peeking must therefore leave the count in
+     * place, or those appends vanish and the viewport drifts permanently - the exact failure this
+     * class exists to prevent.
+     */
+    @Test
+    fun peekingWithoutConsumingKeepsTheCount() {
+        val (buffer, bank) = buffer().bankWiredUp()
+        buffer.getLine(3)
+        repeat(3) { buffer.scrollArea(1, -1, 4) }
+
+        assertEquals(3, bank.peek().appended)
+        assertEquals(3, bank.peek().appended, "a discarded composition must not swallow appends")
+    }
+
+    /** Appends landing between the peek and the commit survive into the next frame. */
+    @Test
+    fun appendsArrivingDuringAFrameAreNotLost() {
+        val (buffer, bank) = buffer().bankWiredUp()
+        buffer.getLine(3)
+        repeat(2) { buffer.scrollArea(1, -1, 4) }
+        val inFlight = bank.peek()
+
+        buffer.scrollArea(1, -1, 4) // arrives after the frame was computed
+        bank.consume(inFlight)
+
+        assertEquals(1, bank.peek().appended, "only the applied count is taken back")
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/SelectionUnderHistoryAppendTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/SelectionUnderHistoryAppendTest.kt
@@ -1,0 +1,94 @@
+package ai.rever.bossterm.compose.ui
+
+import ai.rever.bossterm.compose.SelectionMode
+import ai.rever.bossterm.compose.selection.SelectionTracker
+import ai.rever.bossterm.terminal.model.CharBuffer
+import ai.rever.bossterm.terminal.model.StyleState
+import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Does compensating the scroll offset make a selection slide against the text it covers?
+ *
+ * The PR claimed it might. This test exists to settle that rather than leave a guess in the
+ * description: selection anchors are content-anchored (`SelectionTracker` resolves them by
+ * `TerminalLine` object identity against the render snapshot, every frame), so an append moves the
+ * resolved buffer row and the compensated offset by the same amount, and the on-screen row
+ * (`bufferRow + scrollOffset`) is what has to stay put.
+ *
+ * Checked both ways round, because "stays aligned" is only meaningful against the alternative.
+ */
+class SelectionUnderHistoryAppendTest {
+
+    private fun scenario(): Triple<TerminalTextBuffer, SelectionTracker, Int> {
+        val buffer = TerminalTextBuffer(20, 4, StyleState(), 100)
+        for (row in 1..4) {
+            val chars = "L$row".toCharArray()
+            buffer.writeString(0, row, CharBuffer(chars, 0, chars.size))
+        }
+        // Push two lines into history so there is something to be scrolled up over.
+        repeat(2) { buffer.scrollArea(1, -1, 4) }
+
+        val tracker = SelectionTracker(buffer)
+        // Select the oldest history line, at buffer row -2.
+        tracker.setSelection(0, -2, 3, -2, SelectionMode.NORMAL)
+        return Triple(buffer, tracker, 2)
+    }
+
+    /** Where the selection actually paints: buffer row plus the offset. */
+    private fun screenRow(buffer: TerminalTextBuffer, tracker: SelectionTracker, offset: Int): Int? =
+        tracker.resolveToCoordinates(buffer.createIncrementalSnapshot())?.startRow?.plus(offset)
+
+    @Test
+    fun compensatingTheOffsetKeepsTheSelectionOnScreenWhereItWas() {
+        val (buffer, tracker, offset) = scenario()
+        val before = screenRow(buffer, tracker, offset)
+
+        // A line of streaming output arrives, and the fix folds it into the offset.
+        buffer.scrollArea(1, -1, 4)
+        val compensated = foldHistoryAppends(offset, appended = 1, historyCount = buffer.historyLinesCount)
+
+        assertEquals(
+            before,
+            screenRow(buffer, tracker, compensated),
+            "the selection must paint on the same screen row it did before the append",
+        )
+    }
+
+    /**
+     * The counterfactual. Without compensation the selection moves up a row - but so does the text
+     * under it, which is the drift being fixed. So the selection was never sliding *against* the
+     * text in either regime; both are resolved through the same buffer-row mapping.
+     */
+    @Test
+    fun withoutCompensationTheSelectionMovesWithTheTextNotAgainstIt() {
+        val (buffer, tracker, offset) = scenario()
+        val before = screenRow(buffer, tracker, offset)
+
+        buffer.scrollArea(1, -1, 4)
+        val uncompensated = screenRow(buffer, tracker, offset)
+
+        assertEquals(
+            before!! - 1,
+            uncompensated,
+            "uncompensated, the selection moves up exactly one row - the same one row the text moves",
+        )
+    }
+
+    /** The anchored row itself tracks its line, which is what makes the above hold. */
+    @Test
+    fun theAnchorFollowsItsLineDeeperIntoHistory() {
+        val (buffer, tracker, _) = scenario()
+        val startBefore = tracker.resolveToCoordinates(buffer.createIncrementalSnapshot())?.startRow
+
+        buffer.scrollArea(1, -1, 4)
+        val startAfter = tracker.resolveToCoordinates(buffer.createIncrementalSnapshot())?.startRow
+
+        assertEquals(
+            startBefore!! - 1,
+            startAfter,
+            "one append moves the anchored line one row further from the live bottom",
+        )
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/SelectionUnderHistoryAppendTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/SelectionUnderHistoryAppendTest.kt
@@ -47,7 +47,11 @@ class SelectionUnderHistoryAppendTest {
 
         // A line of streaming output arrives, and the fix folds it into the offset.
         buffer.scrollArea(1, -1, 4)
-        val compensated = foldHistoryAppends(offset, appended = 1, historyCount = buffer.historyLinesCount)
+        val compensated = foldHistoryAppends(
+            offset,
+            HistoryDelta(cleared = false, appended = 1),
+            buffer.historyLinesCount,
+        )
 
         assertEquals(
             before,


### PR DESCRIPTION
The scroll offset is counted back from the **live bottom** of the buffer, so every line appended to history moves the content under the viewport one row further from that anchor. Sit scrolled up while a build streams and the view slides out from under you, one row per emitted line.

Nothing compensated, and nothing could: the hot append path fired no notification at all. `fireHistoryBufferLineCountChanged` only ran from `clearHistory` / `moveScreenLinesToHistory`, so the `scrollArea` path that a streaming process drives once per line published nothing.

## Approach

This is the dual of a problem iTerm2 has in mirror image - its viewport is top-anchored, so head *eviction* moves it - and it takes the same shape of fix: accumulate a count, apply it when the view takes a frame (`syncResult.overflow` → `PTYTextView.refreshAfterSync` → `handleScrollbackOverflow:`).

The count accumulates lock-free on the emulator thread and folds into the offset on the UI thread. Deliberately **not** written straight from the listener, which fires inside the buffer lock on the hottest path - taking Compose's snapshot lock under it is the inversion `ComposeTerminalDisplay` warns about.

Compensation applies only while scrolled up and only on the **main** screen. At offset 0 the view keeps following the bottom; appends banked while following it are discarded when the user leaves the bottom, or the first scrolled frame jumps.

### The alternate screen does accumulate scrollback here

An earlier revision of this description claimed otherwise. That was wrong, and measurement settles it:

```
ALT top==1 region, SU 5 -> history=5  linesAddedToHistory=5
ALT plain line feeds x5 -> history=5  linesAddedToHistory=5
```

`useAlternateBuffer` swaps in a live `CyclicBufferLinesStorage` rather than a null sink, and `scrollArea` has no alternate-screen guard. Folding those appends would walk the offset against a history that is discarded when the TUI exits - reachable without a keystroke, since nothing resets the offset on alt-screen entry. The fold is therefore gated on `!isUsingAlternateBuffer`, and the bank is drained rather than banked so alt-screen appends are never applied late.

That the alt screen accumulates scrollback at all is arguably the deeper bug, but changing it is a core behaviour change and out of scope here.

## Testing

`HistoryAppendAnchorTest`: every append reported (including on the capped-history path where lines are simultaneously discarded, asserted at an exact count), a region not starting at the top reports nothing, adding the reported count holds the viewport on the same content, `moveScreenLinesToHistory` reports, alt-screen appends are reported, and an empty append fires no callback. One test documents the uncompensated drift itself.

Four of the original six fail without the notification, verified by reverting `TerminalTextBuffer.kt` to master. The empty-append test uses a degenerate region rather than `dy == 0` - the latter returns at the top of `scrollArea` and would pass with the guard deleted, verified by deleting it.

Full suites green: **1043 tests, 0 failures** across 118 classes.

## Known gaps

Not exercised in the app, and these want a real screen to judge:
- The fold is computed during composition and rendered from that value, so the first frame is already correct; the `SideEffect` only commits it. Verified by test, not on screen.
- Selections are **not** affected: they are content-anchored and re-resolve by line identity every frame, so `bufferRow + scrollOffset` is invariant across an append. Covered by `SelectionUnderHistoryAppendTest`, including the counterfactual.
- Background tabs are covered: the bank is session-scoped and registered for the tab's lifetime, so a backgrounded tab keeps being compensated.

- History being cleared under a scrolled-up viewport now returns it to the live bottom. `drain()` reports a `HistoryDelta` carrying both the append count and whether history was cleared, taken atomically so the two cannot split across frames.
- All three callers of `addLinesToHistory` are covered: `scrollArea`, `moveScreenLinesToHistory`, and the height shrink - the one with the documented asymmetry, since a height growth pulls lines back out with no event.

**Remaining: never exercised in the app.** Every claim here is backed by a test, but the visual behaviour under sustained streaming output has not been watched on a real screen.

