### PR TITLE
fix(cursor): stop the caret jittering and losing its blink phase during scroll

### DIFF
--- a/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/core/typeahead/TerminalTypeAheadManager.kt
+++ b/bossterm-core-mpp/src/jvmMain/kotlin/ai/rever/bossterm/core/typeahead/TerminalTypeAheadManager.kt
@@ -132,7 +132,18 @@ class TerminalTypeAheadManager(private val myTerminalModel: TypeAheadTerminalMod
         }
     }
 
-    val cursorX: Int
+    /**
+     * The column to draw the caret at while local echo is predicting, or null when there is
+     * nothing predicted and the caret must come from the renderer's own frame.
+     *
+     * Returning null rather than falling back to the live emulator column is the whole point.
+     * A fallback makes this getter answer "where is the cursor right now", which a renderer
+     * then pairs with a row captured from an earlier frame - an x/y the terminal was never in,
+     * re-read on every recomposition (so the caret's column jitters for the length of a scroll
+     * gesture, with no output change at all). Overriding only while actually predicting is all
+     * the contract type-ahead needs.
+     */
+    val predictedCursorX: Int?
         get() {
             myTerminalModel.lock()
             try {
@@ -141,14 +152,9 @@ class TerminalTypeAheadManager(private val myTerminalModel: TypeAheadTerminalMod
                     resetState()
                 }
 
-                val predictions =
-                    this.visiblePredictions
-
-                val cursorX =
-                    if (predictions.isEmpty()) myTerminalModel.currentLineWithCursor.myCursorX else predictions.get(
-                        predictions.size - 1
-                    )?.myPredictedLineWithCursorX?.myCursorX ?: myTerminalModel.currentLineWithCursor.myCursorX
-                return cursorX + 1
+                val predicted = this.visiblePredictions.lastOrNull()
+                    ?.myPredictedLineWithCursorX?.myCursorX ?: return null
+                return predicted + 1
             } finally {
                 myTerminalModel.unlock()
             }

--- a/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/core/typeahead/PredictedCursorXTest.kt
+++ b/bossterm-core-mpp/src/jvmTest/kotlin/ai/rever/bossterm/core/typeahead/PredictedCursorXTest.kt
@@ -1,0 +1,157 @@
+package ai.rever.bossterm.core.typeahead
+
+import ai.rever.bossterm.core.typeahead.TypeAheadTerminalModel.LineWithCursorX
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `predictedCursorX` answers "where should the caret be drawn while local echo is predicting",
+ * and nothing else.
+ *
+ * The property it replaced, `cursorX`, fell back to the LIVE emulator column whenever there was
+ * nothing predicted - which is the steady state. Its only caller paired that live value with a
+ * row captured from an earlier render frame, producing a coordinate the terminal was never in,
+ * and re-read it on every recomposition, so the caret's column jittered for the length of a
+ * scroll gesture with no output change at all. Returning null is what lets the renderer fall
+ * back to its own frame instead.
+ */
+class PredictedCursorXTest {
+
+    private class FakeModel(
+        var cursorX: Int = 0,
+        lineText: String = "",
+        override var isUsingAlternateBuffer: Boolean = false,
+    ) : TypeAheadTerminalModel {
+        var clearPredictionsCalls = 0
+        private val line = StringBuffer(lineText)
+
+        /**
+         * The shell echoing a character back - the only thing that moves the REAL terminal.
+         *
+         * Kept separate from [insertCharacter] and friends on purpose: those are the display
+         * side, where a prediction is painted speculatively, and they must not show up in
+         * [currentLineWithCursor]. The manager compares that against its predictions to decide
+         * whether one came true, so a fake that let prediction application feed back into it
+         * would never match and would reset on every keystroke.
+         */
+        fun echo(ch: Char) {
+            line.insert(cursorX, ch)
+            cursorX++
+        }
+
+        override fun insertCharacter(ch: Char, index: Int) = Unit
+
+        override fun removeCharacters(from: Int, count: Int) = Unit
+
+        override fun moveCursor(index: Int) = Unit
+
+        override fun forceRedraw() = Unit
+
+        override fun clearPredictions() {
+            clearPredictionsCalls++
+        }
+
+        override fun lock() = Unit
+        override fun unlock() = Unit
+
+        override val currentLineWithCursor: LineWithCursorX
+            get() = LineWithCursorX(StringBuffer(line), cursorX)
+
+        override val terminalWidth: Int get() = 80
+        override val isTypeAheadEnabled: Boolean get() = true
+
+        // Zero, so a prediction counts as "visible" immediately rather than waiting on latency.
+        override val latencyThreshold: Long get() = 0L
+        override val shellType: TypeAheadTerminalModel.ShellType?
+            get() = TypeAheadTerminalModel.ShellType.Bash
+    }
+
+    private fun typed(ch: Char) = TerminalTypeAheadManager.TypeAheadEvent(
+        TerminalTypeAheadManager.TypeAheadEvent.EventType.Character,
+        ch,
+    )
+
+    /**
+     * Type a character and let the "shell" echo it back.
+     *
+     * Predictions stay tentative - and so invisible - until the manager has seen a couple of
+     * round-trips to measure latency with, so a test that wants a VISIBLE prediction has to
+     * actually complete a few of them rather than just calling onKeyEvent.
+     */
+    private fun roundTrip(manager: TerminalTypeAheadManager, model: FakeModel, ch: Char) {
+        manager.onKeyEvent(typed(ch))
+        model.echo(ch)
+        manager.onTerminalStateChanged()
+    }
+
+    @Test
+    fun `nothing predicted means the renderer keeps its own frame's column`() {
+        val manager = TerminalTypeAheadManager(FakeModel(cursorX = 7))
+        manager.onTerminalStateChanged()
+
+        assertNull(
+            manager.predictedCursorX,
+            "with no predictions this must NOT answer with the live emulator column - that is " +
+                "the fallback that made the caret jitter",
+        )
+    }
+
+    @Test
+    fun `the live emulator column is never leaked, whatever it is`() {
+        // The whole defect: this getter used to answer with the live column here, which the
+        // renderer then paired with a row from an older frame.
+        for (live in intArrayOf(0, 3, 42, 79)) {
+            val manager = TerminalTypeAheadManager(FakeModel(cursorX = live))
+            manager.onTerminalStateChanged()
+            assertNull(manager.predictedCursorX, "leaked the live column at $live")
+        }
+    }
+
+    @Test
+    fun `a visible prediction supplies its own column, one-indexed`() {
+        val model = FakeModel()
+        val manager = TerminalTypeAheadManager(model)
+        manager.onTerminalStateChanged()
+
+        // Complete enough round-trips for the manager to trust its own predictions.
+        roundTrip(manager, model, 'a')
+        roundTrip(manager, model, 'b')
+        roundTrip(manager, model, 'c')
+
+        // Now type ahead of the shell: nothing echoes this one back.
+        val columnBefore = model.cursorX
+        manager.onKeyEvent(typed('d'))
+
+        assertEquals(
+            columnBefore + 2,
+            manager.predictedCursorX,
+            "the prediction advances the echoed column by one, and the getter is 1-indexed",
+        )
+    }
+
+    @Test
+    fun `the alternate screen drops predictions rather than reporting a stale column`() {
+        val model = FakeModel()
+        val manager = TerminalTypeAheadManager(model)
+        manager.onTerminalStateChanged()
+        roundTrip(manager, model, 'a')
+        roundTrip(manager, model, 'b')
+        roundTrip(manager, model, 'c')
+        manager.onKeyEvent(typed('d'))
+
+        // A full-screen app took over: predictions made against the shell line are meaningless.
+        val clearsBefore = model.clearPredictionsCalls
+        model.isUsingAlternateBuffer = true
+
+        assertNull(
+            manager.predictedCursorX,
+            "the alt-screen reset must leave nothing predicted, not a column from the old line",
+        )
+        assertTrue(
+            model.clearPredictionsCalls > clearsBefore,
+            "the reset has to reach the model, so the painted prediction is taken back too",
+        )
+    }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Compose implementation of TerminalDisplay interface with adaptive debouncing.
@@ -47,6 +48,21 @@ class ComposeTerminalDisplay : TerminalDisplay {
         NORMAL      // PTY output - apply debounce
     }
 
+    /**
+     * The four cursor fields as ONE value.
+     *
+     * Published through an AtomicReference rather than four @Volatile fields because
+     * [setCursor] writes x and then y: a reader landing between the two sees a position the
+     * terminal was never in, and the emulator moves the cursor many times per rendered frame.
+     * Still non-reactive - only `redrawTrigger` drives recomposition.
+     */
+    data class CursorSnapshot(
+        val x: Int,
+        val y: Int,
+        val visible: Boolean,
+        val shape: CursorShape?,
+    )
+
     // Current rendering mode
     @Volatile
     private var currentMode = RedrawMode.INTERACTIVE
@@ -71,10 +87,9 @@ class ComposeTerminalDisplay : TerminalDisplay {
     }
     // Non-reactive cursor state - only redrawTrigger controls recomposition
     // This prevents flickering caused by Compose State updates racing with debounced redraws
-    @Volatile private var _cursorXValue = 0
-    @Volatile private var _cursorYValue = 0
-    @Volatile private var _cursorVisibleValue = true
-    @Volatile private var _cursorShapeValue: CursorShape? = null
+    private val _cursor = AtomicReference(
+        CursorSnapshot(x = 0, y = 0, visible = true, shape = null)
+    )
     private val _bracketedPasteMode = mutableStateOf(false)
     private val _termSize = mutableStateOf(TermSize(80, 24))
 
@@ -98,11 +113,16 @@ class ComposeTerminalDisplay : TerminalDisplay {
     private val _progressState = mutableStateOf(TerminalDisplay.ProgressState.HIDDEN)
     private val _progressValue = mutableStateOf(0)
 
-    // Snapshot getters for cursor - non-reactive, read inside remember() blocks
-    val cursorXSnapshot: Int get() = _cursorXValue
-    val cursorYSnapshot: Int get() = _cursorYValue
-    val cursorVisibleSnapshot: Boolean get() = _cursorVisibleValue
-    val cursorShapeSnapshot: CursorShape? get() = _cursorShapeValue
+    /** All four cursor fields at once - see [CursorSnapshot]. Non-reactive. */
+    val cursorSnapshot: CursorSnapshot get() = _cursor.get()
+
+    // Single-field getters for callers that genuinely want one value (mirror share, tests).
+    // A renderer must use cursorSnapshot instead: reading these one at a time reintroduces
+    // exactly the tear the AtomicReference exists to close.
+    val cursorXSnapshot: Int get() = _cursor.get().x
+    val cursorYSnapshot: Int get() = _cursor.get().y
+    val cursorVisibleSnapshot: Boolean get() = _cursor.get().visible
+    val cursorShapeSnapshot: CursorShape? get() = _cursor.get().shape
     val bracketedPasteMode: State<Boolean> = _bracketedPasteMode
     val termSize: State<TermSize> = _termSize
     val mouseMode: State<MouseMode> = _mouseMode
@@ -164,37 +184,35 @@ class ComposeTerminalDisplay : TerminalDisplay {
      * scrollArea() or other buffer modification methods.
      */
     override fun setCursor(x: Int, y: Int) {
-        if (debugCursor && (_cursorXValue != x || _cursorYValue != y)) {
-            println("🔵 CURSOR MOVE: ($_cursorXValue,$_cursorYValue) → ($x,$y)")
+        // One atomic update, not two field writes: x and y have to land together or a reader
+        // between them sees a position the terminal was never in.
+        val previous = _cursor.getAndUpdate { it.copy(x = x, y = y) }
+        if (debugCursor && (previous.x != x || previous.y != y)) {
+            println("🔵 CURSOR MOVE: (${previous.x},${previous.y}) → ($x,$y)")
         }
-        val changed = _cursorXValue != x || _cursorYValue != y
-        _cursorXValue = x
-        _cursorYValue = y
         // Trigger redraw when cursor moves - fixes p10k/zsh TUI not updating
         // Cursor-only changes (no buffer modification) still need screen refresh
-        if (changed) {
+        if (previous.x != x || previous.y != y) {
             requestRedraw()
         }
     }
 
     override fun setCursorShape(cursorShape: CursorShape?) {
-        if (debugCursor && _cursorShapeValue != cursorShape) {
-            println("🔷 CURSOR SHAPE: $_cursorShapeValue → $cursorShape")
+        val previous = _cursor.getAndUpdate { it.copy(shape = cursorShape) }
+        if (debugCursor && previous.shape != cursorShape) {
+            println("🔷 CURSOR SHAPE: ${previous.shape} → $cursorShape")
         }
-        val changed = _cursorShapeValue != cursorShape
-        _cursorShapeValue = cursorShape
-        if (changed) {
+        if (previous.shape != cursorShape) {
             requestRedraw()
         }
     }
 
     override fun setCursorVisible(isCursorVisible: Boolean) {
-        if (debugCursor && _cursorVisibleValue != isCursorVisible) {
-            println("👁️  CURSOR VISIBLE: $_cursorVisibleValue → $isCursorVisible")
+        val previous = _cursor.getAndUpdate { it.copy(visible = isCursorVisible) }
+        if (debugCursor && previous.visible != isCursorVisible) {
+            println("👁️  CURSOR VISIBLE: ${previous.visible} → $isCursorVisible")
         }
-        val changed = _cursorVisibleValue != isCursorVisible
-        _cursorVisibleValue = isCursorVisible
-        if (changed) {
+        if (previous.visible != isCursorVisible) {
             requestRedraw()
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
@@ -187,6 +187,11 @@ class ComposeTerminalDisplay : TerminalDisplay {
         // Unchanged is the common case - BossTerminal.finishText() calls this after every
         // writeCharacters - and copy() would allocate a CursorSnapshot for each one. Bail
         // before the allocation, the debug print and the redraw bookkeeping alike.
+        //
+        // Check-then-act, deliberately: the AtomicReference is here so READERS see x and y
+        // together, not to make this method atomic against a second writer. The emulator thread
+        // is the only writer, and was the only writer when these were two volatile ints. A
+        // second one would need this guard folded into the update.
         val current = _cursor.get()
         if (current.x == x && current.y == y) return
         if (debugCursor) {
@@ -201,18 +206,20 @@ class ComposeTerminalDisplay : TerminalDisplay {
     }
 
     override fun setCursorShape(cursorShape: CursorShape?) {
-        if (_cursor.get().shape == cursorShape) return
+        val current = _cursor.get()
+        if (current.shape == cursorShape) return
         if (debugCursor) {
-            println("🔷 CURSOR SHAPE: ${_cursor.get().shape} → $cursorShape")
+            println("🔷 CURSOR SHAPE: ${current.shape} → $cursorShape")
         }
         _cursor.getAndUpdate { it.copy(shape = cursorShape) }
         requestRedraw()
     }
 
     override fun setCursorVisible(isCursorVisible: Boolean) {
-        if (_cursor.get().visible == isCursorVisible) return
+        val current = _cursor.get()
+        if (current.visible == isCursorVisible) return
         if (debugCursor) {
-            println("👁️  CURSOR VISIBLE: ${_cursor.get().visible} → $isCursorVisible")
+            println("👁️  CURSOR VISIBLE: ${current.visible} → $isCursorVisible")
         }
         _cursor.getAndUpdate { it.copy(visible = isCursorVisible) }
         requestRedraw()

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplay.kt
@@ -184,37 +184,38 @@ class ComposeTerminalDisplay : TerminalDisplay {
      * scrollArea() or other buffer modification methods.
      */
     override fun setCursor(x: Int, y: Int) {
+        // Unchanged is the common case - BossTerminal.finishText() calls this after every
+        // writeCharacters - and copy() would allocate a CursorSnapshot for each one. Bail
+        // before the allocation, the debug print and the redraw bookkeeping alike.
+        val current = _cursor.get()
+        if (current.x == x && current.y == y) return
+        if (debugCursor) {
+            println("🔵 CURSOR MOVE: (${current.x},${current.y}) → ($x,$y)")
+        }
         // One atomic update, not two field writes: x and y have to land together or a reader
         // between them sees a position the terminal was never in.
-        val previous = _cursor.getAndUpdate { it.copy(x = x, y = y) }
-        if (debugCursor && (previous.x != x || previous.y != y)) {
-            println("🔵 CURSOR MOVE: (${previous.x},${previous.y}) → ($x,$y)")
-        }
+        _cursor.getAndUpdate { it.copy(x = x, y = y) }
         // Trigger redraw when cursor moves - fixes p10k/zsh TUI not updating
         // Cursor-only changes (no buffer modification) still need screen refresh
-        if (previous.x != x || previous.y != y) {
-            requestRedraw()
-        }
+        requestRedraw()
     }
 
     override fun setCursorShape(cursorShape: CursorShape?) {
-        val previous = _cursor.getAndUpdate { it.copy(shape = cursorShape) }
-        if (debugCursor && previous.shape != cursorShape) {
-            println("🔷 CURSOR SHAPE: ${previous.shape} → $cursorShape")
+        if (_cursor.get().shape == cursorShape) return
+        if (debugCursor) {
+            println("🔷 CURSOR SHAPE: ${_cursor.get().shape} → $cursorShape")
         }
-        if (previous.shape != cursorShape) {
-            requestRedraw()
-        }
+        _cursor.getAndUpdate { it.copy(shape = cursorShape) }
+        requestRedraw()
     }
 
     override fun setCursorVisible(isCursorVisible: Boolean) {
-        val previous = _cursor.getAndUpdate { it.copy(visible = isCursorVisible) }
-        if (debugCursor && previous.visible != isCursorVisible) {
-            println("👁️  CURSOR VISIBLE: ${previous.visible} → $isCursorVisible")
+        if (_cursor.get().visible == isCursorVisible) return
+        if (debugCursor) {
+            println("👁️  CURSOR VISIBLE: ${_cursor.get().visible} → $isCursorVisible")
         }
-        if (previous.visible != isCursorVisible) {
-            requestRedraw()
-        }
+        _cursor.getAndUpdate { it.copy(visible = isCursorVisible) }
+        requestRedraw()
     }
 
     override fun beep() {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkDetector.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkDetector.kt
@@ -9,13 +9,18 @@ import java.util.concurrent.CopyOnWriteArrayList
 /**
  * Represents a detected hyperlink in terminal text that may span multiple terminal lines.
  *
+ * All row numbers here are BUFFER rows: 0 is the top of the live screen and negative indices
+ * reach into history, matching `VersionedBufferSnapshot.getLine`. They used to be screen rows,
+ * which meant they silently changed meaning as the viewport scrolled; add `scrollOffset` to
+ * convert one to a screen row for painting or hit-testing.
+ *
  * @property url The URL to open when clicked
  * @property startCol Start column (0-based) in the first row
  * @property endCol End column (exclusive) in the last row
- * @property row Row number of the first line (for backwards compatibility)
- * @property startRow First row of the hyperlink (same as row)
- * @property endRow Last row of the hyperlink (same as startRow for single-line links)
- * @property rowSpans Map of row -> (startCol, endCol) for each row the hyperlink spans
+ * @property row Buffer row of the first line (for backwards compatibility)
+ * @property startRow First buffer row of the hyperlink (same as row)
+ * @property endRow Last buffer row of the hyperlink (same as startRow for single-line links)
+ * @property rowSpans Map of buffer row -> (startCol, endCol) for each row the hyperlink spans
  * @property patternId The ID of the pattern that matched this hyperlink (e.g., "builtin:http")
  * @property matchedText The original text that was matched before URL transformation
  */
@@ -43,8 +48,8 @@ data class Hyperlink(
  * Holds information about joined wrapped lines for hyperlink detection.
  *
  * @property joinedText The concatenated text from all wrapped lines
- * @property startRow The first row (screen coordinates) of the logical line
- * @property endRow The last row (screen coordinates) of the logical line
+ * @property startRow The first row (buffer coordinates) of the logical line
+ * @property endRow The last row (buffer coordinates) of the logical line
  * @property rowOffsets Character offset in joinedText where each row starts
  */
 data class JoinedLineInfo(
@@ -107,6 +112,16 @@ data class HyperlinkPattern(
  */
 class HyperlinkRegistry {
     private val patterns = CopyOnWriteArrayList<HyperlinkPattern>()
+
+    private val _revision = java.util.concurrent.atomic.AtomicInteger(0)
+
+    /**
+     * Bumped on every mutation, so a caller memoizing detection results can key on it.
+     *
+     * Without it an embedder adding or removing a pattern at runtime would never reach an
+     * already-memoized row: the row's line instance does not change, so the memo hits forever.
+     */
+    val revision: Int get() = _revision.get()
 
     init {
         // Register built-in patterns
@@ -236,6 +251,7 @@ class HyperlinkRegistry {
         // Remove existing pattern with same ID
         patterns.removeIf { it.id == pattern.id }
         patterns.add(pattern)
+        _revision.incrementAndGet()
     }
 
     /**
@@ -244,9 +260,8 @@ class HyperlinkRegistry {
      * @param id The pattern ID to remove
      * @return true if pattern was found and removed
      */
-    fun removePattern(id: String): Boolean {
-        return patterns.removeIf { it.id == id }
-    }
+    fun removePattern(id: String): Boolean =
+        patterns.removeIf { it.id == id }.also { if (it) _revision.incrementAndGet() }
 
     /**
      * Get a pattern by ID.
@@ -270,6 +285,7 @@ class HyperlinkRegistry {
      */
     fun clear() {
         patterns.clear()
+        _revision.incrementAndGet()
     }
 
     /**
@@ -553,17 +569,6 @@ object HyperlinkDetector {
     }
 
     /**
-     * Detect hyperlinks in wrapped lines, returning hyperlinks with proper row spans.
-     *
-     * @param snapshot The buffer snapshot
-     * @param bufferRow The row to check, in buffer coordinates (negative reaches into history)
-     * @param terminalWidth Terminal width
-     * @param workingDirectory The current working directory for resolving relative paths (optional)
-     * @param detectFilePaths Whether to detect file paths as hyperlinks (default: true)
-     * @param registry The pattern registry to use (default: global registry)
-     * @return List of hyperlinks that are part of this logical line, in buffer rows
-     */
-    /**
      * Whether [bufferRow] is part of a wrapped logical line, in either direction.
      *
      * `isWrapped` means "this line wraps INTO the next", so a row is a continuation when its
@@ -637,6 +642,17 @@ object HyperlinkDetector {
         )
     }
 
+    /**
+     * Detect hyperlinks in wrapped lines, returning hyperlinks with proper row spans.
+     *
+     * @param snapshot The buffer snapshot
+     * @param bufferRow The row to check, in buffer coordinates (negative reaches into history)
+     * @param terminalWidth Terminal width
+     * @param workingDirectory The current working directory for resolving relative paths (optional)
+     * @param detectFilePaths Whether to detect file paths as hyperlinks (default: true)
+     * @param registry The pattern registry to use (default: global registry)
+     * @return List of hyperlinks that are part of this logical line, in buffer rows
+     */
     fun detectHyperlinksWithWrapping(
         snapshot: VersionedBufferSnapshot,
         bufferRow: Int,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkDetector.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkDetector.kt
@@ -581,14 +581,33 @@ object HyperlinkDetector {
      * an edit to a sibling row goes unnoticed. Just the wrap-flag walk - no rejoin, no regex.
      */
     fun runLinesAt(snapshot: VersionedBufferSnapshot, bufferRow: Int): List<TerminalLine> {
-        if (!isPartOfWrappedRun(snapshot, bufferRow)) return listOf(snapshot.getLine(bufferRow))
+        val oldest = -snapshot.historyLinesCount
+        if (!isPartOfWrappedRun(snapshot, bufferRow)) {
+            // The predecessor's wrap flag is what decided this row is NOT a continuation, so it
+            // is part of the answer and has to be in the key: a TUI rewriting row R-1 so it now
+            // wraps into R would otherwise hit this memo on R's unchanged line and keep
+            // returning the single-row result forever.
+            return if (bufferRow - 1 >= oldest) {
+                listOf(snapshot.getLine(bufferRow), snapshot.getLine(bufferRow - 1))
+            } else {
+                listOf(snapshot.getLine(bufferRow))
+            }
+        }
         var start = bufferRow
-        while (start > -snapshot.historyLinesCount) {
+        while (start > oldest) {
             if (snapshot.getLine(start - 1).isWrapped) start-- else break
         }
+        // Bounds FIRST: getLine returns a fresh createEmpty() out of range, so letting `end`
+        // reach `height` would put a never-identity-equal instance in the key and miss the memo
+        // on every single event - for a run that ends on the last screen row, which is exactly
+        // where a live TUI's wrapped output sits.
         var end = start
-        while (snapshot.getLine(end).isWrapped && end < snapshot.height) end++
-        return (start..end).map { snapshot.getLine(it) }
+        while (end < snapshot.height - 1 && snapshot.getLine(end).isWrapped) end++
+        val lines = ArrayList<TerminalLine>(end - start + 2)
+        for (row in start..end) lines.add(snapshot.getLine(row))
+        // Same reason as above, for the walk that found `start`.
+        if (start - 1 >= oldest) lines.add(snapshot.getLine(start - 1))
+        return lines
     }
 
     /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkDetector.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkDetector.kt
@@ -466,53 +466,43 @@ object HyperlinkDetector {
      * Collect wrapped lines starting from a given row, walking backwards to find the start
      * and forwards to find the end of the logical line.
      *
+     * Rows here are BUFFER rows: 0 is the top of the live screen and negative indices reach
+     * into history, matching [VersionedBufferSnapshot.getLine]. This used to take a screen row
+     * plus a scroll offset and add them, while every caller computed screen rows by
+     * subtracting the offset - so a scrolled-back viewport walked the wrong lines and bounded
+     * the forward walk against the wrong end of the buffer. Working in buffer space removes
+     * the conversion, and with it the chance of getting its sign wrong.
+     *
      * @param snapshot The buffer snapshot
-     * @param row The current row (screen row, 0-based from top of visible area)
-     * @param scrollOffset Current scroll offset (negative = scrolled into history)
+     * @param bufferRow The row to start from, in buffer coordinates
      * @param terminalWidth Terminal width in columns
      * @return JoinedLineInfo containing the complete logical line text and row mapping
      */
     fun collectWrappedLines(
         snapshot: VersionedBufferSnapshot,
-        row: Int,
-        scrollOffset: Int,
+        bufferRow: Int,
         terminalWidth: Int
     ): JoinedLineInfo {
-        val lineIndex = row + scrollOffset
-
         // Find start of logical line (walk backwards while previous line is wrapped)
         // Note: -snapshot.historyLinesCount is the oldest valid history line index
-        var startRow = row
-        var startLineIndex = lineIndex
-        while (startLineIndex > -snapshot.historyLinesCount) {
-            val prevLineIndex = startLineIndex - 1
-            val prevLine = snapshot.getLine(prevLineIndex)
-            if (prevLine.isWrapped) {
-                startLineIndex--
-                startRow--
-            } else {
-                break
-            }
+        var startRow = bufferRow
+        while (startRow > -snapshot.historyLinesCount) {
+            if (snapshot.getLine(startRow - 1).isWrapped) startRow-- else break
         }
 
         // Find end of logical line (walk forwards while current line is wrapped)
         var endRow = startRow
-        var endLineIndex = startLineIndex
         while (true) {
-            val currentLine = snapshot.getLine(endLineIndex)
-            if (!currentLine.isWrapped) {
-                break
-            }
-            endLineIndex++
+            if (!snapshot.getLine(endRow).isWrapped) break
             endRow++
-            if (endLineIndex >= snapshot.height) break
+            if (endRow >= snapshot.height) break
         }
 
         // Join lines with VISUAL WIDTH-aware position tracking
         val joinedText = StringBuilder()
         val rowOffsets = mutableListOf<Int>()
 
-        for (idx in startLineIndex..endLineIndex) {
+        for (idx in startRow..endRow) {
             rowOffsets.add(joinedText.length)
             val line = snapshot.getLine(idx)
             val text = line.text
@@ -520,7 +510,7 @@ object HyperlinkDetector {
 
             // Pad to terminal width based on VISUAL width, not character count
             // This correctly handles double-width characters (CJK, emoji) and DWC markers
-            if (idx < endLineIndex) {
+            if (idx < endRow) {
                 val visualWidth = calculateVisualWidth(line, terminalWidth)
                 if (visualWidth < terminalWidth) {
                     repeat(terminalWidth - visualWidth) {
@@ -566,24 +556,22 @@ object HyperlinkDetector {
      * Detect hyperlinks in wrapped lines, returning hyperlinks with proper row spans.
      *
      * @param snapshot The buffer snapshot
-     * @param screenRow The screen row to check (0-based from top of visible area)
-     * @param scrollOffset Current scroll offset
+     * @param bufferRow The row to check, in buffer coordinates (negative reaches into history)
      * @param terminalWidth Terminal width
      * @param workingDirectory The current working directory for resolving relative paths (optional)
      * @param detectFilePaths Whether to detect file paths as hyperlinks (default: true)
      * @param registry The pattern registry to use (default: global registry)
-     * @return List of hyperlinks that are part of this logical line
+     * @return List of hyperlinks that are part of this logical line, in buffer rows
      */
     fun detectHyperlinksWithWrapping(
         snapshot: VersionedBufferSnapshot,
-        screenRow: Int,
-        scrollOffset: Int,
+        bufferRow: Int,
         terminalWidth: Int,
         workingDirectory: String? = null,
         detectFilePaths: Boolean = true,
         registry: HyperlinkRegistry = this.registry
     ): List<Hyperlink> {
-        val lineInfo = collectWrappedLines(snapshot, screenRow, scrollOffset, terminalWidth)
+        val lineInfo = collectWrappedLines(snapshot, bufferRow, terminalWidth)
 
         // Detect hyperlinks in the joined text (pass the registry)
         val rawHyperlinks = detectHyperlinks(lineInfo.joinedText, lineInfo.startRow, workingDirectory, detectFilePaths, registry)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkDetector.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkDetector.kt
@@ -330,6 +330,17 @@ class HyperlinkRegistry {
  */
 object HyperlinkDetector {
     /**
+     * How far a wrapped-line walk may run in each direction.
+     *
+     * Without it both walks are bounded only by scrollback depth: `cat` a minified file and one
+     * logical line is thousands of rows, so a single pointer move onto a new row walks all of
+     * them, allocates a list that size, and hands the hover memo a key it then compares
+     * element-by-element on the UI thread. At 80 columns this still spans ~5k characters, which
+     * is past the point where a link is usefully detectable anyway.
+     */
+    const val MAX_WRAPPED_RUN_ROWS = 64
+
+    /**
      * The pattern registry. Use this to add/remove custom patterns.
      */
     val registry = HyperlinkRegistry()
@@ -499,20 +510,20 @@ object HyperlinkDetector {
         bufferRow: Int,
         terminalWidth: Int
     ): JoinedLineInfo {
-        // Find start of logical line (walk backwards while previous line is wrapped)
-        // Note: -snapshot.historyLinesCount is the oldest valid history line index
+        // Walk the same rows, with the same bounds, as runLinesAt: it produces the memo key
+        // for this result, so a row this reads and it omits would be a row whose change went
+        // unnoticed. Both stop one short of `height` because getLine returns a fresh
+        // createEmpty() past it - which would pad a full terminal width for a row that is not
+        // there, and put a never-identity-equal instance in that key.
+        val oldest = maxOf(-snapshot.historyLinesCount, bufferRow - MAX_WRAPPED_RUN_ROWS)
         var startRow = bufferRow
-        while (startRow > -snapshot.historyLinesCount) {
+        while (startRow > oldest) {
             if (snapshot.getLine(startRow - 1).isWrapped) startRow-- else break
         }
 
-        // Find end of logical line (walk forwards while current line is wrapped)
         var endRow = startRow
-        while (true) {
-            if (!snapshot.getLine(endRow).isWrapped) break
-            endRow++
-            if (endRow >= snapshot.height) break
-        }
+        val furthest = minOf(snapshot.height - 1, bufferRow + MAX_WRAPPED_RUN_ROWS)
+        while (endRow < furthest && snapshot.getLine(endRow).isWrapped) endRow++
 
         // Join lines with VISUAL WIDTH-aware position tracking
         val joinedText = StringBuilder()
@@ -586,7 +597,7 @@ object HyperlinkDetector {
      * an edit to a sibling row goes unnoticed. Just the wrap-flag walk - no rejoin, no regex.
      */
     fun runLinesAt(snapshot: VersionedBufferSnapshot, bufferRow: Int): List<TerminalLine> {
-        val oldest = -snapshot.historyLinesCount
+        val oldest = maxOf(-snapshot.historyLinesCount, bufferRow - MAX_WRAPPED_RUN_ROWS)
         if (!isPartOfWrappedRun(snapshot, bufferRow)) {
             // The predecessor's wrap flag is what decided this row is NOT a continuation, so it
             // is part of the answer and has to be in the key: a TUI rewriting row R-1 so it now
@@ -607,7 +618,8 @@ object HyperlinkDetector {
         // on every single event - for a run that ends on the last screen row, which is exactly
         // where a live TUI's wrapped output sits.
         var end = start
-        while (end < snapshot.height - 1 && snapshot.getLine(end).isWrapped) end++
+        val furthest = minOf(snapshot.height - 1, bufferRow + MAX_WRAPPED_RUN_ROWS)
+        while (end < furthest && snapshot.getLine(end).isWrapped) end++
         val lines = ArrayList<TerminalLine>(end - start + 2)
         for (row in start..end) lines.add(snapshot.getLine(row))
         // Same reason as above, for the walk that found `start`.

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkDetector.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkDetector.kt
@@ -563,6 +563,61 @@ object HyperlinkDetector {
      * @param registry The pattern registry to use (default: global registry)
      * @return List of hyperlinks that are part of this logical line, in buffer rows
      */
+    /**
+     * Whether [bufferRow] is part of a wrapped logical line, in either direction.
+     *
+     * `isWrapped` means "this line wraps INTO the next", so a row is a continuation when its
+     * PREDECESSOR is wrapped.
+     */
+    fun isPartOfWrappedRun(snapshot: VersionedBufferSnapshot, bufferRow: Int): Boolean =
+        snapshot.getLine(bufferRow).isWrapped ||
+            (bufferRow - 1 >= -snapshot.historyLinesCount && snapshot.getLine(bufferRow - 1).isWrapped)
+
+    /**
+     * The line instances [bufferRow]'s detection result depends on.
+     *
+     * One line for an ordinary row; the whole logical run for a wrapped one, since the rejoin
+     * walks to the run's start and end. Callers memoizing detection must key on all of them, or
+     * an edit to a sibling row goes unnoticed. Just the wrap-flag walk - no rejoin, no regex.
+     */
+    fun runLinesAt(snapshot: VersionedBufferSnapshot, bufferRow: Int): List<TerminalLine> {
+        if (!isPartOfWrappedRun(snapshot, bufferRow)) return listOf(snapshot.getLine(bufferRow))
+        var start = bufferRow
+        while (start > -snapshot.historyLinesCount) {
+            if (snapshot.getLine(start - 1).isWrapped) start-- else break
+        }
+        var end = start
+        while (snapshot.getLine(end).isWrapped && end < snapshot.height) end++
+        return (start..end).map { snapshot.getLine(it) }
+    }
+
+    /**
+     * Hyperlinks on one BUFFER row, in buffer coordinates.
+     *
+     * Offset-free by construction: the same buffer row yields the same answer wherever the
+     * viewport happens to be sitting, which is what lets a caller memo the result across a
+     * scroll. This replaces a per-frame sweep of every visible row that ran the whole registry
+     * per row inside the draw phase - for a result the text pass never read. Only the hover
+     * hit-test and the hover underline consume it, so it is resolved one row at a time, on
+     * demand.
+     */
+    fun detectForBufferRow(
+        snapshot: VersionedBufferSnapshot,
+        bufferRow: Int,
+        terminalWidth: Int,
+        workingDirectory: String?,
+        detectFilePaths: Boolean,
+        registry: HyperlinkRegistry = this.registry,
+    ): List<Hyperlink> = if (isPartOfWrappedRun(snapshot, bufferRow)) {
+        detectHyperlinksWithWrapping(
+            snapshot, bufferRow, terminalWidth, workingDirectory, detectFilePaths, registry
+        )
+    } else {
+        detectHyperlinks(
+            snapshot.getLine(bufferRow).text, bufferRow, workingDirectory, detectFilePaths, registry
+        )
+    }
+
     fun detectHyperlinksWithWrapping(
         snapshot: VersionedBufferSnapshot,
         bufferRow: Int,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkRowCache.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkRowCache.kt
@@ -3,78 +3,78 @@ package ai.rever.bossterm.compose.hyperlinks
 import ai.rever.bossterm.terminal.model.TerminalLine
 
 /**
- * Per-buffer-row hyperlink memo for the hover path.
- *
- * Keyed by the LINE INSTANCES the answer depends on, not by a version hash. The incremental
- * snapshot builder reuses the [TerminalLine] object for a row whose content did not change, so
- * identity is an exact O(1) validity check: a row that changed is the only thing that misses. No
- * scroll offset appears anywhere in the key, which is the point - the previous cache folded the
- * offset into its hash, so every wheel tick missed and re-ran detection over the whole viewport.
- *
- * A wrapped row's answer depends on its whole logical run, so the key for those rows is every
- * line in the run. Bypassing the memo instead would re-run `collectWrappedLines` (a rejoin of
- * the entire logical line) plus the full registry sweep on every pointer-move event - and in a
- * long-output session wrapped rows are the common case, not the exception.
- *
- * [cwd], [detectFilePaths] and the registry revision are part of the key because `detect`
- * resolves against all three: after a `cd` an unchanged line must produce different `file://`
- * targets, and an embedder adding a pattern at runtime must reach rows already memoized - the
- * line instance never changes, so nothing else would ever invalidate them.
- *
- * Deliberately NOT Compose state. It is written from a pointer handler, and the cache it
- * replaces was `mutableStateOf` read and written inside the draw lambda - a draw-phase write to
- * state the draw observer had recorded, which re-invalidated the draw node and cost a second
- * full text render on every frame.
- *
- * Not thread-safe: confined to the UI thread, like the pointer handler that owns it.
- */
+  * Per-buffer-row hyperlink memo for the hover path.
+  *
+  * Keyed by the LINE INSTANCES the answer depends on, not by a version hash. The incremental
+  * snapshot builder reuses the [TerminalLine] object for a row whose content did not change, so
+  * identity is an exact O(1) validity check: a row that changed is the only thing that misses. No
+  * scroll offset appears anywhere in the key, which is the point - the previous cache folded the
+  * offset into its hash, so every wheel tick missed and re-ran detection over the whole viewport.
+  *
+  * A wrapped row's answer depends on its whole logical run, so the key for those rows is every
+  * line in the run. Bypassing the memo instead would re-run `collectWrappedLines` (a rejoin of
+  * the entire logical line) plus the full registry sweep on every pointer-move event - and in a
+  * long-output session wrapped rows are the common case, not the exception.
+  *
+  * [cwd], [detectFilePaths] and the registry revision are part of the key because `detect`
+  * resolves against all three: after a `cd` an unchanged line must produce different `file://`
+  * targets, and an embedder adding a pattern at runtime must reach rows already memoized - the
+  * line instance never changes, so nothing else would ever invalidate them.
+  *
+  * Deliberately NOT Compose state. It is written from a pointer handler, and the cache it
+  * replaces was `mutableStateOf` read and written inside the draw lambda - a draw-phase write to
+  * state the draw observer had recorded, which re-invalidated the draw node and cost a second
+  * full text render on every frame.
+  *
+  * Not thread-safe: confined to the UI thread, like the pointer handler that owns it.
+  */
 internal class HyperlinkRowCache {
-  private class Entry(
-    val lines: List<TerminalLine>,
-    val cwd: String?,
-    val detectFilePaths: Boolean,
-    val registryRevision: Int,
-    val links: List<Hyperlink>,
-  )
+    private class Entry(
+        val lines: List<TerminalLine>,
+        val cwd: String?,
+        val detectFilePaths: Boolean,
+        val registryRevision: Int,
+        val links: List<Hyperlink>,
+    )
 
-  private val rows = HashMap<Int, Entry>()
+    private val rows = HashMap<Int, Entry>()
 
-  /**
-   * Hyperlinks on [bufferRow], detecting only when something the answer depends on changed.
-   *
-   * @param runLines the line instances the answer depends on: just this row's line for an
-   *   ordinary row, every line of the logical run for a wrapped one.
-   */
-  fun linksAt(
-    bufferRow: Int,
-    runLines: List<TerminalLine>,
-    cwd: String?,
-    detectFilePaths: Boolean,
-    registryRevision: Int,
-    detect: () -> List<Hyperlink>,
-  ): List<Hyperlink> {
-    val hit = rows[bufferRow]
-    if (hit != null &&
-      hit.cwd == cwd &&
-      hit.detectFilePaths == detectFilePaths &&
-      hit.registryRevision == registryRevision &&
-      hit.lines.size == runLines.size &&
-      hit.lines.indices.all { hit.lines[it] === runLines[it] }
-    ) {
-      return hit.links
+    /**
+      * Hyperlinks on [bufferRow], detecting only when something the answer depends on changed.
+      *
+      * @param runLines the line instances the answer depends on: just this row's line for an
+      *   ordinary row, every line of the logical run for a wrapped one.
+      */
+    fun linksAt(
+        bufferRow: Int,
+        runLines: List<TerminalLine>,
+        cwd: String?,
+        detectFilePaths: Boolean,
+        registryRevision: Int,
+        detect: () -> List<Hyperlink>,
+    ): List<Hyperlink> {
+        val hit = rows[bufferRow]
+        if (hit != null &&
+            hit.cwd == cwd &&
+            hit.detectFilePaths == detectFilePaths &&
+            hit.registryRevision == registryRevision &&
+            hit.lines.size == runLines.size &&
+            hit.lines.indices.all { hit.lines[it] === runLines[it] }
+        ) {
+            return hit.links
+        }
+        if (rows.size >= MAX_ROWS) rows.clear()
+        return detect().also {
+            rows[bufferRow] = Entry(runLines, cwd, detectFilePaths, registryRevision, it)
+        }
     }
-    if (rows.size >= MAX_ROWS) rows.clear()
-    return detect().also {
-      rows[bufferRow] = Entry(runLines, cwd, detectFilePaths, registryRevision, it)
+
+    fun clear() {
+        rows.clear()
     }
-  }
 
-  fun clear() {
-    rows.clear()
-  }
-
-  private companion object {
-    /** A few screenfuls. Cleared wholesale rather than evicted - this is a hover memo. */
-    const val MAX_ROWS = 512
-  }
+    private companion object {
+        /** A few screenfuls. Cleared wholesale rather than evicted - this is a hover memo. */
+        const val MAX_ROWS = 512
+    }
 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkRowCache.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkRowCache.kt
@@ -1,0 +1,52 @@
+package ai.rever.bossterm.compose.hyperlinks
+
+import ai.rever.bossterm.terminal.model.TerminalLine
+
+/**
+ * Per-buffer-row hyperlink memo, keyed by the LINE INSTANCE rather than a version hash.
+ *
+ * The incremental snapshot builder reuses the [TerminalLine] object for a row whose content did
+ * not change, so identity is an exact O(1) validity check: a row that changed is the only thing
+ * that misses. No scroll offset appears anywhere in the key, which is the point - the previous
+ * cache folded the offset into its hash, so every wheel tick missed and re-ran detection over
+ * the whole viewport.
+ *
+ * Deliberately NOT Compose state. It is written from a pointer handler, and the previous cache
+ * was `mutableStateOf` read and written inside the draw lambda - a draw-phase write to state the
+ * draw observer had recorded, which re-invalidated the draw node and cost a second full text
+ * render on every frame.
+ *
+ * Not thread-safe: confined to the UI thread, like the pointer handler that owns it.
+ */
+internal class HyperlinkRowCache {
+  private val rows = HashMap<Int, Pair<TerminalLine, List<Hyperlink>>>()
+
+  /**
+   * Hyperlinks on [bufferRow], detecting only if [line] is not the instance already memoized.
+   *
+   * [bypass] skips the memo entirely for rows whose answer depends on their neighbours - a
+   * wrapped run's detection walks to the logical line's start, so an unchanged line can still
+   * produce a different result when a sibling row changed. Those are the minority and this runs
+   * once per mouse move, so re-detecting them is cheap and always correct.
+   */
+  fun linksAt(
+    bufferRow: Int,
+    line: TerminalLine,
+    bypass: Boolean = false,
+    detect: () -> List<Hyperlink>,
+  ): List<Hyperlink> {
+    if (bypass) return detect()
+    rows[bufferRow]?.let { (cachedLine, links) -> if (cachedLine === line) return links }
+    if (rows.size > MAX_ROWS) rows.clear()
+    return detect().also { rows[bufferRow] = line to it }
+  }
+
+  fun clear() {
+    rows.clear()
+  }
+
+  private companion object {
+    /** A few screenfuls. Cleared wholesale rather than evicted - this is a hover memo. */
+    const val MAX_ROWS = 512
+  }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkRowCache.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkRowCache.kt
@@ -16,8 +16,10 @@ import ai.rever.bossterm.terminal.model.TerminalLine
  * the entire logical line) plus the full registry sweep on every pointer-move event - and in a
  * long-output session wrapped rows are the common case, not the exception.
  *
- * [cwd] and [detectFilePaths] are part of the key because `detect` resolves relative paths
- * against them: after a `cd`, an unchanged line must produce different `file://` targets.
+ * [cwd], [detectFilePaths] and the registry revision are part of the key because `detect`
+ * resolves against all three: after a `cd` an unchanged line must produce different `file://`
+ * targets, and an embedder adding a pattern at runtime must reach rows already memoized - the
+ * line instance never changes, so nothing else would ever invalidate them.
  *
  * Deliberately NOT Compose state. It is written from a pointer handler, and the cache it
  * replaces was `mutableStateOf` read and written inside the draw lambda - a draw-phase write to
@@ -31,6 +33,7 @@ internal class HyperlinkRowCache {
     val lines: List<TerminalLine>,
     val cwd: String?,
     val detectFilePaths: Boolean,
+    val registryRevision: Int,
     val links: List<Hyperlink>,
   )
 
@@ -47,19 +50,23 @@ internal class HyperlinkRowCache {
     runLines: List<TerminalLine>,
     cwd: String?,
     detectFilePaths: Boolean,
+    registryRevision: Int,
     detect: () -> List<Hyperlink>,
   ): List<Hyperlink> {
     val hit = rows[bufferRow]
     if (hit != null &&
       hit.cwd == cwd &&
       hit.detectFilePaths == detectFilePaths &&
+      hit.registryRevision == registryRevision &&
       hit.lines.size == runLines.size &&
       hit.lines.indices.all { hit.lines[it] === runLines[it] }
     ) {
       return hit.links
     }
-    if (rows.size > MAX_ROWS) rows.clear()
-    return detect().also { rows[bufferRow] = Entry(runLines, cwd, detectFilePaths, it) }
+    if (rows.size >= MAX_ROWS) rows.clear()
+    return detect().also {
+      rows[bufferRow] = Entry(runLines, cwd, detectFilePaths, registryRevision, it)
+    }
   }
 
   fun clear() {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkRowCache.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkRowCache.kt
@@ -3,42 +3,63 @@ package ai.rever.bossterm.compose.hyperlinks
 import ai.rever.bossterm.terminal.model.TerminalLine
 
 /**
- * Per-buffer-row hyperlink memo, keyed by the LINE INSTANCE rather than a version hash.
+ * Per-buffer-row hyperlink memo for the hover path.
  *
- * The incremental snapshot builder reuses the [TerminalLine] object for a row whose content did
- * not change, so identity is an exact O(1) validity check: a row that changed is the only thing
- * that misses. No scroll offset appears anywhere in the key, which is the point - the previous
- * cache folded the offset into its hash, so every wheel tick missed and re-ran detection over
- * the whole viewport.
+ * Keyed by the LINE INSTANCES the answer depends on, not by a version hash. The incremental
+ * snapshot builder reuses the [TerminalLine] object for a row whose content did not change, so
+ * identity is an exact O(1) validity check: a row that changed is the only thing that misses. No
+ * scroll offset appears anywhere in the key, which is the point - the previous cache folded the
+ * offset into its hash, so every wheel tick missed and re-ran detection over the whole viewport.
  *
- * Deliberately NOT Compose state. It is written from a pointer handler, and the previous cache
- * was `mutableStateOf` read and written inside the draw lambda - a draw-phase write to state the
- * draw observer had recorded, which re-invalidated the draw node and cost a second full text
- * render on every frame.
+ * A wrapped row's answer depends on its whole logical run, so the key for those rows is every
+ * line in the run. Bypassing the memo instead would re-run `collectWrappedLines` (a rejoin of
+ * the entire logical line) plus the full registry sweep on every pointer-move event - and in a
+ * long-output session wrapped rows are the common case, not the exception.
+ *
+ * [cwd] and [detectFilePaths] are part of the key because `detect` resolves relative paths
+ * against them: after a `cd`, an unchanged line must produce different `file://` targets.
+ *
+ * Deliberately NOT Compose state. It is written from a pointer handler, and the cache it
+ * replaces was `mutableStateOf` read and written inside the draw lambda - a draw-phase write to
+ * state the draw observer had recorded, which re-invalidated the draw node and cost a second
+ * full text render on every frame.
  *
  * Not thread-safe: confined to the UI thread, like the pointer handler that owns it.
  */
 internal class HyperlinkRowCache {
-  private val rows = HashMap<Int, Pair<TerminalLine, List<Hyperlink>>>()
+  private class Entry(
+    val lines: List<TerminalLine>,
+    val cwd: String?,
+    val detectFilePaths: Boolean,
+    val links: List<Hyperlink>,
+  )
+
+  private val rows = HashMap<Int, Entry>()
 
   /**
-   * Hyperlinks on [bufferRow], detecting only if [line] is not the instance already memoized.
+   * Hyperlinks on [bufferRow], detecting only when something the answer depends on changed.
    *
-   * [bypass] skips the memo entirely for rows whose answer depends on their neighbours - a
-   * wrapped run's detection walks to the logical line's start, so an unchanged line can still
-   * produce a different result when a sibling row changed. Those are the minority and this runs
-   * once per mouse move, so re-detecting them is cheap and always correct.
+   * @param runLines the line instances the answer depends on: just this row's line for an
+   *   ordinary row, every line of the logical run for a wrapped one.
    */
   fun linksAt(
     bufferRow: Int,
-    line: TerminalLine,
-    bypass: Boolean = false,
+    runLines: List<TerminalLine>,
+    cwd: String?,
+    detectFilePaths: Boolean,
     detect: () -> List<Hyperlink>,
   ): List<Hyperlink> {
-    if (bypass) return detect()
-    rows[bufferRow]?.let { (cachedLine, links) -> if (cachedLine === line) return links }
+    val hit = rows[bufferRow]
+    if (hit != null &&
+      hit.cwd == cwd &&
+      hit.detectFilePaths == detectFilePaths &&
+      hit.lines.size == runLines.size &&
+      hit.lines.indices.all { hit.lines[it] === runLines[it] }
+    ) {
+      return hit.links
+    }
     if (rows.size > MAX_ROWS) rows.clear()
-    return detect().also { rows[bufferRow] = line to it }
+    return detect().also { rows[bufferRow] = Entry(runLines, cwd, detectFilePaths, it) }
   }
 
   fun clear() {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -159,6 +159,17 @@ enum class GlyphBlink {
 }
 
 /**
+ * Whether this shape's caret is drawn on the caret blink clock.
+ *
+ * [renderCursorOverlay] consults the clock only for the BLINK_* shapes, so a reader that wants
+ * to avoid subscribing to it needlessly can ask here first.
+ */
+fun CursorShape?.isBlinkingShape(): Boolean = when (this) {
+    CursorShape.BLINK_BLOCK, CursorShape.BLINK_UNDERLINE, CursorShape.BLINK_VERTICAL_BAR -> true
+    else -> false
+}
+
+/**
  * Result of analyzing a character for rendering purposes.
  * Encapsulates surrogate pair handling, double-width detection, and variation selector info.
  *

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -150,7 +150,14 @@ enum class GlyphBlink {
     SLOW,
     RAPID;
 
-    /** Whether a glyph with this attribute is showing, given the two clocks. */
+    /**
+     * Whether a glyph with this attribute is showing, given the two clocks.
+     *
+     * Callers in a Compose draw phase should test [NONE] first: both arguments are evaluated
+     * here, so an unattributed glyph would otherwise subscribe its layer to two clocks that
+     * cannot affect it. That is a property of the call site, not of this function, which is why
+     * the check lives there rather than being duplicated into a second predicate.
+     */
     fun isVisible(slowVisible: Boolean, rapidVisible: Boolean): Boolean = when (this) {
         NONE -> true
         SLOW -> slowVisible

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -105,10 +105,6 @@ data class RenderingContext(
     val terminalWidthCells: Int = 80,
     val terminalHeightCells: Int = 24,
 
-    // Pre-computed hyperlinks cache (for version-based caching optimization)
-    // If provided, hyperlink detection will be skipped and these will be used
-    val precomputedHyperlinks: Map<Int, List<Hyperlink>>? = null,
-
     // Working directory for resolving relative file paths in hyperlinks
     val workingDirectory: String? = null,
 
@@ -538,10 +534,8 @@ object TerminalCanvasRenderer {
      * - Pass 2: Draw all text (reuse cached analysis)
      * - Pass 3: Draw overlays (hyperlinks, search, selection, cursor)
      *
-     * @return Map of row to detected hyperlinks for mouse hover detection
      */
-    fun DrawScope.renderTerminal(ctx: RenderingContext): Map<Int, List<Hyperlink>> {
-        val hyperlinksCache = mutableMapOf<Int, List<Hyperlink>>()
+    fun DrawScope.renderTerminal(ctx: RenderingContext) {
         // Cache character analysis to avoid redundant computation between passes
         val analysisCache = AnalysisCache(ctx.visibleRows, ctx.visibleCols)
 
@@ -566,16 +560,13 @@ object TerminalCanvasRenderer {
             renderSelectionHighlight(ctx)
         }
 
-        // Pass 2: Draw text and collect hyperlinks (reuse cached analysis)
-        val detectedHyperlinks = renderText(ctx, analysisCache)
-        hyperlinksCache.putAll(detectedHyperlinks)
+        // Pass 2: Draw text (reuse cached analysis)
+        renderText(ctx, analysisCache)
 
         // Pass 3: Draw overlays (hyperlinks, search - but NOT selection or cursor).
         // The cursor is drawn in its own overlay Canvas (see renderCursorOverlay) so its
         // blink doesn't re-run this whole pass.
         renderOverlays(ctx)
-
-        return hyperlinksCache
     }
 
     /**
@@ -768,86 +759,48 @@ object TerminalCanvasRenderer {
     }
 
     /**
-     * Detect all hyperlinks in the visible buffer area.
-     * This method can be called independently for caching purposes.
+     * Hyperlinks on one BUFFER row, in buffer coordinates.
      *
-     * Returns a map of row index to list of hyperlinks on that row.
-     * Multi-row hyperlinks are added to ALL rows they span.
+     * Offset-free by construction: the same buffer row yields the same answer wherever the
+     * viewport happens to be sitting, which is what lets a caller memo the result across a
+     * scroll. This replaces a per-frame sweep of every visible row that ran ~14 regexes per
+     * row inside the draw phase - for a result the text pass never read. Only the hover
+     * hit-test and the hover underline consume it, so it is resolved one row at a time, on
+     * demand.
      *
-     * @param ctx The rendering context containing buffer snapshot and scroll state
-     * @return Map of row to detected hyperlinks
+     * Wrapped rows are handled by walking to the logical line's start, which may be off-screen;
+     * the returned spans therefore cover every buffer row the link occupies.
      */
-    fun detectAllHyperlinks(ctx: RenderingContext): Map<Int, List<Hyperlink>> {
-        val snapshot = ctx.bufferSnapshot
-        val hyperlinksCache = mutableMapOf<Int, MutableList<Hyperlink>>()
-
-        for (row in 0 until ctx.visibleRows) {
-            val lineIndex = row - ctx.scrollOffset
-            val line = snapshot.getLine(lineIndex)
-
-            // Detect hyperlinks - handle wrapped lines specially
-            // isWrapped semantics: true means "this line wraps INTO the next line"
-            // Check if this row is a continuation of a wrapped line (previous line was wrapped)
-            val prevLineIndex = lineIndex - 1
-            val isPreviousLineWrapped = if (prevLineIndex >= -snapshot.historyLinesCount) {
-                snapshot.getLine(prevLineIndex).isWrapped
-            } else {
-                false
-            }
-
-            // Determine if we need to detect hyperlinks for this row
-            // Skip continuation rows IF we already processed them (check cache)
-            // This handles the case where start row is scrolled off-screen
-            val shouldDetect = if (isPreviousLineWrapped) {
-                // Continuation row - only detect if not already in cache
-                // (start row might be off-screen and not yet processed)
-                !hyperlinksCache.containsKey(row)
-            } else {
-                true
-            }
-
-            if (shouldDetect) {
-                val isPartOfWrappedSequence = isPreviousLineWrapped || line.isWrapped
-                val hyperlinks = if (isPartOfWrappedSequence) {
-                    // Part of a wrapped sequence - use wrapped detection
-                    // This walks backwards to find start even if off-screen
-                    HyperlinkDetector.detectHyperlinksWithWrapping(
-                        snapshot, row, ctx.scrollOffset, ctx.visibleCols,
-                        ctx.workingDirectory, ctx.detectFilePaths, ctx.hyperlinkRegistry
-                    )
-                } else {
-                    // Single line - use standard detection
-                    HyperlinkDetector.detectHyperlinks(
-                        line.text, row, ctx.workingDirectory, ctx.detectFilePaths, ctx.hyperlinkRegistry
-                    )
-                }
-
-                // Populate cache for ALL rows each hyperlink spans
-                // Note: The same Hyperlink object is intentionally added to multiple rows
-                // to enable efficient lookup when hovering over any part of a wrapped URL
-                for (hyperlink in hyperlinks) {
-                    for (spanRow in hyperlink.rowSpans.keys) {
-                        hyperlinksCache.getOrPut(spanRow) { mutableListOf() }.add(hyperlink)
-                    }
-                }
-            }
+    fun detectHyperlinksForBufferRow(
+        snapshot: VersionedBufferSnapshot,
+        bufferRow: Int,
+        terminalWidth: Int,
+        workingDirectory: String?,
+        detectFilePaths: Boolean,
+        registry: HyperlinkRegistry,
+    ): List<Hyperlink> {
+        val line = snapshot.getLine(bufferRow)
+        // isWrapped semantics: true means "this line wraps INTO the next line", so a row is a
+        // continuation when its PREDECESSOR is wrapped.
+        val isPreviousLineWrapped = bufferRow - 1 >= -snapshot.historyLinesCount &&
+            snapshot.getLine(bufferRow - 1).isWrapped
+        return if (isPreviousLineWrapped || line.isWrapped) {
+            HyperlinkDetector.detectHyperlinksWithWrapping(
+                snapshot, bufferRow, terminalWidth, workingDirectory, detectFilePaths, registry
+            )
+        } else {
+            HyperlinkDetector.detectHyperlinks(
+                line.text, bufferRow, workingDirectory, detectFilePaths, registry
+            )
         }
-
-        return hyperlinksCache
     }
 
     /**
      * Pass 2: Render all text with proper font handling.
      * Reuses character analysis from the cache populated by renderBackgrounds().
-     * Returns map of row to detected hyperlinks.
      */
-    private fun DrawScope.renderText(ctx: RenderingContext, analysisCache: AnalysisCache): Map<Int, List<Hyperlink>> {
+    private fun DrawScope.renderText(ctx: RenderingContext, analysisCache: AnalysisCache) {
         val snapshot = ctx.bufferSnapshot
-
-        // Use precomputed hyperlinks if available (version-based caching),
-        // otherwise detect them fresh
-        val hyperlinksCache: Map<Int, List<Hyperlink>> = ctx.precomputedHyperlinks
-            ?: detectAllHyperlinks(ctx)
 
         // Memoize TextStyle for the duration of this frame, keyed by foreground color
         // (raw ULong, lossless) with the 4 bold/italic combinations in a small array.
@@ -1110,8 +1063,6 @@ object TerminalCanvasRenderer {
 
             flushBatch()
         }
-
-        return hyperlinksCache
     }
 
     /**
@@ -1123,10 +1074,13 @@ object TerminalCanvasRenderer {
         // Hyperlink underline - supports multi-row hyperlinks
         if (ctx.settings.hyperlinkUnderlineOnHover && ctx.hoveredHyperlink != null && ctx.isModifierPressed) {
             val link = ctx.hoveredHyperlink
-            // Draw underline for each row the hyperlink spans
+            // Draw underline for each row the hyperlink spans. Spans are BUFFER rows, so they
+            // convert to screen rows here - which is also why the underline now follows the
+            // link when the viewport scrolls under a held modifier instead of staying put.
             for ((spanRow, span) in link.rowSpans) {
-                if (spanRow in 0 until ctx.visibleRows) {
-                    val y = spanRow * ctx.cellHeight
+                val screenRow = spanRow + ctx.scrollOffset
+                if (screenRow in 0 until ctx.visibleRows) {
+                    val y = screenRow * ctx.cellHeight
                     val underlineY = y + ctx.cellHeight - 1f
                     val startX = span.first * ctx.cellWidth
                     val endX = span.second * ctx.cellWidth

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -21,8 +21,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import ai.rever.bossterm.compose.SelectionMode
 import ai.rever.bossterm.compose.hyperlinks.Hyperlink
-import ai.rever.bossterm.compose.hyperlinks.HyperlinkDetector
-import ai.rever.bossterm.compose.hyperlinks.HyperlinkRegistry
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import ai.rever.bossterm.compose.util.ColorUtils

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/rendering/TerminalCanvasRenderer.kt
@@ -105,15 +105,6 @@ data class RenderingContext(
     val terminalWidthCells: Int = 80,
     val terminalHeightCells: Int = 24,
 
-    // Working directory for resolving relative file paths in hyperlinks
-    val workingDirectory: String? = null,
-
-    // Whether to detect file/folder paths as clickable hyperlinks
-    val detectFilePaths: Boolean = true,
-
-    // Custom hyperlink registry for per-instance pattern customization
-    val hyperlinkRegistry: HyperlinkRegistry = HyperlinkDetector.registry,
-
     // Command blocks resolved to on-screen rows for this frame (empty when the
     // feature is disabled, so the gutter pass is a no-op).
     val commandBlocks: List<RenderableBlock> = emptyList()
@@ -144,7 +135,30 @@ data class CursorGlyph(
     val isBold: Boolean,
     val isItalic: Boolean,
     val isUnderline: Boolean,
+    /**
+     * Which SGR text-blink clock this glyph follows, if any.
+     *
+     * Recorded rather than applied at resolve time so the gate can live in the overlay's DRAW
+     * lambda. Resolution happens in the apply phase, which is outside `observeReads` - a clock
+     * read there subscribes nothing, so the glyph would keep painting after the text pass had
+     * blinked it away.
+     */
+    val blink: GlyphBlink = GlyphBlink.NONE,
 )
+
+/** The SGR blink attribute a repainted cursor glyph carries. */
+enum class GlyphBlink {
+    NONE,
+    SLOW,
+    RAPID;
+
+    /** Whether a glyph with this attribute is showing, given the two clocks. */
+    fun isVisible(slowVisible: Boolean, rapidVisible: Boolean): Boolean = when (this) {
+        NONE -> true
+        SLOW -> slowVisible
+        RAPID -> rapidVisible
+    }
+}
 
 /**
  * Result of analyzing a character for rendering purposes.
@@ -755,43 +769,6 @@ object TerminalCanvasRenderer {
                 // Advance visual position
                 visualCol += analysis.visualWidth
             }
-        }
-    }
-
-    /**
-     * Hyperlinks on one BUFFER row, in buffer coordinates.
-     *
-     * Offset-free by construction: the same buffer row yields the same answer wherever the
-     * viewport happens to be sitting, which is what lets a caller memo the result across a
-     * scroll. This replaces a per-frame sweep of every visible row that ran ~14 regexes per
-     * row inside the draw phase - for a result the text pass never read. Only the hover
-     * hit-test and the hover underline consume it, so it is resolved one row at a time, on
-     * demand.
-     *
-     * Wrapped rows are handled by walking to the logical line's start, which may be off-screen;
-     * the returned spans therefore cover every buffer row the link occupies.
-     */
-    fun detectHyperlinksForBufferRow(
-        snapshot: VersionedBufferSnapshot,
-        bufferRow: Int,
-        terminalWidth: Int,
-        workingDirectory: String?,
-        detectFilePaths: Boolean,
-        registry: HyperlinkRegistry,
-    ): List<Hyperlink> {
-        val line = snapshot.getLine(bufferRow)
-        // isWrapped semantics: true means "this line wraps INTO the next line", so a row is a
-        // continuation when its PREDECESSOR is wrapped.
-        val isPreviousLineWrapped = bufferRow - 1 >= -snapshot.historyLinesCount &&
-            snapshot.getLine(bufferRow - 1).isWrapped
-        return if (isPreviousLineWrapped || line.isWrapped) {
-            HyperlinkDetector.detectHyperlinksWithWrapping(
-                snapshot, bufferRow, terminalWidth, workingDirectory, detectFilePaths, registry
-            )
-        } else {
-            HyperlinkDetector.detectHyperlinks(
-                line.text, bufferRow, workingDirectory, detectFilePaths, registry
-            )
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/BlinkClock.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/BlinkClock.kt
@@ -1,0 +1,78 @@
+package ai.rever.bossterm.compose.ui
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+
+/**
+ * Whether a blinking element is visible [elapsedNanos] past its phase epoch.
+ *
+ * Visible for the first half-period of every cycle, so elapsed 0 starts visible.
+ */
+internal fun blinkVisibleAt(elapsedNanos: Long, periodNanos: Long): Boolean {
+  if (periodNanos <= 0L) return true
+  return (elapsedNanos.coerceAtLeast(0L) / periodNanos) % 2L == 0L
+}
+
+/** Nanos from [elapsedNanos] to the next phase edge. Always in `1..periodNanos`, never 0. */
+internal fun nanosToNextBlinkEdge(elapsedNanos: Long, periodNanos: Long): Long {
+  if (periodNanos <= 0L) return 0L
+  return periodNanos - (elapsedNanos.coerceAtLeast(0L) % periodNanos)
+}
+
+/**
+ * Whole milliseconds to sleep before the next edge, rounded UP.
+ *
+ * Rounding down would wake a fraction of a millisecond BEFORE the edge, recompute the same
+ * phase, and immediately sleep again - a spin at the boundary. Up means every wake lands at or
+ * after the edge it was aimed at.
+ */
+internal fun millisToNextBlinkEdge(elapsedNanos: Long, periodNanos: Long): Long =
+  (nanosToNextBlinkEdge(elapsedNanos, periodNanos) + 999_999L) / 1_000_000L
+
+/**
+ * Drive a blink flag off an ABSOLUTE timeline.
+ *
+ * The shape this replaces was `while (isActive) { delay(period); flag = !flag }`. `delay`
+ * measures from RESUMPTION, and these loops run in the composition's effect context - the AWT
+ * event thread on Compose Desktop, shared with pointer handling, recomposition and drawing. So
+ * under load the resumption lands X ms late, the toggle happens at `period + X`, and the NEXT
+ * delay starts from there: the period stretches and the phase walks. X tracks scroll and output
+ * activity, which is why the blink rate is visibly unstable while scrolling a busy TUI.
+ *
+ * Here the phase is a pure function of the monotonic clock, so a late wake produces the phase
+ * that is CORRECT for the moment it woke, and the next sleep targets the next absolute edge
+ * rather than `now + period`. A stall longer than a period simply skips the toggles it slept
+ * through - real terminals do not replay missed blinks - and the `!= last` guard means a wake
+ * landing inside the same half-period costs no invalidation at all.
+ *
+ * Still exactly two wakeups per period, and none while parked, so the zero-idle-repaint
+ * guarantee that gates these loops on window focus and tab visibility is untouched. A frame-
+ * clock formulation (`withFrameNanos` / `withInfiniteAnimationFrameMillis`) would instead
+ * request a frame at display refresh rate forever, per visible tab, and break it.
+ *
+ * @param periodMs half-cycle length; `<= 0` means "no blink" and returns after showing visible.
+ * @param nowNanos monotonic clock, injectable so the loop is testable on virtual time.
+ * @param onVisible invoked only when the phase actually flips.
+ */
+internal suspend fun runBlinkPhase(
+  periodMs: Int,
+  nowNanos: () -> Long = System::nanoTime,
+  onVisible: (Boolean) -> Unit,
+) {
+  onVisible(true)
+  // The settings slider exposes 0 as "Off". Turning that into delay(0) in a tight loop pegged a
+  // core instead of disabling the blink, so it stays an early return.
+  if (periodMs <= 0) return
+  val periodNanos = periodMs * 1_000_000L
+  val epoch = nowNanos()
+  var last = true
+  while (currentCoroutineContext().isActive) {
+    delay(millisToNextBlinkEdge(nowNanos() - epoch, periodNanos))
+    val visible = blinkVisibleAt(nowNanos() - epoch, periodNanos)
+    if (visible != last) {
+      last = visible
+      onVisible(visible)
+    }
+  }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/CursorOverlay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/CursorOverlay.kt
@@ -58,20 +58,35 @@ internal data class CursorFrame(
 )
 
 /**
- * Identity-stable holder so [CursorOverlay]'s draw lambda has exactly ONE capture.
+ * Identity-stable holder for everything the PAINT phase reads without going through composition.
  *
- * `Canvas(modifier) { }` is `Spacer(modifier.drawBehind(onDraw))`, and `drawBehind`'s element
- * compares the lambda instance - a new instance invalidates the draw node. Kotlin only memoizes
- * a lambda when every capture is stable, and the overlay used to capture the buffer snapshot,
- * the render frame, the settings, the theme and half a dozen more, several of them unstable. So
- * every recomposition of the parent - including one per wheel event - rebuilt it and re-ran the
- * glyph and image resolution with it. One stable capture plus a skippable composable means the
- * parent recomposing does not touch this layer at all.
+ * Two jobs, both about subscription phase:
+ *
+ * 1. `Canvas(modifier) { }` is `Spacer(modifier.drawBehind(onDraw))`, and `drawBehind`'s element
+ *    compares the lambda instance - a new instance invalidates the draw node. Kotlin only
+ *    memoizes a lambda when every capture is stable, and the overlay used to capture the buffer
+ *    snapshot, the render frame, the settings, the theme and more, several unstable. So every
+ *    recomposition of the parent, including one per wheel event, rebuilt it. One stable capture
+ *    plus a skippable composable means the parent recomposing does not touch that layer.
+ * 2. The three blink clocks live here rather than as composition locals so BOTH canvases read
+ *    them in their own draw lambdas. That is the only phase where the read subscribes: the
+ *    caret's [frame] is published from a `SideEffect`, which runs in the apply phase outside
+ *    `observeReads`, so a clock read there would subscribe nothing and the glyph would keep
+ *    painting after the text pass had blinked it away.
  */
 @Stable
-internal class CursorOverlayState {
-  var frame by mutableStateOf<CursorFrame?>(null)
-  var blinkVisible by mutableStateOf(true)
+internal class TerminalPaintState {
+  /** The caret, republished whenever anything it draws changes. */
+  var cursorFrame by mutableStateOf<CursorFrame?>(null)
+
+  /** The caret's own timer (`caretBlinkMs`), read only by the cursor overlay. */
+  var caretVisible by mutableStateOf(true)
+
+  /** SGR 5, read by the text canvas for its cells and by the overlay for the caret's glyph. */
+  var slowBlinkVisible by mutableStateOf(true)
+
+  /** SGR 6, likewise. */
+  var rapidBlinkVisible by mutableStateOf(true)
 }
 
 /**
@@ -83,10 +98,15 @@ internal class CursorOverlayState {
  * from composition into a recomposition loop.
  */
 @Composable
-internal fun CursorOverlay(state: CursorOverlayState) {
+internal fun CursorOverlay(state: TerminalPaintState) {
   Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
-    val f = state.frame ?: return@Canvas
-    val blink = state.blinkVisible
+    val f = state.cursorFrame ?: return@Canvas
+    val blink = state.caretVisible
+    // The SGR clocks gate the repainted glyph HERE, in the draw phase, so this layer repaints
+    // in step with the text pass. resolveCursorGlyph only records which clock the cell follows.
+    val glyph = f.glyph?.takeIf {
+      it.blink.isVisible(state.slowBlinkVisible, state.rapidBlinkVisible)
+    }
     if (size.width < f.cellWidth || size.height < f.cellHeight) return@Canvas
 
     val screenRow = (f.y - 1).coerceAtLeast(0) + f.scrollOffset
@@ -121,7 +141,7 @@ internal fun CursorOverlay(state: CursorOverlayState) {
         focusedAlpha = f.focusedAlpha,
         unfocusedAlpha = f.unfocusedAlpha,
         imageOcclusion = occlusion,
-        cursorGlyph = f.glyph,
+        cursorGlyph = glyph,
         cursorTextColor = f.glyphColor,
         glyphFontFamily = f.glyphFontFamily,
         glyphFontSize = f.glyphFontSize,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/CursorOverlay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/CursorOverlay.kt
@@ -23,6 +23,7 @@ import ai.rever.bossterm.compose.rendering.TerminalCanvasRenderer
 import ai.rever.bossterm.compose.rendering.imageCellSlice
 import ai.rever.bossterm.terminal.CursorShape
 import ai.rever.bossterm.terminal.model.image.ImageCell
+import kotlin.math.ceil
 
 /**
  * Everything the cursor overlay draws, as ONE structurally-comparable value.
@@ -103,25 +104,30 @@ internal class TerminalPaintState {
 internal fun CursorOverlay(state: TerminalPaintState) {
   Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
     val f = state.cursorFrame ?: return@Canvas
-    // Every read below is a SUBSCRIPTION, so each is taken only when it can change what this
-    // layer paints. A steady caret shape ignores the caret clock entirely (see
-    // renderCursorOverlay), and reading it anyway would repaint a pixel-identical frame twice
-    // a period for the whole life of the tab - DECSCUSR 2/4/6 is what plenty of shells set.
-    val blink = if (f.shape.isBlinkingShape()) state.caretVisible else true
-    // Likewise the SGR clocks: an ordinary cell follows neither, and `isVisible(a, b)` would
-    // evaluate both and subscribe to both. Gating HERE rather than at resolve time is what
-    // keeps the caret's glyph in step with the text pass, since resolution runs in the apply
-    // phase where a read subscribes nothing.
-    val glyph = f.glyph?.takeIf { g ->
-      when (g.blink) {
-        GlyphBlink.NONE -> true
-        GlyphBlink.SLOW -> state.slowBlinkVisible
-        GlyphBlink.RAPID -> state.rapidBlinkVisible
-      }
-    }
     if (size.width < f.cellWidth || size.height < f.cellHeight) return@Canvas
 
+    // EVERY read below is a subscription, so bail on anything that means nothing will be
+    // painted BEFORE taking one. `renderCursorOverlay` makes the same two decisions, but by
+    // then the clock has already been read - so a hidden caret (CSI ?25l, which a full-screen
+    // TUI holds for long stretches) or a caret scrolled off-screen would invalidate this layer
+    // twice a period, forever, to draw nothing. `cursorFrame` is read first either way, so a
+    // visibility flip still republishes and repaints.
+    if (!f.visible) return@Canvas
     val screenRow = (f.y - 1).coerceAtLeast(0) + f.scrollOffset
+    if (screenRow < 0 || screenRow >= ceil(size.height / f.cellHeight).toInt()) return@Canvas
+
+    // A steady caret shape ignores the caret clock entirely (see renderCursorOverlay), and
+    // reading it anyway would repaint a pixel-identical frame twice a period for the life of
+    // the tab - DECSCUSR 2/4/6 is what plenty of shells set.
+    val blink = if (f.shape.isBlinkingShape()) state.caretVisible else true
+    // NONE first, so ordinary text keeps this layer out of the SGR clocks entirely: isVisible
+    // evaluates both arguments, and an unattributed cell follows neither. Gating HERE rather
+    // than at resolve time is what keeps the caret's glyph in step with the text pass, since
+    // resolution runs in the apply phase where a read subscribes nothing.
+    val glyph = f.glyph?.takeIf { g ->
+      g.blink == GlyphBlink.NONE ||
+        g.blink.isVisible(state.slowBlinkVisible, state.rapidBlinkVisible)
+    }
     // If the caret sits on an inline image, that cell's alpha masks it, so animated sprite
     // pixels stay above it - matching browser compositing.
     val occlusion = if (f.imageCell != null && f.imageBitmap != null) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/CursorOverlay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/CursorOverlay.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import ai.rever.bossterm.compose.rendering.CursorGlyph
+import ai.rever.bossterm.compose.rendering.GlyphBlink
+import ai.rever.bossterm.compose.rendering.isBlinkingShape
 import ai.rever.bossterm.compose.rendering.TerminalCanvasRenderer
 import ai.rever.bossterm.compose.rendering.imageCellSlice
 import ai.rever.bossterm.terminal.CursorShape
@@ -101,11 +103,21 @@ internal class TerminalPaintState {
 internal fun CursorOverlay(state: TerminalPaintState) {
   Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
     val f = state.cursorFrame ?: return@Canvas
-    val blink = state.caretVisible
-    // The SGR clocks gate the repainted glyph HERE, in the draw phase, so this layer repaints
-    // in step with the text pass. resolveCursorGlyph only records which clock the cell follows.
-    val glyph = f.glyph?.takeIf {
-      it.blink.isVisible(state.slowBlinkVisible, state.rapidBlinkVisible)
+    // Every read below is a SUBSCRIPTION, so each is taken only when it can change what this
+    // layer paints. A steady caret shape ignores the caret clock entirely (see
+    // renderCursorOverlay), and reading it anyway would repaint a pixel-identical frame twice
+    // a period for the whole life of the tab - DECSCUSR 2/4/6 is what plenty of shells set.
+    val blink = if (f.shape.isBlinkingShape()) state.caretVisible else true
+    // Likewise the SGR clocks: an ordinary cell follows neither, and `isVisible(a, b)` would
+    // evaluate both and subscribe to both. Gating HERE rather than at resolve time is what
+    // keeps the caret's glyph in step with the text pass, since resolution runs in the apply
+    // phase where a read subscribes nothing.
+    val glyph = f.glyph?.takeIf { g ->
+      when (g.blink) {
+        GlyphBlink.NONE -> true
+        GlyphBlink.SLOW -> state.slowBlinkVisible
+        GlyphBlink.RAPID -> state.rapidBlinkVisible
+      }
     }
     if (size.width < f.cellWidth || size.height < f.cellHeight) return@Canvas
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/CursorOverlay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/CursorOverlay.kt
@@ -1,0 +1,132 @@
+package ai.rever.bossterm.compose.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import ai.rever.bossterm.compose.rendering.CursorGlyph
+import ai.rever.bossterm.compose.rendering.TerminalCanvasRenderer
+import ai.rever.bossterm.compose.rendering.imageCellSlice
+import ai.rever.bossterm.terminal.CursorShape
+import ai.rever.bossterm.terminal.model.image.ImageCell
+
+/**
+ * Everything the cursor overlay draws, as ONE structurally-comparable value.
+ *
+ * Structural equality is the point rather than a nicety. The incremental snapshot builder reuses
+ * the line instance for an unchanged row, so a frame of streamed output that does not touch the
+ * caret produces an equal [CursorFrame], `mutableStateOf`'s structural equality policy drops the
+ * write, and the overlay is not invalidated at all.
+ *
+ * Everything needing the buffer is resolved before it gets here - only the occlusion slice needs
+ * `DrawScope.size`, so only that stays in the draw lambda.
+ */
+@Immutable
+internal data class CursorFrame(
+  val visible: Boolean,
+  val shape: CursorShape?,
+  val x: Int,
+  /** 1-indexed, as the emulator reports it. */
+  val y: Int,
+  val scrollOffset: Int,
+  val cellWidth: Float,
+  val cellHeight: Float,
+  val bufferWidth: Int,
+  val isFocused: Boolean,
+  val color: Color,
+  val focusedAlpha: Float,
+  val unfocusedAlpha: Float,
+  val glyph: CursorGlyph?,
+  val glyphColor: Color?,
+  val glyphFontFamily: FontFamily?,
+  val glyphFontSize: Float,
+  val glyphMeasurer: TextMeasurer?,
+  val imageCell: ImageCell?,
+  val imageBitmap: ImageBitmap?,
+)
+
+/**
+ * Identity-stable holder so [CursorOverlay]'s draw lambda has exactly ONE capture.
+ *
+ * `Canvas(modifier) { }` is `Spacer(modifier.drawBehind(onDraw))`, and `drawBehind`'s element
+ * compares the lambda instance - a new instance invalidates the draw node. Kotlin only memoizes
+ * a lambda when every capture is stable, and the overlay used to capture the buffer snapshot,
+ * the render frame, the settings, the theme and half a dozen more, several of them unstable. So
+ * every recomposition of the parent - including one per wheel event - rebuilt it and re-ran the
+ * glyph and image resolution with it. One stable capture plus a skippable composable means the
+ * parent recomposing does not touch this layer at all.
+ */
+@Stable
+internal class CursorOverlayState {
+  var frame by mutableStateOf<CursorFrame?>(null)
+  var blinkVisible by mutableStateOf(true)
+}
+
+/**
+ * The caret, in its own Canvas stacked on the text canvas (same modifier chain, so coordinates
+ * line up exactly).
+ *
+ * Both state reads happen inside the draw lambda, which subscribes the draw node and nothing
+ * else - so a blink or a cursor move repaints this layer alone, and neither can be published
+ * from composition into a recomposition loop.
+ */
+@Composable
+internal fun CursorOverlay(state: CursorOverlayState) {
+  Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
+    val f = state.frame ?: return@Canvas
+    val blink = state.blinkVisible
+    if (size.width < f.cellWidth || size.height < f.cellHeight) return@Canvas
+
+    val screenRow = (f.y - 1).coerceAtLeast(0) + f.scrollOffset
+    // If the caret sits on an inline image, that cell's alpha masks it, so animated sprite
+    // pixels stay above it - matching browser compositing.
+    val occlusion = if (f.imageCell != null && f.imageBitmap != null) {
+      imageCellSlice(
+        imageCell = f.imageCell,
+        bitmap = f.imageBitmap,
+        visualColumn = f.x,
+        screenRow = screenRow,
+        visibleColumns = (size.width / f.cellWidth).toInt().coerceAtMost(f.bufferWidth),
+        cellWidth = f.cellWidth,
+        cellHeight = f.cellHeight,
+      )
+    } else {
+      null
+    }
+
+    with(TerminalCanvasRenderer) {
+      renderCursorOverlay(
+        cursorVisible = f.visible,
+        cursorBlinkVisible = blink,
+        cursorShape = f.shape,
+        cursorX = f.x,
+        cursorY = f.y,
+        scrollOffset = f.scrollOffset,
+        cellWidth = f.cellWidth,
+        cellHeight = f.cellHeight,
+        isFocused = f.isFocused,
+        cursorColor = f.color,
+        focusedAlpha = f.focusedAlpha,
+        unfocusedAlpha = f.unfocusedAlpha,
+        imageOcclusion = occlusion,
+        cursorGlyph = f.glyph,
+        cursorTextColor = f.glyphColor,
+        glyphFontFamily = f.glyphFontFamily,
+        glyphFontSize = f.glyphFontSize,
+        glyphMeasurer = f.glyphMeasurer,
+      )
+    }
+  }
+}

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -61,6 +61,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import ai.rever.bossterm.compose.ComposeTerminalDisplay
 import ai.rever.bossterm.compose.ConnectionState
 import ai.rever.bossterm.compose.PreConnectScreen
 import ai.rever.bossterm.compose.actions.addSplitPaneActions
@@ -77,6 +78,7 @@ import ai.rever.bossterm.compose.hyperlinks.Hyperlink
 import ai.rever.bossterm.compose.hyperlinks.HyperlinkDetector
 import ai.rever.bossterm.compose.hyperlinks.HyperlinkInfo
 import ai.rever.bossterm.compose.hyperlinks.HyperlinkRegistry
+import ai.rever.bossterm.compose.hyperlinks.HyperlinkRowCache
 import ai.rever.bossterm.compose.hyperlinks.toHyperlinkInfo
 import ai.rever.bossterm.compose.SelectionMode
 import ai.rever.bossterm.compose.ime.IMEHandler
@@ -139,10 +141,14 @@ private data class StableTerminalRenderFrame(
    */
   val historyDelta: HistoryDelta,
   val imagesById: Map<Long, TerminalImage>,
-  val cursorX: Int,
-  val cursorY: Int,
-  val cursorVisible: Boolean,
-  val cursorShape: CursorShape?,
+  /** Position, visibility and shape as one value, read under the same lock hold as [buffer]. */
+  val cursor: ComposeTerminalDisplay.CursorSnapshot,
+  /**
+   * Local-echo column override, captured with the frame; null whenever type-ahead is not
+   * actually predicting. Read live at composable scope it would re-enter the emulator lock on
+   * every recomposition and pair a fresh column with this frame's row.
+   */
+  val typeAheadCursorX: Int?,
 )
 
 /** UI-thread-confined retention committed only after an accepted composition applies. */
@@ -419,9 +425,12 @@ fun ProperTerminal(
 
   // Hyperlink state from tab
   var hoveredHyperlink by tab.hoveredHyperlink
-  var cachedHyperlinks by remember { mutableStateOf<Map<Int, List<Hyperlink>>>(emptyMap()) }
-  // Version hash for hyperlink caching - reuse cached hyperlinks when buffer unchanged
-  var lastHyperlinkVersionHash by remember { mutableStateOf(0L) }
+  // Hover-time detection, memoized per buffer row on line identity. Plain holders, not Compose
+  // state: nothing in the draw phase reads them, and the cache they replace was read AND
+  // written inside the draw lambda, which invalidated the draw node and cost a second full text
+  // render per frame.
+  val hyperlinkCache = remember(textBuffer) { HyperlinkRowCache() }
+  val hoverSnapshot = remember(textBuffer) { arrayOfNulls<VersionedBufferSnapshot>(1) }
   // Track previous hover state for consumer callbacks
   var previousHoveredHyperlink by remember { mutableStateOf<Hyperlink?>(null) }
 
@@ -713,8 +722,9 @@ fun ProperTerminal(
     }
   }
 
-  // Cursor blink state for BLINK_* cursor shapes
-  var cursorBlinkVisible by remember { mutableStateOf(true) }
+  // Cursor blink state for BLINK_* cursor shapes, plus the frame the overlay draws. Both live
+  // on one identity-stable holder so the overlay's draw lambda has a single stable capture.
+  val cursorOverlay = remember(tab.id) { CursorOverlayState() }
 
   // Use shared font loaded once by Main.kt (performance optimization for multiple tabs)
   // Font loading is expensive and should only happen once, not per tab
@@ -776,11 +786,11 @@ fun ProperTerminal(
     terminal.setCellDimensions(cellWidth, cellHeight)
   }
 
-  // Window focus + tab visibility gate every blink animation. The Canvas draw lambda
-  // reads cursorBlinkVisible / slowBlinkVisible / rapidBlinkVisible, so each toggle
-  // repaints the ENTIRE terminal canvas. Letting those loops run while the window is in
-  // the background — or for a tab that isn't the visible one — wakes the CPU/GPU twice a
-  // second forever for no visible benefit (a major battery drain). Gate them so an idle
+  // Window focus + tab visibility gate every blink animation. Each toggle repaints a Canvas -
+  // the whole text canvas for the two SGR clocks, the small cursor overlay for the caret. Letting
+  // those loops run while the window is in the background, or for a tab that isn't the visible
+  // one, wakes the CPU/GPU twice a second forever for no visible benefit (a major battery
+  // drain). Gate them so an idle
   // or backgrounded terminal produces zero periodic repaints, matching iTerm2/Terminal.app
   // (the cursor stops blinking when the app isn't frontmost). When a loop is parked we
   // freeze its flag to "visible" so the cursor shows solid and blink-attributed text stays
@@ -795,41 +805,31 @@ fun ProperTerminal(
   // to "visible") instead of repainting the whole text canvas once a second for
   // no visible change.
   LaunchedEffect(blinkActive, hasSlowBlinkText, settings.enableTextBlinking, settings.slowTextBlinkMs) {
-    if (!blinkActive || !hasSlowBlinkText || !settings.enableTextBlinking || settings.slowTextBlinkMs <= 0) {
+    if (!blinkActive || !hasSlowBlinkText || !settings.enableTextBlinking) {
       slowBlinkVisible = true
       return@LaunchedEffect
     }
-    while (isActive) {
-      delay(settings.slowTextBlinkMs.toLong())
-      slowBlinkVisible = !slowBlinkVisible
-    }
+    runBlinkPhase(settings.slowTextBlinkMs) { slowBlinkVisible = it }
   }
 
   // RAPID_BLINK animation timer (configurable via settings.rapidTextBlinkMs).
   LaunchedEffect(blinkActive, hasRapidBlinkText, settings.enableTextBlinking, settings.rapidTextBlinkMs) {
-    if (!blinkActive || !hasRapidBlinkText || !settings.enableTextBlinking || settings.rapidTextBlinkMs <= 0) {
+    if (!blinkActive || !hasRapidBlinkText || !settings.enableTextBlinking) {
       rapidBlinkVisible = true
       return@LaunchedEffect
     }
-    while (isActive) {
-      delay(settings.rapidTextBlinkMs.toLong())
-      rapidBlinkVisible = !rapidBlinkVisible
-    }
+    runBlinkPhase(settings.rapidTextBlinkMs) { rapidBlinkVisible = it }
   }
 
   // Cursor blink animation timer (configurable via settings.caretBlinkMs).
   // caretBlinkMs <= 0 means "solid cursor, never blink" (the settings slider exposes 0 as
-  // "Off"); the old code turned that into delay(0) in a tight loop, which pegged a CPU
-  // core instead of disabling the blink. The guard now makes "Off" actually off.
+  // "Off"); runBlinkPhase shows the caret and returns rather than spinning on delay(0).
   LaunchedEffect(blinkActive, settings.caretBlinkMs) {
-    if (!blinkActive || settings.caretBlinkMs <= 0) {
-      cursorBlinkVisible = true
+    if (!blinkActive) {
+      cursorOverlay.blinkVisible = true
       return@LaunchedEffect
     }
-    while (isActive) {
-      delay(settings.caretBlinkMs.toLong())
-      cursorBlinkVisible = !cursorBlinkVisible
-    }
+    runBlinkPhase(settings.caretBlinkMs) { cursorOverlay.blinkVisible = it }
   }
 
   // PTY initialization and process monitoring are now handled by TabController
@@ -1538,15 +1538,32 @@ fun ProperTerminal(
             return@onPointerEvent
           }
 
-          // Check for hyperlink hover
+          // Check for hyperlink hover. Detection is resolved for THIS row only, on demand:
+          // the old per-frame sweep of every visible row ran inside the draw phase for a
+          // result only this handler ever read.
           val col = (pos.x / cellWidth).toInt()
-          val row = (pos.y / cellHeight).toInt() + scrollOffset
-          val absoluteRow = row - scrollOffset
+          val screenRow = (pos.y / cellHeight).toInt()
+          val bufferRow = screenRow - scrollOffset
 
-          // Get hyperlinks for this row (supports multi-row hyperlinks)
-          val hyperlinksForRow = cachedHyperlinks[absoluteRow]
+          val snapshot = hoverSnapshot[0]
+          val hyperlinksForRow = snapshot?.let { snap ->
+            val line = snap.getLine(bufferRow)
+            // A wrapped run's answer depends on its neighbours, so it never comes from the memo.
+            val wrapped = line.isWrapped ||
+              (bufferRow - 1 >= -snap.historyLinesCount && snap.getLine(bufferRow - 1).isWrapped)
+            hyperlinkCache.linksAt(bufferRow, line, bypass = wrapped) {
+              TerminalCanvasRenderer.detectHyperlinksForBufferRow(
+                snapshot = snap,
+                bufferRow = bufferRow,
+                terminalWidth = snap.width,
+                workingDirectory = tab.workingDirectory.value,
+                detectFilePaths = settings.detectFilePaths,
+                registry = hyperlinkRegistry,
+              )
+            }
+          }
           hoveredHyperlink = hyperlinksForRow?.firstOrNull { link ->
-            link.containsPosition(col, absoluteRow)
+            link.containsPosition(col, bufferRow)
           }
 
           // Notify hover consumers when hyperlink hover state changes
@@ -1558,13 +1575,13 @@ fun ProperTerminal(
             // Enter callback for new hyperlink with bounds - notify all consumers
             if (hoveredHyperlink != null) {
               val link = hoveredHyperlink!!
-              // For multi-row hyperlinks, provide bounds for the current row's span
-              val span = link.rowSpans[absoluteRow] ?: Pair(link.startCol, link.endCol)
+              // Spans are keyed by buffer row; the bounds are on-screen pixels.
+              val span = link.rowSpans[bufferRow] ?: Pair(link.startCol, link.endCol)
               val bounds = Rect(
                 left = span.first * cellWidth,
-                top = (absoluteRow) * cellHeight,
+                top = screenRow * cellHeight,
                 right = span.second * cellWidth,
-                bottom = (absoluteRow + 1) * cellHeight
+                bottom = (screenRow + 1) * cellHeight
               )
               tab.hoverConsumers.forEach { it.onMouseEntered(bounds, link.url) }
             }
@@ -1951,15 +1968,37 @@ fun ProperTerminal(
         }
         val capturedFrame = remember(currentTrigger, textBuffer.width, textBuffer.height) {
           display.captureStableRenderFrame {
-            StableTerminalRenderFrame(
-              buffer = textBuffer.createIncrementalSnapshot(),
-              historyDelta = historyAppendBank.peek(),
-              imagesById = imageDataCache.snapshotImages(),
-              cursorX = display.cursorXSnapshot,
-              cursorY = display.cursorYSnapshot,
-              cursorVisible = display.cursorVisibleSnapshot,
-              cursorShape = display.cursorShapeSnapshot,
-            )
+            // Outside the hold: ImageDataCache has its own monitor and nothing needs the image
+            // set to agree with the cursor. Keeps the rule below - one lock at a time on the UI
+            // thread - true without needing an argument about the cache's own ordering.
+            val images = imageDataCache.snapshotImages()
+            // ONE hold of the terminal buffer lock, so the snapshot, the appends banked against
+            // it and the cursor that belongs to it all describe the same instant.
+            // createIncrementalSnapshot() releases the lock before returning, so reading the
+            // cursor after it paired text from T0 with a caret from T1 - and the emulator moves
+            // the caret many times per rendered frame.
+            //
+            // LOCK ORDER: the UI thread takes ONLY myLock here, and touches no Compose state and
+            // no other monitor under it. captureStableRenderFrame takes syncUpdateLock before
+            // this lambda and again after it returns, never during, so the emulator's
+            // myLock -> syncUpdateLock order (setCursor fires requestRedraw inside the buffer
+            // lock) is never inverted - the hazard documented on captureStableRenderFrame and on
+            // HistoryAppendBank. myLock is reentrant, so the nested acquisition inside
+            // createIncrementalSnapshot is free, and this replaces TWO acquisitions per
+            // composition with one: the type-ahead column used to take it again, live, outside
+            // the capture entirely.
+            textBuffer.lock()
+            try {
+              StableTerminalRenderFrame(
+                buffer = textBuffer.createIncrementalSnapshot(),
+                historyDelta = historyAppendBank.peek(),
+                imagesById = images,
+                cursor = display.cursorSnapshot,
+                typeAheadCursorX = tab.typeAheadManager?.predictedCursorX,
+              )
+            } finally {
+              textBuffer.unlock()
+            }
           }
         }
         val renderFrame = stableFrameHolder.frameFor(capturedFrame)
@@ -1998,6 +2037,12 @@ fun ProperTerminal(
           // Only frames from a composition that reached apply become future fallbacks.
           capturedFrame?.let(stableFrameHolder::commit)
         }
+        SideEffect {
+          // Hand the pointer handler the snapshot that was actually drawn. A plain array cell
+          // rather than Compose state: the hover path is the only reader, and making it state
+          // would put a write in the apply phase that recomposes the whole composable.
+          hoverSnapshot[0] = renderFrame?.buffer
+        }
         // A first mount during ?2026 has no trusted fallback frame yet. Leave only
         // terminal-dependent layers empty until the synchronized update publishes
         // its redraw; sibling overlays such as search remain composed.
@@ -2005,12 +2050,13 @@ fun ProperTerminal(
           val bufferSnapshot = renderFrame.buffer
           // Cursor and content must come from the same committed ?2026 frame. Kitty
           // image updates temporarily move the real cursor to the placement anchor.
-          val cursorX = renderFrame.cursorX
-          val cursorY = renderFrame.cursorY
-          val cursorVisible = renderFrame.cursorVisible
-          val cursorShape = renderFrame.cursorShape
-          // Type-ahead manager can override cursor X for local echo prediction
-          val effectiveCursorX = tab.typeAheadManager?.let { it.cursorX - 1 } ?: cursorX
+          val cursorX = renderFrame.cursor.x
+          val cursorY = renderFrame.cursor.y
+          val cursorVisible = renderFrame.cursor.visible
+          val cursorShape = renderFrame.cursor.shape
+          // Type-ahead overrides the column while local echo is predicting - taken from the
+          // frame, so it describes the same instant as the row beside it.
+          val effectiveCursorX = renderFrame.typeAheadCursorX?.minus(1) ?: cursorX
 
           Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
             // Guard against invalid canvas sizes during resize - prevents drawText constraint failures
@@ -2031,18 +2077,6 @@ fun ProperTerminal(
             val baseCursorColor = if (customCursorColor != null) {
               Color(customCursorColor.red, customCursorColor.green, customCursorColor.blue)
             } else activeTheme.cursorColor
-
-            // Version-based hyperlink caching: compute hash including scroll position
-            // since visible content changes with scroll even if buffer content is same
-            val currentVersionHash = bufferSnapshot.computeVersionHash() * 31 + effectiveScrollOffset
-
-            // Reuse cached hyperlinks if buffer content and scroll position unchanged
-            val precomputedHyperlinks = if (currentVersionHash == lastHyperlinkVersionHash &&
-                                            cachedHyperlinks.isNotEmpty()) {
-              cachedHyperlinks
-            } else {
-              null // Force fresh detection
-            }
 
             // Resolve content-anchored selection to current coordinates
             // This allows selection to follow content as terminal scrolls
@@ -2109,10 +2143,9 @@ fun ProperTerminal(
               cursorX = effectiveCursorX,
               cursorY = cursorY,
               cursorVisible = cursorVisible,
-              // The text pass no longer draws the cursor (it lives in its own overlay Canvas
-              // below), so pass a constant here. Reading the real cursorBlinkVisible state in
-              // this draw lambda would re-subscribe the whole text canvas to the blink and
-              // defeat the optimization.
+              // The text pass no longer draws the cursor (it lives in CursorOverlay below), so
+              // pass a constant here. Reading the caret's blink state in this draw lambda would
+              // re-subscribe the whole text canvas to it and defeat the optimization.
               cursorBlinkVisible = true,
               cursorShape = cursorShape,
               cursorColor = baseCursorColor,
@@ -2124,19 +2157,15 @@ fun ProperTerminal(
               imageDataById = renderFrame.imagesById,
               terminalWidthCells = bufferSnapshot.width,
               terminalHeightCells = bufferSnapshot.height,
-              precomputedHyperlinks = precomputedHyperlinks,
               workingDirectory = tab.workingDirectory.value,
               detectFilePaths = settings.detectFilePaths,
               hyperlinkRegistry = hyperlinkRegistry,
               commandBlocks = resolvedCommandBlocks
             )
 
-            // Render terminal using extracted renderer - returns detected hyperlinks
+            // Render terminal using extracted renderer
             with(TerminalCanvasRenderer) {
-              val detectedHyperlinks = renderTerminal(renderingContext)
-              // Update cache for next frame
-              cachedHyperlinks = detectedHyperlinks
-              lastHyperlinkVersionHash = currentVersionHash
+              renderTerminal(renderingContext)
             }
 
             // Reflect the renderer's blink-presence findings into composition state. Only
@@ -2147,87 +2176,73 @@ fun ProperTerminal(
             if (hasRapidBlinkText != blinkProbe[1]) hasRapidBlinkText = blinkProbe[1]
           }
 
-          // Cursor overlay — drawn in its own Canvas, stacked on top of the text canvas above
-          // (same modifier, so coordinates line up exactly). This is the ONLY place that reads
-          // cursorBlinkVisible, so the ~0.5s blink invalidates just this tiny layer instead of
-          // re-running the full text render. Cursor position is read from the same
-          // composition-scoped snapshots the text canvas uses, so it stays in sync as content
-          // and scroll change. If the cursor intersects an inline image, that cell's alpha masks
-          // the cursor so animated sprite pixels remain above it, matching browser compositing.
-          Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
-            if (size.width < cellWidth || size.height < cellHeight) return@Canvas
+          // Cursor overlay - its own Canvas stacked on the text canvas above, hoisted into a
+          // skippable composable so a recomposition of THIS composable (one per wheel event,
+          // one per frame of streamed output) no longer rebuilds its draw lambda and re-runs
+          // the glyph and image resolution with it. See CursorOverlayState.
+          //
+          // Published from a SideEffect - the apply phase, after composition and before
+          // layout/draw - so the overlay paints this frame's values in this frame. It sits
+          // after the fold's SideEffect on purpose, so `effectiveScrollOffset` is the value the
+          // text canvas actually drew with.
+          SideEffect {
             val customCursorColor = terminal.cursorColor
             val baseCursorColor = if (customCursorColor != null) {
               Color(customCursorColor.red, customCursorColor.green, customCursorColor.blue)
             } else activeTheme.cursorColor
-            with(TerminalCanvasRenderer) {
-              val bufferCursorRow = (cursorY - 1).coerceAtLeast(0)
-              val cursorScreenRow = bufferCursorRow + effectiveScrollOffset
-              val cursorImageCell = bufferSnapshot.getLine(bufferCursorRow).getImageCellAt(effectiveCursorX)
-              val cursorImageSlice = cursorImageCell?.let { imageCell ->
-                renderFrame.imagesById[imageCell.imageId]?.let { image ->
-                  ImageRenderer.getOrDecodeImage(image)
-                }?.let { bitmap ->
-                  imageCellSlice(
-                    imageCell = imageCell,
-                    bitmap = bitmap,
-                    visualColumn = effectiveCursorX,
-                    screenRow = cursorScreenRow,
-                    visibleColumns = (size.width / cellWidth).toInt().coerceAtMost(bufferSnapshot.width),
-                    cellWidth = cellWidth,
-                    cellHeight = cellHeight,
-                  )
-                }
-              }
-              renderCursorOverlay(
-                cursorVisible = cursorVisible,
-                cursorBlinkVisible = cursorBlinkVisible,
-                cursorShape = cursorShape,
-                cursorX = effectiveCursorX,
-                cursorY = cursorY,
-                scrollOffset = effectiveScrollOffset,
-                cellWidth = cellWidth,
-                cellHeight = cellHeight,
-                isFocused = isFocused,
-                cursorColor = baseCursorColor,
-                focusedAlpha = settings.cursorFocusedAlpha,
-                unfocusedAlpha = settings.cursorUnfocusedAlpha,
-                imageOcclusion = cursorImageSlice,
-                // Resolved HERE, not in the overlay: deciding whether a cell may be
-                // repainted needs the cell's style, which the overlay cannot see.
-                // Returns null for every case the text pass itself declines to
-                // draw, so the block simply stays solid rather than painting
-                // something the rest of the screen is not showing.
-                // Only the block shapes repaint, so skip the analysis entirely for
-                // the others: this overlay exists to be the cheap layer that the
-                // blink repaints twice a second.
-                cursorGlyph = if (cursorShape.isBlock()) resolveCursorGlyph(
-                    line = bufferSnapshot.getLine(bufferCursorRow),
-                    visualColumn = effectiveCursorX,
-                    terminalWidth = bufferSnapshot.width,
-                    // display.ambiguousCharsAreDoubleWidth(), NOT the setting: the
-                    // text canvas feeds the classifier from the display, and the
-                    // whole premise here is mirroring what the text pass decided.
-                    // Both read false today, so a divergence would be silent - and
-                    // safe in the wrong way, since it only ever makes this decline.
-                    ambiguousCharsAreDoubleWidth = display.ambiguousCharsAreDoubleWidth(),
-                    // The SGR text-blink clocks, NOT cursorBlinkVisible: that one is
-                    // the caret timer and gating text blink on it is wrong in both
-                    // directions (see resolveCursorGlyph).
-                    slowBlinkVisible = slowBlinkVisible,
-                    rapidBlinkVisible = rapidBlinkVisible,
-                ) else null,
-                cursorTextColor = cursorGlyphColor(
-                    theme = activeTheme,
-                    effectiveFill = baseCursorColor,
-                    fillIsAppSet = customCursorColor != null,
-                ),
-                glyphFontFamily = sharedFont,
-                glyphFontSize = effectiveFontSize,
-                glyphMeasurer = textMeasurer,
-              )
-            }
+            val bufferCursorRow = (cursorY - 1).coerceAtLeast(0)
+            val cursorLine = bufferSnapshot.getLine(bufferCursorRow)
+            val cursorImageCell = cursorLine.getImageCellAt(effectiveCursorX)
+            cursorOverlay.frame = CursorFrame(
+              visible = cursorVisible,
+              shape = cursorShape,
+              x = effectiveCursorX,
+              y = cursorY,
+              scrollOffset = effectiveScrollOffset,
+              cellWidth = cellWidth,
+              cellHeight = cellHeight,
+              bufferWidth = bufferSnapshot.width,
+              isFocused = isFocused,
+              color = baseCursorColor,
+              focusedAlpha = settings.cursorFocusedAlpha,
+              unfocusedAlpha = settings.cursorUnfocusedAlpha,
+              // Resolved HERE, not in the overlay: deciding whether a cell may be
+              // repainted needs the cell's style, which the overlay cannot see.
+              // Returns null for every case the text pass itself declines to
+              // draw, so the block simply stays solid rather than painting
+              // something the rest of the screen is not showing.
+              // Only the block shapes repaint, so skip the analysis entirely for
+              // the others: this overlay exists to be the cheap layer that the
+              // blink repaints twice a second.
+              glyph = if (cursorShape.isBlock()) resolveCursorGlyph(
+                  line = cursorLine,
+                  visualColumn = effectiveCursorX,
+                  terminalWidth = bufferSnapshot.width,
+                  // display.ambiguousCharsAreDoubleWidth(), NOT the setting: the
+                  // text canvas feeds the classifier from the display, and the
+                  // whole premise here is mirroring what the text pass decided.
+                  // Both read false today, so a divergence would be silent - and
+                  // safe in the wrong way, since it only ever makes this decline.
+                  ambiguousCharsAreDoubleWidth = display.ambiguousCharsAreDoubleWidth(),
+                  // The SGR text-blink clocks, NOT the caret timer: gating text blink on the
+                  // caret's clock is wrong in both directions (see resolveCursorGlyph).
+                  slowBlinkVisible = slowBlinkVisible,
+                  rapidBlinkVisible = rapidBlinkVisible,
+              ) else null,
+              glyphColor = cursorGlyphColor(
+                  theme = activeTheme,
+                  effectiveFill = baseCursorColor,
+                  fillIsAppSet = customCursorColor != null,
+              ),
+              glyphFontFamily = sharedFont,
+              glyphFontSize = effectiveFontSize,
+              glyphMeasurer = textMeasurer,
+              imageCell = cursorImageCell,
+              imageBitmap = cursorImageCell?.let { renderFrame.imagesById[it.imageId] }
+                ?.let { ImageRenderer.getOrDecodeImage(it) },
+            )
           }
+          CursorOverlay(cursorOverlay)
 
           // IME (Input Method Editor) handler for CJK input
           // Provides invisible TextField for IME composition (Pinyin, Hiragana, etc.)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -55,6 +55,7 @@ import ai.rever.bossterm.terminal.model.TerminalTextBuffer
 import ai.rever.bossterm.terminal.model.image.TerminalImage
 import ai.rever.bossterm.terminal.model.pool.VersionedBufferSnapshot
 import ai.rever.bossterm.compose.rendering.CursorGlyph
+import ai.rever.bossterm.compose.rendering.GlyphBlink
 import ai.rever.bossterm.compose.rendering.analyzeCharacter
 import ai.rever.bossterm.terminal.util.CharUtils
 import kotlinx.coroutines.Job
@@ -150,6 +151,17 @@ private data class StableTerminalRenderFrame(
    */
   val typeAheadCursorX: Int?,
 )
+
+/**
+ * A plain mutable box, UI-thread-confined.
+ *
+ * Deliberately not Compose state: this hands the pointer handler the snapshot the last frame
+ * drew, and making it state would put a write in the apply phase that recomposes the whole
+ * composable once per frame.
+ */
+internal class UiRef<T> {
+  var value: T? = null
+}
 
 /** UI-thread-confined retention committed only after an accepted composition applies. */
 internal class StableRenderFrameHolder<T : Any> {
@@ -430,7 +442,7 @@ fun ProperTerminal(
   // written inside the draw lambda, which invalidated the draw node and cost a second full text
   // render per frame.
   val hyperlinkCache = remember(textBuffer) { HyperlinkRowCache() }
-  val hoverSnapshot = remember(textBuffer) { arrayOfNulls<VersionedBufferSnapshot>(1) }
+  val hoverSnapshot = remember(textBuffer) { UiRef<VersionedBufferSnapshot>() }
   // Track previous hover state for consumer callbacks
   var previousHoveredHyperlink by remember { mutableStateOf<Hyperlink?>(null) }
 
@@ -449,8 +461,6 @@ fun ProperTerminal(
   // Type-ahead cursor override is handled separately in the Canvas
 
   // Blink state for SLOW_BLINK and RAPID_BLINK text attributes
-  var slowBlinkVisible by remember { mutableStateOf(true) }
-  var rapidBlinkVisible by remember { mutableStateOf(true) }
 
   // Whether blink-attributed text is actually present in the visible region. The
   // renderer writes this back each frame via `blinkProbe` (no extra scan), and the
@@ -724,7 +734,7 @@ fun ProperTerminal(
 
   // Cursor blink state for BLINK_* cursor shapes, plus the frame the overlay draws. Both live
   // on one identity-stable holder so the overlay's draw lambda has a single stable capture.
-  val cursorOverlay = remember(tab.id) { CursorOverlayState() }
+  val paintState = remember(tab.id) { TerminalPaintState() }
 
   // Use shared font loaded once by Main.kt (performance optimization for multiple tabs)
   // Font loading is expensive and should only happen once, not per tab
@@ -806,19 +816,19 @@ fun ProperTerminal(
   // no visible change.
   LaunchedEffect(blinkActive, hasSlowBlinkText, settings.enableTextBlinking, settings.slowTextBlinkMs) {
     if (!blinkActive || !hasSlowBlinkText || !settings.enableTextBlinking) {
-      slowBlinkVisible = true
+      paintState.slowBlinkVisible = true
       return@LaunchedEffect
     }
-    runBlinkPhase(settings.slowTextBlinkMs) { slowBlinkVisible = it }
+    runBlinkPhase(settings.slowTextBlinkMs) { paintState.slowBlinkVisible = it }
   }
 
   // RAPID_BLINK animation timer (configurable via settings.rapidTextBlinkMs).
   LaunchedEffect(blinkActive, hasRapidBlinkText, settings.enableTextBlinking, settings.rapidTextBlinkMs) {
     if (!blinkActive || !hasRapidBlinkText || !settings.enableTextBlinking) {
-      rapidBlinkVisible = true
+      paintState.rapidBlinkVisible = true
       return@LaunchedEffect
     }
-    runBlinkPhase(settings.rapidTextBlinkMs) { rapidBlinkVisible = it }
+    runBlinkPhase(settings.rapidTextBlinkMs) { paintState.rapidBlinkVisible = it }
   }
 
   // Cursor blink animation timer (configurable via settings.caretBlinkMs).
@@ -826,10 +836,10 @@ fun ProperTerminal(
   // "Off"); runBlinkPhase shows the caret and returns rather than spinning on delay(0).
   LaunchedEffect(blinkActive, settings.caretBlinkMs) {
     if (!blinkActive) {
-      cursorOverlay.blinkVisible = true
+      paintState.caretVisible = true
       return@LaunchedEffect
     }
-    runBlinkPhase(settings.caretBlinkMs) { cursorOverlay.blinkVisible = it }
+    runBlinkPhase(settings.caretBlinkMs) { paintState.caretVisible = it }
   }
 
   // PTY initialization and process monitoring are now handled by TabController
@@ -1545,18 +1555,26 @@ fun ProperTerminal(
           val screenRow = (pos.y / cellHeight).toInt()
           val bufferRow = screenRow - scrollOffset
 
-          val snapshot = hoverSnapshot[0]
-          val hyperlinksForRow = snapshot?.let { snap ->
-            val line = snap.getLine(bufferRow)
-            // A wrapped run's answer depends on its neighbours, so it never comes from the memo.
-            val wrapped = line.isWrapped ||
-              (bufferRow - 1 >= -snap.historyLinesCount && snap.getLine(bufferRow - 1).isWrapped)
-            hyperlinkCache.linksAt(bufferRow, line, bypass = wrapped) {
-              TerminalCanvasRenderer.detectHyperlinksForBufferRow(
+          val snapshot = hoverSnapshot.value
+          // Out of range would hand the memo a fresh createEmpty() line every event, so it
+          // would never hit and would fill with junk keys. Nothing is there to hover anyway.
+          val inRange = snapshot != null &&
+            bufferRow >= -snapshot.historyLinesCount && bufferRow < snapshot.height
+          val hyperlinksForRow = if (!inRange) null else snapshot!!.let { snap ->
+            val cwd = tab.workingDirectory.value
+            hyperlinkCache.linksAt(
+              bufferRow = bufferRow,
+              // A wrapped row's answer depends on its whole logical run, so the key is every
+              // line in it - an edit to a sibling row has to miss.
+              runLines = HyperlinkDetector.runLinesAt(snap, bufferRow),
+              cwd = cwd,
+              detectFilePaths = settings.detectFilePaths,
+            ) {
+              HyperlinkDetector.detectForBufferRow(
                 snapshot = snap,
                 bufferRow = bufferRow,
                 terminalWidth = snap.width,
-                workingDirectory = tab.workingDirectory.value,
+                workingDirectory = cwd,
                 detectFilePaths = settings.detectFilePaths,
                 registry = hyperlinkRegistry,
               )
@@ -1978,23 +1996,28 @@ fun ProperTerminal(
             // cursor after it paired text from T0 with a caret from T1 - and the emulator moves
             // the caret many times per rendered frame.
             //
-            // LOCK ORDER: the UI thread takes ONLY myLock here, and touches no Compose state and
-            // no other monitor under it. captureStableRenderFrame takes syncUpdateLock before
-            // this lambda and again after it returns, never during, so the emulator's
-            // myLock -> syncUpdateLock order (setCursor fires requestRedraw inside the buffer
-            // lock) is never inverted - the hazard documented on captureStableRenderFrame and on
-            // HistoryAppendBank. myLock is reentrant, so the nested acquisition inside
-            // createIncrementalSnapshot is free, and this replaces TWO acquisitions per
-            // composition with one: the type-ahead column used to take it again, live, outside
-            // the capture entirely.
+            // LOCK ORDER: the UI thread takes myLock here and, under it, only ever takes
+            // syncUpdateLock - the same myLock -> syncUpdateLock order the emulator uses
+            // (setCursor fires requestRedraw inside the buffer lock), so it is never inverted.
+            // That inner acquisition is reachable: on the alternate screen with live
+            // predictions, predictedCursorX resets state, which fires a model change and so a
+            // redraw request. No Compose state is touched under the lock, which is the hazard
+            // documented on captureStableRenderFrame and on HistoryAppendBank.
+            // captureStableRenderFrame itself takes syncUpdateLock before this lambda and again
+            // after it returns, never during. myLock is reentrant, so the nested acquisitions
+            // below are free, and this replaces TWO acquisitions per composition with one: the
+            // type-ahead column used to take it again, live, outside the capture entirely.
             textBuffer.lock()
             try {
+              // Type-ahead FIRST: its reset path clears predictions off the lines, and doing
+              // that after the snapshot would mutate lines the snapshot is already sharing.
+              val typeAheadX = tab.typeAheadManager?.predictedCursorX
               StableTerminalRenderFrame(
                 buffer = textBuffer.createIncrementalSnapshot(),
                 historyDelta = historyAppendBank.peek(),
                 imagesById = images,
                 cursor = display.cursorSnapshot,
-                typeAheadCursorX = tab.typeAheadManager?.predictedCursorX,
+                typeAheadCursorX = typeAheadX,
               )
             } finally {
               textBuffer.unlock()
@@ -2041,7 +2064,7 @@ fun ProperTerminal(
           // Hand the pointer handler the snapshot that was actually drawn. A plain array cell
           // rather than Compose state: the hover path is the only reader, and making it state
           // would put a write in the apply phase that recomposes the whole composable.
-          hoverSnapshot[0] = renderFrame?.buffer
+          hoverSnapshot.value = renderFrame?.buffer
         }
         // A first mount during ?2026 has no trusted fallback frame yet. Leave only
         // terminal-dependent layers empty until the synchronized update publishes
@@ -2152,14 +2175,11 @@ fun ProperTerminal(
               isFocused = isFocused,
               hoveredHyperlink = hoveredHyperlink,
               isModifierPressed = isModifierPressed,
-              slowBlinkVisible = slowBlinkVisible,
-              rapidBlinkVisible = rapidBlinkVisible,
+              slowBlinkVisible = paintState.slowBlinkVisible,
+              rapidBlinkVisible = paintState.rapidBlinkVisible,
               imageDataById = renderFrame.imagesById,
               terminalWidthCells = bufferSnapshot.width,
               terminalHeightCells = bufferSnapshot.height,
-              workingDirectory = tab.workingDirectory.value,
-              detectFilePaths = settings.detectFilePaths,
-              hyperlinkRegistry = hyperlinkRegistry,
               commandBlocks = resolvedCommandBlocks
             )
 
@@ -2179,7 +2199,7 @@ fun ProperTerminal(
           // Cursor overlay - its own Canvas stacked on the text canvas above, hoisted into a
           // skippable composable so a recomposition of THIS composable (one per wheel event,
           // one per frame of streamed output) no longer rebuilds its draw lambda and re-runs
-          // the glyph and image resolution with it. See CursorOverlayState.
+          // the glyph and image resolution with it. See TerminalPaintState.
           //
           // Published from a SideEffect - the apply phase, after composition and before
           // layout/draw - so the overlay paints this frame's values in this frame. It sits
@@ -2193,7 +2213,7 @@ fun ProperTerminal(
             val bufferCursorRow = (cursorY - 1).coerceAtLeast(0)
             val cursorLine = bufferSnapshot.getLine(bufferCursorRow)
             val cursorImageCell = cursorLine.getImageCellAt(effectiveCursorX)
-            cursorOverlay.frame = CursorFrame(
+            paintState.cursorFrame = CursorFrame(
               visible = cursorVisible,
               shape = cursorShape,
               x = effectiveCursorX,
@@ -2224,10 +2244,6 @@ fun ProperTerminal(
                   // Both read false today, so a divergence would be silent - and
                   // safe in the wrong way, since it only ever makes this decline.
                   ambiguousCharsAreDoubleWidth = display.ambiguousCharsAreDoubleWidth(),
-                  // The SGR text-blink clocks, NOT the caret timer: gating text blink on the
-                  // caret's clock is wrong in both directions (see resolveCursorGlyph).
-                  slowBlinkVisible = slowBlinkVisible,
-                  rapidBlinkVisible = rapidBlinkVisible,
               ) else null,
               glyphColor = cursorGlyphColor(
                   theme = activeTheme,
@@ -2242,7 +2258,7 @@ fun ProperTerminal(
                 ?.let { ImageRenderer.getOrDecodeImage(it) },
             )
           }
-          CursorOverlay(cursorOverlay)
+          CursorOverlay(paintState)
 
           // IME (Input Method Editor) handler for CJK input
           // Provides invisible TextField for IME composition (Pinyin, Hiragana, etc.)
@@ -2655,8 +2671,6 @@ internal fun resolveCursorGlyph(
     visualColumn: Int,
     terminalWidth: Int,
     ambiguousCharsAreDoubleWidth: Boolean,
-    slowBlinkVisible: Boolean,
-    rapidBlinkVisible: Boolean,
 ): CursorGlyph? {
     if (visualColumn < 0 || visualColumn >= terminalWidth) return null
 
@@ -2692,14 +2706,20 @@ internal fun resolveCursorGlyph(
 
     val style = line.getStyleAt(column)
     if (style?.hasOption(BossTextStyle.Option.HIDDEN) == true) return null
-    if (style?.hasOption(BossTextStyle.Option.SLOW_BLINK) == true && !slowBlinkVisible) return null
-    if (style?.hasOption(BossTextStyle.Option.RAPID_BLINK) == true && !rapidBlinkVisible) return null
 
     return CursorGlyph(
         text = char.toString(),
         isBold = style?.hasOption(BossTextStyle.Option.BOLD) == true,
         isItalic = style?.hasOption(BossTextStyle.Option.ITALIC) == true,
         isUnderline = style?.hasOption(BossTextStyle.Option.UNDERLINED) == true,
+        // Recorded, not applied: this runs in the apply phase, where a clock read subscribes
+        // nothing. The overlay gates on it in its draw lambda instead, so a text-blink toggle
+        // repaints the caret's glyph in step with the text pass.
+        blink = when {
+            style?.hasOption(BossTextStyle.Option.SLOW_BLINK) == true -> GlyphBlink.SLOW
+            style?.hasOption(BossTextStyle.Option.RAPID_BLINK) == true -> GlyphBlink.RAPID
+            else -> GlyphBlink.NONE
+        },
     )
 }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -167,6 +167,9 @@ internal class UiRef<T> {
 internal class HoverRow(
   val snapshot: VersionedBufferSnapshot,
   val bufferRow: Int,
+  val cwd: String?,
+  val detectFilePaths: Boolean,
+  val registryRevision: Int,
   val links: List<Hyperlink>,
 )
 
@@ -1578,8 +1581,21 @@ fun ProperTerminal(
           val inRange = snapshot != null &&
             bufferRow >= -snapshot.historyLinesCount && bufferRow < snapshot.height
           val hyperlinksForRow = if (!inRange) null else snapshot!!.let { snap ->
+            val cwd = tab.workingDirectory.value
+            val detectPaths = settings.detectFilePaths
+            val revision = hyperlinkRegistry.revision
             val previous = lastHover.value
-            if (previous != null && previous.snapshot === snap && previous.bufferRow == bufferRow) {
+            // Every component the memo checks, checked here too: a fresh snapshot arrives with
+            // any output, but on an IDLE terminal a settings toggle or a runtime addPattern
+            // produces none, so a short-circuit keyed on the snapshot alone would serve the
+            // stale answer indefinitely.
+            if (previous != null &&
+              previous.snapshot === snap &&
+              previous.bufferRow == bufferRow &&
+              previous.cwd == cwd &&
+              previous.detectFilePaths == detectPaths &&
+              previous.registryRevision == revision
+            ) {
               // The pointer crosses many pixels per row, so the overwhelming majority of Move
               // events land on the row the last one did. Short-circuit before runLinesAt: its
               // backwards walk is bounded by history depth, not by the viewport, so one mouse
@@ -1588,25 +1604,26 @@ fun ProperTerminal(
               // a memo hit.
               previous.links
             } else {
-              val cwd = tab.workingDirectory.value
               hyperlinkCache.linksAt(
                 bufferRow = bufferRow,
                 // A wrapped row's answer depends on its whole logical run, so the key is every
                 // line in it - an edit to a sibling row has to miss.
                 runLines = HyperlinkDetector.runLinesAt(snap, bufferRow),
                 cwd = cwd,
-                detectFilePaths = settings.detectFilePaths,
-                registryRevision = hyperlinkRegistry.revision,
+                detectFilePaths = detectPaths,
+                registryRevision = revision,
               ) {
                 HyperlinkDetector.detectForBufferRow(
                   snapshot = snap,
                   bufferRow = bufferRow,
                   terminalWidth = snap.width,
                   workingDirectory = cwd,
-                  detectFilePaths = settings.detectFilePaths,
+                  detectFilePaths = detectPaths,
                   registry = hyperlinkRegistry,
                 )
-              }.also { lastHover.value = HoverRow(snap, bufferRow, it) }
+              }.also {
+                lastHover.value = HoverRow(snap, bufferRow, cwd, detectPaths, revision, it)
+              }
             }
           }
           hoveredHyperlink = hyperlinksForRow?.firstOrNull { link ->
@@ -2243,9 +2260,7 @@ fun ProperTerminal(
           // the glyph and image resolution with it. See TerminalPaintState.
           //
           // Published from a SideEffect - the apply phase, after composition and before
-          // layout/draw - so the overlay paints this frame's values in this frame. It sits
-          // after the fold's SideEffect on purpose, so `effectiveScrollOffset` is the value the
-          // text canvas actually drew with.
+          // layout/draw - so the overlay paints this frame's values in this frame.
           SideEffect {
             val bufferCursorRow = (cursorY - 1).coerceAtLeast(0)
             val cursorLine = bufferSnapshot.getLine(bufferCursorRow)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -163,6 +163,13 @@ internal class UiRef<T> {
   var value: T? = null
 }
 
+/** The last hover resolution, so repeat events on the same row cost nothing. */
+internal class HoverRow(
+  val snapshot: VersionedBufferSnapshot,
+  val bufferRow: Int,
+  val links: List<Hyperlink>,
+)
+
 /** UI-thread-confined retention committed only after an accepted composition applies. */
 internal class StableRenderFrameHolder<T : Any> {
   private var frame: T? = null
@@ -443,6 +450,8 @@ fun ProperTerminal(
   // render per frame.
   val hyperlinkCache = remember(textBuffer) { HyperlinkRowCache() }
   val hoverSnapshot = remember(textBuffer) { UiRef<VersionedBufferSnapshot>() }
+  // Last row resolved, so a Move that stays on it skips the run walk entirely.
+  val lastHover = remember(textBuffer) { UiRef<HoverRow>() }
   // Track previous hover state for consumer callbacks
   var previousHoveredHyperlink by remember { mutableStateOf<Hyperlink?>(null) }
 
@@ -460,7 +469,6 @@ fun ProperTerminal(
   // This prevents flickering caused by cursor updates triggering separate recompositions
   // Type-ahead cursor override is handled separately in the Canvas
 
-  // Blink state for SLOW_BLINK and RAPID_BLINK text attributes
 
   // Whether blink-attributed text is actually present in the visible region. The
   // renderer writes this back each frame via `blinkProbe` (no extra scan), and the
@@ -805,11 +813,11 @@ fun ProperTerminal(
   // the whole text canvas for the two SGR clocks, the small cursor overlay for the caret. Letting
   // those loops run while the window is in the background, or for a tab that isn't the visible
   // one, wakes the CPU/GPU twice a second forever for no visible benefit (a major battery
-  // drain). Gate them so an idle
-  // or backgrounded terminal produces zero periodic repaints, matching iTerm2/Terminal.app
-  // (the cursor stops blinking when the app isn't frontmost). When a loop is parked we
-  // freeze its flag to "visible" so the cursor shows solid and blink-attributed text stays
-  // readable; the renderer still draws the unfocused cursor style from `isFocused`.
+  // drain). Gate them so an idle or backgrounded terminal produces zero periodic repaints,
+  // matching iTerm2/Terminal.app (the cursor stops blinking when the app isn't frontmost). When
+  // a loop is parked we freeze its flag to "visible" so the cursor shows solid and
+  // blink-attributed text stays readable; the renderer still draws the unfocused cursor style
+  // from `isFocused`.
   val blinkActive = isActiveTab && LocalWindowInfo.current.isWindowFocused
 
   // SLOW_BLINK animation timer (configurable via settings.slowTextBlinkMs).
@@ -1570,23 +1578,35 @@ fun ProperTerminal(
           val inRange = snapshot != null &&
             bufferRow >= -snapshot.historyLinesCount && bufferRow < snapshot.height
           val hyperlinksForRow = if (!inRange) null else snapshot!!.let { snap ->
-            val cwd = tab.workingDirectory.value
-            hyperlinkCache.linksAt(
-              bufferRow = bufferRow,
-              // A wrapped row's answer depends on its whole logical run, so the key is every
-              // line in it - an edit to a sibling row has to miss.
-              runLines = HyperlinkDetector.runLinesAt(snap, bufferRow),
-              cwd = cwd,
-              detectFilePaths = settings.detectFilePaths,
-            ) {
-              HyperlinkDetector.detectForBufferRow(
-                snapshot = snap,
+            val previous = lastHover.value
+            if (previous != null && previous.snapshot === snap && previous.bufferRow == bufferRow) {
+              // The pointer crosses many pixels per row, so the overwhelming majority of Move
+              // events land on the row the last one did. Short-circuit before runLinesAt: its
+              // backwards walk is bounded by history depth, not by the viewport, so one mouse
+              // move over a long wrapped run (a `cat` of a file with no newlines) would walk
+              // thousands of rows and then compare thousands of references, per event, even on
+              // a memo hit.
+              previous.links
+            } else {
+              val cwd = tab.workingDirectory.value
+              hyperlinkCache.linksAt(
                 bufferRow = bufferRow,
-                terminalWidth = snap.width,
-                workingDirectory = cwd,
+                // A wrapped row's answer depends on its whole logical run, so the key is every
+                // line in it - an edit to a sibling row has to miss.
+                runLines = HyperlinkDetector.runLinesAt(snap, bufferRow),
+                cwd = cwd,
                 detectFilePaths = settings.detectFilePaths,
-                registry = hyperlinkRegistry,
-              )
+                registryRevision = hyperlinkRegistry.revision,
+              ) {
+                HyperlinkDetector.detectForBufferRow(
+                  snapshot = snap,
+                  bufferRow = bufferRow,
+                  terminalWidth = snap.width,
+                  workingDirectory = cwd,
+                  detectFilePaths = settings.detectFilePaths,
+                  registry = hyperlinkRegistry,
+                )
+              }.also { lastHover.value = HoverRow(snap, bufferRow, it) }
             }
           }
           hoveredHyperlink = hyperlinksForRow?.firstOrNull { link ->
@@ -2071,9 +2091,9 @@ fun ProperTerminal(
           capturedFrame?.let(stableFrameHolder::commit)
         }
         SideEffect {
-          // Hand the pointer handler the snapshot that was actually drawn. A plain array cell
-          // rather than Compose state: the hover path is the only reader, and making it state
-          // would put a write in the apply phase that recomposes the whole composable.
+          // Hand the pointer handler the snapshot that was actually drawn. A plain box rather
+          // than Compose state: the hover path is the only reader, and making it state would put
+          // a write in the apply phase that recomposes the whole composable.
           hoverSnapshot.value = renderFrame?.buffer
         }
         // A first mount during ?2026 has no trusted fallback frame yet. Leave only
@@ -2728,6 +2748,12 @@ internal fun resolveCursorGlyph(
         // Recorded, not applied: this runs in the apply phase, where a clock read subscribes
         // nothing. The overlay gates on it in its draw lambda instead, so a text-blink toggle
         // repaints the caret's glyph in step with the text pass.
+        //
+        // A cell carrying BOTH SGR 5 and SGR 6 follows the slow clock here, where the old
+        // gate-at-resolve-time hid the glyph if either clock was off. The combination is
+        // ill-defined in the spec and the text pass itself picks one, so following one clock
+        // matches what the cell underneath is doing; the deliberate part is that it is a
+        // choice, not an oversight.
         blink = when {
             style?.hasOption(BossTextStyle.Option.SLOW_BLINK) == true -> GlyphBlink.SLOW
             style?.hasOption(BossTextStyle.Option.RAPID_BLINK) == true -> GlyphBlink.RAPID

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -517,6 +517,9 @@ fun ProperTerminal(
     } finally {
       buffer.unlock()
     }
+    // Every negative buffer row the memo holds just stopped existing, and the entries pin the
+    // lines that were dropped.
+    hyperlinkCache.clear()
     display.requestImmediateRedraw()
   }
 
@@ -734,7 +737,9 @@ fun ProperTerminal(
 
   // Cursor blink state for BLINK_* cursor shapes, plus the frame the overlay draws. Both live
   // on one identity-stable holder so the overlay's draw lambda has a single stable capture.
-  val paintState = remember(tab.id) { TerminalPaintState() }
+  // Unkeyed on purpose: the three blink LaunchedEffects capture this holder but are not keyed
+  // on it, so a key here could leave them writing an orphaned instance while the caret froze.
+  val paintState = remember { TerminalPaintState() }
 
   // Use shared font loaded once by Main.kt (performance optimization for multiple tabs)
   // Font loading is expensive and should only happen once, not per tab
@@ -1066,6 +1071,10 @@ fun ProperTerminal(
               // Reset scroll to bottom on resize - history size may have changed, making old offset invalid
               // This ensures the user sees the current screen content after resize
               scrollOffset = 0
+              // A reflow rewrites every line, so every memoized row is stale. Dropping them also
+              // releases the TerminalLines the memo pins, which would otherwise outlive their
+              // eviction from history.
+              hyperlinkCache.clear()
               // Also notify the process handle if available (must be launched in coroutine)
               scope.launch {
                 processHandle?.resize(newCols, newRows)
@@ -1997,12 +2006,13 @@ fun ProperTerminal(
             // the caret many times per rendered frame.
             //
             // LOCK ORDER: the UI thread takes myLock here and, under it, only ever takes
-            // syncUpdateLock - the same myLock -> syncUpdateLock order the emulator uses
-            // (setCursor fires requestRedraw inside the buffer lock), so it is never inverted.
-            // That inner acquisition is reachable: on the alternate screen with live
-            // predictions, predictedCursorX resets state, which fires a model change and so a
-            // redraw request. No Compose state is touched under the lock, which is the hazard
-            // documented on captureStableRenderFrame and on HistoryAppendBank.
+            // monitors the emulator also takes in that order, so it is never inverted. The
+            // emulator runs myLock -> syncUpdateLock (setCursor fires requestRedraw inside the
+            // buffer lock) and myLock -> the debouncer monitor; predictedCursorX's alt-screen
+            // reset reaches the latter through terminateCall, and the debouncer runs its
+            // callback outside its own monitor, so neither nests the other way. No Compose
+            // state is touched under the lock, which is the hazard documented on
+            // captureStableRenderFrame and on HistoryAppendBank.
             // captureStableRenderFrame itself takes syncUpdateLock before this lambda and again
             // after it returns, never during. myLock is reentrant, so the nested acquisitions
             // below are free, and this replaces TWO acquisitions per composition with one: the
@@ -2081,6 +2091,25 @@ fun ProperTerminal(
           // frame, so it describes the same instant as the row beside it.
           val effectiveCursorX = renderFrame.typeAheadCursorX?.minus(1) ?: cursorX
 
+          // Read at COMPOSABLE scope, not inside the SideEffect that publishes the caret frame.
+          // A SideEffect runs in the apply phase, outside observeReads, so a read there
+          // subscribes nothing: `activeTheme` is collectAsState and `isFocused` is tab state, so
+          // reading them only in the effect would leave the caret on the old theme colour and
+          // the old focus alpha until some unrelated recomposition happened to fire - on an idle
+          // terminal, indefinitely. Reading them here is what re-runs the effect. (Window focus
+          // is separate and already gates the blink loops via `blinkActive`; this is in-window
+          // focus, so clicking into the search field has to dim the caret.)
+          val caretIsFocused = isFocused
+          val appCursorColor = terminal.cursorColor
+          val baseCursorColor = if (appCursorColor != null) {
+            Color(appCursorColor.red, appCursorColor.green, appCursorColor.blue)
+          } else activeTheme.cursorColor
+          val caretGlyphColor = cursorGlyphColor(
+            theme = activeTheme,
+            effectiveFill = baseCursorColor,
+            fillIsAppSet = appCursorColor != null,
+          )
+
           Canvas(modifier = Modifier.padding(start = 4.dp, top = 4.dp).fillMaxSize().clipToBounds()) {
             // Guard against invalid canvas sizes during resize - prevents drawText constraint failures
             if (size.width < cellWidth || size.height < cellHeight) return@Canvas
@@ -2092,14 +2121,6 @@ fun ProperTerminal(
             // Use ceil for rows to include partially visible bottom row (Canvas clips automatically)
             val visibleCols = (size.width / cellWidth).toInt().coerceAtMost(bufferSnapshot.width)
             val visibleRows = kotlin.math.ceil(size.height / cellHeight).toInt().coerceAtMost(bufferSnapshot.height)
-
-            // Get cursor color from terminal (OSC 12), falling back to the active theme's
-            // cursor color so the cursor stays visible against light and dark backgrounds
-            // alike when no app has overridden it.
-            val customCursorColor = terminal.cursorColor
-            val baseCursorColor = if (customCursorColor != null) {
-              Color(customCursorColor.red, customCursorColor.green, customCursorColor.blue)
-            } else activeTheme.cursorColor
 
             // Resolve content-anchored selection to current coordinates
             // This allows selection to follow content as terminal scrolls
@@ -2206,10 +2227,6 @@ fun ProperTerminal(
           // after the fold's SideEffect on purpose, so `effectiveScrollOffset` is the value the
           // text canvas actually drew with.
           SideEffect {
-            val customCursorColor = terminal.cursorColor
-            val baseCursorColor = if (customCursorColor != null) {
-              Color(customCursorColor.red, customCursorColor.green, customCursorColor.blue)
-            } else activeTheme.cursorColor
             val bufferCursorRow = (cursorY - 1).coerceAtLeast(0)
             val cursorLine = bufferSnapshot.getLine(bufferCursorRow)
             val cursorImageCell = cursorLine.getImageCellAt(effectiveCursorX)
@@ -2222,7 +2239,7 @@ fun ProperTerminal(
               cellWidth = cellWidth,
               cellHeight = cellHeight,
               bufferWidth = bufferSnapshot.width,
-              isFocused = isFocused,
+              isFocused = caretIsFocused,
               color = baseCursorColor,
               focusedAlpha = settings.cursorFocusedAlpha,
               unfocusedAlpha = settings.cursorUnfocusedAlpha,
@@ -2245,11 +2262,7 @@ fun ProperTerminal(
                   // safe in the wrong way, since it only ever makes this decline.
                   ambiguousCharsAreDoubleWidth = display.ambiguousCharsAreDoubleWidth(),
               ) else null,
-              glyphColor = cursorGlyphColor(
-                  theme = activeTheme,
-                  effectiveFill = baseCursorColor,
-                  fillIsAppSet = customCursorColor != null,
-              ),
+              glyphColor = caretGlyphColor,
               glyphFontFamily = sharedFont,
               glyphFontSize = effectiveFontSize,
               glyphMeasurer = textMeasurer,

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplayCursorTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ComposeTerminalDisplayCursorTest.kt
@@ -1,0 +1,83 @@
+package ai.rever.bossterm.compose
+
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The cursor must be readable as one value.
+ *
+ * `setCursor` writes x and then y. With four independent `@Volatile` fields a reader landing
+ * between the two writes sees a position the terminal was never in - and the renderer reads them
+ * on the UI thread while the emulator moves the caret many times per rendered frame, so the
+ * window is hit in practice rather than in theory.
+ *
+ * This test fails reliably against separate volatiles and passes against the AtomicReference.
+ */
+class ComposeTerminalDisplayCursorTest {
+
+    @Test
+    fun aReaderNeverSeesAPositionTheTerminalWasNeverIn() {
+        val display = ComposeTerminalDisplay()
+        val a = 0 to 1
+        val b = 79 to 50
+        // Seed it, so the display's initial (0,0) is not itself a "torn" observation.
+        display.setCursor(a.first, a.second)
+        val running = java.util.concurrent.atomic.AtomicBoolean(true)
+        val torn = java.util.concurrent.atomic.AtomicReference<Pair<Int, Int>?>(null)
+
+        val writer = thread {
+            var i = 0L
+            while (running.get()) {
+                if (i++ % 2 == 0L) display.setCursor(a.first, a.second)
+                else display.setCursor(b.first, b.second)
+            }
+        }
+
+        repeat(200_000) {
+            val seen = display.cursorSnapshot.let { it.x to it.y }
+            if (seen != a && seen != b) {
+                torn.compareAndSet(null, seen)
+            }
+        }
+        running.set(false)
+        writer.join()
+
+        assertEquals(
+            null,
+            torn.get(),
+            "x and y must land together; a mixed pair means the two writes were observable apart",
+        )
+    }
+
+    @Test
+    fun theSingleFieldGettersAgreeWithTheSnapshot() {
+        val display = ComposeTerminalDisplay()
+        display.setCursor(12, 34)
+        display.setCursorVisible(false)
+
+        val snapshot = display.cursorSnapshot
+        assertEquals(12, snapshot.x)
+        assertEquals(34, snapshot.y)
+        assertTrue(!snapshot.visible)
+        assertEquals(snapshot.x, display.cursorXSnapshot)
+        assertEquals(snapshot.y, display.cursorYSnapshot)
+        assertEquals(snapshot.visible, display.cursorVisibleSnapshot)
+        assertEquals(snapshot.shape, display.cursorShapeSnapshot)
+    }
+
+    @Test
+    fun anUnchangedWriteIsStillReflectedWithoutDisturbingTheOtherFields() {
+        val display = ComposeTerminalDisplay()
+        display.setCursor(5, 6)
+        display.setCursorShape(ai.rever.bossterm.terminal.CursorShape.STEADY_BLOCK)
+        // A shape write must not clobber the position - the whole value is replaced by copy().
+        assertEquals(5, display.cursorSnapshot.x)
+        assertEquals(6, display.cursorSnapshot.y)
+        assertEquals(
+            ai.rever.bossterm.terminal.CursorShape.STEADY_BLOCK,
+            display.cursorSnapshot.shape,
+        )
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkBufferRowTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkBufferRowTest.kt
@@ -254,4 +254,66 @@ class HyperlinkBufferRowTest {
         cache.linksAt(1, run, cwd = "/b", detectFilePaths = false, registryRevision = 0, detect = detect)
         assertEquals(3, detections, "toggling path detection must invalidate too")
     }
+
+    /**
+     * The run walk is capped, so one pathological logical line cannot make a pointer move
+     * O(scrollback). `cat` of a minified file is a single wrapped run thousands of rows long.
+     */
+    @Test
+    fun theRunWalkIsBoundedRegardlessOfHowLongTheLogicalLineIs() {
+        val rows = HyperlinkDetector.MAX_WRAPPED_RUN_ROWS * 4
+        val buffer = TerminalTextBuffer(20, 8, StyleState(), rows * 2)
+        // Every line wraps into the next, so the logical line is the whole scrollback.
+        repeat(rows) {
+            write(buffer, 1, "x".repeat(20))
+            buffer.getLine(0).isWrapped = true
+            buffer.scrollArea(1, -1, 8)
+        }
+        val snapshot = buffer.createIncrementalSnapshot()
+
+        val run = HyperlinkDetector.runLinesAt(snapshot, 0)
+        assertTrue(
+            run.size <= 2 * HyperlinkDetector.MAX_WRAPPED_RUN_ROWS + 2,
+            "the walk must be capped, was ${run.size} rows for a $rows-row run",
+        )
+    }
+
+    /**
+     * A runtime pattern change has to reach rows already memoized - the line instance never
+     * changes, so nothing else would ever invalidate them.
+     */
+    @Test
+    fun aRegistryChangeReDetectsAnUnchangedLine() {
+        val buffer = TerminalTextBuffer(40, 4, StyleState(), 100)
+        write(buffer, 2, "see TICKET-42 ok")
+        val run = listOf(buffer.createIncrementalSnapshot().getLine(1))
+        val cache = HyperlinkRowCache()
+        var detections = 0
+        val detect = { detections++; emptyList<Hyperlink>() }
+
+        cache.linksAt(1, run, null, false, registryRevision = 0, detect = detect)
+        cache.linksAt(1, run, null, false, registryRevision = 0, detect = detect)
+        assertEquals(1, detections, "same registry, same line: one detection")
+
+        cache.linksAt(1, run, null, false, registryRevision = 1, detect = detect)
+        assertEquals(2, detections, "a pattern added at runtime must invalidate memoized rows")
+    }
+
+    @Test
+    fun theRegistryRevisionMovesOnEveryMutation() {
+        val registry = HyperlinkRegistry()
+        val before = registry.revision
+        registry.addPattern(
+            HyperlinkPattern(id = "test:x", regex = Regex("x"), priority = 99),
+        )
+        val afterAdd = registry.revision
+        assertTrue(afterAdd > before, "addPattern must bump the revision")
+
+        registry.removePattern("test:x")
+        assertTrue(registry.revision > afterAdd, "removePattern must bump it too")
+
+        val afterRemove = registry.revision
+        registry.removePattern("test:not-there")
+        assertEquals(afterRemove, registry.revision, "a no-op removal must not bump it")
+    }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkBufferRowTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkBufferRowTest.kt
@@ -1,6 +1,5 @@
 package ai.rever.bossterm.compose.hyperlinks
 
-import ai.rever.bossterm.compose.rendering.TerminalCanvasRenderer
 import ai.rever.bossterm.terminal.model.CharBuffer
 import ai.rever.bossterm.terminal.model.StyleState
 import ai.rever.bossterm.terminal.model.TerminalTextBuffer
@@ -25,7 +24,7 @@ class HyperlinkBufferRowTest {
     }
 
     private fun links(buffer: TerminalTextBuffer, bufferRow: Int) =
-        TerminalCanvasRenderer.detectHyperlinksForBufferRow(
+        HyperlinkDetector.detectForBufferRow(
             snapshot = buffer.createIncrementalSnapshot(),
             bufferRow = bufferRow,
             terminalWidth = buffer.width,
@@ -96,7 +95,7 @@ class HyperlinkBufferRowTest {
         var detections = 0
 
         repeat(5) {
-            cache.linksAt(1, snapshot.getLine(1)) {
+            cache.linksAt(1, listOf(snapshot.getLine(1)), cwd = null, detectFilePaths = false) {
                 detections++
                 emptyList()
             }
@@ -112,27 +111,84 @@ class HyperlinkBufferRowTest {
         var detections = 0
         val detect = { detections++; emptyList<Hyperlink>() }
 
-        cache.linksAt(1, buffer.createIncrementalSnapshot().getLine(1), detect = detect)
+        cache.linksAt(1, listOf(buffer.createIncrementalSnapshot().getLine(1)), null, false, detect)
         write(buffer, 2, "second line entirely")
-        cache.linksAt(1, buffer.createIncrementalSnapshot().getLine(1), detect = detect)
+        cache.linksAt(1, listOf(buffer.createIncrementalSnapshot().getLine(1)), null, false, detect)
 
         assertEquals(2, detections, "a changed row must miss")
     }
 
+    /**
+     * A wrapped row must still memoize.
+     *
+     * The first version of this cache bypassed the memo for any wrapped row, which meant every
+     * pointer-move event re-ran the whole-logical-line rejoin plus the registry sweep - on the
+     * UI thread, in a session where wrapped rows are the common case, not the exception.
+     */
     @Test
-    fun bypassSkipsTheMemoEntirely() {
-        val buffer = TerminalTextBuffer(40, 4, StyleState(), 100)
-        write(buffer, 2, "wrapped content")
-        val line = buffer.createIncrementalSnapshot().getLine(1)
+    fun aWrappedRunMemoizesWhileEveryLineInItIsUnchanged() {
+        val buffer = TerminalTextBuffer(20, 4, StyleState(), 100)
+        write(buffer, 1, "https://example.com/")
+        write(buffer, 2, "deep/path")
+        buffer.getLine(0).isWrapped = true
+        val snapshot = buffer.createIncrementalSnapshot()
         val cache = HyperlinkRowCache()
         var detections = 0
 
-        repeat(3) {
-            cache.linksAt(1, line, bypass = true) {
-                detections++
-                emptyList()
-            }
+        repeat(5) {
+            cache.linksAt(
+                bufferRow = 0,
+                runLines = HyperlinkDetector.runLinesAt(snapshot, 0),
+                cwd = null,
+                detectFilePaths = false,
+            ) { detections++; emptyList() }
         }
-        assertEquals(3, detections, "wrapped rows depend on neighbours, so they never memoize")
+        assertEquals(1, detections, "an unchanged wrapped run must not re-detect per event")
+    }
+
+    @Test
+    fun aWrappedRunReDetectsWhenASiblingLineChanges() {
+        val buffer = TerminalTextBuffer(20, 4, StyleState(), 100)
+        write(buffer, 1, "https://example.com/")
+        write(buffer, 2, "deep/path")
+        buffer.getLine(0).isWrapped = true
+        val cache = HyperlinkRowCache()
+        var detections = 0
+        val detect = { detections++; emptyList<Hyperlink>() }
+
+        val first = buffer.createIncrementalSnapshot()
+        cache.linksAt(0, HyperlinkDetector.runLinesAt(first, 0), null, false, detect)
+        // Row 0 itself is untouched - the CONTINUATION changes, and it is part of the answer.
+        write(buffer, 2, "other/path/here")
+        val second = buffer.createIncrementalSnapshot()
+        cache.linksAt(0, HyperlinkDetector.runLinesAt(second, 0), null, false, detect)
+
+        assertEquals(2, detections, "the run's other lines are part of the key")
+    }
+
+    /**
+     * Detection resolves relative paths against the working directory, so an unchanged line
+     * must still re-detect after a `cd` - otherwise a stale `file://` target survives forever,
+     * since the line instance never changes.
+     */
+    @Test
+    fun aWorkingDirectoryChangeReDetectsAnUnchangedLine() {
+        val buffer = TerminalTextBuffer(40, 4, StyleState(), 100)
+        write(buffer, 2, "see ./src/main.kt")
+        val snapshot = buffer.createIncrementalSnapshot()
+        val cache = HyperlinkRowCache()
+        var detections = 0
+        val detect = { detections++; emptyList<Hyperlink>() }
+        val run = listOf(snapshot.getLine(1))
+
+        cache.linksAt(1, run, cwd = "/a", detectFilePaths = true, detect = detect)
+        cache.linksAt(1, run, cwd = "/a", detectFilePaths = true, detect = detect)
+        assertEquals(1, detections, "same cwd, same line: one detection")
+
+        cache.linksAt(1, run, cwd = "/b", detectFilePaths = true, detect = detect)
+        assertEquals(2, detections, "a cd must invalidate paths resolved against the old cwd")
+
+        cache.linksAt(1, run, cwd = "/b", detectFilePaths = false, detect = detect)
+        assertEquals(3, detections, "toggling path detection must invalidate too")
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkBufferRowTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkBufferRowTest.kt
@@ -1,0 +1,138 @@
+package ai.rever.bossterm.compose.hyperlinks
+
+import ai.rever.bossterm.compose.rendering.TerminalCanvasRenderer
+import ai.rever.bossterm.terminal.model.CharBuffer
+import ai.rever.bossterm.terminal.model.StyleState
+import ai.rever.bossterm.terminal.model.TerminalTextBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Hyperlink detection in BUFFER coordinates.
+ *
+ * The point of the conversion is that a viewport position can no longer be a parameter, so
+ * "pure scrolling reuses detection" is a fact about the signature rather than a claim about a
+ * cache hit rate. These tests pin that, and pin the wrapped-line walk that used to add the
+ * scroll offset where every caller subtracted it.
+ */
+class HyperlinkBufferRowTest {
+
+    private fun write(buffer: TerminalTextBuffer, row: Int, text: String) {
+        val chars = text.toCharArray()
+        buffer.writeString(0, row, CharBuffer(chars, 0, chars.size))
+    }
+
+    private fun links(buffer: TerminalTextBuffer, bufferRow: Int) =
+        TerminalCanvasRenderer.detectHyperlinksForBufferRow(
+            snapshot = buffer.createIncrementalSnapshot(),
+            bufferRow = bufferRow,
+            terminalWidth = buffer.width,
+            workingDirectory = null,
+            detectFilePaths = false,
+            registry = HyperlinkDetector.registry,
+        )
+
+    @Test
+    fun aLinkOnTheLiveScreenIsFoundAtItsBufferRow() {
+        val buffer = TerminalTextBuffer(40, 4, StyleState(), 100)
+        write(buffer, 2, "see https://example.com ok")
+
+        val found = links(buffer, bufferRow = 1)
+        assertEquals(1, found.size)
+        assertEquals("https://example.com", found[0].url)
+        assertEquals(1, found[0].row, "rows are buffer rows, not screen rows")
+    }
+
+    @Test
+    fun aLinkScrolledIntoHistoryKeepsItsNegativeBufferRow() {
+        val buffer = TerminalTextBuffer(40, 4, StyleState(), 100)
+        write(buffer, 1, "see https://example.com ok")
+        // Push it two rows back into history.
+        repeat(2) { buffer.scrollArea(1, -1, 4) }
+
+        val found = links(buffer, bufferRow = -2)
+        assertEquals(1, found.size, "history rows are addressable by negative index")
+        assertEquals("https://example.com", found[0].url)
+        assertEquals(-2, found[0].row)
+    }
+
+    /**
+     * The regression test for the sign bug.
+     *
+     * `collectWrappedLines` used to compute `row + scrollOffset` while its only caller computed
+     * screen rows as `row - scrollOffset`, so a wrapped link that had scrolled into history was
+     * assembled from the wrong lines entirely. With the offset gone there is nothing left to get
+     * backwards, and the spans land on the two rows the link actually occupies.
+     */
+    @Test
+    fun aWrappedLinkInHistorySpansTheRowsItActuallyOccupies() {
+        val buffer = TerminalTextBuffer(20, 4, StyleState(), 100)
+        // The first row must fill all 20 columns exactly. A short row is padded to the terminal
+        // width when the logical line is rejoined, and that padding would put a space inside the
+        // URL - a genuine gap, not a wrap.
+        write(buffer, 1, "https://example.com/")
+        write(buffer, 2, "deep/path")
+        buffer.getLine(0).isWrapped = true
+        repeat(2) { buffer.scrollArea(1, -1, 4) }
+
+        // Both halves now sit in history at buffer rows -2 and -1.
+        val found = links(buffer, bufferRow = -2)
+        val link = found.firstOrNull { it.url.contains("example.com") }
+        assertNotNull(link, "the wrapped link should be detected from its first row")
+        assertTrue(
+            link.rowSpans.keys.containsAll(listOf(-2, -1)),
+            "spans should cover both history rows, were ${link.rowSpans.keys}",
+        )
+    }
+
+    @Test
+    fun theMemoReturnsTheCachedListWhileTheLineInstanceIsUnchanged() {
+        val buffer = TerminalTextBuffer(40, 4, StyleState(), 100)
+        write(buffer, 2, "see https://example.com ok")
+        val snapshot = buffer.createIncrementalSnapshot()
+        val cache = HyperlinkRowCache()
+        var detections = 0
+
+        repeat(5) {
+            cache.linksAt(1, snapshot.getLine(1)) {
+                detections++
+                emptyList()
+            }
+        }
+        assertEquals(1, detections, "a scroll must not re-detect an unchanged row")
+    }
+
+    @Test
+    fun theMemoReDetectsWhenTheLineInstanceIsReplaced() {
+        val buffer = TerminalTextBuffer(40, 4, StyleState(), 100)
+        write(buffer, 2, "first")
+        val cache = HyperlinkRowCache()
+        var detections = 0
+        val detect = { detections++; emptyList<Hyperlink>() }
+
+        cache.linksAt(1, buffer.createIncrementalSnapshot().getLine(1), detect = detect)
+        write(buffer, 2, "second line entirely")
+        cache.linksAt(1, buffer.createIncrementalSnapshot().getLine(1), detect = detect)
+
+        assertEquals(2, detections, "a changed row must miss")
+    }
+
+    @Test
+    fun bypassSkipsTheMemoEntirely() {
+        val buffer = TerminalTextBuffer(40, 4, StyleState(), 100)
+        write(buffer, 2, "wrapped content")
+        val line = buffer.createIncrementalSnapshot().getLine(1)
+        val cache = HyperlinkRowCache()
+        var detections = 0
+
+        repeat(3) {
+            cache.linksAt(1, line, bypass = true) {
+                detections++
+                emptyList()
+            }
+        }
+        assertEquals(3, detections, "wrapped rows depend on neighbours, so they never memoize")
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkBufferRowTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkBufferRowTest.kt
@@ -95,7 +95,7 @@ class HyperlinkBufferRowTest {
         var detections = 0
 
         repeat(5) {
-            cache.linksAt(1, listOf(snapshot.getLine(1)), cwd = null, detectFilePaths = false) {
+            cache.linksAt(1, listOf(snapshot.getLine(1)), cwd = null, detectFilePaths = false, registryRevision = 0) {
                 detections++
                 emptyList()
             }
@@ -111,9 +111,9 @@ class HyperlinkBufferRowTest {
         var detections = 0
         val detect = { detections++; emptyList<Hyperlink>() }
 
-        cache.linksAt(1, listOf(buffer.createIncrementalSnapshot().getLine(1)), null, false, detect)
+        cache.linksAt(1, listOf(buffer.createIncrementalSnapshot().getLine(1)), null, false, 0, detect)
         write(buffer, 2, "second line entirely")
-        cache.linksAt(1, listOf(buffer.createIncrementalSnapshot().getLine(1)), null, false, detect)
+        cache.linksAt(1, listOf(buffer.createIncrementalSnapshot().getLine(1)), null, false, 0, detect)
 
         assertEquals(2, detections, "a changed row must miss")
     }
@@ -141,6 +141,7 @@ class HyperlinkBufferRowTest {
                 runLines = HyperlinkDetector.runLinesAt(snapshot, 0),
                 cwd = null,
                 detectFilePaths = false,
+                registryRevision = 0,
             ) { detections++; emptyList() }
         }
         assertEquals(1, detections, "an unchanged wrapped run must not re-detect per event")
@@ -157,11 +158,11 @@ class HyperlinkBufferRowTest {
         val detect = { detections++; emptyList<Hyperlink>() }
 
         val first = buffer.createIncrementalSnapshot()
-        cache.linksAt(0, HyperlinkDetector.runLinesAt(first, 0), null, false, detect)
+        cache.linksAt(0, HyperlinkDetector.runLinesAt(first, 0), null, false, 0, detect)
         // Row 0 itself is untouched - the CONTINUATION changes, and it is part of the answer.
         write(buffer, 2, "other/path/here")
         val second = buffer.createIncrementalSnapshot()
-        cache.linksAt(0, HyperlinkDetector.runLinesAt(second, 0), null, false, detect)
+        cache.linksAt(0, HyperlinkDetector.runLinesAt(second, 0), null, false, 0, detect)
 
         assertEquals(2, detections, "the run's other lines are part of the key")
     }
@@ -187,15 +188,18 @@ class HyperlinkBufferRowTest {
         val cache = HyperlinkRowCache()
         var detections = 0
         repeat(5) {
-            cache.linksAt(2, HyperlinkDetector.runLinesAt(snapshot, 2), null, false) {
+            cache.linksAt(2, HyperlinkDetector.runLinesAt(snapshot, 2), null, false, 0) {
                 detections++; emptyList()
             }
         }
         assertEquals(1, detections, "a run at the bottom of the screen must not re-detect")
 
+        // Exact instances, not a size bound: the bug put a fresh out-of-range createEmpty() in
+        // the list, which a size check would happily accept.
+        val run = HyperlinkDetector.runLinesAt(snapshot, 2)
         assertTrue(
-            HyperlinkDetector.runLinesAt(snapshot, 2).size <= buffer.height + 1,
-            "the walk must not run past the last screen row",
+            run.all { line -> (-snapshot.historyLinesCount until snapshot.height).any { snapshot.getLine(it) === line } },
+            "every line in the key must be one the snapshot actually holds",
         )
     }
 
@@ -214,13 +218,13 @@ class HyperlinkBufferRowTest {
         val detect = { detections++; emptyList<Hyperlink>() }
 
         val first = buffer.createIncrementalSnapshot()
-        cache.linksAt(1, HyperlinkDetector.runLinesAt(first, 1), null, false, detect)
+        cache.linksAt(1, HyperlinkDetector.runLinesAt(first, 1), null, false, 0, detect)
 
         // Row 1's own line is untouched; only its PREDECESSOR changes.
         write(buffer, 1, "https://example.com/")
         buffer.getLine(0).isWrapped = true
         val second = buffer.createIncrementalSnapshot()
-        cache.linksAt(1, HyperlinkDetector.runLinesAt(second, 1), null, false, detect)
+        cache.linksAt(1, HyperlinkDetector.runLinesAt(second, 1), null, false, 0, detect)
 
         assertEquals(2, detections, "the predecessor's wrap flag is part of the answer")
     }
@@ -240,14 +244,14 @@ class HyperlinkBufferRowTest {
         val detect = { detections++; emptyList<Hyperlink>() }
         val run = listOf(snapshot.getLine(1))
 
-        cache.linksAt(1, run, cwd = "/a", detectFilePaths = true, detect = detect)
-        cache.linksAt(1, run, cwd = "/a", detectFilePaths = true, detect = detect)
+        cache.linksAt(1, run, cwd = "/a", detectFilePaths = true, registryRevision = 0, detect = detect)
+        cache.linksAt(1, run, cwd = "/a", detectFilePaths = true, registryRevision = 0, detect = detect)
         assertEquals(1, detections, "same cwd, same line: one detection")
 
-        cache.linksAt(1, run, cwd = "/b", detectFilePaths = true, detect = detect)
+        cache.linksAt(1, run, cwd = "/b", detectFilePaths = true, registryRevision = 0, detect = detect)
         assertEquals(2, detections, "a cd must invalidate paths resolved against the old cwd")
 
-        cache.linksAt(1, run, cwd = "/b", detectFilePaths = false, detect = detect)
+        cache.linksAt(1, run, cwd = "/b", detectFilePaths = false, registryRevision = 0, detect = detect)
         assertEquals(3, detections, "toggling path detection must invalidate too")
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkBufferRowTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/hyperlinks/HyperlinkBufferRowTest.kt
@@ -167,6 +167,65 @@ class HyperlinkBufferRowTest {
     }
 
     /**
+     * A run ending on the LAST screen row must still memoize.
+     *
+     * `getLine` returns a fresh `createEmpty()` out of range, so a forward walk that checked the
+     * wrap flag before the bounds could let `end` reach `height` and put a never-identity-equal
+     * instance in the key - missing the memo on every single event, for exactly the rows a live
+     * TUI's wrapped output occupies.
+     */
+    @Test
+    fun aWrappedRunEndingOnTheLastRowStillMemoizes() {
+        val buffer = TerminalTextBuffer(20, 4, StyleState(), 100)
+        write(buffer, 3, "https://example.com/")
+        write(buffer, 4, "deep/path")
+        buffer.getLine(2).isWrapped = true
+        // The run is rows 2..3, and 3 is the last screen row of a 4-row buffer.
+        buffer.getLine(3).isWrapped = true
+
+        val snapshot = buffer.createIncrementalSnapshot()
+        val cache = HyperlinkRowCache()
+        var detections = 0
+        repeat(5) {
+            cache.linksAt(2, HyperlinkDetector.runLinesAt(snapshot, 2), null, false) {
+                detections++; emptyList()
+            }
+        }
+        assertEquals(1, detections, "a run at the bottom of the screen must not re-detect")
+
+        assertTrue(
+            HyperlinkDetector.runLinesAt(snapshot, 2).size <= buffer.height + 1,
+            "the walk must not run past the last screen row",
+        )
+    }
+
+    /**
+     * The predecessor decides whether a row is a continuation, so it belongs in the key even for
+     * a row that is currently NOT wrapped. A TUI rewriting row R-1 so it wraps into R leaves R's
+     * own line untouched, and without this the memo would keep returning the single-row answer.
+     */
+    @Test
+    fun aRowReDetectsWhenItsPredecessorStartsWrappingIntoIt() {
+        val buffer = TerminalTextBuffer(20, 4, StyleState(), 100)
+        write(buffer, 1, "plain")
+        write(buffer, 2, "https://example.com")
+        val cache = HyperlinkRowCache()
+        var detections = 0
+        val detect = { detections++; emptyList<Hyperlink>() }
+
+        val first = buffer.createIncrementalSnapshot()
+        cache.linksAt(1, HyperlinkDetector.runLinesAt(first, 1), null, false, detect)
+
+        // Row 1's own line is untouched; only its PREDECESSOR changes.
+        write(buffer, 1, "https://example.com/")
+        buffer.getLine(0).isWrapped = true
+        val second = buffer.createIncrementalSnapshot()
+        cache.linksAt(1, HyperlinkDetector.runLinesAt(second, 1), null, false, detect)
+
+        assertEquals(2, detections, "the predecessor's wrap flag is part of the answer")
+    }
+
+    /**
      * Detection resolves relative paths against the working directory, so an unchanged line
      * must still re-detect after a `cd` - otherwise a stale `file://` target survives forever,
      * since the line instance never changes.

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/BlinkClockTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/BlinkClockTest.kt
@@ -70,6 +70,9 @@ class BlinkClockTest {
     fun theOldFixedDelayLoopDriftsAndTheAbsoluteEdgeLoopDoesNot() {
         val period = 500L
         // Deterministic pseudo-random lateness in 0..400ms; a fixed seed keeps the test stable.
+        // Bounded BELOW one period on purpose: the per-edge invariant asserted at the end only
+        // holds while a late wake does not skip an edge outright. Widening this range would
+        // make the assertion fail for a reason that is not a regression.
         var seed = 12345L
         val lateness = LongArray(20) {
             seed = (seed * 1103515245 + 12345) and 0x7FFFFFFF

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/BlinkClockTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/BlinkClockTest.kt
@@ -1,0 +1,105 @@
+package ai.rever.bossterm.compose.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val MS = 1_000_000L
+
+/**
+ * The arithmetic behind a blink that keeps its phase when the UI thread is busy.
+ *
+ * Extracted from the composable for the same reason as `foldHistoryAppends`: the edges are
+ * ordinary assertions rather than something needing a Compose harness.
+ */
+class BlinkClockTest {
+
+    @Test
+    fun visibilityAlternatesEveryPeriod() {
+        val period = 500 * MS
+        assertTrue(blinkVisibleAt(0, period), "a fresh phase starts visible")
+        assertTrue(blinkVisibleAt(499 * MS, period))
+        assertTrue(!blinkVisibleAt(500 * MS, period), "the first edge hides it")
+        assertTrue(!blinkVisibleAt(999 * MS, period))
+        assertTrue(blinkVisibleAt(1000 * MS, period))
+        assertTrue(!blinkVisibleAt(1500 * MS, period))
+    }
+
+    @Test
+    fun anUnsetPeriodIsAlwaysVisible() {
+        assertTrue(blinkVisibleAt(12_345, periodNanos = 0))
+        assertTrue(blinkVisibleAt(12_345, periodNanos = -1))
+    }
+
+    @Test
+    fun negativeElapsedIsVisibleRatherThanACrash() {
+        // A clock that appears to run backwards must not produce a negative modulus.
+        assertTrue(blinkVisibleAt(-1, 500 * MS))
+        assertEquals(500 * MS, nanosToNextBlinkEdge(-1, 500 * MS))
+    }
+
+    @Test
+    fun theNextEdgeIsNeverZeroAndNeverBeyondOnePeriod() {
+        val period = 500 * MS
+        for (elapsed in longArrayOf(0, 1, 250 * MS, 499 * MS, 500 * MS, 501 * MS, 10_000 * MS)) {
+            val next = nanosToNextBlinkEdge(elapsed, period)
+            assertTrue(next in 1..period, "elapsed=$elapsed produced $next")
+        }
+        assertEquals(period, nanosToNextBlinkEdge(0, period), "exact multiples sleep a full period")
+        assertEquals(period, nanosToNextBlinkEdge(period, period))
+    }
+
+    @Test
+    fun theSleepRoundsUpSoAWakeNeverLandsBeforeItsEdge() {
+        // Rounding down would wake a fraction of a millisecond early, recompute the same phase
+        // and immediately re-sleep - a spin at the boundary.
+        assertEquals(1L, millisToNextBlinkEdge(499 * MS + 999_999L, 500 * MS))
+        assertEquals(500L, millisToNextBlinkEdge(0, 500 * MS))
+        assertEquals(1L, millisToNextBlinkEdge(499 * MS, 500 * MS))
+    }
+
+    /**
+     * The characterisation test that names the bug.
+     *
+     * Both models are driven by the same sequence of late wakes. The old shape restarted its
+     * delay from wherever it happened to resume, so lateness accumulated; the absolute-edge
+     * shape re-derives the phase from the epoch, so each edge is late by that wake's delay only
+     * and never by the sum of everything before it.
+     */
+    @Test
+    fun theOldFixedDelayLoopDriftsAndTheAbsoluteEdgeLoopDoesNot() {
+        val period = 500L
+        // Deterministic pseudo-random lateness in 0..400ms; a fixed seed keeps the test stable.
+        var seed = 12345L
+        val lateness = LongArray(20) {
+            seed = (seed * 1103515245 + 12345) and 0x7FFFFFFF
+            seed % 401
+        }
+
+        // Old: next wake is scheduled `period` after the previous RESUMPTION.
+        var oldNow = 0L
+        val oldEdges = lateness.map { late -> oldNow += period + late; oldNow }
+
+        // New: next wake targets the next absolute edge past the epoch.
+        var newNow = 0L
+        val newEdges = lateness.map { late ->
+            newNow += (period - newNow % period) + late
+            newNow
+        }
+
+        val idealLast = 20 * period
+        assertTrue(
+            oldEdges.last() > idealLast + 3_000,
+            "the fixed-delay loop should have drifted seconds past ${idealLast}ms, " +
+                "was ${oldEdges.last()}ms",
+        )
+        newEdges.forEachIndexed { i, edge ->
+            val ideal = (i + 1) * period
+            assertTrue(
+                edge - ideal == lateness[i],
+                "edge $i should be late by exactly its own wake (${lateness[i]}ms), " +
+                    "was ${edge - ideal}ms past ${ideal}ms",
+            )
+        }
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/BlinkPhaseLoopTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/BlinkPhaseLoopTest.kt
@@ -1,0 +1,108 @@
+package ai.rever.bossterm.compose.ui
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The blink loop on virtual time.
+ *
+ * The wall clock is injected separately from the scheduler on purpose: a test scheduler always
+ * resumes a `delay` exactly on schedule, so the only way to model "the UI thread was blocked
+ * and the resumption landed late" is to move the wall clock ahead of it. That skew is the whole
+ * failure mode these tests exist for.
+ */
+class BlinkPhaseLoopTest {
+
+    @Test
+    fun edgesLandOnTheAbsoluteTimeline() = runTest {
+        val seen = mutableListOf<Pair<Long, Boolean>>()
+        backgroundScope.launch {
+            runBlinkPhase(
+                periodMs = 500,
+                nowNanos = { testScheduler.currentTime * 1_000_000L },
+            ) { seen += testScheduler.currentTime to it }
+        }
+
+        runCurrent()
+        assertEquals(listOf(0L to true), seen, "the caret shows before the first edge")
+
+        repeat(3) { advanceTimeBy(500); runCurrent() }
+        assertEquals(
+            listOf(0L to true, 500L to false, 1000L to true, 1500L to false),
+            seen,
+        )
+    }
+
+    @Test
+    fun aStallLandingInTheSameHalfPeriodCostsNoInvalidation() = runTest {
+        var wallMs = 0L
+        val seen = mutableListOf<Boolean>()
+        backgroundScope.launch {
+            runBlinkPhase(periodMs = 500, nowNanos = { wallMs * 1_000_000L }) { seen += it }
+        }
+        runCurrent()
+        assertEquals(listOf(true), seen)
+
+        // 1300ms of wall time passed while the dispatcher was blocked. 1300/500 = 2, an even
+        // half-period, so the phase is still "visible" and nothing should be published.
+        wallMs = 1300
+        advanceTimeBy(500); runCurrent()
+        assertEquals(listOf(true), seen, "a wake inside the same half-period must not invalidate")
+    }
+
+    @Test
+    fun aLongStallSkipsTheMissedTogglesRatherThanReplayingThem() = runTest {
+        var wallMs = 0L
+        val seen = mutableListOf<Boolean>()
+        backgroundScope.launch {
+            runBlinkPhase(periodMs = 500, nowNanos = { wallMs * 1_000_000L }) { seen += it }
+        }
+        runCurrent()
+
+        // 1600ms in one jump: three edges were slept through. Real terminals do not replay
+        // missed blinks - the caret simply shows the phase that is correct for now.
+        wallMs = 1600
+        advanceTimeBy(500); runCurrent()
+        assertEquals(listOf(true, false), seen, "exactly one toggle, not a catch-up burst")
+    }
+
+    @Test
+    fun aNonPositivePeriodShowsTheCaretAndStops() = runTest {
+        val seen = mutableListOf<Boolean>()
+        backgroundScope.launch {
+            runBlinkPhase(periodMs = 0, nowNanos = { testScheduler.currentTime * 1_000_000L }) {
+                seen += it
+            }
+        }
+        runCurrent()
+        advanceTimeBy(10_000); runCurrent()
+        assertEquals(listOf(true), seen, "'Off' must be off, not a delay(0) spin")
+    }
+
+    /**
+     * The battery guard.
+     *
+     * An idle terminal is allowed exactly two wakeups per period and no more. This is what
+     * fails if anyone re-formulates the loop on the frame clock, which would tick at display
+     * refresh rate forever, per visible tab.
+     */
+    @Test
+    fun tenSecondsCostsExactlyTwentyToggles() = runTest {
+        var toggles = 0
+        backgroundScope.launch {
+            runBlinkPhase(
+                periodMs = 500,
+                nowNanos = { testScheduler.currentTime * 1_000_000L },
+            ) { toggles++ }
+        }
+        runCurrent()
+        toggles = 0 // discard the initial "visible"
+
+        repeat(20) { advanceTimeBy(500); runCurrent() }
+        assertEquals(20, toggles, "10s / 500ms = 20 edges, no extra wakeups")
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/CursorFrameEqualityTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/CursorFrameEqualityTest.kt
@@ -1,0 +1,74 @@
+package ai.rever.bossterm.compose.ui
+
+import androidx.compose.ui.graphics.Color
+import ai.rever.bossterm.terminal.CursorShape
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * [CursorFrame] equality decides whether the overlay repaints.
+ *
+ * The frame is published from a `SideEffect` into `mutableStateOf`, whose default structural
+ * equality policy drops a write that equals the current value. So "an output frame that does
+ * not touch the caret must not invalidate the cursor layer" is exactly the predicate below -
+ * which is why it can be pinned with a plain assertion instead of a UI harness.
+ */
+class CursorFrameEqualityTest {
+
+    private fun frame(
+        x: Int = 4,
+        y: Int = 7,
+        scrollOffset: Int = 0,
+        visible: Boolean = true,
+        shape: CursorShape? = CursorShape.BLINK_BLOCK,
+    ) = CursorFrame(
+        visible = visible,
+        shape = shape,
+        x = x,
+        y = y,
+        scrollOffset = scrollOffset,
+        cellWidth = 8f,
+        cellHeight = 16f,
+        bufferWidth = 80,
+        isFocused = true,
+        color = Color.White,
+        focusedAlpha = 1f,
+        unfocusedAlpha = 0.3f,
+        glyph = null,
+        glyphColor = Color.Black,
+        glyphFontFamily = null,
+        glyphFontSize = 12f,
+        glyphMeasurer = null,
+        imageCell = null,
+        imageBitmap = null,
+    )
+
+    @Test
+    fun rebuildingFromTheSameInputsProducesAnEqualFrame() {
+        assertEquals(
+            frame(),
+            frame(),
+            "an output frame that leaves the caret alone must not invalidate the overlay",
+        )
+    }
+
+    @Test
+    fun movingTheCaretProducesADifferentFrame() {
+        assertNotEquals(frame(), frame(x = 5))
+        assertNotEquals(frame(), frame(y = 8))
+    }
+
+    @Test
+    fun scrollingProducesADifferentFrame() {
+        // The caret's screen row is `y - 1 + scrollOffset`, so a scroll genuinely moves it and
+        // the layer does have to repaint.
+        assertNotEquals(frame(), frame(scrollOffset = 3))
+    }
+
+    @Test
+    fun hidingOrReshapingTheCaretProducesADifferentFrame() {
+        assertNotEquals(frame(), frame(visible = false))
+        assertNotEquals(frame(), frame(shape = CursorShape.STEADY_UNDERLINE))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/CursorFrameEqualityTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/CursorFrameEqualityTest.kt
@@ -1,6 +1,9 @@
 package ai.rever.bossterm.compose.ui
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import ai.rever.bossterm.compose.rendering.CursorGlyph
+import ai.rever.bossterm.compose.rendering.GlyphBlink
 import ai.rever.bossterm.terminal.CursorShape
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -70,5 +73,53 @@ class CursorFrameEqualityTest {
     fun hidingOrReshapingTheCaretProducesADifferentFrame() {
         assertNotEquals(frame(), frame(visible = false))
         assertNotEquals(frame(), frame(shape = CursorShape.STEADY_UNDERLINE))
+    }
+
+    /**
+     * The glyph is a data class, so two frames built from the same cell compare equal and the
+     * overlay is not invalidated - and a different character, style or blink attribute does
+     * invalidate it. Left uncovered originally, which is why the blink-gate regression got
+     * through: every case used `glyph = null`.
+     */
+    @Test
+    fun theRepaintedGlyphParticipatesInEquality() {
+        val glyph = CursorGlyph("a", isBold = false, isItalic = false, isUnderline = false)
+        assertEquals(frame().copy(glyph = glyph), frame().copy(glyph = glyph))
+        assertEquals(
+            frame().copy(glyph = glyph),
+            frame().copy(glyph = CursorGlyph("a", isBold = false, isItalic = false, isUnderline = false)),
+            "an equal glyph must not invalidate, even as a distinct instance",
+        )
+        assertNotEquals(
+            frame().copy(glyph = glyph),
+            frame().copy(glyph = glyph.copy(text = "b")),
+        )
+        assertNotEquals(
+            frame().copy(glyph = glyph),
+            frame().copy(glyph = glyph.copy(isBold = true)),
+        )
+        assertNotEquals(
+            frame().copy(glyph = glyph),
+            frame().copy(glyph = glyph.copy(blink = GlyphBlink.SLOW)),
+            "the blink attribute is what the draw-time gate keys on",
+        )
+        assertNotEquals(frame().copy(glyph = glyph), frame().copy(glyph = null))
+    }
+
+    /**
+     * `ImageBitmap` has no structural equality, so it falls back to identity. That is correct
+     * here only because `ImageRenderer.getOrDecodeImage` caches, handing back the same instance
+     * for an unchanged image - pinned so a change to that caching is caught here rather than as
+     * a caret that repaints every frame over an inline image.
+     */
+    @Test
+    fun theImageOcclusionParticipatesInEquality() {
+        val bitmap = ImageBitmap(2, 2)
+        assertEquals(frame().copy(imageBitmap = bitmap), frame().copy(imageBitmap = bitmap))
+        assertNotEquals(
+            frame().copy(imageBitmap = bitmap),
+            frame().copy(imageBitmap = ImageBitmap(2, 2)),
+        )
+        assertNotEquals(frame().copy(imageBitmap = bitmap), frame().copy(imageBitmap = null))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/CursorFrameEqualityTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/CursorFrameEqualityTest.kt
@@ -76,6 +76,24 @@ class CursorFrameEqualityTest {
     }
 
     /**
+     * Focus and theme colour reach the caret through the frame, so they have to invalidate it.
+     *
+     * The gap this closes is not equality itself - it is that nothing pinned "a focus change
+     * updates the caret" at all, which is how a regression that dropped their subscription got
+     * through. Both are now read at composable scope so the publishing effect re-runs; this is
+     * the half of that contract a unit test can hold.
+     */
+    @Test
+    fun focusAndColourInvalidateTheOverlay() {
+        assertNotEquals(frame(), frame().copy(isFocused = false))
+        assertNotEquals(frame(), frame().copy(color = Color.Red))
+        assertNotEquals(frame(), frame().copy(glyphColor = Color.Red))
+        // The alphas are what `isFocused` actually selects between in the renderer.
+        assertNotEquals(frame(), frame().copy(focusedAlpha = 0.5f))
+        assertNotEquals(frame(), frame().copy(unfocusedAlpha = 0.5f))
+    }
+
+    /**
      * The glyph is a data class, so two frames built from the same cell compare equal and the
      * overlay is not invalidated - and a different character, style or blink attribute does
      * invalidate it. Left uncovered originally, which is why the blink-gate regression got

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/ResolveCursorGlyphTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ui/ResolveCursorGlyphTest.kt
@@ -2,12 +2,15 @@ package ai.rever.bossterm.compose.ui
 
 import ai.rever.bossterm.terminal.TextStyle
 import ai.rever.bossterm.compose.rendering.CursorGlyph
+import ai.rever.bossterm.compose.rendering.GlyphBlink
 import ai.rever.bossterm.terminal.model.CharBuffer
 import ai.rever.bossterm.terminal.model.TerminalLine
 import ai.rever.bossterm.terminal.util.CharUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * What a block cursor is allowed to repaint on top of itself.
@@ -35,21 +38,21 @@ class ResolveCursorGlyphTest {
 
     @Test
     fun `a plain character is repainted`() {
-        assertEquals(CursorGlyph("a", isBold = false, isItalic = false, isUnderline = false), resolveCursorGlyph(line("abc"), visualColumn = 0, terminalWidth = 3, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
-        assertEquals(CursorGlyph("c", isBold = false, isItalic = false, isUnderline = false), resolveCursorGlyph(line("abc"), visualColumn = 2, terminalWidth = 3, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
+        assertEquals(CursorGlyph("a", isBold = false, isItalic = false, isUnderline = false), resolveCursorGlyph(line("abc"), visualColumn = 0, terminalWidth = 3, ambiguousCharsAreDoubleWidth = false))
+        assertEquals(CursorGlyph("c", isBold = false, isItalic = false, isUnderline = false), resolveCursorGlyph(line("abc"), visualColumn = 2, terminalWidth = 3, ambiguousCharsAreDoubleWidth = false))
     }
 
     @Test
     fun `a blank cell has nothing to put back`() {
-        assertNull(resolveCursorGlyph(line("a c"), visualColumn = 1, terminalWidth = 3, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
+        assertNull(resolveCursorGlyph(line("a c"), visualColumn = 1, terminalWidth = 3, ambiguousCharsAreDoubleWidth = false))
         // Past the end of the line reads as an empty cell, not a crash.
-        assertNull(resolveCursorGlyph(line("a"), visualColumn = 4, terminalWidth = 8, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
+        assertNull(resolveCursorGlyph(line("a"), visualColumn = 4, terminalWidth = 8, ambiguousCharsAreDoubleWidth = false))
     }
 
     @Test
     fun `out of range columns are rejected`() {
-        assertNull(resolveCursorGlyph(line("abc"), visualColumn = -1, terminalWidth = 3, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
-        assertNull(resolveCursorGlyph(line("abc"), visualColumn = 3, terminalWidth = 3, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
+        assertNull(resolveCursorGlyph(line("abc"), visualColumn = -1, terminalWidth = 3, ambiguousCharsAreDoubleWidth = false))
+        assertNull(resolveCursorGlyph(line("abc"), visualColumn = 3, terminalWidth = 3, ambiguousCharsAreDoubleWidth = false))
     }
 
     /**
@@ -60,7 +63,7 @@ class ResolveCursorGlyphTest {
     @Test
     fun `a DWC trailing cell is rejected`() {
         val wide = line("你${CharUtils.DWC}")
-        assertNull(resolveCursorGlyph(wide, visualColumn = 1, terminalWidth = 2, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
+        assertNull(resolveCursorGlyph(wide, visualColumn = 1, terminalWidth = 2, ambiguousCharsAreDoubleWidth = false))
     }
 
     /**
@@ -70,7 +73,7 @@ class ResolveCursorGlyphTest {
     @Test
     fun `a double-width lead cell is rejected`() {
         val wide = line("你${CharUtils.DWC}")
-        assertNull(resolveCursorGlyph(wide, visualColumn = 0, terminalWidth = 2, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
+        assertNull(resolveCursorGlyph(wide, visualColumn = 0, terminalWidth = 2, ambiguousCharsAreDoubleWidth = false))
     }
 
     /**
@@ -80,8 +83,8 @@ class ResolveCursorGlyphTest {
     @Test
     fun `surrogate halves are rejected`() {
         val emoji = line("😀") // U+1F600
-        assertNull(resolveCursorGlyph(emoji, visualColumn = 0, terminalWidth = 2, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
-        assertNull(resolveCursorGlyph(emoji, visualColumn = 1, terminalWidth = 2, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
+        assertNull(resolveCursorGlyph(emoji, visualColumn = 0, terminalWidth = 2, ambiguousCharsAreDoubleWidth = false))
+        assertNull(resolveCursorGlyph(emoji, visualColumn = 1, terminalWidth = 2, ambiguousCharsAreDoubleWidth = false))
     }
 
     /**
@@ -92,37 +95,50 @@ class ResolveCursorGlyphTest {
     @Test
     fun `a concealed cell is never revealed`() {
         val hidden = line("secret", styleWith(TextStyle.Option.HIDDEN))
-        assertNull(resolveCursorGlyph(hidden, visualColumn = 0, terminalWidth = 6, ambiguousCharsAreDoubleWidth = false, slowBlinkVisible = true, rapidBlinkVisible = true))
+        assertNull(resolveCursorGlyph(hidden, visualColumn = 0, terminalWidth = 6, ambiguousCharsAreDoubleWidth = false))
     }
 
     /**
-     * Each SGR blink option is gated against its OWN clock. The first version of
-     * this passed one `blinkVisible` for both and was handed the CARET timer, so a
-     * blink-off cell was repainted whenever the caret happened to be solid, and a
-     * steady cell flashed on the caret's clock. One parameter could not see it.
+     * Each SGR blink option is carried separately, so the overlay can gate it against its OWN
+     * clock. An early version passed one `blinkVisible` for both and was handed the CARET
+     * timer, so a blink-off cell was repainted whenever the caret happened to be solid, and a
+     * steady cell flashed on the caret's clock. One flag could not see the difference.
+     *
+     * The gate then moved out of here entirely - see the comment in the test body.
      */
     @Test
-    fun `each blink option follows its own clock`() {
+    fun `each blink option is recorded so the overlay can gate on its own clock`() {
+        // The clock is applied in the overlay's DRAW lambda, not here: resolution runs in the
+        // apply phase, where reading a clock subscribes nothing, so a glyph gated at resolve
+        // time would keep painting after the text pass had blinked it away. What resolution
+        // owes the overlay is which clock the cell follows.
         val slow = line("x", styleWith(TextStyle.Option.SLOW_BLINK))
-        assertEquals(
-            CursorGlyph("x", isBold = false, isItalic = false, isUnderline = false),
-            resolveCursorGlyph(slow, 0, 1, false, slowBlinkVisible = true, rapidBlinkVisible = false),
-            "slow blink on",
-        )
-        assertNull(
-            resolveCursorGlyph(slow, 0, 1, false, slowBlinkVisible = false, rapidBlinkVisible = true),
-            "slow blink off must not be repainted just because the rapid clock is on",
-        )
+        assertEquals(GlyphBlink.SLOW, resolveCursorGlyph(slow, 0, 1, false)?.blink)
 
         val rapid = line("x", styleWith(TextStyle.Option.RAPID_BLINK))
+        assertEquals(GlyphBlink.RAPID, resolveCursorGlyph(rapid, 0, 1, false)?.blink)
+
         assertEquals(
-            CursorGlyph("x", isBold = false, isItalic = false, isUnderline = false),
-            resolveCursorGlyph(rapid, 0, 1, false, slowBlinkVisible = false, rapidBlinkVisible = true),
-            "rapid blink on",
+            GlyphBlink.NONE,
+            resolveCursorGlyph(line("x"), 0, 1, false)?.blink,
+            "an unattributed cell follows no clock",
         )
-        assertNull(
-            resolveCursorGlyph(rapid, 0, 1, false, slowBlinkVisible = true, rapidBlinkVisible = false),
-            "rapid blink off must not be repainted just because the slow clock is on",
+    }
+
+    @Test
+    fun `a glyph shows only while its own clock is on`() {
+        assertTrue(GlyphBlink.NONE.isVisible(slowVisible = false, rapidVisible = false))
+
+        assertTrue(GlyphBlink.SLOW.isVisible(slowVisible = true, rapidVisible = false))
+        assertFalse(
+            GlyphBlink.SLOW.isVisible(slowVisible = false, rapidVisible = true),
+            "slow blink off must not show just because the rapid clock is on",
+        )
+
+        assertTrue(GlyphBlink.RAPID.isVisible(slowVisible = false, rapidVisible = true))
+        assertFalse(
+            GlyphBlink.RAPID.isVisible(slowVisible = true, rapidVisible = false),
+            "rapid blink off must not show just because the slow clock is on",
         )
     }
 
@@ -143,14 +159,14 @@ class ResolveCursorGlyphTest {
     fun `characters needing a fallback font are rejected`() {
         // U+23F8 PAUSE, inside the technical-symbol range.
         assertNull(
-            resolveCursorGlyph(line("\u23F8"), 0, 1, false, slowBlinkVisible = true, rapidBlinkVisible = true),
+            resolveCursorGlyph(line("\u23F8"), 0, 1, false),
             "a technical symbol routes to a fallback family",
         )
         // U+231A WATCH, listed in UnicodeConstants.isBmpEmoji. Picked by reading
         // that predicate rather than guessing: U+2764 HEAVY BLACK HEART is NOT in
         // it, so an earlier version of this assertion failed for being wrong.
         assertNull(
-            resolveCursorGlyph(line("\u231A"), 0, 1, false, slowBlinkVisible = true, rapidBlinkVisible = true),
+            resolveCursorGlyph(line("\u231A"), 0, 1, false),
             "a BMP emoji-presentation symbol routes to a fallback family",
         )
     }
@@ -160,7 +176,7 @@ class ResolveCursorGlyphTest {
     fun `plain BMP math is repainted in the terminal font`() {
         assertEquals(
             CursorGlyph("\u2200", isBold = false, isItalic = false, isUnderline = false),
-            resolveCursorGlyph(line("\u2200"), 0, 1, false, slowBlinkVisible = true, rapidBlinkVisible = true),
+            resolveCursorGlyph(line("\u2200"), 0, 1, false),
         )
     }
 
@@ -170,12 +186,12 @@ class ResolveCursorGlyphTest {
         val bold = line("b", styleWith(TextStyle.Option.BOLD))
         assertEquals(
             CursorGlyph("b", isBold = true, isItalic = false, isUnderline = false),
-            resolveCursorGlyph(bold, 0, 1, false, slowBlinkVisible = true, rapidBlinkVisible = true),
+            resolveCursorGlyph(bold, 0, 1, false),
         )
         val italic = line("i", styleWith(TextStyle.Option.ITALIC))
         assertEquals(
             CursorGlyph("i", isBold = false, isItalic = true, isUnderline = false),
-            resolveCursorGlyph(italic, 0, 1, false, slowBlinkVisible = true, rapidBlinkVisible = true),
+            resolveCursorGlyph(italic, 0, 1, false),
         )
     }
 
@@ -200,16 +216,16 @@ class ResolveCursorGlyphTest {
 
         assertEquals(
             CursorGlyph("o", isBold = false, isItalic = false, isUnderline = false),
-            resolveCursorGlyph(l, visualColumn = 1, terminalWidth = 5, false, true, true),
+            resolveCursorGlyph(l, visualColumn = 1, terminalWidth = 5, false),
             "visual 1 is 'o'; indexing the buffer directly would give the U+FE0F selector",
         )
         assertEquals(
             CursorGlyph("k", isBold = false, isItalic = false, isUnderline = false),
-            resolveCursorGlyph(l, visualColumn = 2, terminalWidth = 5, false, true, true),
+            resolveCursorGlyph(l, visualColumn = 2, terminalWidth = 5, false),
             "visual 2 is 'k'; indexing the buffer directly would give the DWC marker",
         )
         assertNull(
-            resolveCursorGlyph(l, visualColumn = 3, terminalWidth = 5, false, true, true),
+            resolveCursorGlyph(l, visualColumn = 3, terminalWidth = 5, false),
             "visual 3 is the empty cell the caret usually rests in; indexing the " +
                 "buffer directly would paint a phantom 'o' there",
         )


### PR DESCRIPTION
Scrolling a Claude Code session made the caret's blink rate visibly wander and its position jump. Claude Code is an Ink TUI on the **primary** screen, so the wheel drives local scrollback while the app repaints constantly by moving the cursor up N rows and rewriting.

Four independent causes, all on the AWT event thread. Each is amplified by scroll for the same reason: `scrollOffset` is read at composable scope (`ProperTerminal.kt:241`), so every wheel event (60-120/s on a trackpad) fully recomposes the ~2700-line composable.

## 1. The caret's column never came from the render frame

`ProperTerminal.kt:2013` read `typeAheadManager.cursorX` at composable scope - outside `remember`, outside `captureStableRenderFrame`. That getter falls back to the **live** emulator column whenever `predictions.isEmpty()`, which is the steady state, and type-ahead is on by default for every local tab.

So the painted caret paired a fresh column with a row captured from an earlier frame - an x/y the terminal was never in - and re-read it on every wheel event, making the column jitter for the length of a gesture with no output change at all. Present at `scrollOffset == 0` too. It also took the emulator buffer lock on the UI thread and copied the cursor's whole line into a `StringBuffer`, per recomposition.

`predictedCursorX` now returns `null` when nothing is predicted, and the frame carries it. Overriding only while actually predicting is the whole contract type-ahead needs.

## 2. Cursor and content were captured at different instants

`createIncrementalSnapshot()` takes and **releases** the buffer lock before returning, so the four unsynchronised `@Volatile` cursor reads that followed described a state at or after the text. Separately, `setCursor` wrote `x` then `y` non-atomically, so a reader could catch the new x with the old y.

Both fields now live in one `AtomicReference<CursorSnapshot>`, and buffer + banked history delta + cursor are captured under a **single** `textBuffer.lock()` hold. The UI thread goes from two buffer-lock acquisitions per composition to one.

Lock order is stated in the code: the UI thread takes only `myLock` and touches no Compose state and no other monitor under it, and `captureStableRenderFrame` takes `syncUpdateLock` before and after the lambda but never during - so the emulator's `myLock -> syncUpdateLock` order is never inverted.

## 3. The blink was a fixed-delay loop on a busy thread

```kotlin
while (isActive) { delay(caretBlinkMs); cursorBlinkVisible = !cursorBlinkVisible }
```

`delay` measures from **resumption**. A wake that lands X ms late toggles at `period + X`, and the next delay starts from there - so the period stretches and the phase walks, with X tracking scroll and output activity. Pure drift, not a restart, which is why it reads as the rate changing rather than jumping.

`runBlinkPhase` derives the phase from a monotonic epoch and sleeps to the next **absolute** edge. Under zero load the behaviour is identical; it diverges only when a wake is late. A stall longer than a period skips the toggles it slept through rather than replaying them.

Deliberately **not** `withFrameNanos` / `withInfiniteAnimationFrameMillis`: awaiting the frame clock *requests* a frame, so the loop would wake at display refresh rate forever, per visible tab, breaking the zero-idle-repaint guarantee the `blinkActive` gate and `blinkProbe` parking exist to provide. `BlinkPhaseLoopTest.tenSecondsCostsExactlyTwentyToggles` is the regression test for that.

## 4. Every wheel event cost two full text renders

`cachedHyperlinks` / `lastHyperlinkVersionHash` were `mutableStateOf`, **read** inside the text-canvas draw lambda and **written** inside the same lambda - a draw-phase write to state the draw observer had recorded, which re-invalidates the draw node. Each frame therefore drew twice: once detecting, once hitting the cache.

The key was `computeVersionHash() * 31 + effectiveScrollOffset`, so every wheel tick missed and re-ran detection - ~14 registry patterns including four filesystem-path regexes - over every visible row.

And the result was never used for drawing: inside `renderText` the map is only assigned and returned. Its sole consumers are the hover hit-test and the hover underline.

Detection moves to **buffer-row space** end-to-end and runs one row at a time on hover, memoized on `TerminalLine` identity (the snapshot builder reuses the instance for an unchanged row, so a pure scroll is a 100% hit and no offset appears in the key).

**Fixes a real sign bug on the way:** `collectWrappedLines` computed `row + scrollOffset` while its only caller path computed screen rows as `row - scrollOffset`, so wrapped-line detection read the wrong lines whenever the viewport was scrolled. Also fixes stale hover underlines, since `hoveredHyperlink` no longer holds screen rows that scrolling invalidates.

## 5. The cursor overlay could not be memoized

`Canvas(modifier) { }` is `Spacer(modifier.drawBehind(onDraw))`, and `drawBehind`'s element compares the lambda instance. The overlay's lambda captured the buffer snapshot, render frame, settings, theme, measurer and more - several unstable - so the compiler could not memoize it and every parent recomposition rebuilt it, re-running `resolveCursorGlyph`, `getImageCellAt` and `getOrDecodeImage` with it. The comment claiming it was "the cheap layer" was true only for blink-only changes.

It is now a skippable composable over one `@Stable` holder, published from a `SideEffect` placed after the fold's (so it uses the offset the text canvas actually drew with). `CursorFrame` is structurally comparable, so an output frame that does not touch the caret drops the write entirely.

To be precise about what this buys: the resolution itself still runs once per successful recomposition, in the apply phase rather than the draw phase, since the `SideEffect` is unconditional. What is saved is the **paint** and the draw-node invalidation - the layer stops repainting for recompositions that have nothing to do with the caret.

The clocks live on that same holder rather than as composition locals, so **both** canvases read them in their own draw lambda. That matters: a `SideEffect` runs outside `observeReads`, so resolving the glyph's blink gate there would subscribe nothing and leave a block caret painting a glyph the text pass had blinked away. `resolveCursorGlyph` records which clock the cell follows; `CursorOverlay` applies it at draw time.

## Breaking for embedders

The subtle one, and the reason to lead with it: **`tab.hoveredHyperlink` (public on `TerminalSession`) now carries buffer rows.** Its `row` / `startRow` / `endRow` / `rowSpans` used to be screen rows, so they silently changed meaning as the viewport scrolled; add `scrollOffset` to convert. Nothing in-repo reads them (`toHyperlinkInfo` does not expose rows), so this compiles fine and behaves differently - which is why it needs the release note more than the rest.

The mechanical ones, which an embedder will hit as compile errors:

| Change | Was |
|---|---|
| `TerminalCanvasRenderer.detectAllHyperlinks` removed | replaced by `HyperlinkDetector.detectForBufferRow` (one row, on demand) |
| `TerminalCanvasRenderer.renderTerminal` returns `Unit` | returned `Map<Int, List<Hyperlink>>` |
| `RenderingContext` loses `precomputedHyperlinks`, `workingDirectory`, `detectFilePaths`, `hyperlinkRegistry` | a public data class, so `copy()` and `componentN()` shift |
| `HyperlinkDetector.collectWrappedLines` / `detectHyperlinksWithWrapping` lose `scrollOffset` | took a screen row plus an offset; now take a buffer row |
| `TerminalTypeAheadManager.cursorX` → `predictedCursorX`, now `Int?` | non-null, and fell back to the live column |

`HyperlinkDetector.MAX_WRAPPED_RUN_ROWS` also caps how far a wrapped-line walk runs (64 rows each way), so a single logical line longer than that is no longer detected end-to-end. That bounds a pointer move to O(cap) instead of O(scrollback); at 80 columns the cap still spans ~5k characters.

## Not changed

`cursorScreenRow = (cursorY - 1) + scrollOffset` is correct - the text renderer maps `bufferRow = screenRow - scrollOffset`, so inverting it for a live screen row gives exactly this, and the live screen genuinely recedes as you scroll up. The caret still draws while scrolled back, so a TUI's transient mid-redraw `cursorY` can still surface in scrollback; hiding it at `scrollOffset != 0` is a small follow-up if that turns out to matter.

The `?2026`-rejected-frame path is not a caret defect: the retained frame's text and cursor come from the same object, and the fold is already gated to accepted captures (`a5c0bd2f`).

## Out of scope, filed mentally

- `scrollOffset` as a `MutableState` read at composable scope, recomposing all ~2700 lines per wheel event. This PR removes most of its *cost* without touching its *shape*.
- The scrollbar's `LaunchedEffect` restarting per wheel tick.
- `requestImmediateRedraw` launching two coroutines per call.
- The SGR text-blink phase still resets when `hasSlowBlinkText` flips, which the draw lambda writes back per frame - so blink text scrolling in and out of the viewport restarts that effect and resets its epoch. The caret's phase is now stable; this is the remaining discontinuity for *text* blink.
- Resetting the blink phase on keystroke the way iTerm2 does. Worth having, but it must key off **user input only** - resetting on emulator cursor movement would make the caret solid while output streams and then blink off from whenever the last redraw landed, which is this PR's symptom reintroduced as a feature.

## Testing

**1069 tests green, 24 new.** All five modules compile (`./gradlew build` fails in any worktree for an unrelated reason - `local.properties` is gitignored so there is no Android SDK path; the main checkout has none either).

- `BlinkClockTest` - phase arithmetic, the round-**up** boundary guard, and a characterisation test driving the old `now + period` model and the new absolute-edge model through the same 20 late wakes: the old one drifts seconds past ideal, the new one is late by each wake's own delay and nothing more.
- `BlinkPhaseLoopTest` - virtual time with an injected wall clock (a test scheduler always resumes on schedule, so a stall can only be modelled by moving the clock ahead of it). Covers exact edges, no catch-up burst, "Off" not spinning, and the battery guard.
- `ComposeTerminalDisplayCursorTest` - 200k reads against a writer alternating two positions. **Verified to fail against a reintroduced split write**, catching `(79, 1)`: new x, old y.
- `HyperlinkBufferRowTest` - offset-invariance, history rows at negative indices, the wrapped-link-in-history regression test for the sign bug, and the memo's identity behaviour.
- `CursorFrameEqualityTest` - pins the predicate that decides whether the overlay repaints, without a UI harness.

Existing `CursorOverlayTest`, `ResolveCursorGlyphTest`, `FoldHistoryAppendsTest`, `HistoryAppendBankTest` and `HistoryAppendAnchorTest` pass untouched.

**Manual check (not run - AGENTS.md says the app is yours to run):** open `claude`, stream a long response, trackpad-scroll hard for ~20s. The caret's column should hold still during the gesture and the blink should stay on a steady beat. Control: repeat in `vim`, where the wheel is forwarded to the app and no local scroll happens - nothing should change there.
