### PR TITLE
fix(input): submit commands with CR, not LF

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,10 +252,13 @@ Located in: `compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/shell/S
 
 ```kotlin
 state.sendCtrlC()                    // Interrupt
-state.write("command\n")             // Send text
+state.write("command\n")             // Send text (newlines normalized to CR — submits everywhere)
 state.sendCtrlC(tabIndex = 0)        // Target tab by index
 state.write("cmd\n", tabId = "id")   // Target tab by ID
 ```
+
+`write()` is the embedder-facing convenience and normalizes newlines; `writeUserInput()` underneath
+it is verbatim, for callers that need to send a literal LF. See the CR note above.
 
 ## Development Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,8 +257,12 @@ state.sendCtrlC(tabIndex = 0)        // Target tab by index
 state.write("cmd\n", tabId = "id")   // Target tab by ID
 ```
 
-`write()` is the embedder-facing convenience and normalizes newlines; `writeUserInput()` underneath
-it is verbatim, for callers that need to send a literal LF. See the CR note above.
+`write()` / `writeToFocusedPane()` are the embedder-facing convenience and normalize newlines, so
+`"\n"` presses Enter on every platform. `TerminalTab.writeUserInput()` underneath them is verbatim —
+reachable on the tabbed API via the public `activeTab`, and used by MCP `send_input`, which is the
+one caller that must be able to send a literal LF. `EmbeddableTerminalState` keeps its `session`
+internal, so the single-terminal API has no verbatim path; add one if an embedder needs Ctrl+J.
+See the CR note above.
 
 ## Development Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,31 @@ own title. The OSC 2 slot is cleared at prompt start so a program that set one s
 window after it exits - which needs OSC 133, so it does not happen inside tmux/screen or without the
 shell integration.
 
+### The submit character is CR, and LF is not a fallback (measured)
+
+Anything writing a command to a PTY programmatically must end it with `\r`, via `submitLine()` in
+`compose-ui/.../util/TerminalSubmit.kt`. Never `\n`, never `\r\n`.
+
+`TerminalKeyEncoder` sends CR for the Enter key and `pasteText` normalizes pasted newlines to CR, so
+a writer using LF is not simulating a keypress. On a Unix pty you cannot tell — the line discipline's
+`ICRNL` maps CR to NL on input, so LF submits too, which is why LF sat in the AI-launch path, the git
+menu items, `run_command` and `run_in_panel` for years. ConPTY does no such translation:
+
+| sent | runs? | after |
+|---|---|---|
+| `\n` | **no** | text stranded at a `>>` continuation prompt (LF is Ctrl+J → PSReadLine inserts a newline) |
+| `\r` | yes | clean prompt |
+| `\r\n` | yes | **the NEXT prompt is `>>`** — the orphan LF is typed into it |
+| `\n\r` | yes | runs, but the command echoes on a continuation line |
+
+Measured against Windows PowerShell 5.1 over ConPTY by writing each form to a real pane and reading
+the scrollback back. The `\r\n` row is the trap: it looks correct because the command works, and the
+damage lands on the user's next keystrokes.
+
+`send_input` (MCP) is the deliberate exception — it stays byte-verbatim, because a bare LF is a
+keystroke a caller may actually want (a newline inside a multi-line prompt to an AI CLI) and
+rewriting it would remove the only way to send one. Its tool description carries the warning instead.
+
 ### Emoji Rendering
 Skia ignores variation selectors (U+FE0F). Peek-ahead to detect, switch to `FontFamily.Default`, render as unit.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,11 +258,11 @@ state.write("cmd\n", tabId = "id")   // Target tab by ID
 ```
 
 `write()` / `writeToFocusedPane()` are the embedder-facing convenience and normalize newlines, so
-`"\n"` presses Enter on every platform. `TerminalTab.writeUserInput()` underneath them is verbatim —
-reachable on the tabbed API via the public `activeTab`, and used by MCP `send_input`, which is the
-one caller that must be able to send a literal LF. `EmbeddableTerminalState` keeps its `session`
-internal, so the single-terminal API has no verbatim path; add one if an embedder needs Ctrl+J.
-See the CR note above.
+`"\n"` presses Enter on every platform. The verbatim path underneath is `TerminalTab.writeUserInput()`
+— reachable on the tabbed API via the public `activeTab`, as `EmbeddableTerminalState.writeVerbatim()`
+on the single-terminal API, and used by MCP `send_input`. Reach for it only when you mean keystrokes
+rather than a command: a bare LF is Ctrl+J, which is how a multi-line prompt gets typed into an AI
+CLI. See the CR note above.
 
 ## Development Guidelines
 

--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -163,11 +163,17 @@ kotlin {
 // rather than whatever working directory the runner picked. Injected instead of sniffed upward for
 // settings.gradle.kts: the sniff resolves nothing when an IDE run config starts at the repo root,
 // and an empty scan is a test that passes without looking at anything.
-// Set in doFirst rather than as a task property on purpose: a systemProperty becomes a task input,
-// and an absolute checkout path as an input makes the test task non-relocatable, costing build-cache
-// hits across CI agents. Applied at execution time instead, before the test JVM forks.
-tasks.withType<Test> {
-    doFirst { systemProperty("bossterm.repoRoot", rootDir.absolutePath) }
+// SubmitCharacterCoverageTest scans sibling modules, so it needs the repo root rather than whatever
+// working directory the runner picked. Passed as an argument provider, not a systemProperty: the
+// latter becomes a task input, and an absolute checkout path as an input makes the test task
+// non-relocatable, costing build-cache hits across agents. A CommandLineArgumentProvider with no
+// annotated getters contributes nothing to the input snapshot, which is exactly what's wanted.
+//
+// Captured into a local first, and configureEach rather than withType {}: reading `rootDir` inside a
+// task action is a configuration-cache violation, and the eager form realizes every test task.
+val repoRootPath = rootDir.absolutePath
+tasks.withType<Test>().configureEach {
+    jvmArgumentProviders.add(CommandLineArgumentProvider { listOf("-Dbossterm.repoRoot=$repoRootPath") })
 }
 
 // Configure JAR manifest with version information for library consumers

--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -159,6 +159,14 @@ kotlin {
     }
 }
 
+// SubmitCharacterCoverageTest scans sibling modules for LF submits, so it needs the repo root
+// rather than whatever working directory the runner picked. Injected instead of sniffed upward for
+// settings.gradle.kts: the sniff resolves nothing when an IDE run config starts at the repo root,
+// and an empty scan is a test that passes without looking at anything.
+tasks.withType<Test> {
+    systemProperty("bossterm.repoRoot", rootDir.absolutePath)
+}
+
 // Configure JAR manifest with version information for library consumers
 // This enables Version.CURRENT to read the version when used as a Maven dependency
 tasks.withType<Jar> {

--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -159,15 +159,13 @@ kotlin {
     }
 }
 
-// SubmitCharacterCoverageTest scans sibling modules for LF submits, so it needs the repo root
-// rather than whatever working directory the runner picked. Injected instead of sniffed upward for
-// settings.gradle.kts: the sniff resolves nothing when an IDE run config starts at the repo root,
-// and an empty scan is a test that passes without looking at anything.
 // SubmitCharacterCoverageTest scans sibling modules, so it needs the repo root rather than whatever
-// working directory the runner picked. Passed as an argument provider, not a systemProperty: the
-// latter becomes a task input, and an absolute checkout path as an input makes the test task
-// non-relocatable, costing build-cache hits across agents. A CommandLineArgumentProvider with no
-// annotated getters contributes nothing to the input snapshot, which is exactly what's wanted.
+// working directory the runner picked — its own fallback sniffs upward for settings.gradle.kts,
+// which works but leaves the roots depending on where the runner started. Passed as an argument
+// provider, not a systemProperty: the latter becomes a task input, and an absolute checkout path as
+// an input makes the test task non-relocatable, costing build-cache hits across agents. A
+// CommandLineArgumentProvider with no annotated getters contributes nothing to the input snapshot,
+// which is exactly what's wanted.
 //
 // Captured into a local first, and configureEach rather than withType {}: reading `rootDir` inside a
 // task action is a configuration-cache violation, and the eager form realizes every test task.

--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -163,8 +163,11 @@ kotlin {
 // rather than whatever working directory the runner picked. Injected instead of sniffed upward for
 // settings.gradle.kts: the sniff resolves nothing when an IDE run config starts at the repo root,
 // and an empty scan is a test that passes without looking at anything.
+// Set in doFirst rather than as a task property on purpose: a systemProperty becomes a task input,
+// and an absolute checkout path as an input makes the test task non-relocatable, costing build-cache
+// hits across CI agents. Applied at execution time instead, before the test JVM forks.
 tasks.withType<Test> {
-    systemProperty("bossterm.repoRoot", rootDir.absolutePath)
+    doFirst { systemProperty("bossterm.repoRoot", rootDir.absolutePath) }
 }
 
 // Configure JAR manifest with version information for library consumers

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -55,6 +55,7 @@ import ai.rever.bossterm.compose.terminal.PerformanceMode
 import ai.rever.bossterm.compose.terminal.drainTerminalEmulator
 import ai.rever.bossterm.compose.ui.ProperTerminal
 import ai.rever.bossterm.compose.util.loadTerminalFont
+import ai.rever.bossterm.compose.util.submitLine
 import ai.rever.bossterm.compose.features.ContextMenuController
 import ai.rever.bossterm.compose.features.shouldUseNativeMenus
 import ai.rever.bossterm.compose.ime.IMEState
@@ -1150,8 +1151,8 @@ private suspend fun initializeProcess(
                         session.terminal.addCommandStateListener(completionListener)
                     }
 
-                    // Send the command followed by newline
-                    processHandle.write(initialCommand + "\n")
+                    // Send the command followed by Enter (CR — see submitLine)
+                    processHandle.write(submitLine(initialCommand))
                 } finally {
                     // Clean up the temporary listener
                     session.terminal.removeCommandStateListener(promptListener)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -672,6 +672,23 @@ class EmbeddableTerminalState {
     }
 
     /**
+     * Send text to the terminal byte-for-byte, with no newline conversion.
+     *
+     * The escape hatch [write] gives up by normalizing. A bare LF is Ctrl+J — "insert a newline
+     * without submitting" — which is how you type a multi-line prompt into an AI CLI, and is the
+     * same need that keeps MCP `send_input` verbatim. The tabbed API reaches this through its public
+     * `activeTab.writeUserInput`; this class keeps `session` internal, so without this method the
+     * single-terminal embedder would have no way to express it at all.
+     *
+     * Use [write] unless you specifically mean keystrokes: `\r` submits, `\n` does not.
+     *
+     * @param text Text to send to the shell, unmodified
+     */
+    fun writeVerbatim(text: String) {
+        session?.writeUserInput(text)
+    }
+
+    /**
      * Send raw bytes to the terminal process.
      * Useful for sending control characters like Ctrl+C (0x03) or Ctrl+D (0x04).
      *

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/EmbeddableTerminal.kt
@@ -55,6 +55,7 @@ import ai.rever.bossterm.compose.terminal.PerformanceMode
 import ai.rever.bossterm.compose.terminal.drainTerminalEmulator
 import ai.rever.bossterm.compose.ui.ProperTerminal
 import ai.rever.bossterm.compose.util.loadTerminalFont
+import ai.rever.bossterm.compose.util.normalizeSubmitNewlines
 import ai.rever.bossterm.compose.util.submitLine
 import ai.rever.bossterm.compose.features.ContextMenuController
 import ai.rever.bossterm.compose.features.shouldUseNativeMenus
@@ -355,7 +356,7 @@ fun EmbeddableTerminal(
             onInstallConfirm = { assistant, originalCommand, clearLineCallback ->
                 // Show installation wizard directly
                 val terminalWriter: (String) -> Unit = { text ->
-                    session.writeUserInput(text)
+                    session.writeUserInput(normalizeSubmitNewlines(text))
                 }
                 val resolved = aiState.launcher.resolveInstallCommands(assistant)
                 toolWizardParams = ToolInstallWizardParams(
@@ -404,7 +405,7 @@ fun EmbeddableTerminal(
 
                 // Add AI assistant menu items
                 if (resolvedSettings.aiAssistantsEnabled) {
-                    val terminalWriter: (String) -> Unit = { text -> session.writeUserInput(text) }
+                    val terminalWriter: (String) -> Unit = { text -> session.writeUserInput(normalizeSubmitNewlines(text)) }
                     val aiItems = aiState.menuProvider.getMenuItems(
                         terminalWriter = terminalWriter,
                         onInstallRequest = { assistant, command, npmCommand ->
@@ -417,7 +418,7 @@ fun EmbeddableTerminal(
                 }
 
                 // Add Version Control menu items
-                val terminalWriter: (String) -> Unit = { text -> session.writeUserInput(text) }
+                val terminalWriter: (String) -> Unit = { text -> session.writeUserInput(normalizeSubmitNewlines(text)) }
                 val vcsItems = vcsMenuProvider.getMenuItems(
                     terminalWriter = terminalWriter,
                     onInstallRequest = { toolId, command, npmCommand ->
@@ -661,12 +662,13 @@ class EmbeddableTerminalState {
 
     /**
      * Send text input to the terminal.
-     * Use "\n" for enter key.
+     * Use "\n" (or "\r") for the enter key — newlines are normalized to the CR a terminal actually
+     * sends, so the same call submits on Windows/ConPTY as well as Unix. See `submitLine`.
      *
      * @param text Text to send to the shell
      */
     fun write(text: String) {
-        session?.writeUserInput(text)
+        session?.writeUserInput(normalizeSubmitNewlines(text))
     }
 
     /**
@@ -834,7 +836,7 @@ class EmbeddableTerminalState {
             assistant = assistant,
             command = resolved.command,
             npmCommand = resolved.npmFallback,
-            terminalWriter = { text -> currentSession.writeUserInput(text) }
+            terminalWriter = { text -> currentSession.writeUserInput(normalizeSubmitNewlines(text)) }
         )
         return true
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -627,9 +627,10 @@ fun TabbedTerminal(
                     )
                     return
                 }
-                // A null args means "let the user finish the line" — no trailing newline.
+                // A null args means "let the user finish the line" — prefill, don't submit.
                 writeToTerminal(
-                    if (argsOrNull == null) "${ollama.command} run " else "${ollama.command} $argsOrNull\n"
+                    if (argsOrNull == null) "${ollama.command} run "
+                    else submitLine("${ollama.command} $argsOrNull")
                 )
             }
             onRunLocalModel = { model -> runOllama(model?.let { "run $it" }) }
@@ -686,7 +687,7 @@ fun TabbedTerminal(
                     "fish" -> "source ~/.config/fish/config.fish"
                     else -> "source ~/.bashrc"
                 }
-                writeToTerminal(submitLine("$sourceCmd"))
+                writeToTerminal(submitLine(sourceCmd))
             }
 
             // Starship

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -534,11 +534,11 @@ fun TabbedTerminal(
         val activeTab = tabController.tabs.getOrNull(tabController.activeTabIndex) ?: return@LaunchedEffect
         val splitState = getOrCreateSplitState(activeTab)
 
-        // Helper to write to terminal. Normalizes newlines to CR on the way through, so the menu
-        // handlers below (and GitUtils, and the install wizard's terminalWriter) can keep writing
-        // the readable "cmd\n" and still press Enter rather than Ctrl+J — a bare LF does not submit
-        // under ConPTY. See normalizeSubmitNewlines. Callers that deliberately prefill without
-        // submitting just omit the trailing newline, exactly as before.
+        // Helper to write to terminal. Normalizes newlines to CR on the way through, so a bare LF
+        // handed to it still presses Enter rather than Ctrl+J — see normalizeSubmitNewlines. The
+        // handlers below all submit with submitLine themselves, so this is a backstop for writers
+        // we don't own rather than the thing the menus depend on. Callers that deliberately prefill
+        // without submitting just omit the trailing newline, exactly as before.
         val writeToTerminal: (String) -> Unit = { cmd ->
             activeTab.writeUserInput(normalizeSubmitNewlines(cmd))
         }
@@ -2027,9 +2027,10 @@ fun TabbedTerminal(
                         }
                     }
 
-                    // Add Version Control menu items. Menu providers spell their commands with a
-                    // readable trailing "\n" (VersionControlMenuProvider alone has ~30); the writer
-                    // is what turns that into an Enter, so it must normalize — see submitLine.
+                    // Add Version Control menu items. Normalizing here is defence in depth, not the
+                    // mechanism: every in-repo provider now submits with submitLine, so deleting
+                    // this would break nothing in-tree. It covers writers from outside — an
+                    // embedder's voiceToolSource or a third-party menu provider handing us "cmd\n".
                     val terminalWriter: (String) -> Unit = { text ->
                         splitState.getFocusedSession()?.writeUserInput(normalizeSubmitNewlines(text))
                     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -75,6 +75,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicReference
 import ai.rever.bossterm.compose.util.loadTerminalFont
+import ai.rever.bossterm.compose.util.normalizeSubmitNewlines
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.TerminalSettingsOverride
 import ai.rever.bossterm.compose.features.NativeContextMenuOverride
@@ -532,8 +533,14 @@ fun TabbedTerminal(
         val activeTab = tabController.tabs.getOrNull(tabController.activeTabIndex) ?: return@LaunchedEffect
         val splitState = getOrCreateSplitState(activeTab)
 
-        // Helper to write to terminal
-        val writeToTerminal: (String) -> Unit = { cmd -> activeTab.writeUserInput(cmd) }
+        // Helper to write to terminal. Normalizes newlines to CR on the way through, so the menu
+        // handlers below (and GitUtils, and the install wizard's terminalWriter) can keep writing
+        // the readable "cmd\n" and still press Enter rather than Ctrl+J — a bare LF does not submit
+        // under ConPTY. See normalizeSubmitNewlines. Callers that deliberately prefill without
+        // submitting just omit the trailing newline, exactly as before.
+        val writeToTerminal: (String) -> Unit = { cmd ->
+            activeTab.writeUserInput(normalizeSubmitNewlines(cmd))
+        }
 
         // Get current working directory from focused session
         val getWorkingDir: () -> String? = {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -76,6 +76,7 @@ import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicReference
 import ai.rever.bossterm.compose.util.loadTerminalFont
 import ai.rever.bossterm.compose.util.normalizeSubmitNewlines
+import ai.rever.bossterm.compose.util.submitLine
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.TerminalSettingsOverride
 import ai.rever.bossterm.compose.features.NativeContextMenuOverride
@@ -636,7 +637,7 @@ fun TabbedTerminal(
             onListLocalModels = { runOllama("list") }
 
             // Git commands (path-aware using GitUtils)
-            onGitInit = { writeToTerminal("git ${GitUtils.Commands.INIT}\n") }
+            onGitInit = { writeToTerminal(submitLine("git ${GitUtils.Commands.INIT}")) }
             onGitClone = { writeToTerminal("git ${GitUtils.Commands.CLONE}") }
             onGitStatus = { gitCmd(GitUtils.Commands.STATUS) }
             onGitDiff = { gitCmd(GitUtils.Commands.DIFF) }
@@ -663,8 +664,8 @@ fun TabbedTerminal(
             onGitStashPop = { gitCmd(GitUtils.Commands.STASH_POP) }
 
             // GitHub CLI commands (path-aware using GitUtils)
-            onGhAuthStatus = { writeToTerminal("gh ${GitUtils.GhCommands.AUTH_STATUS}\n") }
-            onGhAuthLogin = { writeToTerminal("gh ${GitUtils.GhCommands.AUTH_LOGIN}\n") }
+            onGhAuthStatus = { writeToTerminal(submitLine("gh ${GitUtils.GhCommands.AUTH_STATUS}")) }
+            onGhAuthLogin = { writeToTerminal(submitLine("gh ${GitUtils.GhCommands.AUTH_LOGIN}")) }
             onGhSetDefault = { ghCmd(GitUtils.GhCommands.SET_DEFAULT) }
             onGhRepoClone = { writeToTerminal("gh ${GitUtils.GhCommands.REPO_CLONE}") }
             onGhPrList = { ghCmd(GitUtils.GhCommands.PR_LIST) }
@@ -676,32 +677,32 @@ fun TabbedTerminal(
             onGhRepoView = { ghCmd(GitUtils.GhCommands.REPO_VIEW_WEB) }
 
             // Shell config
-            onEditZshrc = { writeToTerminal("\${EDITOR:-nano} ~/.zshrc\n") }
-            onEditBashrc = { writeToTerminal("\${EDITOR:-nano} ~/.bashrc\n") }
-            onEditFishConfig = { writeToTerminal("\${EDITOR:-nano} ~/.config/fish/config.fish\n") }
+            onEditZshrc = { writeToTerminal(submitLine("\${EDITOR:-nano} ~/.zshrc")) }
+            onEditBashrc = { writeToTerminal(submitLine("\${EDITOR:-nano} ~/.bashrc")) }
+            onEditFishConfig = { writeToTerminal(submitLine("\${EDITOR:-nano} ~/.config/fish/config.fish")) }
             onReloadShellConfig = {
                 val sourceCmd = when (currentShell) {
                     "zsh" -> "source ~/.zshrc"
                     "fish" -> "source ~/.config/fish/config.fish"
                     else -> "source ~/.bashrc"
                 }
-                writeToTerminal("$sourceCmd\n")
+                writeToTerminal(submitLine("$sourceCmd"))
             }
 
             // Starship
-            onStarshipEditConfig = { writeToTerminal("\${EDITOR:-nano} ~/.config/starship.toml\n") }
-            onStarshipPresets = { writeToTerminal("starship preset --list\n") }
+            onStarshipEditConfig = { writeToTerminal(submitLine("\${EDITOR:-nano} ~/.config/starship.toml")) }
+            onStarshipPresets = { writeToTerminal(submitLine("starship preset --list")) }
 
             // Oh My Zsh
-            onOhMyZshUpdate = { writeToTerminal("omz update\n") }
-            onOhMyZshThemes = { writeToTerminal("ls ~/.oh-my-zsh/themes/\n") }
-            onOhMyZshPlugins = { writeToTerminal("ls ~/.oh-my-zsh/plugins/\n") }
+            onOhMyZshUpdate = { writeToTerminal(submitLine("omz update")) }
+            onOhMyZshThemes = { writeToTerminal(submitLine("ls ~/.oh-my-zsh/themes/")) }
+            onOhMyZshPlugins = { writeToTerminal(submitLine("ls ~/.oh-my-zsh/plugins/")) }
 
             // Prezto
-            onPreztoUpdate = { writeToTerminal("cd ~/.zprezto && git pull && git submodule update --init --recursive && cd -\n") }
-            onPreztoEditConfig = { writeToTerminal("\${EDITOR:-nano} ~/.zpreztorc\n") }
-            onPreztoListThemes = { writeToTerminal("ls ~/.zprezto/modules/prompt/functions/ | grep prompt_ | sed 's/prompt_//'\n") }
-            onPreztoShowModules = { writeToTerminal("grep '^\\s*zmodule' ~/.zpreztorc 2>/dev/null || grep \"'\" ~/.zpreztorc | head -20\n") }
+            onPreztoUpdate = { writeToTerminal(submitLine("cd ~/.zprezto && git pull && git submodule update --init --recursive && cd -")) }
+            onPreztoEditConfig = { writeToTerminal(submitLine("\${EDITOR:-nano} ~/.zpreztorc")) }
+            onPreztoListThemes = { writeToTerminal(submitLine("ls ~/.zprezto/modules/prompt/functions/ | grep prompt_ | sed 's/prompt_//'")) }
+            onPreztoShowModules = { writeToTerminal(submitLine("grep '^\\s*zmodule' ~/.zpreztorc 2>/dev/null || grep \"'\" ~/.zpreztorc | head -20")) }
         }
     }
 
@@ -845,7 +846,7 @@ fun TabbedTerminal(
                 onInstallConfirm = { assistant, originalCommand, clearLineCallback ->
                     // Show installation wizard directly
                     val terminalWriter: (String) -> Unit = { text ->
-                        tab.writeUserInput(text)
+                        tab.writeUserInput(normalizeSubmitNewlines(text))
                     }
                     val resolved = aiState.launcher.resolveInstallCommands(assistant)
                     toolWizardParams = ToolInstallWizardParams(
@@ -1950,7 +1951,7 @@ fun TabbedTerminal(
                     // Add AI assistant menu items
                     if (settings.aiAssistantsEnabled) {
                         val terminalWriter: (String) -> Unit = { text ->
-                            splitState.getFocusedSession()?.writeUserInput(text)
+                            splitState.getFocusedSession()?.writeUserInput(normalizeSubmitNewlines(text))
                         }
                         val aiItems = aiState.menuProvider.getMenuItems(
                             terminalWriter = terminalWriter,
@@ -2030,9 +2031,11 @@ fun TabbedTerminal(
                         }
                     }
 
-                    // Add Version Control menu items
+                    // Add Version Control menu items. Menu providers spell their commands with a
+                    // readable trailing "\n" (VersionControlMenuProvider alone has ~30); the writer
+                    // is what turns that into an Enter, so it must normalize — see submitLine.
                     val terminalWriter: (String) -> Unit = { text ->
-                        splitState.getFocusedSession()?.writeUserInput(text)
+                        splitState.getFocusedSession()?.writeUserInput(normalizeSubmitNewlines(text))
                     }
                     val vcsItems = vcsMenuProvider.getMenuItems(
                         terminalWriter = terminalWriter,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -563,12 +563,12 @@ fun TabbedTerminal(
 
         // Helper to run git command in working directory using shared GitUtils
         val gitCmd: (String) -> Unit = { cmd ->
-            writeToTerminal(GitUtils.gitCommand(cmd, getWorkingDir()))
+            writeToTerminal(submitLine(GitUtils.gitCommand(cmd, getWorkingDir())))
         }
 
         // Helper to run gh command in working directory using shared GitUtils
         val ghCmd: (String) -> Unit = { cmd ->
-            writeToTerminal(GitUtils.ghCommand(cmd, getWorkingDir()))
+            writeToTerminal(submitLine(GitUtils.ghCommand(cmd, getWorkingDir())))
         }
 
         // Get current shell from environment
@@ -654,12 +654,8 @@ fun TabbedTerminal(
             onGitBranch = { gitCmd(GitUtils.Commands.BRANCH) }
             onGitCheckoutPrev = { gitCmd(GitUtils.Commands.CHECKOUT_PREV) }
             onGitCheckoutNew = {
-                // Prefill only: the user still needs to type the new branch name.
-                val command = GitUtils.gitCommand(
-                    GitUtils.Commands.CHECKOUT_NEW,
-                    getWorkingDir()
-                ).removeSuffix("\n")
-                writeToTerminal(command)
+                // Prefill only: the user still needs to type the new branch name, so no submitLine.
+                writeToTerminal(GitUtils.gitCommand(GitUtils.Commands.CHECKOUT_NEW, getWorkingDir()))
             }
             onGitStash = { gitCmd(GitUtils.Commands.STASH) }
             onGitStashPop = { gitCmd(GitUtils.Commands.STASH_POP) }
@@ -1594,8 +1590,7 @@ fun TabbedTerminal(
                     tabController.switchToTab(tabIndex)
                     splitStates[tab.id]?.setFocusedPane(paneId)
                     val cwd = session.workingDirectory.value
-                    val command = GitUtils.gitCommand("worktree add ", cwd).removeSuffix("\n")
-                    session.writeUserInput(command)
+                    session.writeUserInput(GitUtils.gitCommand("worktree add ", cwd))
                 },
                 onShareTab = { index ->
                     tabController.tabs.getOrNull(index)?.let { startShare(it.id, ai.rever.bossterm.compose.share.ShareScope.TAB) }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -10,6 +10,7 @@ import ai.rever.bossterm.compose.ai.AIInstallDialogParams
 import ai.rever.bossterm.compose.search.RabinKarpSearch
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.settings.TerminalSettings
+import ai.rever.bossterm.compose.util.normalizeSubmitNewlines
 import ai.rever.bossterm.compose.splits.NavigationDirection
 import ai.rever.bossterm.compose.splits.SplitOrientation
 import ai.rever.bossterm.compose.splits.SplitViewState
@@ -437,7 +438,8 @@ class TabbedTerminalState {
 
     /**
      * Send text input to the active terminal tab.
-     * Use "\n" for enter key.
+     * Use "\n" (or "\r") for the enter key — newlines are normalized to the CR a terminal actually
+     * sends, so the same call submits on Windows/ConPTY as well as Unix. See `submitLine`.
      *
      * This method is asynchronous - it queues the text and returns immediately.
      *
@@ -446,7 +448,7 @@ class TabbedTerminalState {
      * @param text Text to send to the shell
      */
     fun write(text: String) {
-        activeTab?.writeUserInput(text)
+        activeTab?.writeUserInput(normalizeSubmitNewlines(text))
     }
 
     /**
@@ -460,7 +462,7 @@ class TabbedTerminalState {
      * @param tabIndex Index of the tab to send input to (0-based)
      */
     fun write(text: String, tabIndex: Int) {
-        tabs.getOrNull(tabIndex)?.writeUserInput(text)
+        tabs.getOrNull(tabIndex)?.writeUserInput(normalizeSubmitNewlines(text))
     }
 
     /**
@@ -475,7 +477,7 @@ class TabbedTerminalState {
      */
     fun write(text: String, tabId: String): Boolean {
         val tab = getTabById(tabId) ?: return false
-        tab.writeUserInput(text)
+        tab.writeUserInput(normalizeSubmitNewlines(text))
         return true
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -1010,12 +1010,18 @@ class TabbedTerminalState {
      *
      * Use [write] unless you specifically mean keystrokes: `\r` submits, `\n` does not.
      *
+     * Routes through [findSession], which validates the tab and falls back to that tab's own
+     * session when it has no splits. An earlier version fell back to [activeTab], which meant an
+     * unsplit background tab — `splitStates` is populated lazily, so any tab never activated — or a
+     * stale id would type into whatever the user was looking at, and still return true. On an API
+     * whose whole purpose is raw keystrokes, that misdelivers a `y\r` or a password.
+     *
      * @param text Text to send to the shell, unmodified
      * @param tabId Target tab ID. If null, uses the active tab.
-     * @return true if the text was sent, false if tab/pane not found
+     * @return true if the text was sent, false if the tab was not found
      */
     fun writeVerbatim(text: String, tabId: String? = null): Boolean {
-        val session = getFocusedSplitSession(tabId) ?: activeTab ?: return false
+        val session = findSession(resolveTabId(tabId) ?: return false) ?: return false
         session.writeUserInput(text)
         return true
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -987,12 +987,17 @@ class TabbedTerminalState {
      * sibling of that API and has to press Enter the same way. See `submitLine`. Use
      * [writeVerbatim] when you mean keystrokes rather than a command.
      *
+     * Resolves through [findSession], like [writeVerbatim]. It used to use [getFocusedSplitSession],
+     * which returns null when `splitStates` has no entry for the tab — populated lazily, so an
+     * unsplit tab that had never been activated returned false even though it has exactly one pane
+     * to write to. The two are documented as a pair and now resolve as one.
+     *
      * @param text Text to send
      * @param tabId Target tab ID. If null, uses the active tab.
-     * @return true if the text was sent, false if tab/pane not found
+     * @return true if the text was sent, false if the tab was not found
      */
     fun writeToFocusedPane(text: String, tabId: String? = null): Boolean {
-        val session = getFocusedSplitSession(tabId) ?: return false
+        val session = findSession(resolveTabId(tabId) ?: return false) ?: return false
         session.writeUserInput(normalizeSubmitNewlines(text))
         return true
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -984,7 +984,8 @@ class TabbedTerminalState {
      * Send text input to the focused pane of the specified tab.
      *
      * Newlines are normalized to CR, same as the [write] overloads — this is the split-pane
-     * sibling of that API and has to press Enter the same way. See `submitLine`.
+     * sibling of that API and has to press Enter the same way. See `submitLine`. Use
+     * [writeVerbatim] when you mean keystrokes rather than a command.
      *
      * @param text Text to send
      * @param tabId Target tab ID. If null, uses the active tab.
@@ -993,6 +994,29 @@ class TabbedTerminalState {
     fun writeToFocusedPane(text: String, tabId: String? = null): Boolean {
         val session = getFocusedSplitSession(tabId) ?: return false
         session.writeUserInput(normalizeSubmitNewlines(text))
+        return true
+    }
+
+    /**
+     * Send text to the focused pane byte-for-byte, with no newline conversion.
+     *
+     * The escape hatch [write] and [writeToFocusedPane] give up by normalizing. A bare LF is Ctrl+J
+     * — "insert a newline without submitting" — which is how a multi-line prompt gets typed into an
+     * AI CLI, and is the same need that keeps MCP `send_input` verbatim.
+     *
+     * Mirrors `EmbeddableTerminalState.writeVerbatim`. Reachable before this existed only via the
+     * public `activeTab` / [getFocusedSplitSession], which is not where anyone would look; the two
+     * public APIs now offer the same shape for the same need.
+     *
+     * Use [write] unless you specifically mean keystrokes: `\r` submits, `\n` does not.
+     *
+     * @param text Text to send to the shell, unmodified
+     * @param tabId Target tab ID. If null, uses the active tab.
+     * @return true if the text was sent, false if tab/pane not found
+     */
+    fun writeVerbatim(text: String, tabId: String? = null): Boolean {
+        val session = getFocusedSplitSession(tabId) ?: activeTab ?: return false
+        session.writeUserInput(text)
         return true
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminalState.kt
@@ -983,13 +983,16 @@ class TabbedTerminalState {
     /**
      * Send text input to the focused pane of the specified tab.
      *
+     * Newlines are normalized to CR, same as the [write] overloads — this is the split-pane
+     * sibling of that API and has to press Enter the same way. See `submitLine`.
+     *
      * @param text Text to send
      * @param tabId Target tab ID. If null, uses the active tab.
      * @return true if the text was sent, false if tab/pane not found
      */
     fun writeToFocusedPane(text: String, tabId: String? = null): Boolean {
         val session = getFocusedSplitSession(tabId) ?: return false
-        session.writeUserInput(text)
+        session.writeUserInput(normalizeSubmitNewlines(text))
         return true
     }
 
@@ -1101,7 +1104,7 @@ class TabbedTerminalState {
             assistant = assistant,
             command = resolved.command,
             npmCommand = resolved.npmFallback,
-            terminalWriter = { text -> tab.writeUserInput(text) }
+            terminalWriter = { text -> tab.writeUserInput(normalizeSubmitNewlines(text)) }
         )
         return true
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantInstallDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantInstallDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.ai
 
+import ai.rever.bossterm.compose.util.submitLine
 import ai.rever.bossterm.compose.EmbeddableTerminal
 import ai.rever.bossterm.compose.settings.SettingsTheme
 import ai.rever.bossterm.compose.settings.TerminalSettingsOverride
@@ -309,17 +310,17 @@ fun AIInstallDialogHost(
             onInstallComplete = { success ->
                 // Write result to parent terminal using echo for proper ANSI handling
                 if (success) {
-                    p.terminalWriter("echo -e '\\033[32m✓ ${p.assistant.displayName} installed successfully!\\033[0m'\n")
+                    p.terminalWriter(submitLine("echo -e '\\033[32m✓ ${p.assistant.displayName} installed successfully!\\033[0m'"))
                     // If there's a command to run after install, source shell and execute it
                     p.commandToRunAfter?.let { cmd ->
                         // Source shell profile to pick up PATH changes, then run original command
                         // Escape single quotes in the command for safe embedding
                         val escapedCmd = cmd.replace("'", "'\\''")
                         // Use a fresh login shell to get updated PATH, then run the command
-                        p.terminalWriter("\$SHELL -l -c '$escapedCmd'\n")
+                        p.terminalWriter(submitLine("\$SHELL -l -c '$escapedCmd'"))
                     }
                 } else {
-                    p.terminalWriter("echo -e '\\033[31m✗ ${p.assistant.displayName} installation failed.\\033[0m'\n")
+                    p.terminalWriter(submitLine("echo -e '\\033[31m✗ ${p.assistant.displayName} installation failed.\\033[0m'"))
                 }
             }
         )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantInstallDialog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/AIAssistantInstallDialog.kt
@@ -314,8 +314,15 @@ fun AIInstallDialogHost(
                     // If there's a command to run after install, source shell and execute it
                     p.commandToRunAfter?.let { cmd ->
                         // Source shell profile to pick up PATH changes, then run original command
-                        // Escape single quotes in the command for safe embedding
-                        val escapedCmd = cmd.replace("'", "'\\''")
+                        // Escape single quotes in the command for safe embedding, and flatten it to
+                        // one line. submitLine rewrites INTERIOR newlines too, so an LF surviving
+                        // into the quoted argument would become a real Enter inside the quotes —
+                        // splitting the command and leaving the quote unterminated, rather than
+                        // passing a multi-line argument. Nothing reaches here with an LF today
+                        // (commandToRunAfter is a launch line or an intercepted prompt line); this
+                        // makes that a guarantee of this call rather than a property of its callers.
+                        val escapedCmd = cmd.lineSequence().joinToString(" ") { it.trim() }
+                            .replace("'", "'\\''")
                         // Use a fresh login shell to get updated PATH, then run the command
                         p.terminalWriter(submitLine("\$SHELL -l -c '$escapedCmd'"))
                     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/ToolCommandProvider.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/ToolCommandProvider.kt
@@ -3,6 +3,7 @@ package ai.rever.bossterm.compose.ai
 import ai.rever.bossterm.compose.settings.AIAssistantConfigData
 import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import ai.rever.bossterm.compose.util.UrlOpener
+import ai.rever.bossterm.compose.util.submitLine
 
 /**
  * Provides commands for launching and installing tools.
@@ -21,11 +22,11 @@ class ToolCommandProvider {
         assistant: AIAssistantDefinition,
         config: AIAssistantConfigData? = null
     ): String {
-        return "${launchCommandText(assistant, config)}\n"
+        return submitLine(launchCommandText(assistant, config))
     }
 
     /**
-     * The launch command as text, without the trailing newline that submits it.
+     * The launch command as text, without the trailing Enter that submits it.
      *
      * Public because "what would launching this look like?" is needed in places that aren't writing
      * to the PTY right now — notably the install wizard's `commandToRunAfter`, which used to pass

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/ToolInstallWizard.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ai/ToolInstallWizard.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.ai
 
+import ai.rever.bossterm.compose.util.submitLine
 import androidx.compose.runtime.*
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -130,19 +131,19 @@ fun ToolInstallWizard(
                 // Build a single command to avoid race conditions between separate terminalWriter calls
                 if (isBrewTool && commandToRunAfter != null) {
                     // For brew: source shellenv AND run the command in ONE line
-                    terminalWriter("echo '✓ ${tool.displayName} installed successfully!' && eval \"\$(/opt/homebrew/bin/brew shellenv 2>/dev/null)\" && eval \"\$(/usr/local/bin/brew shellenv 2>/dev/null)\"; $commandToRunAfter\n")
+                    terminalWriter(submitLine("echo '✓ ${tool.displayName} installed successfully!' && eval \"\$(/opt/homebrew/bin/brew shellenv 2>/dev/null)\" && eval \"\$(/usr/local/bin/brew shellenv 2>/dev/null)\"; $commandToRunAfter"))
                 } else if (isBrewTool) {
                     // Brew install without command to run after
-                    terminalWriter("echo '✓ ${tool.displayName} installed successfully!' && eval \"\$(/opt/homebrew/bin/brew shellenv 2>/dev/null)\" && eval \"\$(/usr/local/bin/brew shellenv 2>/dev/null)\"\n")
+                    terminalWriter(submitLine("echo '✓ ${tool.displayName} installed successfully!' && eval \"\$(/opt/homebrew/bin/brew shellenv 2>/dev/null)\" && eval \"\$(/usr/local/bin/brew shellenv 2>/dev/null)\""))
                 } else if (commandToRunAfter != null) {
                     // Non-brew tool with command to run after
-                    terminalWriter("echo '✓ ${tool.displayName} installed successfully!'\n")
+                    terminalWriter(submitLine("echo '✓ ${tool.displayName} installed successfully!'"))
                     val escapedCmd = commandToRunAfter.replace("'", "'\\''")
                     // Source nvm explicitly since $SHELL -l -c doesn't source .zshrc/.bashrc
-                    terminalWriter("export NVM_DIR=\"\$HOME/.nvm\" && [ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\" && $escapedCmd\n")
+                    terminalWriter(submitLine("export NVM_DIR=\"\$HOME/.nvm\" && [ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\" && $escapedCmd"))
                 } else {
                     // Just echo success
-                    terminalWriter("echo '✓ ${tool.displayName} installed successfully!'\n")
+                    terminalWriter(submitLine("echo '✓ ${tool.displayName} installed successfully!'"))
                 }
             }
             onComplete(success)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/blocks/CommandBlockActions.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/blocks/CommandBlockActions.kt
@@ -9,6 +9,7 @@ import ai.rever.bossterm.compose.actions.KeyStroke
 import ai.rever.bossterm.compose.actions.TerminalAction
 import ai.rever.bossterm.compose.selection.SelectionEngine
 import ai.rever.bossterm.compose.settings.SettingsManager
+import ai.rever.bossterm.compose.util.submitLine
 
 /**
  * Keyboard actions for command blocks (Phase 1). All actions are gated by
@@ -135,7 +136,7 @@ object CommandBlockActions {
             handler = handler@{ _ ->
                 if (!enabled()) return@handler false
                 val cmd = blocks().lastOrNull { it.commandText != null }?.commandText ?: return@handler false
-                session.writeUserInput(cmd + "\n")
+                session.writeUserInput(submitLine(cmd))
                 true
             }
         )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonMcpServer.kt
@@ -110,11 +110,13 @@ class DaemonMcpServer(
 
         server.addTool(
             name = "send_input",
-            description = "Write text to a daemon session's stdin. Include '\\n' to submit.",
+            description = "Write text to a daemon session's stdin, verbatim. End with '\\r' " +
+                    "(what Enter sends) to submit; a bare '\\n' is Ctrl+J and inserts a newline " +
+                    "without running anything.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("session_id") { put("type", "string") }
-                    putJsonObject("text") { put("type", "string"); put("description", "Raw text; include '\\n' to submit.") }
+                    putJsonObject("text") { put("type", "string"); put("description", "Raw text; end with '\\r' to submit.") }
                 },
                 required = listOf("session_id", "text"),
             ),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonMcpTools.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/daemon/DaemonMcpTools.kt
@@ -72,7 +72,7 @@ class DaemonMcpTools(private val host: SessionHost) {
         return buildJsonObject { put("text", sb.toString()) }.toString()
     }
 
-    /** Write text to a session's stdin (caller appends '\n' to submit). */
+    /** Write text to a session's stdin (caller appends '\r' to submit — a bare '\n' is Ctrl+J). */
     fun sendInput(args: JsonObject): String {
         val id = args.str("session_id") ?: return err("Missing required argument: session_id")
         val text = args.str("text") ?: return err("Missing required argument: text")

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1109,10 +1109,8 @@ class BossTermMcpServer(
             when (panel) {
                 "new_tab" -> {
                     // Both createTab and the split path (createSessionForSplit) hold
-                    // initialCommand until OSC 133;A and then submit it themselves, so strip
-                    // any caller-provided trailing separator for a consistent contract. Trim
-                    // CR as well as LF: removeSuffix("\n") alone left the CR of a CRLF-ending
-                    // script behind, which then submitted twice.
+                    // initialCommand until OSC 133;A and then submit it themselves, so strip any
+                    // caller-provided trailing separator for a consistent contract.
                     val normalizedScript = stripTrailingSubmit(script)
                     val newId = state.createTab(
                         workingDir = workingDir,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -5,6 +5,7 @@ import ai.rever.bossterm.compose.TerminalSession
 import ai.rever.bossterm.compose.debug.ChunkSource
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.tabs.TerminalTab
+import ai.rever.bossterm.compose.util.stripTrailingSubmit
 import ai.rever.bossterm.compose.util.submitLine
 import ai.rever.bossterm.terminal.model.CommandStateListener
 import ai.rever.bossterm.terminal.model.TerminalTextBuffer
@@ -1111,7 +1112,7 @@ class BossTermMcpServer(
                     // any caller-provided trailing separator for a consistent contract. Trim
                     // CR as well as LF: removeSuffix("\n") alone left the CR of a CRLF-ending
                     // script behind, which then submitted twice.
-                    val normalizedScript = script.trimEnd('\r', '\n')
+                    val normalizedScript = stripTrailingSubmit(script)
                     val newId = state.createTab(
                         workingDir = workingDir,
                         initialCommand = normalizedScript.ifEmpty { null }
@@ -1131,7 +1132,7 @@ class BossTermMcpServer(
                     // Normalize the trailing separator: createSessionForSplit's initialCommand
                     // path submits it, matching the new_tab branch. An empty script means
                     // "just split, don't run anything".
-                    val normalizedScript = script.trimEnd('\r', '\n').ifEmpty { null }
+                    val normalizedScript = stripTrailingSubmit(script).ifEmpty { null }
                     // Anchor stacking: if there's already an MCP scratch pane for
                     // this tab and the caller asked for horizontal_split, stack
                     // the new pane to the RIGHT of that existing pane instead of

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -5,6 +5,7 @@ import ai.rever.bossterm.compose.TerminalSession
 import ai.rever.bossterm.compose.debug.ChunkSource
 import ai.rever.bossterm.compose.settings.SettingsManager
 import ai.rever.bossterm.compose.tabs.TerminalTab
+import ai.rever.bossterm.compose.util.submitLine
 import ai.rever.bossterm.terminal.model.CommandStateListener
 import ai.rever.bossterm.terminal.model.TerminalTextBuffer
 import java.io.ByteArrayInputStream
@@ -67,7 +68,10 @@ import kotlinx.serialization.json.putJsonObject
  *   - `read_debug_console`  — read recent entries from a tab's debug-data buffer.
  *
  * Write tools (gated by `BossTermMcpConfig.allowWriteTools`):
- *   - `send_input`          — write raw text to a tab's stdin (queued).
+ *   - `send_input`          — write raw text to a tab's stdin (queued). The one tool that does
+ *                             NOT submit for the caller, because a bare LF is a meaningful
+ *                             keystroke here (Ctrl+J) and rewriting it would remove the only way
+ *                             to send it. Every other write path goes through `submitLine`.
  *   - `send_signal`         — send ctrl_c / ctrl_d / ctrl_z to a tab (queued).
  *   - `run_in_panel`        — open a new tab / split pane and run a script in it.
  *   - `close_panel`         — close a split pane, or a whole tab (never a window's last tab).
@@ -825,8 +829,14 @@ class BossTermMcpServer(
             name = toolName("send_input"),
             description = describe(
                 "send_input",
-                "Write text to a tab's shell stdin. The caller is responsible for " +
-                        "appending a trailing '\\n' if they want a command to actually execute. " +
+                "Write text to a tab's shell stdin, verbatim — this tool presses no keys of its " +
+                        "own. To run a command, end the text with '\\r' (carriage return, what the " +
+                        "Enter key sends). A bare '\\n' is NOT Enter: it is Ctrl+J, which inserts a " +
+                        "newline into the line editor without submitting, so the command sits at a " +
+                        "'>>' continuation prompt and read_scrollback shows no result. Send '\\r' on " +
+                        "its own to press Enter with nothing typed. '\\n' is still the right choice " +
+                        "when you want that newline — a multi-line prompt to an AI CLI, for " +
+                        "instance — which is why this tool does not rewrite it for you. " +
                         "When `pane_id` is supplied (e.g. the value returned by run_in_panel), " +
                         "writes go to that specific split; otherwise to the tab's primary session."
             ),
@@ -838,7 +848,8 @@ class BossTermMcpServer(
                     }
                     putJsonObject("text") {
                         put("type", "string")
-                        put("description", "Raw text to write. Include '\\n' to submit.")
+                        put("description", "Raw text to write. End with '\\r' to submit it; " +
+                                "'\\n' inserts a newline without submitting.")
                     }
                     putJsonObject("pane_id") {
                         put("type", "string")
@@ -1033,7 +1044,8 @@ class BossTermMcpServer(
                 "Open a new terminal panel and write a script to it. Modes: " +
                         "'new_tab' (fresh tab with initialCommand), 'horizontal_split' (split " +
                         "below focused pane), 'vertical_split' (split beside focused pane). " +
-                        "Include '\\n' in the script to submit it as a command. " +
+                        "The script is always submitted, so a trailing newline is optional " +
+                        "(and is stripped rather than pressing Enter twice). " +
                         "All three modes wait for the shell's OSC 133;A prompt-ready signal " +
                         "(or the configured fallback delay) before sending the script, so the " +
                         "command runs cleanly rather than racing with shell startup."
@@ -1046,7 +1058,9 @@ class BossTermMcpServer(
                     }
                     putJsonObject("script") {
                         put("type", "string")
-                        put("description", "Raw text to write to the new panel's shell. Include '\\n' to submit.")
+                        put("description", "The command to run in the new panel. Submitted for " +
+                                "you; a trailing newline is optional. Empty means \"just open the " +
+                                "panel and run nothing\".")
                     }
                     putJsonObject("tab_id") {
                         put("type", "string")
@@ -1093,9 +1107,11 @@ class BossTermMcpServer(
             when (panel) {
                 "new_tab" -> {
                     // Both createTab and the split path (createSessionForSplit) hold
-                    // initialCommand until OSC 133;A and auto-append '\n', so strip
-                    // any caller-provided trailing newline for a consistent contract.
-                    val normalizedScript = script.removeSuffix("\n")
+                    // initialCommand until OSC 133;A and then submit it themselves, so strip
+                    // any caller-provided trailing separator for a consistent contract. Trim
+                    // CR as well as LF: removeSuffix("\n") alone left the CR of a CRLF-ending
+                    // script behind, which then submitted twice.
+                    val normalizedScript = script.trimEnd('\r', '\n')
                     val newId = state.createTab(
                         workingDir = workingDir,
                         initialCommand = normalizedScript.ifEmpty { null }
@@ -1112,10 +1128,10 @@ class BossTermMcpServer(
                     val configuredDefault = SettingsManager.instance.settings.value.mcpDefaultSplitRatio
                     val requestedRatio = args.optionalFloat("split_ratio")
                     val effectiveRatio = (requestedRatio ?: configuredDefault).coerceIn(0.05f, 0.95f)
-                    // Normalize the trailing newline: createSessionForSplit's initialCommand
-                    // path auto-appends '\n', matching the new_tab branch. An empty script
-                    // means "just split, don't run anything".
-                    val normalizedScript = script.removeSuffix("\n").ifEmpty { null }
+                    // Normalize the trailing separator: createSessionForSplit's initialCommand
+                    // path submits it, matching the new_tab branch. An empty script means
+                    // "just split, don't run anything".
+                    val normalizedScript = script.trimEnd('\r', '\n').ifEmpty { null }
                     // Anchor stacking: if there's already an MCP scratch pane for
                     // this tab and the caller asked for horizontal_split, stack
                     // the new pane to the RIGHT of that existing pane instead of
@@ -1862,7 +1878,7 @@ class BossTermMcpServer(
             val historyAtSend = textBuffer.historyLinesCount
             val cursorYAtSend = terminal.cursorY - 1
 
-            val toWrite = if (script.endsWith("\n")) script else script + "\n"
+            val toWrite = submitLine(script)
             // Flip the gate BEFORE the write so the listener counts the next
             // B as ours. This races ONLY with the user concurrently running
             // their own command in this same pane: if they hit Enter (firing a

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1536,7 +1536,9 @@ class BossTermMcpServer(
                 properties = buildJsonObject {
                     putJsonObject("script") {
                         put("type", "string")
-                        put("description", "Shell command to run. A trailing newline is added if absent.")
+                        put("description", "Shell command to run. Submitted for you, so a trailing " +
+                                "newline is optional — and only ever one Enter is sent, however " +
+                                "many trailing newlines you include.")
                     }
                     putJsonObject("pane_id") {
                         put("type", "string")

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1045,8 +1045,9 @@ class BossTermMcpServer(
                 "Open a new terminal panel and write a script to it. Modes: " +
                         "'new_tab' (fresh tab with initialCommand), 'horizontal_split' (split " +
                         "below focused pane), 'vertical_split' (split beside focused pane). " +
-                        "The script is always submitted, so a trailing newline is optional " +
-                        "(and is stripped rather than pressing Enter twice). " +
+                        "A non-empty script is always submitted, so a trailing newline is optional " +
+                        "(and is stripped rather than pressing Enter twice); an empty one just " +
+                        "opens the panel. " +
                         "All three modes wait for the shell's OSC 133;A prompt-ready signal " +
                         "(or the configured fallback delay) before sending the script, so the " +
                         "command runs cleanly rather than racing with shell startup."

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1045,9 +1045,9 @@ class BossTermMcpServer(
                 "Open a new terminal panel and write a script to it. Modes: " +
                         "'new_tab' (fresh tab with initialCommand), 'horizontal_split' (split " +
                         "below focused pane), 'vertical_split' (split beside focused pane). " +
-                        "A non-empty script is always submitted, so a trailing newline is optional " +
-                        "(and is stripped rather than pressing Enter twice); an empty one just " +
-                        "opens the panel. " +
+                        "A non-empty script is always submitted, so trailing newlines are optional " +
+                        "and are collapsed into the single Enter it sends; a script that is empty " +
+                        "(or only newlines) just opens the panel. " +
                         "All three modes wait for the shell's OSC 133;A prompt-ready signal " +
                         "(or the configured fallback delay) before sending the script, so the " +
                         "command runs cleanly rather than racing with shell startup."

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/McpSettingsSection.kt
@@ -309,7 +309,7 @@ private fun toolDescription(name: String): String = when (name) {
     "search_output" -> "Regex-search a tab/pane's scrollback for matches."
     "get_last_command" -> "Return the most recently completed OSC 133 command."
     "read_debug_console" -> "Read recent entries from a tab's debug-data buffer."
-    "send_input" -> "Write raw text (including newlines) to a tab/pane's stdin."
+    "send_input" -> "Write raw text to a tab/pane's stdin, verbatim (end with \\r to submit)."
     "send_signal" -> "Send ctrl_c / ctrl_d / ctrl_z to a tab/pane."
     "run_in_panel" -> "Open a new tab or split pane and run a script in it (fire-and-forget)."
     "run_command" ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/shell/ShellCustomizationMenuProvider.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/shell/ShellCustomizationMenuProvider.kt
@@ -304,7 +304,7 @@ class ShellCustomizationMenuProvider {
                         if (onInstallRequest != null) {
                             onInstallRequest("starship-uninstall", uninstallCmd, null)
                         } else {
-                            terminalWriter(submitLine("$uninstallCmd"))
+                            terminalWriter(submitLine(uninstallCmd))
                         }
                     }
                 )
@@ -431,7 +431,7 @@ class ShellCustomizationMenuProvider {
                         if (onInstallRequest != null) {
                             onInstallRequest("oh-my-zsh-uninstall", uninstallCmd, null)
                         } else {
-                            terminalWriter(submitLine("$uninstallCmd"))
+                            terminalWriter(submitLine(uninstallCmd))
                         }
                     }
                 )
@@ -513,7 +513,7 @@ class ShellCustomizationMenuProvider {
                         if (onInstallRequest != null) {
                             onInstallRequest("prezto-uninstall", uninstallCmd, null)
                         } else {
-                            terminalWriter(submitLine("$uninstallCmd"))
+                            terminalWriter(submitLine(uninstallCmd))
                         }
                     }
                 )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/shell/ShellCustomizationMenuProvider.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/shell/ShellCustomizationMenuProvider.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.shell
 
+import ai.rever.bossterm.compose.util.submitLine
 import ai.rever.bossterm.compose.ContextMenuElement
 import ai.rever.bossterm.compose.ContextMenuItem
 import ai.rever.bossterm.compose.ContextMenuSection
@@ -203,12 +204,12 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "starship_config_edit",
                     label = "Edit Config",
-                    action = { terminalWriter("\${EDITOR:-nano} ~/.config/starship.toml\n") }
+                    action = { terminalWriter(submitLine("\${EDITOR:-nano} ~/.config/starship.toml")) }
                 ),
                 ContextMenuItem(
                     id = "starship_config_init",
                     label = "Create Default Config",
-                    action = { terminalWriter("mkdir -p ~/.config && starship preset -o ~/.config/starship.toml\n") }
+                    action = { terminalWriter(submitLine("mkdir -p ~/.config && starship preset -o ~/.config/starship.toml")) }
                 ),
 
                 // Presets section
@@ -220,37 +221,37 @@ class ShellCustomizationMenuProvider {
                         ContextMenuItem(
                             id = "starship_preset_nerd",
                             label = "Nerd Font Symbols",
-                            action = { terminalWriter("starship preset nerd-font-symbols -o ~/.config/starship.toml\n") }
+                            action = { terminalWriter(submitLine("starship preset nerd-font-symbols -o ~/.config/starship.toml")) }
                         ),
                         ContextMenuItem(
                             id = "starship_preset_plain",
                             label = "Plain Text",
-                            action = { terminalWriter("starship preset plain-text-symbols -o ~/.config/starship.toml\n") }
+                            action = { terminalWriter(submitLine("starship preset plain-text-symbols -o ~/.config/starship.toml")) }
                         ),
                         ContextMenuItem(
                             id = "starship_preset_nonerd",
                             label = "No Nerd Font",
-                            action = { terminalWriter("starship preset no-nerd-font -o ~/.config/starship.toml\n") }
+                            action = { terminalWriter(submitLine("starship preset no-nerd-font -o ~/.config/starship.toml")) }
                         ),
                         ContextMenuItem(
                             id = "starship_preset_pastel",
                             label = "Pastel Powerline",
-                            action = { terminalWriter("starship preset pastel-powerline -o ~/.config/starship.toml\n") }
+                            action = { terminalWriter(submitLine("starship preset pastel-powerline -o ~/.config/starship.toml")) }
                         ),
                         ContextMenuItem(
                             id = "starship_preset_bracketed",
                             label = "Bracketed Segments",
-                            action = { terminalWriter("starship preset bracketed-segments -o ~/.config/starship.toml\n") }
+                            action = { terminalWriter(submitLine("starship preset bracketed-segments -o ~/.config/starship.toml")) }
                         ),
                         ContextMenuItem(
                             id = "starship_preset_gruvbox",
                             label = "Gruvbox Rainbow",
-                            action = { terminalWriter("starship preset gruvbox-rainbow -o ~/.config/starship.toml\n") }
+                            action = { terminalWriter(submitLine("starship preset gruvbox-rainbow -o ~/.config/starship.toml")) }
                         ),
                         ContextMenuItem(
                             id = "starship_preset_tokyo",
                             label = "Tokyo Night",
-                            action = { terminalWriter("starship preset tokyo-night -o ~/.config/starship.toml\n") }
+                            action = { terminalWriter(submitLine("starship preset tokyo-night -o ~/.config/starship.toml")) }
                         )
                     )
                 ),
@@ -261,21 +262,21 @@ class ShellCustomizationMenuProvider {
                     id = "starship_setup_bash",
                     label = "Setup for Bash",
                     action = {
-                        terminalWriter("echo 'eval \"\$(starship init bash)\"' >> ~/.bashrc && echo '✓ Added to ~/.bashrc' && source ~/.bashrc\n")
+                        terminalWriter(submitLine("echo 'eval \"\$(starship init bash)\"' >> ~/.bashrc && echo '✓ Added to ~/.bashrc' && source ~/.bashrc"))
                     }
                 ),
                 ContextMenuItem(
                     id = "starship_setup_zsh",
                     label = "Setup for Zsh",
                     action = {
-                        terminalWriter("echo 'eval \"\$(starship init zsh)\"' >> ~/.zshrc && echo '✓ Added to ~/.zshrc' && source ~/.zshrc\n")
+                        terminalWriter(submitLine("echo 'eval \"\$(starship init zsh)\"' >> ~/.zshrc && echo '✓ Added to ~/.zshrc' && source ~/.zshrc"))
                     }
                 ),
                 ContextMenuItem(
                     id = "starship_setup_fish",
                     label = "Setup for Fish",
                     action = {
-                        terminalWriter("echo 'starship init fish | source' >> ~/.config/fish/config.fish && echo '✓ Added to config.fish' && source ~/.config/fish/config.fish\n")
+                        terminalWriter(submitLine("echo 'starship init fish | source' >> ~/.config/fish/config.fish && echo '✓ Added to config.fish' && source ~/.config/fish/config.fish"))
                     }
                 ),
 
@@ -284,7 +285,7 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "starship_help",
                     label = "Help",
-                    action = { terminalWriter("starship --help\n") }
+                    action = { terminalWriter(submitLine("starship --help")) }
                 ),
                 ContextMenuItem(
                     id = "starship_docs",
@@ -303,7 +304,7 @@ class ShellCustomizationMenuProvider {
                         if (onInstallRequest != null) {
                             onInstallRequest("starship-uninstall", uninstallCmd, null)
                         } else {
-                            terminalWriter("$uninstallCmd\n")
+                            terminalWriter(submitLine("$uninstallCmd"))
                         }
                     }
                 )
@@ -327,7 +328,7 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "ohmyzsh_current_theme",
                     label = "Show Current Theme",
-                    action = { terminalWriter("echo \"Current theme: \$ZSH_THEME\"\n") }
+                    action = { terminalWriter(submitLine("echo \"Current theme: \$ZSH_THEME\"")) }
                 ),
                 ContextMenuSubmenu(
                     id = "ohmyzsh_themes_submenu",
@@ -336,37 +337,37 @@ class ShellCustomizationMenuProvider {
                         ContextMenuItem(
                             id = "ohmyzsh_theme_robbyrussell",
                             label = "robbyrussell (default)",
-                            action = { terminalWriter("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"robbyrussell\"/' ~/.zshrc && echo '✓ Theme changed to robbyrussell - run: source ~/.zshrc'\n") }
+                            action = { terminalWriter(submitLine("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"robbyrussell\"/' ~/.zshrc && echo '✓ Theme changed to robbyrussell - run: source ~/.zshrc'")) }
                         ),
                         ContextMenuItem(
                             id = "ohmyzsh_theme_agnoster",
                             label = "agnoster",
-                            action = { terminalWriter("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"agnoster\"/' ~/.zshrc && echo '✓ Theme changed to agnoster - run: source ~/.zshrc'\n") }
+                            action = { terminalWriter(submitLine("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"agnoster\"/' ~/.zshrc && echo '✓ Theme changed to agnoster - run: source ~/.zshrc'")) }
                         ),
                         ContextMenuItem(
                             id = "ohmyzsh_theme_avit",
                             label = "avit",
-                            action = { terminalWriter("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"avit\"/' ~/.zshrc && echo '✓ Theme changed to avit - run: source ~/.zshrc'\n") }
+                            action = { terminalWriter(submitLine("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"avit\"/' ~/.zshrc && echo '✓ Theme changed to avit - run: source ~/.zshrc'")) }
                         ),
                         ContextMenuItem(
                             id = "ohmyzsh_theme_bira",
                             label = "bira",
-                            action = { terminalWriter("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"bira\"/' ~/.zshrc && echo '✓ Theme changed to bira - run: source ~/.zshrc'\n") }
+                            action = { terminalWriter(submitLine("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"bira\"/' ~/.zshrc && echo '✓ Theme changed to bira - run: source ~/.zshrc'")) }
                         ),
                         ContextMenuItem(
                             id = "ohmyzsh_theme_candy",
                             label = "candy",
-                            action = { terminalWriter("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"candy\"/' ~/.zshrc && echo '✓ Theme changed to candy - run: source ~/.zshrc'\n") }
+                            action = { terminalWriter(submitLine("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"candy\"/' ~/.zshrc && echo '✓ Theme changed to candy - run: source ~/.zshrc'")) }
                         ),
                         ContextMenuItem(
                             id = "ohmyzsh_theme_dst",
                             label = "dst",
-                            action = { terminalWriter("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"dst\"/' ~/.zshrc && echo '✓ Theme changed to dst - run: source ~/.zshrc'\n") }
+                            action = { terminalWriter(submitLine("sed -i 's/^ZSH_THEME=.*/ZSH_THEME=\"dst\"/' ~/.zshrc && echo '✓ Theme changed to dst - run: source ~/.zshrc'")) }
                         ),
                         ContextMenuItem(
                             id = "ohmyzsh_theme_list",
                             label = "List All Themes",
-                            action = { terminalWriter("ls ~/.oh-my-zsh/themes/\n") }
+                            action = { terminalWriter(submitLine("ls ~/.oh-my-zsh/themes/")) }
                         )
                     )
                 ),
@@ -376,17 +377,17 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "ohmyzsh_show_plugins",
                     label = "Show Active Plugins",
-                    action = { terminalWriter("grep '^plugins=' ~/.zshrc\n") }
+                    action = { terminalWriter(submitLine("grep '^plugins=' ~/.zshrc")) }
                 ),
                 ContextMenuItem(
                     id = "ohmyzsh_list_plugins",
                     label = "List Available Plugins",
-                    action = { terminalWriter("ls ~/.oh-my-zsh/plugins/\n") }
+                    action = { terminalWriter(submitLine("ls ~/.oh-my-zsh/plugins/")) }
                 ),
                 ContextMenuItem(
                     id = "ohmyzsh_edit_plugins",
                     label = "Edit Plugins",
-                    action = { terminalWriter("\${EDITOR:-nano} ~/.zshrc\n") }
+                    action = { terminalWriter(submitLine("\${EDITOR:-nano} ~/.zshrc")) }
                 ),
 
                 // Maintenance section
@@ -394,17 +395,17 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "ohmyzsh_update",
                     label = "Update Oh My Zsh",
-                    action = { terminalWriter("omz update\n") }
+                    action = { terminalWriter(submitLine("omz update")) }
                 ),
                 ContextMenuItem(
                     id = "ohmyzsh_reload",
                     label = "Reload Config",
-                    action = { terminalWriter("source ~/.zshrc\n") }
+                    action = { terminalWriter(submitLine("source ~/.zshrc")) }
                 ),
                 ContextMenuItem(
                     id = "ohmyzsh_edit_zshrc",
                     label = "Edit .zshrc",
-                    action = { terminalWriter("\${EDITOR:-nano} ~/.zshrc\n") }
+                    action = { terminalWriter(submitLine("\${EDITOR:-nano} ~/.zshrc")) }
                 ),
 
                 // Help section
@@ -412,7 +413,7 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "ohmyzsh_help",
                     label = "Help",
-                    action = { terminalWriter("omz help\n") }
+                    action = { terminalWriter(submitLine("omz help")) }
                 ),
                 ContextMenuItem(
                     id = "ohmyzsh_docs",
@@ -430,7 +431,7 @@ class ShellCustomizationMenuProvider {
                         if (onInstallRequest != null) {
                             onInstallRequest("oh-my-zsh-uninstall", uninstallCmd, null)
                         } else {
-                            terminalWriter("$uninstallCmd\n")
+                            terminalWriter(submitLine("$uninstallCmd"))
                         }
                     }
                 )
@@ -454,12 +455,12 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "prezto_show_modules",
                     label = "Show Loaded Modules",
-                    action = { terminalWriter("grep '^\\s*zmodule' ~/.zpreztorc 2>/dev/null || grep \"'\" ~/.zpreztorc | head -20\n") }
+                    action = { terminalWriter(submitLine("grep '^\\s*zmodule' ~/.zpreztorc 2>/dev/null || grep \"'\" ~/.zpreztorc | head -20")) }
                 ),
                 ContextMenuItem(
                     id = "prezto_edit_modules",
                     label = "Edit Modules",
-                    action = { terminalWriter("\${EDITOR:-nano} ~/.zpreztorc\n") }
+                    action = { terminalWriter(submitLine("\${EDITOR:-nano} ~/.zpreztorc")) }
                 ),
 
                 // Theme section
@@ -467,12 +468,12 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "prezto_show_theme",
                     label = "Show Current Theme",
-                    action = { terminalWriter("grep 'zstyle.*theme' ~/.zpreztorc\n") }
+                    action = { terminalWriter(submitLine("grep 'zstyle.*theme' ~/.zpreztorc")) }
                 ),
                 ContextMenuItem(
                     id = "prezto_list_themes",
                     label = "List Themes",
-                    action = { terminalWriter("ls ~/.zprezto/modules/prompt/functions/ | grep prompt_ | sed 's/prompt_//'\n") }
+                    action = { terminalWriter(submitLine("ls ~/.zprezto/modules/prompt/functions/ | grep prompt_ | sed 's/prompt_//'")) }
                 ),
 
                 // Maintenance section
@@ -480,17 +481,17 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "prezto_update",
                     label = "Update Prezto",
-                    action = { terminalWriter("cd ~/.zprezto && git pull && git submodule update --init --recursive && cd -\n") }
+                    action = { terminalWriter(submitLine("cd ~/.zprezto && git pull && git submodule update --init --recursive && cd -")) }
                 ),
                 ContextMenuItem(
                     id = "prezto_reload",
                     label = "Reload Config",
-                    action = { terminalWriter("source ~/.zshrc\n") }
+                    action = { terminalWriter(submitLine("source ~/.zshrc")) }
                 ),
                 ContextMenuItem(
                     id = "prezto_edit_zshrc",
                     label = "Edit .zshrc",
-                    action = { terminalWriter("\${EDITOR:-nano} ~/.zshrc\n") }
+                    action = { terminalWriter(submitLine("\${EDITOR:-nano} ~/.zshrc")) }
                 ),
 
                 // Help section
@@ -512,7 +513,7 @@ class ShellCustomizationMenuProvider {
                         if (onInstallRequest != null) {
                             onInstallRequest("prezto-uninstall", uninstallCmd, null)
                         } else {
-                            terminalWriter("$uninstallCmd\n")
+                            terminalWriter(submitLine("$uninstallCmd"))
                         }
                     }
                 )
@@ -541,22 +542,22 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "zsh_version",
                     label = "Show Version",
-                    action = { terminalWriter("zsh --version\n") }
+                    action = { terminalWriter(submitLine("zsh --version")) }
                 ),
                 ContextMenuItem(
                     id = "zsh_set_default",
                     label = "Set as Default Shell",
-                    action = { terminalWriter("chsh -s \$(which zsh) && echo '✓ Default shell changed to Zsh. Log out and log back in for new tabs to use Zsh.' && exec zsh -l\n") }
+                    action = { terminalWriter(submitLine("chsh -s \$(which zsh) && echo '✓ Default shell changed to Zsh. Log out and log back in for new tabs to use Zsh.' && exec zsh -l")) }
                 ),
                 ContextMenuItem(
                     id = "zsh_edit_zshrc",
                     label = "Edit .zshrc",
-                    action = { terminalWriter("\${EDITOR:-nano} ~/.zshrc\n") }
+                    action = { terminalWriter(submitLine("\${EDITOR:-nano} ~/.zshrc")) }
                 ),
                 ContextMenuItem(
                     id = "zsh_reload",
                     label = "Reload Config",
-                    action = { terminalWriter("source ~/.zshrc\n") }
+                    action = { terminalWriter(submitLine("source ~/.zshrc")) }
                 )
             )
         )
@@ -573,27 +574,27 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "bash_version",
                     label = "Show Version",
-                    action = { terminalWriter("bash --version\n") }
+                    action = { terminalWriter(submitLine("bash --version")) }
                 ),
                 ContextMenuItem(
                     id = "bash_set_default",
                     label = "Set as Default Shell",
-                    action = { terminalWriter("chsh -s \$(which bash) && echo '✓ Default shell changed to Bash. Log out and log back in for new tabs to use Bash.' && exec bash -l\n") }
+                    action = { terminalWriter(submitLine("chsh -s \$(which bash) && echo '✓ Default shell changed to Bash. Log out and log back in for new tabs to use Bash.' && exec bash -l")) }
                 ),
                 ContextMenuItem(
                     id = "bash_edit_bashrc",
                     label = "Edit .bashrc",
-                    action = { terminalWriter("\${EDITOR:-nano} ~/.bashrc\n") }
+                    action = { terminalWriter(submitLine("\${EDITOR:-nano} ~/.bashrc")) }
                 ),
                 ContextMenuItem(
                     id = "bash_edit_profile",
                     label = "Edit .bash_profile",
-                    action = { terminalWriter("\${EDITOR:-nano} ~/.bash_profile\n") }
+                    action = { terminalWriter(submitLine("\${EDITOR:-nano} ~/.bash_profile")) }
                 ),
                 ContextMenuItem(
                     id = "bash_reload",
                     label = "Reload Config",
-                    action = { terminalWriter("source ~/.bashrc\n") }
+                    action = { terminalWriter(submitLine("source ~/.bashrc")) }
                 )
             )
         )
@@ -649,27 +650,27 @@ class ShellCustomizationMenuProvider {
                 ContextMenuItem(
                     id = "fish_version",
                     label = "Show Version",
-                    action = { terminalWriter("fish --version\n") }
+                    action = { terminalWriter(submitLine("fish --version")) }
                 ),
                 ContextMenuItem(
                     id = "fish_set_default",
                     label = "Set as Default Shell",
-                    action = { terminalWriter("chsh -s \$(which fish) && echo '✓ Default shell changed to Fish. Log out and log back in for new tabs to use Fish.' && exec fish -l\n") }
+                    action = { terminalWriter(submitLine("chsh -s \$(which fish) && echo '✓ Default shell changed to Fish. Log out and log back in for new tabs to use Fish.' && exec fish -l")) }
                 ),
                 ContextMenuItem(
                     id = "fish_edit_config",
                     label = "Edit config.fish",
-                    action = { terminalWriter("\${EDITOR:-nano} ~/.config/fish/config.fish\n") }
+                    action = { terminalWriter(submitLine("\${EDITOR:-nano} ~/.config/fish/config.fish")) }
                 ),
                 ContextMenuItem(
                     id = "fish_reload",
                     label = "Reload Config",
-                    action = { terminalWriter("source ~/.config/fish/config.fish\n") }
+                    action = { terminalWriter(submitLine("source ~/.config/fish/config.fish")) }
                 ),
                 ContextMenuItem(
                     id = "fish_web_config",
                     label = "Web Config (GUI)",
-                    action = { terminalWriter("fish_config\n") }
+                    action = { terminalWriter(submitLine("fish_config")) }
                 )
             )
         )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -33,6 +33,7 @@ import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import ai.rever.bossterm.compose.ime.IMEState
 import ai.rever.bossterm.compose.osc.WorkingDirectoryOSCListener
 import ai.rever.bossterm.compose.settings.TerminalSettings
+import ai.rever.bossterm.compose.util.submitLine
 import ai.rever.bossterm.compose.typeahead.ComposeTypeAheadModel
 import ai.rever.bossterm.compose.typeahead.CoroutineDebouncer
 import ai.rever.bossterm.compose.notification.CommandNotificationHandler
@@ -1693,8 +1694,8 @@ class TabController(
                                 tab.terminal.addCommandStateListener(completionListener)
                             }
 
-                            // Send the command followed by newline
-                            handle.write(initialCommand + "\n")
+                            // Send the command followed by Enter (CR — see submitLine)
+                            handle.write(submitLine(initialCommand))
                         } finally {
                             // Clean up the pre-registered listener
                             tab.terminal.removeCommandStateListener(promptListener)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabController.kt
@@ -436,7 +436,8 @@ class TabController(
      * @param command Shell command to execute (default: $SHELL or /bin/sh)
      * @param arguments Command-line arguments for the shell (default: empty)
      * @param onProcessExit Callback invoked when shell process exits (before auto-closing tab)
-     * @param initialCommand Optional command to execute after terminal is ready (sent as input with newline)
+     * @param initialCommand Optional command to execute after terminal is ready (submitted via
+     *                       `submitLine`, so a trailing newline is optional)
      * @param tabId Optional stable ID for this tab (default: auto-generated UUID). Use this to assign
      *              a predictable ID that survives tab reordering and can be used for reliable lookup.
      * @return The newly created TerminalTab

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TerminalTab.kt
@@ -23,6 +23,7 @@ import ai.rever.bossterm.terminal.emulator.BossEmulator
 import ai.rever.bossterm.terminal.model.BossTerminal
 import ai.rever.bossterm.terminal.model.TerminalTextBuffer
 import ai.rever.bossterm.compose.debug.DebugDataCollector
+import ai.rever.bossterm.compose.util.normalizeSubmitNewlines
 import ai.rever.bossterm.compose.selection.SelectionTracker
 import ai.rever.bossterm.compose.typeahead.ComposeTypeAheadModel
 import ai.rever.bossterm.compose.ai.AICommandInterceptor
@@ -545,8 +546,9 @@ data class TerminalTab(
     override fun pasteText(text: String) {
         if (text.isEmpty()) return
 
-        // Normalize newlines: CRLF/LF → CR (terminal standard)
-        var normalized = text.replace("\r\n", "\n").replace('\n', '\r')
+        // Normalize newlines: CRLF/LF → CR (terminal standard). Shared with every programmatic
+        // writer so the two can't drift — see submitLine for why CR and not LF.
+        var normalized = normalizeSubmitNewlines(text)
 
         // Wrap with bracketed paste sequences if mode enabled
         if (display.bracketedPasteMode.value) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -2379,6 +2379,12 @@ fun ProperTerminal(
             ai.rever.bossterm.compose.palette.PaletteSources.collect(
               actions = actionRegistry,
               recentCommands = commandBlocks.mapNotNull { it.commandText },
+              // Prefill, so verbatim: the command lands at the prompt for the user to edit and
+              // submit themselves. One of four such sites in this file (command palette, history
+              // search, AI suggestion, and the non-auto-run workflow below) — all single-line
+              // today, so no LF reaches the PTY. If a multi-line source ever feeds one, the answer
+              // is bracketed paste like pasteText, not submitLine: converting the newlines would
+              // run the lines instead of offering them. See submitLine for why CR and not LF.
               insertCommand = { cmd -> tab.writeUserInput(cmd) },
               workflows = workflows,
               onRunWorkflow = { wf -> pendingWorkflow = wf }
@@ -2443,6 +2449,7 @@ fun ProperTerminal(
           ai.rever.bossterm.compose.history.HistorySearchOverlay(
             visible = true,
             history = historyEntries,
+            // Prefill, verbatim — see insertCommand above for why these four sites stay raw.
             onSelect = { cmd -> tab.writeUserInput(cmd); restoreFocus() },
             onDismiss = { restoreFocus() },
             aiEnabled = settings.aiCommandBarEnabled && settings.aiCommandBarPrintFlag.isNotBlank(),
@@ -2454,6 +2461,8 @@ fun ProperTerminal(
                   printFlag = settings.aiCommandBarPrintFlag,
                   naturalLanguage = query
                 )
+                // Prefill, verbatim — see insertCommand above. AiCommandSuggester returns one
+                // trimmed line, so there is nothing to convert even if we wanted to.
                 if (!suggestion.isNullOrBlank()) tab.writeUserInput(suggestion)
               }
             }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -2411,8 +2411,9 @@ fun ProperTerminal(
             },
             onSubmit = { rendered ->
               // Auto-run submits; otherwise the rendered text is left at the prompt for the user to
-              // edit, so it must NOT be normalized — a multi-line workflow keeps its LFs until they
-              // are actually meant as Enters.
+              // edit, so it is passed through untouched. Note the prefill only really holds on
+              // Windows: under ICRNL a multi-line workflow's LFs submit each line on arrival
+              // anyway. Unchanged from before this rule existed — just not universal.
               tab.writeUserInput(
                 if (settings.workflowsAutoRun) submitLine(rendered) else rendered
               )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/ui/ProperTerminal.kt
@@ -68,6 +68,7 @@ import ai.rever.bossterm.compose.PreConnectScreen
 import ai.rever.bossterm.compose.actions.addSplitPaneActions
 import ai.rever.bossterm.compose.actions.addTabManagementActions
 import ai.rever.bossterm.compose.actions.createBuiltinActions
+import ai.rever.bossterm.compose.util.submitLine
 import ai.rever.bossterm.compose.splits.NavigationDirection
 import ai.rever.bossterm.compose.menu.MenuActions
 import ai.rever.bossterm.compose.debug.DebugWindow
@@ -514,7 +515,7 @@ fun ProperTerminal(
   // Helper functions for context menu actions
   fun clearBuffer() {
     scope.launch {
-      tab.writeUserInput("clear\n")
+      tab.writeUserInput(submitLine("clear"))
     }
   }
 
@@ -733,7 +734,7 @@ fun ProperTerminal(
       onClear = {
         // Clear screen by sending 'clear' command (same as context menu)
         scope.launch {
-          tab.writeUserInput("clear\n")
+          tab.writeUserInput(submitLine("clear"))
         }
       }
       onFind = { actionRegistry.getAction("search")?.executeFromMenu() }
@@ -1231,7 +1232,7 @@ fun ProperTerminal(
                         .replace("$", "\\$")
                         .replace("`", "\\`")
                       // Send cd command followed by ls to show folder contents
-                      tab.writeUserInput("cd \"$escapedPath\" && ls\n")
+                      tab.writeUserInput(submitLine("cd \"$escapedPath\" && ls"))
                     }
                   }
                 }
@@ -2409,7 +2410,12 @@ fun ProperTerminal(
               }
             },
             onSubmit = { rendered ->
-              tab.writeUserInput(rendered + if (settings.workflowsAutoRun) "\n" else "")
+              // Auto-run submits; otherwise the rendered text is left at the prompt for the user to
+              // edit, so it must NOT be normalized — a multi-line workflow keeps its LFs until they
+              // are actually meant as Enters.
+              tab.writeUserInput(
+                if (settings.workflowsAutoRun) submitLine(rendered) else rendered
+              )
             }
           )
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/TerminalSubmit.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/TerminalSubmit.kt
@@ -1,0 +1,43 @@
+package ai.rever.bossterm.compose.util
+
+/**
+ * The bytes that press Enter at a shell prompt.
+ *
+ * CR (0x0D), not LF. That is what `TerminalKeyEncoder` sends for the Enter key
+ * (`putCode(VK_ENTER, Ascii.CR.code)`) and what `TerminalTab.pasteText` normalizes pasted newlines
+ * to, so anything writing a command programmatically has to agree with them or it is not simulating
+ * a keypress at all.
+ *
+ * On a Unix pty the distinction is invisible: the line discipline's `ICRNL` maps CR to NL on input,
+ * so a bare LF submits too. That is why LF sat in this codebase for years without anyone noticing.
+ * ConPTY does no such translation — it parses the input stream as VT and turns a bare LF into
+ * Ctrl+J, which PSReadLine binds to "insert a newline in the edit buffer". Measured on Windows
+ * PowerShell 5.1: `echo TEST` + LF printed nothing and left the shell showing a `>>` continuation
+ * prompt; the command only ran once a CR arrived.
+ *
+ * CRLF is not the fix either, and this is the trap worth writing down. The CR submits, and then the
+ * orphan LF is delivered to the *next* prompt and drops that one into continuation mode — so the
+ * command works and the user's following keystrokes land in a multiline buffer. Measured the same
+ * way: `echo TEST-CRLF` ran, and the prompt after it was `>>`. Exactly one trailing CR, no LF.
+ */
+private const val SUBMIT = '\r'
+
+/**
+ * Newlines as a terminal receives them from a keyboard: CRLF/LF → CR.
+ *
+ * The same normalization `pasteText` applies to clipboard text, minus the bracketed-paste wrapper.
+ * Use this on text that is a command (or several) rather than raw keystrokes; for a single command
+ * prefer [submitLine], which also guarantees the trailing Enter.
+ */
+fun normalizeSubmitNewlines(text: String): String =
+    text.replace("\r\n", "\n").replace('\n', SUBMIT)
+
+/**
+ * [command] plus exactly one Enter, whatever newlines it arrived with.
+ *
+ * Idempotent over the trailing separator: `"ls"`, `"ls\n"`, `"ls\r"` and `"ls\r\n"` all produce
+ * `"ls\r"`, so callers don't have to know whether the string they were handed already ends in one.
+ * An empty [command] yields a bare Enter, which is a blank line at the prompt.
+ */
+fun submitLine(command: String): String =
+    normalizeSubmitNewlines(command).trimEnd(SUBMIT) + SUBMIT

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/TerminalSubmit.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/TerminalSubmit.kt
@@ -1,5 +1,9 @@
-/**
+/*
  * The bytes that press Enter at a shell prompt: CR, never LF.
+ *
+ * A plain block comment, not KDoc: sitting before `package` it attaches to no declaration, so it
+ * would never surface on hover or in Dokka however it were spelled. The load-bearing text is
+ * repeated on the two functions below, where it does.
  *
  * CR (0x0D) is what `TerminalKeyEncoder` sends for the Enter key (`putCode(VK_ENTER, Ascii.CR.code)`)
  * and what `TerminalTab.pasteText` normalizes pasted newlines to, so anything writing a command

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/TerminalSubmit.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/TerminalSubmit.kt
@@ -56,12 +56,17 @@ fun submitLine(command: String): String =
     normalizeSubmitNewlines(command).trimEnd(SUBMIT) + SUBMIT
 
 /**
- * Drop a caller-supplied trailing Enter, for the paths that submit later and would otherwise do it
- * twice.
+ * Drop a caller-supplied trailing Enter from a script that something downstream will submit.
  *
  * MCP `run_in_panel` hands its script to `initialCommand`, which holds it until OSC 133;A and then
- * calls [submitLine] itself — so the tool's contract is "a trailing newline is optional". This used
- * to be `removeSuffix("\n")`, which left the CR of a CRLF-terminated script in place and submitted
- * the command twice.
+ * calls [submitLine] itself — so the tool's contract is "a trailing newline is optional".
+ *
+ * Note what this does and does not buy, because the obvious reason is the wrong one: [submitLine] is
+ * idempotent over any trailing separator, so it cannot double-submit whether or not the caller's
+ * newline was stripped first. (It could when the downstream write was `initialCommand + "\n"` — a
+ * CRLF script kept its CR through `removeSuffix("\n")` and got a second Enter — but that is fixed at
+ * the writer now.) What this still decides is the *empty* case: `run_in_panel` treats an empty
+ * script as "just open the panel", and only stripping CR as well as LF makes `"\r\n"` reach that
+ * branch instead of opening a panel and pressing Enter in it.
  */
 fun stripTrailingSubmit(text: String): String = text.trimEnd('\r', '\n')

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/TerminalSubmit.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/TerminalSubmit.kt
@@ -1,12 +1,9 @@
-package ai.rever.bossterm.compose.util
-
 /**
- * The bytes that press Enter at a shell prompt.
+ * The bytes that press Enter at a shell prompt: CR, never LF.
  *
- * CR (0x0D), not LF. That is what `TerminalKeyEncoder` sends for the Enter key
- * (`putCode(VK_ENTER, Ascii.CR.code)`) and what `TerminalTab.pasteText` normalizes pasted newlines
- * to, so anything writing a command programmatically has to agree with them or it is not simulating
- * a keypress at all.
+ * CR (0x0D) is what `TerminalKeyEncoder` sends for the Enter key (`putCode(VK_ENTER, Ascii.CR.code)`)
+ * and what `TerminalTab.pasteText` normalizes pasted newlines to, so anything writing a command
+ * programmatically has to agree with them or it is not simulating a keypress at all.
  *
  * On a Unix pty the distinction is invisible: the line discipline's `ICRNL` maps CR to NL on input,
  * so a bare LF submits too. That is why LF sat in this codebase for years without anyone noticing.
@@ -19,15 +16,27 @@ package ai.rever.bossterm.compose.util
  * orphan LF is delivered to the *next* prompt and drops that one into continuation mode — so the
  * command works and the user's following keystrokes land in a multiline buffer. Measured the same
  * way: `echo TEST-CRLF` ran, and the prompt after it was `>>`. Exactly one trailing CR, no LF.
+ *
+ * `TerminalTab.writeUserInput` deliberately does NOT normalize, which is why these helpers exist at
+ * the call sites instead. It is the verbatim path that MCP `send_input` needs: a bare LF is a
+ * keystroke a caller may genuinely want (a newline inside a multi-line prompt to an AI CLI), and
+ * normalizing centrally would remove the only way to send one.
  */
+package ai.rever.bossterm.compose.util
+
 private const val SUBMIT = '\r'
 
 /**
  * Newlines as a terminal receives them from a keyboard: CRLF/LF → CR.
  *
- * The same normalization `pasteText` applies to clipboard text, minus the bracketed-paste wrapper.
- * Use this on text that is a command (or several) rather than raw keystrokes; for a single command
- * prefer [submitLine], which also guarantees the trailing Enter.
+ * The same normalization `pasteText` applies to clipboard text (it calls this), minus the
+ * bracketed-paste wrapper. Use this on text that is a command — or several — but whose trailing
+ * separator the caller controls: a menu writer handed `"git status\n"`, or a public `write()` whose
+ * documented contract lets an embedder decide whether to submit. For a single command you are
+ * definitely running, prefer [submitLine], which also guarantees the trailing Enter.
+ *
+ * Adds nothing of its own, so `normalizeSubmitNewlines("git checkout -b ")` still leaves the caret
+ * at the prompt for the user to finish typing.
  */
 fun normalizeSubmitNewlines(text: String): String =
     text.replace("\r\n", "\n").replace('\n', SUBMIT)
@@ -38,6 +47,10 @@ fun normalizeSubmitNewlines(text: String): String =
  * Idempotent over the trailing separator: `"ls"`, `"ls\n"`, `"ls\r"` and `"ls\r\n"` all produce
  * `"ls\r"`, so callers don't have to know whether the string they were handed already ends in one.
  * An empty [command] yields a bare Enter, which is a blank line at the prompt.
+ *
+ * Trailing blank lines are collapsed along with it, so this cannot express "submit, then press
+ * Enter again" — which some TUIs want as a confirmation. That is deliberate for a helper whose job
+ * is one command, and MCP `send_input` is the escape hatch for driving keystrokes precisely.
  */
 fun submitLine(command: String): String =
     normalizeSubmitNewlines(command).trimEnd(SUBMIT) + SUBMIT

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/TerminalSubmit.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/util/TerminalSubmit.kt
@@ -54,3 +54,14 @@ fun normalizeSubmitNewlines(text: String): String =
  */
 fun submitLine(command: String): String =
     normalizeSubmitNewlines(command).trimEnd(SUBMIT) + SUBMIT
+
+/**
+ * Drop a caller-supplied trailing Enter, for the paths that submit later and would otherwise do it
+ * twice.
+ *
+ * MCP `run_in_panel` hands its script to `initialCommand`, which holds it until OSC 133;A and then
+ * calls [submitLine] itself — so the tool's contract is "a trailing newline is optional". This used
+ * to be `removeSuffix("\n")`, which left the CR of a CRLF-terminated script in place and submitted
+ * the command twice.
+ */
+fun stripTrailingSubmit(text: String): String = text.trimEnd('\r', '\n')

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/vcs/GitUtils.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/vcs/GitUtils.kt
@@ -159,29 +159,40 @@ object GitUtils {
 
     /**
      * Build a git command that runs in the specified directory.
+     *
+     * Returns the command text only — no trailing separator. It used to end in "\n", which made
+     * this the one builder still handing out a submit character: two of its callers had to
+     * `removeSuffix` it back off, and a new `writeUserInput(gitCommand(…))` would have compiled,
+     * shipped, and failed on Windows only, with no literal for `SubmitCharacterCoverageTest` to
+     * catch. Callers that mean to run it wrap in `submitLine`; callers prefilling the prompt
+     * (Checkout New Branch…, Add Worktree…) just use it as-is.
+     *
      * @param cmd The git subcommand and arguments (e.g., "status", "log --oneline -10")
      * @param cwd The working directory (if null, runs without -C flag)
-     * @return The full command string with newline
+     * @return The full command string, unsubmitted
      */
     fun gitCommand(cmd: String, cwd: String?): String {
         return if (cwd != null) {
-            "git -C ${shellQuote(cwd)} $cmd\n"
+            "git -C ${shellQuote(cwd)} $cmd"
         } else {
-            "git $cmd\n"
+            "git $cmd"
         }
     }
 
     /**
      * Build a gh command that runs in the specified directory.
+     *
+     * Unsubmitted, same as [gitCommand].
+     *
      * @param cmd The gh subcommand and arguments (e.g., "pr list", "issue create")
      * @param cwd The working directory (if null, runs without cd)
-     * @return The full command string with newline
+     * @return The full command string, unsubmitted
      */
     fun ghCommand(cmd: String, cwd: String?): String {
         return if (cwd != null) {
-            "cd ${shellQuote(cwd)} && gh $cmd\n"
+            "cd ${shellQuote(cwd)} && gh $cmd"
         } else {
-            "gh $cmd\n"
+            "gh $cmd"
         }
     }
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/vcs/VersionControlMenuProvider.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/vcs/VersionControlMenuProvider.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.vcs
 
+import ai.rever.bossterm.compose.util.submitLine
 import ai.rever.bossterm.compose.ContextMenuElement
 import ai.rever.bossterm.compose.ContextMenuItem
 import ai.rever.bossterm.compose.ContextMenuSection
@@ -221,7 +222,7 @@ class VersionControlMenuProvider {
                     ContextMenuItem(
                         id = "git_init",
                         label = "git init",
-                        action = { terminalWriter("git init\n") }
+                        action = { terminalWriter(submitLine("git init")) }
                     ),
                     ContextMenuItem(
                         id = "git_clone",
@@ -238,66 +239,66 @@ class VersionControlMenuProvider {
             ContextMenuItem(
                 id = "git_status",
                 label = "git status",
-                action = { terminalWriter("git status\n") }
+                action = { terminalWriter(submitLine("git status")) }
             ),
             ContextMenuItem(
                 id = "git_diff",
                 label = "git diff",
-                action = { terminalWriter("git diff\n") }
+                action = { terminalWriter(submitLine("git diff")) }
             ),
             ContextMenuItem(
                 id = "git_log",
                 label = "git log --oneline -10",
-                action = { terminalWriter("git log --oneline -10\n") }
+                action = { terminalWriter(submitLine("git log --oneline -10")) }
             ),
             ContextMenuSection(id = "git_staging_section", label = "Staging"),
             ContextMenuItem(
                 id = "git_add_all",
                 label = "git add .",
-                action = { terminalWriter("git add .\n") }
+                action = { terminalWriter(submitLine("git add .")) }
             ),
             ContextMenuItem(
                 id = "git_add_interactive",
                 label = "git add -p",
-                action = { terminalWriter("git add -p\n") }
+                action = { terminalWriter(submitLine("git add -p")) }
             ),
             ContextMenuItem(
                 id = "git_reset",
                 label = "git reset HEAD",
-                action = { terminalWriter("git reset HEAD\n") }
+                action = { terminalWriter(submitLine("git reset HEAD")) }
             ),
             ContextMenuSection(id = "git_commit_section", label = "Commit"),
             ContextMenuItem(
                 id = "git_commit",
                 label = "git commit",
-                action = { terminalWriter("git commit\n") }
+                action = { terminalWriter(submitLine("git commit")) }
             ),
             ContextMenuItem(
                 id = "git_commit_amend",
                 label = "git commit --amend",
-                action = { terminalWriter("git commit --amend\n") }
+                action = { terminalWriter(submitLine("git commit --amend")) }
             ),
             ContextMenuSection(id = "git_remote_section", label = "Remote"),
             ContextMenuItem(
                 id = "git_push",
                 label = "git push",
-                action = { terminalWriter("git push\n") }
+                action = { terminalWriter(submitLine("git push")) }
             ),
             ContextMenuItem(
                 id = "git_pull",
                 label = "git pull",
-                action = { terminalWriter("git pull\n") }
+                action = { terminalWriter(submitLine("git pull")) }
             ),
             ContextMenuItem(
                 id = "git_fetch",
                 label = "git fetch --all",
-                action = { terminalWriter("git fetch --all\n") }
+                action = { terminalWriter(submitLine("git fetch --all")) }
             ),
             ContextMenuSection(id = "git_branch_section", label = "Branches"),
             ContextMenuItem(
                 id = "git_branch",
                 label = "git branch -a",
-                action = { terminalWriter("git branch -a\n") }
+                action = { terminalWriter(submitLine("git branch -a")) }
             ),
             buildCheckoutSubmenu(terminalWriter),
             buildSwitchSubmenu(terminalWriter)
@@ -321,7 +322,7 @@ class VersionControlMenuProvider {
             ContextMenuItem(
                 id = "git_checkout_prev",
                 label = "Previous branch (-)",
-                action = { terminalWriter("git checkout -\n") }
+                action = { terminalWriter(submitLine("git checkout -")) }
             )
         )
 
@@ -338,7 +339,7 @@ class VersionControlMenuProvider {
                         id = "git_checkout_branch_$branch",
                         label = label,
                         enabled = enabled,
-                        action = { terminalWriter("git checkout $branch\n") }
+                        action = { terminalWriter(submitLine("git checkout $branch")) }
                     )
                 )
             }
@@ -377,7 +378,7 @@ class VersionControlMenuProvider {
             ContextMenuItem(
                 id = "git_checkout_discard",
                 label = "Discard all changes (-- .)",
-                action = { terminalWriter("git checkout -- .\n") }
+                action = { terminalWriter(submitLine("git checkout -- .")) }
             )
         )
 
@@ -399,7 +400,7 @@ class VersionControlMenuProvider {
             ContextMenuItem(
                 id = "git_switch_prev",
                 label = "Previous branch (-)",
-                action = { terminalWriter("git switch -\n") }
+                action = { terminalWriter(submitLine("git switch -")) }
             )
         )
 
@@ -416,7 +417,7 @@ class VersionControlMenuProvider {
                         id = "git_switch_branch_$branch",
                         label = label,
                         enabled = enabled,
-                        action = { terminalWriter("git switch $branch\n") }
+                        action = { terminalWriter(submitLine("git switch $branch")) }
                     )
                 )
             }
@@ -477,12 +478,12 @@ class VersionControlMenuProvider {
                     ContextMenuItem(
                         id = "gh_auth_status",
                         label = "gh auth status",
-                        action = { terminalWriter("gh auth status\n") }
+                        action = { terminalWriter(submitLine("gh auth status")) }
                     ),
                     ContextMenuItem(
                         id = "gh_auth_login",
                         label = "gh auth login",
-                        action = { terminalWriter("gh auth login\n") }
+                        action = { terminalWriter(submitLine("gh auth login")) }
                     ),
                     ContextMenuSection(id = "gh_repo_section", label = "Repository"),
                     ContextMenuItem(
@@ -503,7 +504,7 @@ class VersionControlMenuProvider {
                     ContextMenuItem(
                         id = "gh_set_default",
                         label = "Set default repository",
-                        action = { terminalWriter("gh repo set-default\n") }
+                        action = { terminalWriter(submitLine("gh repo set-default")) }
                     ),
                     ContextMenuSection(id = "gh_warning_section"),
                     ContextMenuItem(
@@ -522,28 +523,28 @@ class VersionControlMenuProvider {
             ContextMenuItem(
                 id = "gh_auth_status",
                 label = "gh auth status",
-                action = { terminalWriter("gh auth status\n") }
+                action = { terminalWriter(submitLine("gh auth status")) }
             ),
             ContextMenuItem(
                 id = "gh_auth_login",
                 label = "gh auth login",
-                action = { terminalWriter("gh auth login\n") }
+                action = { terminalWriter(submitLine("gh auth login")) }
             ),
             ContextMenuSection(id = "gh_pr_section", label = "Pull Requests"),
             ContextMenuItem(
                 id = "gh_pr_list",
                 label = "gh pr list",
-                action = { terminalWriter("gh pr list\n") }
+                action = { terminalWriter(submitLine("gh pr list")) }
             ),
             ContextMenuItem(
                 id = "gh_pr_status",
                 label = "gh pr status",
-                action = { terminalWriter("gh pr status\n") }
+                action = { terminalWriter(submitLine("gh pr status")) }
             ),
             ContextMenuItem(
                 id = "gh_pr_create",
                 label = "gh pr create",
-                action = { terminalWriter("gh pr create\n") }
+                action = { terminalWriter(submitLine("gh pr create")) }
             ),
             ContextMenuItem(
                 id = "gh_pr_checkout",
@@ -553,18 +554,18 @@ class VersionControlMenuProvider {
             ContextMenuItem(
                 id = "gh_pr_view",
                 label = "gh pr view --web",
-                action = { terminalWriter("gh pr view --web\n") }
+                action = { terminalWriter(submitLine("gh pr view --web")) }
             ),
             ContextMenuSection(id = "gh_issue_section", label = "Issues"),
             ContextMenuItem(
                 id = "gh_issue_list",
                 label = "gh issue list",
-                action = { terminalWriter("gh issue list\n") }
+                action = { terminalWriter(submitLine("gh issue list")) }
             ),
             ContextMenuItem(
                 id = "gh_issue_create",
                 label = "gh issue create",
-                action = { terminalWriter("gh issue create\n") }
+                action = { terminalWriter(submitLine("gh issue create")) }
             ),
             ContextMenuItem(
                 id = "gh_issue_view",
@@ -575,7 +576,7 @@ class VersionControlMenuProvider {
             ContextMenuItem(
                 id = "gh_repo_view",
                 label = "gh repo view --web",
-                action = { terminalWriter("gh repo view --web\n") }
+                action = { terminalWriter(submitLine("gh repo view --web")) }
             ),
             ContextMenuItem(
                 id = "gh_repo_clone",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/HostVoiceCallController.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/HostVoiceCallController.kt
@@ -870,7 +870,9 @@ internal class HostVoiceCallController(
             // No trailing "…" in the template: clip() adds one when it actually truncates, so this
             // rendered "Typing: hello wor……". run_command above gets it right; the viewer's mirror
             // produces a single ellipsis too.
-            "send_input" -> arg("text")?.let { "Typing: ${clip(it.replace("\n", "⏎"), 40)}" } ?: "Typing…"
+            // CR as well as LF: the agent is told to submit with \r, so matching only \n left a raw
+            // carriage return in the pill for every command it ran. Mirrored in viewer.js.
+            "send_input" -> arg("text")?.let { "Typing: ${clip(it.replace(SUBMIT_KEYS, "⏎"), 40)}" } ?: "Typing…"
             "send_signal" -> arg("signal")?.let { "Sending $it…" } ?: "Sending a signal…"
             "get_last_command" -> "Checking the last command…"
             "list_panes" -> "Looking at the split panes…"
@@ -901,6 +903,13 @@ internal class HostVoiceCallController(
 
     internal companion object {
         val json = Json { ignoreUnknownKeys = true }
+
+        /**
+         * Every submit spelling the agent might send, so the status pill shows one ⏎ per Enter.
+         *
+         * CRLF first, or a `\r\n` would render as two. Matches `viewer.js`'s `/\r\n?|\n/g`.
+         */
+        val SUBMIT_KEYS = Regex("\r\n?|\n")
 
         /**
          * Hard ceiling on one in-app call — deliberately SHORTER than OpenAI's own 60-minute session

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/VoiceInstructions.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/VoiceInstructions.kt
@@ -86,11 +86,19 @@ private fun builtInRules(names: Set<String>, confirmationWording: String): Strin
         // reads a scrollback showing no result and reports the command as having failed or hung. Stated
         // once, as its own rule, because it applies to every use of the tool: shell commands, a REPL, a
         // y/n prompt, a password.
+        //
+        // CR alone, and this rule used to say \r\n, which is measurably wrong. Enter is CR; the LF is
+        // a second keystroke (Ctrl+J) that arrives at the NEXT prompt and drops it into continuation
+        // mode, so the agent's command runs and the following one lands in a multiline buffer. Verified
+        // against Windows PowerShell over ConPTY: `echo x` + CRLF printed x and left a `>>` prompt
+        // behind, while CR alone left the shell clean.
         appendLine(
-            "- send_input types text but does not press Enter. End every send with \\r\\n to submit " +
+            "- send_input types text but does not press Enter. End every send with \\r to submit " +
                 "it - shell commands, REPL lines, and answers to interactive prompts alike. Text " +
                 "without it just sits at the prompt unexecuted, which reads as a hung command rather " +
-                "than a missing keystroke. Send \\r\\n on its own to press Enter with no text."
+                "than a missing keystroke. Send \\r on its own to press Enter with no text. Do not " +
+                "add \\n after the \\r: Enter is the \\r, and the extra \\n gets typed into the next " +
+                "prompt."
         )
     }
     if ("run_command" in names || "send_input" in names) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/VoiceToolCatalog.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/VoiceToolCatalog.kt
@@ -111,7 +111,7 @@ object VoiceToolCatalog {
         VoiceToolDef(
             name = "send_input",
             description = "Type raw text into a tab's terminal (for interactive programs - TUIs, prompts). " +
-                    "Include a trailing \\n to submit.",
+                    "Include a trailing \\r to submit it; \\n only inserts a newline.",
             parameters = objectSchema(required = listOf("text")) {
                 putJsonObject("text") { put("type", "string"); put("description", "Text to type.") }
                 putJsonObject("tab_id") { put("type", "string"); put("description", TAB_ID_DESC) }

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -570,7 +570,9 @@
       if (name === "send_input" && a.text)
         // The ellipsis only when it actually truncates — "Typing: ls…" for a two-character command
         // read as though something were still coming. Matches describeTool.
-        return "Typing: " + a.text.slice(0, 40).replace(/\n/g, "⏎") + (a.text.length > 40 ? "…" : "");
+        // \r as well as \n, CRLF first so one Enter renders as one ⏎. The agent is told to submit
+        // with \r, so matching only \n left a raw CR in the caption. Mirrors HostVoiceCallController.
+        return "Typing: " + a.text.slice(0, 40).replace(/\r\n?|\n/g, "⏎") + (a.text.length > 40 ? "…" : "");
       if (name === "send_signal" && a.signal) return "Sending " + a.signal + "…";
       if (name === "get_last_command") return "Checking the last command…";
       if (name === "list_panes") return "Looking at the split panes…";

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -567,15 +567,18 @@
         return "Running: " + a.script.slice(0, 60) + (a.script.length > 60 ? "…" : "");
       if (name === "read_scrollback") return "Reading the terminal…";
       if (name === "search_output" && a.pattern) return "Searching for “" + a.pattern.slice(0, 40) + "”…";
-      if (name === "send_input" && a.text)
+      if (name === "send_input" && a.text) {
         // The ellipsis only when it actually truncates — "Typing: ls…" for a two-character command
         // read as though something were still coming. Matches describeTool.
         // \r as well as \n, CRLF first so one Enter renders as one ⏎. The agent is told to submit
         // with \r, so matching only \n left a raw CR in the caption. Mirrors HostVoiceCallController
         // — including the order: replace THEN clip, or a CRLF straddling index 40 clips differently
         // on the two surfaces.
+        // Braces are load-bearing: a `const` under a braceless `if` is a SyntaxError that takes the
+        // whole file's parse down with it.
         const typed = a.text.replace(/\r\n?|\n/g, "⏎");
         return "Typing: " + typed.slice(0, 40) + (typed.length > 40 ? "…" : "");
+      }
       if (name === "send_signal" && a.signal) return "Sending " + a.signal + "…";
       if (name === "get_last_command") return "Checking the last command…";
       if (name === "list_panes") return "Looking at the split panes…";

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -1353,11 +1353,16 @@
     var canRead = controlGranted && navigator.clipboard && navigator.clipboard.readText;
     ctxEl.appendChild(ctxItem("Paste", canRead, function () {
       navigator.clipboard.readText().then(function (txt) {
-        // CRLF/LF -> CR, the same normalization TerminalTab.pasteText applies in-app and xterm
-        // applies on its own paste path. This menu item hand-rolls the paste and so gets neither:
-        // the Input lane is verbatim by design (it carries xterm's onData keystrokes), so a pasted
-        // "git status\n" would reach a Windows host as Ctrl+J and sit at a >> continuation prompt.
-        if (txt) sendInput(paneId, txt.replace(/\r\n?|\n/g, "\r"));
+        // term.paste, not sendInput: it does BOTH halves of what TerminalTab.pasteText does in-app
+        // — CRLF/LF to CR, and the ESC[200~ / ESC[201~ wrapper when the pane has DECSET 2004 on,
+        // keyed off the ?2004h xterm saw in the mirrored output. It then routes through term.onData
+        // below, which is the same Input lane, so nothing else changes.
+        //
+        // Hand-rolling the newline conversion here got the first half and silently dropped the
+        // second, which is the half that stops a multi-line snippet running line by line in an
+        // editor or a REPL. The Input lane is verbatim by design (it carries onData keystrokes), so
+        // this is the only layer that can apply either.
+        if (txt) { try { term.paste(txt); } catch (e) { sendInput(paneId, txt.replace(/\r\n?|\n/g, "\r")); } }
       }).catch(function () {});
     }));
     ctxEl.appendChild(ctxItem("Select all", true, function () { try { term.selectAll(); } catch (e) {} }));

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -571,8 +571,11 @@
         // The ellipsis only when it actually truncates — "Typing: ls…" for a two-character command
         // read as though something were still coming. Matches describeTool.
         // \r as well as \n, CRLF first so one Enter renders as one ⏎. The agent is told to submit
-        // with \r, so matching only \n left a raw CR in the caption. Mirrors HostVoiceCallController.
-        return "Typing: " + a.text.slice(0, 40).replace(/\r\n?|\n/g, "⏎") + (a.text.length > 40 ? "…" : "");
+        // with \r, so matching only \n left a raw CR in the caption. Mirrors HostVoiceCallController
+        // — including the order: replace THEN clip, or a CRLF straddling index 40 clips differently
+        // on the two surfaces.
+        const typed = a.text.replace(/\r\n?|\n/g, "⏎");
+        return "Typing: " + typed.slice(0, 40) + (typed.length > 40 ? "…" : "");
       if (name === "send_signal" && a.signal) return "Sending " + a.signal + "…";
       if (name === "get_last_command") return "Checking the last command…";
       if (name === "list_panes") return "Looking at the split panes…";

--- a/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
+++ b/compose-ui/src/desktopMain/resources/share-viewer/viewer.js
@@ -1353,7 +1353,11 @@
     var canRead = controlGranted && navigator.clipboard && navigator.clipboard.readText;
     ctxEl.appendChild(ctxItem("Paste", canRead, function () {
       navigator.clipboard.readText().then(function (txt) {
-        if (txt) sendInput(paneId, txt);
+        // CRLF/LF -> CR, the same normalization TerminalTab.pasteText applies in-app and xterm
+        // applies on its own paste path. This menu item hand-rolls the paste and so gets neither:
+        // the Input lane is verbatim by design (it carries xterm's onData keystrokes), so a pasted
+        // "git status\n" would reach a Windows host as Ctrl+J and sit at a >> continuation prompt.
+        if (txt) sendInput(paneId, txt.replace(/\r\n?|\n/g, "\r"));
       }).catch(function () {});
     }));
     ctxEl.appendChild(ctxItem("Select all", true, function () { try { term.selectAll(); } catch (e) {} }));

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ai/AIAssistantLaunchCommandTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ai/AIAssistantLaunchCommandTest.kt
@@ -35,7 +35,7 @@ class AIAssistantLaunchCommandTest {
     @Test
     fun `codex launches with danger full access sandbox`() {
         assertEquals(
-            "codex --sandbox danger-full-access\n",
+            "codex --sandbox danger-full-access\r",
             provider.getLaunchCommand(builtin(AIAssistantIds.CODEX))
         )
     }
@@ -53,7 +53,7 @@ class AIAssistantLaunchCommandTest {
     @Test
     fun `yolo disabled launches the bare command`() {
         assertEquals(
-            "codex\n",
+            "codex\r",
             provider.getLaunchCommand(builtin(AIAssistantIds.CODEX), AIAssistantConfigData(yoloEnabled = false))
         )
     }
@@ -61,7 +61,7 @@ class AIAssistantLaunchCommandTest {
     @Test
     fun `custom yolo flag overrides the built-in default`() {
         assertEquals(
-            "codex --my-flag\n",
+            "codex --my-flag\r",
             provider.getLaunchCommand(builtin(AIAssistantIds.CODEX), AIAssistantConfigData(customYoloFlag = "--my-flag"))
         )
     }
@@ -75,15 +75,15 @@ class AIAssistantLaunchCommandTest {
     @Test
     fun `open source assistants launch with their own auto-mode flags`() {
         assertEquals(
-            "grok --always-approve\n",
+            "grok --always-approve\r",
             provider.getLaunchCommand(builtin(AIAssistantIds.GROK_BUILD))
         )
         assertEquals(
-            "kimi --yolo\n",
+            "kimi --yolo\r",
             provider.getLaunchCommand(builtin(AIAssistantIds.KIMI_CODE))
         )
         assertEquals(
-            "hermes --yolo\n",
+            "hermes --yolo\r",
             provider.getLaunchCommand(builtin(AIAssistantIds.HERMES))
         )
     }
@@ -94,7 +94,7 @@ class AIAssistantLaunchCommandTest {
         // appended to every launch and break it.
         val ollama = builtin(AIAssistantIds.OLLAMA)
         assertEquals("", ollama.yoloFlag)
-        assertEquals("ollama\n", provider.getLaunchCommand(ollama))
+        assertEquals("ollama\r", provider.getLaunchCommand(ollama))
     }
 
     /**
@@ -140,17 +140,17 @@ class AIAssistantLaunchCommandTest {
         val openclaw = builtin(AIAssistantIds.OPENCLAW)
         assertEquals("openclaw", openclaw.command, "command must stay a bare binary name for PATH detection")
         assertEquals(
-            "openclaw tui --message '/exec security=full ask=off'\n",
+            "openclaw tui --message '/exec security=full ask=off'\r",
             provider.getLaunchCommand(openclaw)
         )
         // Auto mode off still has to launch a usable session, i.e. keep the subcommand.
         assertEquals(
-            "openclaw tui\n",
+            "openclaw tui\r",
             provider.getLaunchCommand(openclaw, AIAssistantConfigData(yoloEnabled = false))
         )
         // A custom command replaces the whole invocation, subcommand included.
         assertEquals(
-            "my-claw\n",
+            "my-claw\r",
             provider.getLaunchCommand(
                 openclaw,
                 AIAssistantConfigData(customCommand = "my-claw", yoloEnabled = false)
@@ -193,7 +193,7 @@ class AIAssistantLaunchCommandTest {
                 "\"grep\":\"allow\",\"bash\":\"allow\",\"task\":\"allow\",\"skill\":\"allow\"," +
                 "\"lsp\":\"allow\",\"question\":\"allow\",\"webfetch\":\"allow\"," +
                 "\"websearch\":\"allow\",\"external_directory\":\"allow\"," +
-                "\"doom_loop\":\"allow\"}' opencode\n",
+                "\"doom_loop\":\"allow\"}' opencode\r",
             provider.getLaunchCommand(opencode)
         )
         listOf("--auto-approve", "--auto", "--dangerously-skip-permissions").forEach { rejected ->
@@ -204,7 +204,7 @@ class AIAssistantLaunchCommandTest {
         }
         // Auto mode OFF must drop the env prefix entirely, or it isn't really off.
         assertEquals(
-            "opencode\n",
+            "opencode\r",
             provider.getLaunchCommand(opencode, AIAssistantConfigData(yoloEnabled = false))
         )
     }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
@@ -16,24 +16,26 @@ import kotlin.test.assertTrue
  * which fails when the two MCP registries drift apart.
  *
  * Scans source rather than behaviour because the failure is a literal in an argument list, and there
- * is no seam to observe it through without booting a PTY per menu item.
+ * is no seam to observe it through without booting a PTY per menu item. Its reach is the limit of
+ * what it can promise: a writer handed a `String` parameter has no literal to match, so this catches
+ * the common shape, not every possible one.
  */
 class SubmitCharacterCoverageTest {
 
-    private val sourceRoot = File("src/desktopMain/kotlin")
-
     /**
-     * Writers that intentionally pass bytes straight through, keyed by the file that owns them.
+     * Every module that can type at a prompt, not just this one.
      *
-     * `send_input` is the deliberate one: a bare LF is Ctrl+J, a keystroke a caller may genuinely
-     * want (a newline inside a multi-line prompt to an AI CLI), so normalizing it centrally would
-     * remove the only way to send one. Anything added here needs the same argument in writing.
+     * The examples are in scope deliberately — `tabbed-example` called `writeToFocusedPane("…\n")`,
+     * and because it sat outside the original scan the public API behind it stayed broken through a
+     * whole review round. Sample code is the copy-paste source for embedders, so it has to hold the
+     * same line as the library.
      */
-    private val verbatimByDesign = setOf(
-        "BossTermMcpServer.kt",   // send_input — documented escape hatch
-        "DaemonMcpTools.kt",      // daemon send_input, same contract
-        "TerminalSubmit.kt",      // the helper itself
-    )
+    private val scanRoots = listOf(
+        "src/desktopMain/kotlin",
+        "../bossterm-app/src/desktopMain/kotlin",
+        "../tabbed-example/src/desktopMain/kotlin",
+        "../embedded-example/src/desktopMain/kotlin",
+    ).map { File(it) }.filter { it.isDirectory }
 
     /**
      * `writeUserInput("…\n")` / `terminalWriter("…\n")` — a literal LF handed to a terminal write.
@@ -51,26 +53,29 @@ class SubmitCharacterCoverageTest {
         """(writeUserInput|terminalWriter|writeToTerminal)\([^)"]*\+\s*"\\n"\s*\)"""
     )
 
+    private fun sources() = scanRoots.asSequence()
+        .flatMap { it.walkTopDown() }
+        .filter { it.isFile && it.extension == "kt" }
+
     @Test
     fun `no write path submits with a bare line feed`() {
         val offenders = mutableListOf<String>()
 
-        sourceRoot.walkTopDown()
-            .filter { it.isFile && it.extension == "kt" }
-            .filterNot { it.name in verbatimByDesign }
-            .forEach { file ->
-                file.readLines().forEachIndexed { index, line ->
-                    if (literalLfSubmit.containsMatchIn(line) || concatenatedLfSubmit.containsMatchIn(line)) {
-                        offenders += "${file.name}:${index + 1}  ${line.trim()}"
-                    }
+        sources().forEach { file ->
+            file.readLines().forEachIndexed { index, line ->
+                if (line.contains(VERBATIM_MARKER)) return@forEachIndexed
+                if (literalLfSubmit.containsMatchIn(line) || concatenatedLfSubmit.containsMatchIn(line)) {
+                    offenders += "${file.name}:${index + 1}  ${line.trim()}"
                 }
             }
+        }
 
         assertTrue(
             offenders.isEmpty(),
             buildString {
                 appendLine("These write paths submit with LF, which does not press Enter under ConPTY.")
-                appendLine("Wrap the command in submitLine(), or normalizeSubmitNewlines() at the writer:")
+                appendLine("Wrap the command in submitLine(), or normalizeSubmitNewlines() at the writer.")
+                appendLine("If a line genuinely needs a raw LF, mark it `// $VERBATIM_MARKER` and say why:")
                 offenders.forEach { appendLine("  $it") }
             },
         )
@@ -82,12 +87,50 @@ class SubmitCharacterCoverageTest {
      */
     @Test
     fun `the scan reaches the sources it claims to cover`() {
-        val files = sourceRoot.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+        val files = sources().toList()
         assertTrue(files.size > 100, "expected to scan the desktop sources, found ${files.size}")
+        for (regressed in listOf("TabbedTerminal.kt", "ProperTerminal.kt", "TabbedTerminalState.kt")) {
+            assertTrue(files.any { it.name == regressed }, "$regressed must be in scope")
+        }
         assertTrue(
-            files.any { it.name == "TabbedTerminal.kt" } && files.any { it.name == "ProperTerminal.kt" },
-            "the files that regressed must be in scope",
+            scanRoots.size >= 4,
+            "the example modules must be scanned - that is where writeToFocusedPane slipped through",
         )
+    }
+
+    /**
+     * The other half of the rule: the public API must normalize, so that `"cmd\n"` at ITS call sites
+     * — the documented spelling, used throughout both example apps — actually presses Enter.
+     *
+     * This is the check that would have caught `writeToFocusedPane`, which shipped LF-only through a
+     * whole review round. The literal scan above structurally cannot: the bug is in a function whose
+     * argument is a parameter, so there is no `\n` literal to match. Asserted on the source because
+     * the alternative is booting a PTY per overload.
+     */
+    @Test
+    fun `every public write entry point normalizes newlines`() {
+        val surfaces = mapOf(
+            "TabbedTerminalState.kt" to listOf("fun write(", "fun writeToFocusedPane("),
+            "EmbeddableTerminal.kt" to listOf("fun write("),
+        )
+        for ((fileName, signatures) in surfaces) {
+            val file = sources().firstOrNull { it.name == fileName }
+                ?: error("$fileName not found in the scan roots")
+            val lines = file.readLines()
+            for (signature in signatures) {
+                val declarations = lines.withIndex().filter { it.value.contains(signature) }
+                assertTrue(declarations.isNotEmpty(), "no `$signature` found in $fileName")
+                for ((index, decl) in declarations) {
+                    // The body is short by construction; a handful of lines covers every overload.
+                    val body = lines.subList(index, minOf(index + 6, lines.size)).joinToString("\n")
+                    assertTrue(
+                        body.contains("normalizeSubmitNewlines") || body.contains("submitLine"),
+                        "$fileName:${index + 1} `${decl.trim()}` must normalize newlines — it is a " +
+                            "public write API and its documented contract is that \\n presses Enter",
+                    )
+                }
+            }
+        }
     }
 
     /** And it has to be capable of failing — the regex must match the shape it is meant to catch. */
@@ -96,10 +139,23 @@ class SubmitCharacterCoverageTest {
         assertTrue(literalLfSubmit.containsMatchIn("""tab.writeUserInput("clear\n")"""))
         assertTrue(literalLfSubmit.containsMatchIn("""terminalWriter("git status\n")"""))
         assertTrue(concatenatedLfSubmit.containsMatchIn("""session.writeUserInput(cmd + "\n")"""))
-        // Socket protocols legitimately write LF — the scan must not reach for those.
-        assertTrue(!literalLfSubmit.containsMatchIn("""write(line); write("\n"); flush()"""))
-        // And must not fire on the fixed forms, or it would block the correct code.
+        // The normalizing public API is NOT in the pattern: "cmd\n" is its documented spelling and
+        // is correct there. Its own guarantee is covered by the test above instead.
+        assertTrue(!literalLfSubmit.containsMatchIn("""state.writeToFocusedPane("echo hi\n")"""))
+        // Must not fire on the fixed forms, or it would block the correct code.
         assertTrue(!literalLfSubmit.containsMatchIn("""tab.writeUserInput(submitLine("clear"))"""))
         assertTrue(!literalLfSubmit.containsMatchIn("""session.writeUserInput(normalizeSubmitNewlines(text))"""))
+        // Socket protocols legitimately write LF — the scan must not reach for those.
+        assertTrue(!literalLfSubmit.containsMatchIn("""write(line); write("\n"); flush()"""))
+    }
+
+    private companion object {
+        /**
+         * Per-line opt-out. Narrow on purpose: excluding a whole file left `BossTermMcpServer`'s
+         * `run_command` and `run_in_panel` — two of the paths this rule exists to protect —
+         * unguarded just because `send_input` shares the file. A line claiming the exemption has to
+         * say so on the line itself.
+         */
+        const val VERBATIM_MARKER = "verbatim-by-design"
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
@@ -45,12 +45,12 @@ class SubmitCharacterCoverageTest {
      * mean "type this at a shell prompt" belong here.
      */
     private val literalLfSubmit = Regex(
-        """(writeUserInput|terminalWriter|writeToTerminal)\(\s*"[^"]*\\n"\s*\)"""
+        """$WRITERS\(\s*"(?:\\.|[^"\\])*\\n"\s*\)"""
     )
 
     /** `writeUserInput(cmd + "\n")` — the same mistake spelled with concatenation. */
     private val concatenatedLfSubmit = Regex(
-        """(writeUserInput|terminalWriter|writeToTerminal)\([^)"]*\+\s*"\\n"\s*\)"""
+        """$WRITERS\(.*\+\s*"\\n"\s*\)"""
     )
 
     private fun sources() = scanRoots.asSequence()
@@ -139,6 +139,18 @@ class SubmitCharacterCoverageTest {
         assertTrue(literalLfSubmit.containsMatchIn("""tab.writeUserInput("clear\n")"""))
         assertTrue(literalLfSubmit.containsMatchIn("""terminalWriter("git status\n")"""))
         assertTrue(concatenatedLfSubmit.containsMatchIn("""session.writeUserInput(cmd + "\n")"""))
+        // A command containing an escaped quote. `[^"]*` stopped dead at the backslash-quote, so
+        // ~10 real lines in ShellCustomizationMenuProvider — starship_setup_*, *_set_default,
+        // ohmyzsh_current_theme — were invisible to this scan while looking guarded.
+        assertTrue(
+            literalLfSubmit.containsMatchIn("""terminalWriter("echo \"theme: \${'$'}ZSH_THEME\"\n")"""),
+            "an escaped quote inside the command must not hide the LF",
+        )
+        // The initialCommand path behind run_in_panel, which the plain-name list used to miss.
+        assertTrue(concatenatedLfSubmit.containsMatchIn("""handle.write(initialCommand + "\n")"""))
+        assertTrue(concatenatedLfSubmit.containsMatchIn("""processHandle.write(initialCommand + "\n")"""))
+        // A call nested in the argument, which `[^)"]*` used to let through.
+        assertTrue(concatenatedLfSubmit.containsMatchIn("""tab.writeUserInput(render(x) + "\n")"""))
         // The normalizing public API is NOT in the pattern: "cmd\n" is its documented spelling and
         // is correct there. Its own guarantee is covered by the test above instead.
         assertTrue(!literalLfSubmit.containsMatchIn("""state.writeToFocusedPane("echo hi\n")"""))
@@ -150,6 +162,17 @@ class SubmitCharacterCoverageTest {
     }
 
     private companion object {
+        /**
+         * The names that mean "type this at a shell prompt".
+         *
+         * `handle`/`processHandle` are qualified rather than a bare `write(`, because `DaemonClient`
+         * and `DaemonControlChannel` write newline-delimited JSON to a socket, where LF is the
+         * protocol and correct. Those two are the `initialCommand` path behind MCP `run_in_panel`,
+         * which is one of the bugs this PR fixed and so has to stay guarded.
+         */
+        const val WRITERS =
+            """(writeUserInput|terminalWriter|writeToTerminal|(?:handle|processHandle)\.write)"""
+
         /**
          * Per-line opt-out. Narrow on purpose: excluding a whole file left `BossTermMcpServer`'s
          * `run_command` and `run_in_panel` — two of the paths this rule exists to protect —

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
@@ -1,0 +1,105 @@
+package ai.rever.bossterm.compose.util
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * No write path may submit with a bare LF.
+ *
+ * The helper's own unit tests were never the hard part — `submitLine` was correct from the first
+ * commit. What actually broke was call sites: the context menu built its own `terminalWriter` that
+ * skipped normalization, so right-click → Git → Status stranded at a `>>` prompt on Windows while
+ * the identical item on the Tools menu worked. That class of drift is invisible to anyone developing
+ * on macOS or Linux, where `ICRNL` makes LF submit anyway, so it has to be caught by the build
+ * rather than by review. Same reasoning as [ai.rever.bossterm.compose.mcp.AttachTargetCoverageTest],
+ * which fails when the two MCP registries drift apart.
+ *
+ * Scans source rather than behaviour because the failure is a literal in an argument list, and there
+ * is no seam to observe it through without booting a PTY per menu item.
+ */
+class SubmitCharacterCoverageTest {
+
+    private val sourceRoot = File("src/desktopMain/kotlin")
+
+    /**
+     * Writers that intentionally pass bytes straight through, keyed by the file that owns them.
+     *
+     * `send_input` is the deliberate one: a bare LF is Ctrl+J, a keystroke a caller may genuinely
+     * want (a newline inside a multi-line prompt to an AI CLI), so normalizing it centrally would
+     * remove the only way to send one. Anything added here needs the same argument in writing.
+     */
+    private val verbatimByDesign = setOf(
+        "BossTermMcpServer.kt",   // send_input — documented escape hatch
+        "DaemonMcpTools.kt",      // daemon send_input, same contract
+        "TerminalSubmit.kt",      // the helper itself
+    )
+
+    /**
+     * `writeUserInput("…\n")` / `terminalWriter("…\n")` — a literal LF handed to a terminal write.
+     *
+     * Deliberately does NOT include a bare `write(`: `DaemonClient` and `DaemonControlChannel` write
+     * newline-delimited JSON to a socket, where LF is the protocol and correct. Only the names that
+     * mean "type this at a shell prompt" belong here.
+     */
+    private val literalLfSubmit = Regex(
+        """(writeUserInput|terminalWriter|writeToTerminal)\(\s*"[^"]*\\n"\s*\)"""
+    )
+
+    /** `writeUserInput(cmd + "\n")` — the same mistake spelled with concatenation. */
+    private val concatenatedLfSubmit = Regex(
+        """(writeUserInput|terminalWriter|writeToTerminal)\([^)"]*\+\s*"\\n"\s*\)"""
+    )
+
+    @Test
+    fun `no write path submits with a bare line feed`() {
+        val offenders = mutableListOf<String>()
+
+        sourceRoot.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .filterNot { it.name in verbatimByDesign }
+            .forEach { file ->
+                file.readLines().forEachIndexed { index, line ->
+                    if (literalLfSubmit.containsMatchIn(line) || concatenatedLfSubmit.containsMatchIn(line)) {
+                        offenders += "${file.name}:${index + 1}  ${line.trim()}"
+                    }
+                }
+            }
+
+        assertTrue(
+            offenders.isEmpty(),
+            buildString {
+                appendLine("These write paths submit with LF, which does not press Enter under ConPTY.")
+                appendLine("Wrap the command in submitLine(), or normalizeSubmitNewlines() at the writer:")
+                offenders.forEach { appendLine("  $it") }
+            },
+        )
+    }
+
+    /**
+     * The scan has to actually be looking at something — an empty or mis-rooted walk would pass
+     * this suite while catching nothing, which is the failure mode of every source-scanning test.
+     */
+    @Test
+    fun `the scan reaches the sources it claims to cover`() {
+        val files = sourceRoot.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+        assertTrue(files.size > 100, "expected to scan the desktop sources, found ${files.size}")
+        assertTrue(
+            files.any { it.name == "TabbedTerminal.kt" } && files.any { it.name == "ProperTerminal.kt" },
+            "the files that regressed must be in scope",
+        )
+    }
+
+    /** And it has to be capable of failing — the regex must match the shape it is meant to catch. */
+    @Test
+    fun `the pattern matches the regression it exists to prevent`() {
+        assertTrue(literalLfSubmit.containsMatchIn("""tab.writeUserInput("clear\n")"""))
+        assertTrue(literalLfSubmit.containsMatchIn("""terminalWriter("git status\n")"""))
+        assertTrue(concatenatedLfSubmit.containsMatchIn("""session.writeUserInput(cmd + "\n")"""))
+        // Socket protocols legitimately write LF — the scan must not reach for those.
+        assertTrue(!literalLfSubmit.containsMatchIn("""write(line); write("\n"); flush()"""))
+        // And must not fire on the fixed forms, or it would block the correct code.
+        assertTrue(!literalLfSubmit.containsMatchIn("""tab.writeUserInput(submitLine("clear"))"""))
+        assertTrue(!literalLfSubmit.containsMatchIn("""session.writeUserInput(normalizeSubmitNewlines(text))"""))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
@@ -31,42 +31,74 @@ class SubmitCharacterCoverageTest {
      * same line as the library.
      */
     private val scanRoots = listOf(
-        "src/desktopMain/kotlin",
-        "../bossterm-app/src/desktopMain/kotlin",
-        "../tabbed-example/src/desktopMain/kotlin",
-        "../embedded-example/src/desktopMain/kotlin",
-    ).map { File(it) }.filter { it.isDirectory }
+        "compose-ui/src/desktopMain/kotlin",
+        "bossterm-app/src/desktopMain/kotlin",
+        "tabbed-example/src/desktopMain/kotlin",
+        "embedded-example/src/desktopMain/kotlin",
+    ).map { File(repoRoot, it) }.filter { it.isDirectory }
 
-    /**
-     * `writeUserInput("…\n")` / `terminalWriter("…\n")` — a literal LF handed to a terminal write.
-     *
-     * Deliberately does NOT include a bare `write(`: `DaemonClient` and `DaemonControlChannel` write
-     * newline-delimited JSON to a socket, where LF is the protocol and correct. Only the names that
-     * mean "type this at a shell prompt" belong here.
-     */
-    private val literalLfSubmit = Regex(
-        """$WRITERS\(\s*"(?:\\.|[^"\\])*\\n"\s*\)"""
-    )
-
-    /** `writeUserInput(cmd + "\n")` — the same mistake spelled with concatenation. */
-    private val concatenatedLfSubmit = Regex(
-        """$WRITERS\(.*\+\s*"\\n"\s*\)"""
-    )
+    /** Finds where a write call starts; the argument is then read by balancing parentheses. */
+    private val writerCall = Regex("""$WRITERS\s*\(""")
 
     private fun sources() = scanRoots.asSequence()
         .flatMap { it.walkTopDown() }
         .filter { it.isFile && it.extension == "kt" }
+
+    /**
+     * The argument text of the call starting at [openParen], up to its matching close.
+     *
+     * Balances parentheses rather than matching a regex, and tracks string state so a `)` inside a
+     * command literal doesn't end the scan early. Line-scoped regexes were the previous approach and
+     * they missed two of the shapes this rule exists for — a call wrapped across lines, and a
+     * separator chosen by a conditional — because in both the writer name and the `\n` sit on
+     * different lines, or the `\n` isn't adjacent to the closing paren.
+     */
+    private fun argumentText(text: String, openParen: Int): String {
+        var depth = 0
+        var i = openParen
+        var inString = false
+        var escaped = false
+        while (i < text.length) {
+            val c = text[i]
+            when {
+                escaped -> escaped = false
+                inString && c == '\\' -> escaped = true
+                c == '"' -> inString = !inString
+                inString -> {}
+                c == '(' -> depth++
+                c == ')' -> {
+                    depth--
+                    if (depth == 0) return text.substring(openParen + 1, i)
+                }
+            }
+            i++
+        }
+        return text.substring(openParen + 1)
+    }
+
+    /** An LF escape appearing inside a string literal — `"…\n"`, however the call is spelled. */
+    private val lfInsideStringLiteral = Regex(""""(?:\\.|[^"\\])*\\n(?:\\.|[^"\\])*"""")
 
     @Test
     fun `no write path submits with a bare line feed`() {
         val offenders = mutableListOf<String>()
 
         sources().forEach { file ->
-            file.readLines().forEachIndexed { index, line ->
-                if (line.contains(VERBATIM_MARKER)) return@forEachIndexed
-                if (literalLfSubmit.containsMatchIn(line) || concatenatedLfSubmit.containsMatchIn(line)) {
-                    offenders += "${file.name}:${index + 1}  ${line.trim()}"
-                }
+            val text = file.readText()
+            // Precomputed so a match's offset can be reported as a line number.
+            val lineStarts = text.mapIndexedNotNull { i, c -> if (c == '\n') i + 1 else null }
+            fun lineOf(offset: Int) = lineStarts.count { it <= offset } + 1
+
+            for (match in writerCall.findAll(text)) {
+                val openParen = match.range.last
+                val argument = argumentText(text, openParen)
+                if (!lfInsideStringLiteral.containsMatchIn(argument)) continue
+                // The opt-out may sit on any line the call spans.
+                val start = lineOf(match.range.first)
+                val end = lineOf(openParen + argument.length)
+                val spanned = text.lines().subList(start - 1, minOf(end, text.lines().size))
+                if (spanned.any { it.contains(VERBATIM_MARKER) }) continue
+                offenders += "${file.name}:$start  ${match.value}${argument.trim().take(90)})"
             }
         }
 
@@ -75,7 +107,7 @@ class SubmitCharacterCoverageTest {
             buildString {
                 appendLine("These write paths submit with LF, which does not press Enter under ConPTY.")
                 appendLine("Wrap the command in submitLine(), or normalizeSubmitNewlines() at the writer.")
-                appendLine("If a line genuinely needs a raw LF, mark it `// $VERBATIM_MARKER` and say why:")
+                appendLine("If one genuinely needs a raw LF, mark it `// $VERBATIM_MARKER` and say why:")
                 offenders.forEach { appendLine("  $it") }
             },
         )
@@ -133,32 +165,57 @@ class SubmitCharacterCoverageTest {
         }
     }
 
-    /** And it has to be capable of failing — the regex must match the shape it is meant to catch. */
+    /** Runs the real scan over one snippet, so these cases can't drift from what the scan does. */
+    private fun flags(snippet: String): Boolean {
+        val match = writerCall.find(snippet) ?: return false
+        val argument = argumentText(snippet, match.range.last)
+        return lfInsideStringLiteral.containsMatchIn(argument)
+    }
+
+    /** And it has to be capable of failing — the scan must catch the shapes it is meant to. */
     @Test
     fun `the pattern matches the regression it exists to prevent`() {
-        assertTrue(literalLfSubmit.containsMatchIn("""tab.writeUserInput("clear\n")"""))
-        assertTrue(literalLfSubmit.containsMatchIn("""terminalWriter("git status\n")"""))
-        assertTrue(concatenatedLfSubmit.containsMatchIn("""session.writeUserInput(cmd + "\n")"""))
+        assertTrue(flags("""tab.writeUserInput("clear\n")"""))
+        assertTrue(flags("""terminalWriter("git status\n")"""))
+        assertTrue(flags("""session.writeUserInput(cmd + "\n")"""))
         // A command containing an escaped quote. `[^"]*` stopped dead at the backslash-quote, so
         // ~10 real lines in ShellCustomizationMenuProvider — starship_setup_*, *_set_default,
         // ohmyzsh_current_theme — were invisible to this scan while looking guarded.
         assertTrue(
-            literalLfSubmit.containsMatchIn("""terminalWriter("echo \"theme: \${'$'}ZSH_THEME\"\n")"""),
+            flags("""terminalWriter("echo \"theme: \${'$'}ZSH_THEME\"\n")"""),
             "an escaped quote inside the command must not hide the LF",
         )
         // The initialCommand path behind run_in_panel, which the plain-name list used to miss.
-        assertTrue(concatenatedLfSubmit.containsMatchIn("""handle.write(initialCommand + "\n")"""))
-        assertTrue(concatenatedLfSubmit.containsMatchIn("""processHandle.write(initialCommand + "\n")"""))
+        assertTrue(flags("""handle.write(initialCommand + "\n")"""))
+        assertTrue(flags("""processHandle.write(initialCommand + "\n")"""))
         // A call nested in the argument, which `[^)"]*` used to let through.
-        assertTrue(concatenatedLfSubmit.containsMatchIn("""tab.writeUserInput(render(x) + "\n")"""))
-        // The normalizing public API is NOT in the pattern: "cmd\n" is its documented spelling and
-        // is correct there. Its own guarantee is covered by the test above instead.
-        assertTrue(!literalLfSubmit.containsMatchIn("""state.writeToFocusedPane("echo hi\n")"""))
+        assertTrue(flags("""tab.writeUserInput(render(x) + "\n")"""))
+        // The two shapes the line-scoped version missed. Both were real pre-fix code in this PR, in
+        // the two files this suite names as must-be-in-scope, so "the common shape" was too generous
+        // a description of what it covered.
+        assertTrue(
+            // The ollama launch line: writer name and literal ended up on different lines.
+            flags("writeToTerminal(\n    if (a == null) \"run \" else \"run \$a\\n\"\n)"),
+            "a call spanning lines must still be scanned",
+        )
+        assertTrue(
+            // Workflow auto-run: the "\n" is not adjacent to the closing paren.
+            flags("""tab.writeUserInput(rendered + if (auto) "\n" else "")"""),
+            "a conditional separator must still be scanned",
+        )
+        // A `)` inside the command must not end the argument scan early.
+        assertTrue(flags("""terminalWriter("echo \$(date)\n")"""))
+        // The normalizing public API is NOT scanned: "cmd\n" is its documented spelling and is
+        // correct there. Its own guarantee is covered by `every public write entry point…` instead.
+        assertTrue(!flags("""state.writeToFocusedPane("echo hi\n")"""))
         // Must not fire on the fixed forms, or it would block the correct code.
-        assertTrue(!literalLfSubmit.containsMatchIn("""tab.writeUserInput(submitLine("clear"))"""))
-        assertTrue(!literalLfSubmit.containsMatchIn("""session.writeUserInput(normalizeSubmitNewlines(text))"""))
+        assertTrue(!flags("""tab.writeUserInput(submitLine("clear"))"""))
+        assertTrue(!flags("""session.writeUserInput(normalizeSubmitNewlines(text))"""))
+        assertTrue(!flags("""tab.writeUserInput(if (auto) submitLine(rendered) else rendered)"""))
         // Socket protocols legitimately write LF — the scan must not reach for those.
-        assertTrue(!literalLfSubmit.containsMatchIn("""write(line); write("\n"); flush()"""))
+        assertTrue(!flags("""write(line); write("\n"); flush()"""))
+        // Nor for a non-writer that happens to share a line with one.
+        assertTrue(!flags("""sb.append(x + "\n")"""))
     }
 
     private companion object {
@@ -169,6 +226,14 @@ class SubmitCharacterCoverageTest {
          * and `DaemonControlChannel` write newline-delimited JSON to a socket, where LF is the
          * protocol and correct. Those two are the `initialCommand` path behind MCP `run_in_panel`,
          * which is one of the bugs this PR fixed and so has to stay guarded.
+         *
+         * Three names are excluded on purpose, for two different reasons:
+         *  - `write` / `writeToFocusedPane` normalize internally, so `"cmd\n"` is their documented
+         *    spelling and correct at their call sites. That they normalize is asserted separately by
+         *    `every public write entry point normalizes newlines`.
+         *  - `writeVerbatim` exists precisely to send raw bytes, so calling it IS the opt-out; adding
+         *    it here would mean marking every legitimate use `$VERBATIM_MARKER`. The name is the
+         *    warning, and its KDoc says `\r` submits and `\n` does not.
          */
         const val WRITERS =
             """(writeUserInput|terminalWriter|writeToTerminal|(?:handle|processHandle)\.write)"""
@@ -180,5 +245,18 @@ class SubmitCharacterCoverageTest {
          * say so on the line itself.
          */
         const val VERBATIM_MARKER = "verbatim-by-design"
+
+        /**
+         * Anchored on `settings.gradle.kts` rather than relative paths, so the scan roots resolve
+         * the same whichever directory the runner picks.
+         *
+         * Gradle sets the working dir to the project dir, but an IDE run config may use the repo
+         * root — and with relative roots that produced an empty scan, which the LF test passes
+         * vacuously. `the scan reaches the sources it claims to cover` does catch it, but reports
+         * "found 0" rather than pointing at the cause.
+         */
+        val repoRoot: File = generateSequence(File(".").absoluteFile) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error("could not locate the repo root from ${File(".").absolutePath}")
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
@@ -60,10 +60,13 @@ class SubmitCharacterCoverageTest {
      */
     private fun moduleNames(): List<String> {
         val settings = File(repoRoot, "settings.gradle.kts").readText()
-        // Every include(...) block, not just the first — a second one used to be invisible.
+        // Every include(...) block, not just the first — a second one used to be invisible. And
+        // `:` inside the class, so a nested `include(":foo:bar")` maps to its directory instead of
+        // being dropped: a dropped module never enters `modules`, so the every-module-contributes
+        // assertion below cannot catch it either — the same silent rot this function exists to stop.
         return Regex("""include\s*\(([^)]*)\)""").findAll(settings)
-            .flatMap { block -> Regex(""""\s*:([\w-]+)\s*"""").findAll(block.groupValues[1]) }
-            .map { it.groupValues[1] }
+            .flatMap { block -> Regex(""""\s*:([\w:-]+)\s*"""").findAll(block.groupValues[1]) }
+            .map { it.groupValues[1].replace(':', '/') }
             .distinct()
             .toList()
     }
@@ -99,6 +102,21 @@ class SubmitCharacterCoverageTest {
         while (i < limit) {
             val c = text[i]
             val tripleQuote = c == '"' && text.startsWith("\"\"\"", i)
+            // Comments first, outside strings: an apostrophe ("// don't submit"), a stray quote, or
+            // an unbalanced paren ("// see write(") in a comment inside the call span would
+            // otherwise desync the walk and fail the build on perfectly correct code — landing on
+            // whoever next touched the file rather than whoever wrote the comment.
+            if (!inString && !inRawString && !escaped) {
+                if (text.startsWith("//", i)) {
+                    i = text.indexOf('\n', i).takeIf { it >= 0 } ?: text.length
+                    continue
+                }
+                if (text.startsWith("/*", i)) {
+                    val end = text.indexOf("*/", i + 2)
+                    i = if (end >= 0) end + 2 else text.length
+                    continue
+                }
+            }
             when {
                 // A raw string ends only at the next """, and has no escapes inside it. Handled
                 // first because otherwise its three quotes toggle `inString` an odd number of times
@@ -148,7 +166,8 @@ class SubmitCharacterCoverageTest {
                 if (!lfInsideStringLiteral.containsMatchIn(argument)) continue
                 // The opt-out may sit on any line the call spans.
                 val start = lineOf(match.range.first)
-                val end = lineOf(openParen + argument.length)
+                // +2 spans the closing paren: a marker on a line holding only `)` still counts.
+                val end = lineOf(openParen + argument.length + 2)
                 val spanned = text.lines().subList(start - 1, minOf(end, text.lines().size))
                 if (spanned.any { it.contains(VERBATIM_MARKER) }) continue
                 offenders += "${file.name}:$start  ${match.value}${argument.trim().take(90)})"
@@ -365,6 +384,12 @@ class SubmitCharacterCoverageTest {
         )
         // A `)` inside the command must not end the argument scan early.
         assertTrue(flags("""terminalWriter("echo \$(date)\n")"""))
+        // Comments inside the call must not desync the walk. An apostrophe, a stray quote and an
+        // unbalanced paren each used to run the scanner past the call and fail the build on code
+        // that was correct — the first two by flipping string state, the third by depth.
+        assertTrue(flags("terminalWriter( // don't submit twice\n    \"ls\\n\"\n)"))
+        assertTrue(flags("terminalWriter( /* see write( */ \"ls\\n\")"))
+        assertTrue(!flags("terminalWriter( // don't\n    submitLine(\"ls\")\n)"))
         // Shapes that used to unbalance the scanner and make it run to EOF, turning a correct
         // change to unrelated code into a build failure. A raw string, and a char literal holding
         // a quote — both must parse, and neither is an LF submit.

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
@@ -42,7 +42,10 @@ class SubmitCharacterCoverageTest {
      */
     private val scanRoots: List<File> = moduleNames().flatMap { module ->
         File(repoRoot, "$module/src").listFiles().orEmpty()
-            .filter { it.isDirectory && it.name.endsWith("Main") }
+            // "main" as well as "*Main": a plain-JVM module uses the conventional src/main/kotlin,
+            // and "main".endsWith("Main") is false — which would fail the every-module assertion
+            // below for a module that is laid out perfectly normally.
+            .filter { it.isDirectory && (it.name.endsWith("Main") || it.name == "main") }
             .map { File(it, "kotlin") }
             .filter { it.isDirectory }
     }
@@ -224,17 +227,20 @@ class SubmitCharacterCoverageTest {
         for ((fileName, signatures) in surfaces) {
             val file = sources().firstOrNull { it.name == fileName }
                 ?: error("$fileName not found in the scan roots")
-            val lines = file.readLines()
+            val text = file.readText()
             for (signature in signatures) {
-                val declarations = lines.withIndex().filter { it.value.contains(signature) }
-                assertTrue(declarations.isNotEmpty(), "no `$signature` found in $fileName")
-                for ((index, decl) in declarations) {
-                    // The body is short by construction; a handful of lines covers every overload.
-                    val body = lines.subList(index, minOf(index + 6, lines.size)).joinToString("\n")
+                // Every overload, not just the first: TabbedTerminalState.write has three.
+                val declarations = Regex(Regex.escape(signature)).findAll(text).count()
+                assertTrue(declarations > 0, "no `$signature` found in $fileName")
+                var searchFrom = 0
+                repeat(declarations) {
+                    val at = text.indexOf(signature, searchFrom)
+                    val body = bodyFrom(text, at, "$signature in $fileName")
+                    searchFrom = at + signature.length
                     assertTrue(
                         body.contains("normalizeSubmitNewlines") || body.contains("submitLine"),
-                        "$fileName:${index + 1} `${decl.trim()}` must normalize newlines — it is a " +
-                            "public write API and its documented contract is that \\n presses Enter",
+                        "`$signature` in $fileName must normalize newlines — it is a public write " +
+                            "API and its documented contract is that \\n presses Enter:\n$body",
                     )
                 }
             }
@@ -256,19 +262,67 @@ class SubmitCharacterCoverageTest {
      */
     @Test
     fun `targeted writes resolve through findSession, never the active tab`() {
-        val file = sources().firstOrNull { it.name == "TabbedTerminalState.kt" }
-            ?: error("TabbedTerminalState.kt not found in the scan roots")
-        val lines = file.readLines()
         for (signature in listOf("fun writeVerbatim(", "fun writeToFocusedPane(")) {
-            val index = lines.indexOfFirst { it.contains(signature) }
-            assertTrue(index >= 0, "no `$signature` in TabbedTerminalState.kt")
-            val body = lines.subList(index, minOf(index + 6, lines.size)).joinToString("\n")
+            val body = bodyOf("TabbedTerminalState.kt", signature)
             assertTrue(
                 !body.contains("?: activeTab"),
                 "`$signature` must not fall back to the active tab - a caller that named a tab " +
                     "gets its keystrokes delivered somewhere else entirely:\n$body",
             )
         }
+    }
+
+    /**
+     * The verbatim APIs must stay verbatim.
+     *
+     * Their whole reason for existing is that `write()` normalizes: a bare LF is Ctrl+J, the way a
+     * multi-line prompt gets typed into an AI CLI. Nothing pinned the Embeddable one at all, and the
+     * Tabbed one only against the old `?: activeTab` shape — so a well-meaning "make all the write
+     * paths consistent" sweep could normalize them and remove the only escape hatch either public
+     * API has, with the whole suite still green.
+     */
+    @Test
+    fun `the verbatim write APIs do not normalize`() {
+        for ((fileName, signature) in listOf(
+            "TabbedTerminalState.kt" to "fun writeVerbatim(",
+            "EmbeddableTerminal.kt" to "fun writeVerbatim(",
+        )) {
+            val body = bodyOf(fileName, signature)
+            assertTrue(
+                !body.contains("normalizeSubmitNewlines") && !body.contains("submitLine"),
+                "`$signature` in $fileName must pass bytes through untouched:\n$body",
+            )
+        }
+    }
+
+    /**
+     * The body of the function declared by [signature], from its brace to the matching one.
+     *
+     * Braces rather than a fixed line window: a 6-line window silently changed meaning whenever a
+     * KDoc line was added or a body reformatted, so these assertions could start passing (or
+     * failing) for reasons unrelated to the rule they encode.
+     */
+    private fun bodyOf(fileName: String, signature: String): String {
+        val file = sources().firstOrNull { it.name == fileName }
+            ?: error("$fileName not found in the scan roots")
+        val text = file.readText()
+        val start = text.indexOf(signature)
+        require(start >= 0) { "no `$signature` in $fileName" }
+        return bodyFrom(text, start, "$signature in $fileName")
+    }
+
+    /** The braced body of the declaration starting at [declIndex]. */
+    private fun bodyFrom(text: String, declIndex: Int, what: String): String {
+        val open = text.indexOf('{', declIndex)
+        require(open >= 0) { "`$what` has no body" }
+        var depth = 0
+        for (i in open until text.length) {
+            when (text[i]) {
+                '{' -> depth++
+                '}' -> if (--depth == 0) return text.substring(open, i + 1)
+            }
+        }
+        error("unbalanced braces after `$what`")
     }
 
     /** Runs the real scan over one snippet, so these cases can't drift from what the scan does. */

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
@@ -23,29 +23,46 @@ import kotlin.test.assertTrue
 class SubmitCharacterCoverageTest {
 
     /**
-     * Every module that can type at a prompt, not just this one.
+     * Every Kotlin source set of every included module — `desktopMain`, `jvmMain`, `commonMain`,
+     * whatever a module happens to use.
      *
-     * The examples are in scope deliberately — `tabbed-example` called `writeToFocusedPane("…\n")`,
+     * The examples are in scope deliberately: `tabbed-example` called `writeToFocusedPane("…\n")`,
      * and because it sat outside the original scan the public API behind it stayed broken through a
      * whole review round. Sample code is the copy-paste source for embedders, so it has to hold the
      * same line as the library.
+     *
+     * Every production source set is taken rather than naming `desktopMain`, because the previous
+     * version filtered non-existent directories away silently — `bossterm-core-mpp` (which uses
+     * `jvmMain`) and `compose-ui`'s `commonMain` were dropped without a word while the KDoc claimed
+     * every included module was covered. Nothing to catch in them today, but "move a source set and
+     * the guard quietly stops guarding" is the precise rot this suite exists to prevent.
+     *
+     * Test source sets are excluded: this very file holds `writeUserInput("clear\n")` as a fixture
+     * for the scan's own self-tests, and scanning them makes the suite fail on its own examples.
      */
-    private val scanRoots = moduleNames()
-        .map { File(repoRoot, "$it/src/desktopMain/kotlin") }
-        .filter { it.isDirectory }
+    private val scanRoots: List<File> = moduleNames().flatMap { module ->
+        File(repoRoot, "$module/src").listFiles().orEmpty()
+            .filter { it.isDirectory && it.name.endsWith("Main") }
+            .map { File(it, "kotlin") }
+            .filter { it.isDirectory }
+    }
 
     /**
      * Every module `settings.gradle.kts` includes, so the guard extends itself.
      *
      * Was a hardcoded four-module list, which meant a new module was silently unguarded and a
-     * renamed one failed with a message about example modules. Reading the include block instead
+     * renamed one failed with a message about example modules. Reading the include blocks instead
      * matters more here than it would elsewhere: the whole point of this suite is catching drift
      * that nobody is looking for, and "nobody added the new module to the scan" is exactly that.
      */
     private fun moduleNames(): List<String> {
         val settings = File(repoRoot, "settings.gradle.kts").readText()
-        val includeBlock = settings.substringAfter("include(").substringBefore(")")
-        return Regex(""""\s*:([\w-]+)\s*"""").findAll(includeBlock).map { it.groupValues[1] }.toList()
+        // Every include(...) block, not just the first — a second one used to be invisible.
+        return Regex("""include\s*\(([^)]*)\)""").findAll(settings)
+            .flatMap { block -> Regex(""""\s*:([\w-]+)\s*"""").findAll(block.groupValues[1]) }
+            .map { it.groupValues[1] }
+            .distinct()
+            .toList()
     }
 
     /** Finds where a write call starts; the argument is then read by balancing parentheses. */
@@ -68,6 +85,7 @@ class SubmitCharacterCoverageTest {
         var depth = 0
         var i = openParen
         var inString = false
+        var inRawString = false
         var escaped = false
         // A write call's argument is one expression. If the parens haven't balanced by here, the
         // scanner has lost track — a raw string, a char literal holding a quote, a quote inside a
@@ -77,11 +95,21 @@ class SubmitCharacterCoverageTest {
         val limit = minOf(text.length, openParen + MAX_CALL_CHARS)
         while (i < limit) {
             val c = text[i]
+            val tripleQuote = c == '"' && text.startsWith("\"\"\"", i)
             when {
+                // A raw string ends only at the next """, and has no escapes inside it. Handled
+                // first because otherwise its three quotes toggle `inString` an odd number of times
+                // and the scan runs on into the rest of the file.
+                inRawString -> if (tripleQuote) { inRawString = false; i += 2 }
                 escaped -> escaped = false
                 inString && c == '\\' -> escaped = true
+                tripleQuote && !inString -> { inRawString = true; i += 2 }
                 c == '"' -> inString = !inString
                 inString -> {}
+                c == '\'' -> {
+                    // Char literal: skip it whole, so '"' doesn't flip the string state.
+                    i += if (text.startsWith("'\\", i)) 3 else 2
+                }
                 c == '(' -> depth++
                 c == ')' -> {
                     depth--
@@ -158,14 +186,23 @@ class SubmitCharacterCoverageTest {
         for (regressed in listOf("TabbedTerminal.kt", "ProperTerminal.kt", "TabbedTerminalState.kt")) {
             assertTrue(files.any { it.name == regressed }, "$regressed must be in scope")
         }
-        // Derived from settings.gradle.kts, so this also fails if the include block stops parsing.
-        assertTrue(moduleNames().size >= 5, "expected every included module, got ${moduleNames()}")
-        for (module in listOf("tabbed-example", "embedded-example")) {
+        // Derived from settings.gradle.kts, so this also fails if the include blocks stop parsing.
+        val modules = moduleNames()
+        assertTrue(modules.size >= 5, "expected every included module, got $modules")
+        // Asserted AFTER the directory filter, which is where the previous version lost modules:
+        // it checked the names and then silently dropped any whose layout wasn't desktopMain.
+        val paths = scanRoots.map { it.path.replace('\\', '/') }
+        for (module in modules) {
             assertTrue(
-                scanRoots.any { it.path.replace('\\', '/').contains("/$module/") },
-                "$module must be scanned - sample code is what embedders copy, and it is where " +
-                    "writeToFocusedPane's LF call slipped through a whole review round",
+                paths.any { it.contains("/$module/src/") },
+                "module '$module' is included but contributes no scanned source root - it has no " +
+                    "src/*/kotlin, or its layout changed. Found roots: $paths",
             )
+        }
+        // Sample code is what embedders copy, and is where writeToFocusedPane's LF call slipped
+        // through a whole review round.
+        for (module in listOf("tabbed-example", "embedded-example")) {
+            assertTrue(paths.any { it.contains("/$module/src/") }, "$module must be scanned")
         }
     }
 
@@ -201,6 +238,36 @@ class SubmitCharacterCoverageTest {
                     )
                 }
             }
+        }
+    }
+
+    /**
+     * A targeted write API must not silently retarget when its tab can't be resolved.
+     *
+     * [ai.rever.bossterm.compose.TabbedTerminalState.writeVerbatim] shipped for one review round
+     * falling back to `activeTab`. `splitStates` is populated lazily, so a tab that had never been
+     * activated resolved to null and the text went to whatever the user was looking at — returning
+     * true. Harmless for a command; on a verbatim keystroke API it misdelivers a `y\r` or a
+     * password. `findSession` is the correct resolver: it validates the tab and falls back to that
+     * tab's own session.
+     *
+     * Structural because constructing a real `TabbedTerminalState` means Compose state plus live
+     * PTY sessions; this at least fails if the fallback returns.
+     */
+    @Test
+    fun `targeted writes resolve through findSession, never the active tab`() {
+        val file = sources().firstOrNull { it.name == "TabbedTerminalState.kt" }
+            ?: error("TabbedTerminalState.kt not found in the scan roots")
+        val lines = file.readLines()
+        for (signature in listOf("fun writeVerbatim(", "fun writeToFocusedPane(")) {
+            val index = lines.indexOfFirst { it.contains(signature) }
+            assertTrue(index >= 0, "no `$signature` in TabbedTerminalState.kt")
+            val body = lines.subList(index, minOf(index + 6, lines.size)).joinToString("\n")
+            assertTrue(
+                !body.contains("?: activeTab"),
+                "`$signature` must not fall back to the active tab - a caller that named a tab " +
+                    "gets its keystrokes delivered somewhere else entirely:\n$body",
+            )
         }
     }
 
@@ -244,6 +311,14 @@ class SubmitCharacterCoverageTest {
         )
         // A `)` inside the command must not end the argument scan early.
         assertTrue(flags("""terminalWriter("echo \$(date)\n")"""))
+        // Shapes that used to unbalance the scanner and make it run to EOF, turning a correct
+        // change to unrelated code into a build failure. A raw string, and a char literal holding
+        // a quote — both must parse, and neither is an LF submit.
+        assertTrue(!flags("terminalWriter(\"\"\"multi\nline\"\"\")"))
+        assertTrue(!flags("""terminalWriter(cmd.trim('"'))"""))
+        assertTrue(!flags("""terminalWriter(cmd.trim('\''))"""))
+        // …and a raw string that DOES carry an escaped LF is still caught.
+        assertTrue(flags("terminalWriter(\"\"\"x\"\"\" + \"y\\n\")"))
         // The normalizing public API is NOT scanned: "cmd\n" is its documented spelling and is
         // correct there. Its own guarantee is covered by `every public write entry point…` instead.
         assertTrue(!flags("""state.writeToFocusedPane("echo hi\n")"""))

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
@@ -64,7 +64,12 @@ class SubmitCharacterCoverageTest {
         // `:` inside the class, so a nested `include(":foo:bar")` maps to its directory instead of
         // being dropped: a dropped module never enters `modules`, so the every-module-contributes
         // assertion below cannot catch it either — the same silent rot this function exists to stop.
-        return Regex("""include\s*\(([^)]*)\)""").findAll(settings)
+        //
+        // Line comments stripped first, or a commented-out `// include(":legacy")` yields a phantom
+        // module that then fails that same assertion. (argumentText goes to this trouble too; this
+        // parser had no excuse not to.)
+        val live = settings.lines().joinToString("\n") { it.substringBefore("//") }
+        return Regex("""include\s*\(([^)]*)\)""").findAll(live)
             .flatMap { block -> Regex(""""\s*:([\w:-]+)\s*"""").findAll(block.groupValues[1]) }
             .map { it.groupValues[1].replace(':', '/') }
             .distinct()
@@ -213,12 +218,21 @@ class SubmitCharacterCoverageTest {
         assertTrue(modules.size >= 5, "expected every included module, got $modules")
         // Asserted AFTER the directory filter, which is where the previous version lost modules:
         // it checked the names and then silently dropped any whose layout wasn't desktopMain.
+        //
+        // Only modules that actually hold Kotlin, though. Demanding a scanned root from EVERY
+        // included module was stronger than the intent: a Java-only, resources-only or BOM-style
+        // module would fail this suite with a message about submit characters, a long way from its
+        // cause. What the check is really for is a source set that MOVED — a module with Kotlin
+        // somewhere but none of it reachable.
         val paths = scanRoots.map { it.path.replace('\\', '/') }
         for (module in modules) {
+            val dir = File(repoRoot, module)
+            val hasKotlin = dir.walkTopDown().any { it.isFile && it.extension == "kt" }
+            if (!hasKotlin) continue
             assertTrue(
                 paths.any { it.contains("/$module/src/") },
-                "module '$module' is included but contributes no scanned source root - it has no " +
-                    "src/*/kotlin, or its layout changed. Found roots: $paths",
+                "module '$module' has Kotlin sources but contributes no scanned root - its source " +
+                    "set moved out of src/*Main/kotlin or src/main/kotlin. Found roots: $paths",
             )
         }
         // Sample code is what embedders copy, and is where writeToFocusedPane's LF call slipped

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/SubmitCharacterCoverageTest.kt
@@ -30,12 +30,23 @@ class SubmitCharacterCoverageTest {
      * whole review round. Sample code is the copy-paste source for embedders, so it has to hold the
      * same line as the library.
      */
-    private val scanRoots = listOf(
-        "compose-ui/src/desktopMain/kotlin",
-        "bossterm-app/src/desktopMain/kotlin",
-        "tabbed-example/src/desktopMain/kotlin",
-        "embedded-example/src/desktopMain/kotlin",
-    ).map { File(repoRoot, it) }.filter { it.isDirectory }
+    private val scanRoots = moduleNames()
+        .map { File(repoRoot, "$it/src/desktopMain/kotlin") }
+        .filter { it.isDirectory }
+
+    /**
+     * Every module `settings.gradle.kts` includes, so the guard extends itself.
+     *
+     * Was a hardcoded four-module list, which meant a new module was silently unguarded and a
+     * renamed one failed with a message about example modules. Reading the include block instead
+     * matters more here than it would elsewhere: the whole point of this suite is catching drift
+     * that nobody is looking for, and "nobody added the new module to the scan" is exactly that.
+     */
+    private fun moduleNames(): List<String> {
+        val settings = File(repoRoot, "settings.gradle.kts").readText()
+        val includeBlock = settings.substringAfter("include(").substringBefore(")")
+        return Regex(""""\s*:([\w-]+)\s*"""").findAll(includeBlock).map { it.groupValues[1] }.toList()
+    }
 
     /** Finds where a write call starts; the argument is then read by balancing parentheses. */
     private val writerCall = Regex("""$WRITERS\s*\(""")
@@ -53,12 +64,18 @@ class SubmitCharacterCoverageTest {
      * separator chosen by a conditional — because in both the writer name and the `\n` sit on
      * different lines, or the `\n` isn't adjacent to the closing paren.
      */
-    private fun argumentText(text: String, openParen: Int): String {
+    private fun argumentText(text: String, openParen: Int): String? {
         var depth = 0
         var i = openParen
         var inString = false
         var escaped = false
-        while (i < text.length) {
+        // A write call's argument is one expression. If the parens haven't balanced by here, the
+        // scanner has lost track — a raw string, a char literal holding a quote, a quote inside a
+        // comment — and running on to EOF would blame a later `\n` in the file on this call. Give up
+        // instead: `argumentText` returns null and the caller reports it as unparseable, which sends
+        // the next reader to the right place rather than a confidently wrong one.
+        val limit = minOf(text.length, openParen + MAX_CALL_CHARS)
+        while (i < limit) {
             val c = text[i]
             when {
                 escaped -> escaped = false
@@ -73,7 +90,7 @@ class SubmitCharacterCoverageTest {
             }
             i++
         }
-        return text.substring(openParen + 1)
+        return null
     }
 
     /** An LF escape appearing inside a string literal — `"…\n"`, however the call is spelled. */
@@ -82,6 +99,7 @@ class SubmitCharacterCoverageTest {
     @Test
     fun `no write path submits with a bare line feed`() {
         val offenders = mutableListOf<String>()
+        val unparseable = mutableListOf<String>()
 
         sources().forEach { file ->
             val text = file.readText()
@@ -92,6 +110,10 @@ class SubmitCharacterCoverageTest {
             for (match in writerCall.findAll(text)) {
                 val openParen = match.range.last
                 val argument = argumentText(text, openParen)
+                if (argument == null) {
+                    unparseable += "${file.name}:${lineOf(match.range.first)}  ${match.value}…"
+                    continue
+                }
                 if (!lfInsideStringLiteral.containsMatchIn(argument)) continue
                 // The opt-out may sit on any line the call spans.
                 val start = lineOf(match.range.first)
@@ -111,6 +133,18 @@ class SubmitCharacterCoverageTest {
                 offenders.forEach { appendLine("  $it") }
             },
         )
+        // Reported separately from a plain pass: a call the scanner couldn't read is a call it
+        // didn't check, and silently treating that as clean is how a guard rots into decoration.
+        assertTrue(
+            unparseable.isEmpty(),
+            buildString {
+                appendLine("Could not find the end of these write calls within $MAX_CALL_CHARS chars.")
+                appendLine("argumentText balances parens and tracks double quotes only, so a raw")
+                appendLine("string, a char literal holding a quote, or a quote inside a comment in")
+                appendLine("the call will throw it off. Teach it that shape, or simplify the call:")
+                unparseable.forEach { appendLine("  $it") }
+            },
+        )
     }
 
     /**
@@ -124,10 +158,15 @@ class SubmitCharacterCoverageTest {
         for (regressed in listOf("TabbedTerminal.kt", "ProperTerminal.kt", "TabbedTerminalState.kt")) {
             assertTrue(files.any { it.name == regressed }, "$regressed must be in scope")
         }
-        assertTrue(
-            scanRoots.size >= 4,
-            "the example modules must be scanned - that is where writeToFocusedPane slipped through",
-        )
+        // Derived from settings.gradle.kts, so this also fails if the include block stops parsing.
+        assertTrue(moduleNames().size >= 5, "expected every included module, got ${moduleNames()}")
+        for (module in listOf("tabbed-example", "embedded-example")) {
+            assertTrue(
+                scanRoots.any { it.path.replace('\\', '/').contains("/$module/") },
+                "$module must be scanned - sample code is what embedders copy, and it is where " +
+                    "writeToFocusedPane's LF call slipped through a whole review round",
+            )
+        }
     }
 
     /**
@@ -168,7 +207,7 @@ class SubmitCharacterCoverageTest {
     /** Runs the real scan over one snippet, so these cases can't drift from what the scan does. */
     private fun flags(snippet: String): Boolean {
         val match = writerCall.find(snippet) ?: return false
-        val argument = argumentText(snippet, match.range.last)
+        val argument = argumentText(snippet, match.range.last) ?: return false
         return lfInsideStringLiteral.containsMatchIn(argument)
     }
 
@@ -246,17 +285,24 @@ class SubmitCharacterCoverageTest {
          */
         const val VERBATIM_MARKER = "verbatim-by-design"
 
+        /** Generous for one expression, short enough that a lost scanner gives up near the call. */
+        const val MAX_CALL_CHARS = 600
+
         /**
-         * Anchored on `settings.gradle.kts` rather than relative paths, so the scan roots resolve
-         * the same whichever directory the runner picks.
+         * Injected by the build (`bossterm.repoRoot`), so the scan roots resolve the same whichever
+         * directory the runner picks.
          *
-         * Gradle sets the working dir to the project dir, but an IDE run config may use the repo
-         * root — and with relative roots that produced an empty scan, which the LF test passes
-         * vacuously. `the scan reaches the sources it claims to cover` does catch it, but reports
-         * "found 0" rather than pointing at the cause.
+         * Falls back to sniffing upward for `settings.gradle.kts`, which covers running the class
+         * outside Gradle. Relative paths were the original approach and they resolved to nothing
+         * when an IDE run config started at the repo root — an empty scan that the LF test passes
+         * vacuously. Failing loudly here beats a green test that looked at no files.
          */
-        val repoRoot: File = generateSequence(File(".").absoluteFile) { it.parentFile }
-            .firstOrNull { File(it, "settings.gradle.kts").isFile }
-            ?: error("could not locate the repo root from ${File(".").absolutePath}")
+        val repoRoot: File = System.getProperty("bossterm.repoRoot")?.let(::File)
+            ?: generateSequence(File(".").absoluteFile) { it.parentFile }
+                .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error(
+                "repo root not found: pass -Dbossterm.repoRoot, or run from inside the repo " +
+                    "(cwd was ${File(".").absolutePath})"
+            )
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/TerminalSubmitTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/TerminalSubmitTest.kt
@@ -51,12 +51,13 @@ class TerminalSubmitTest {
     }
 
     /**
-     * `run_in_panel`'s contract: "a trailing newline is optional".
+     * `run_in_panel`'s contract: "a trailing newline is optional", and an empty script just opens
+     * the panel.
      *
-     * The tool hands its script to `initialCommand`, which submits it later, so a caller-supplied
-     * Enter has to come off first. The old `removeSuffix("\n")` handled `"ls\n"` but left the CR of
-     * `"ls\r\n"` behind — the script then arrived as `"ls\r"` and got a second CR appended, running
-     * the command twice. That is the case worth pinning.
+     * The empty case is the one that actually depends on this. `submitLine` downstream is idempotent
+     * over any trailing separator, so stripping cannot be what prevents a double submit — but only
+     * stripping CR as well as LF makes a script of `"\r\n"` reach the `ifEmpty { null }` branch
+     * rather than opening a panel and pressing Enter in it.
      */
     @Test
     fun `a caller-supplied Enter is stripped before a later submit`() {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/TerminalSubmitTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/TerminalSubmitTest.kt
@@ -51,6 +51,27 @@ class TerminalSubmitTest {
     }
 
     /**
+     * `run_in_panel`'s contract: "a trailing newline is optional".
+     *
+     * The tool hands its script to `initialCommand`, which submits it later, so a caller-supplied
+     * Enter has to come off first. The old `removeSuffix("\n")` handled `"ls\n"` but left the CR of
+     * `"ls\r\n"` behind — the script then arrived as `"ls\r"` and got a second CR appended, running
+     * the command twice. That is the case worth pinning.
+     */
+    @Test
+    fun `a caller-supplied Enter is stripped before a later submit`() {
+        for (input in listOf("ls", "ls\n", "ls\r", "ls\r\n", "ls\n\r", "ls\r\n\r\n")) {
+            assertEquals("ls", stripTrailingSubmit(input), "input was ${input.debug()}")
+        }
+        // Round-tripped through the submit it precedes: still exactly one Enter.
+        assertEquals("ls\r", submitLine(stripTrailingSubmit("ls\r\n")))
+        // Interior newlines are a multi-command script and must survive.
+        assertEquals("cd /tmp\nls", stripTrailingSubmit("cd /tmp\nls\n"))
+        // Empty stays empty — run_in_panel reads that as "just open the panel".
+        assertEquals("", stripTrailingSubmit("\r\n"))
+    }
+
+    /**
      * The normalize-only helper must NOT add a submit — it backs paste-like writes where trailing
      * text is still being typed.
      */

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/TerminalSubmitTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/TerminalSubmitTest.kt
@@ -83,5 +83,21 @@ class TerminalSubmitTest {
         assertTrue(normalizeSubmitNewlines("echo hi\n").endsWith("\r"))
     }
 
+    /**
+     * The composition every in-tree menu item now relies on: the literal adds the CR via
+     * [submitLine], and the writer runs [normalizeSubmitNewlines] over the result on the way through.
+     *
+     * Which means a CR must survive normalization untouched. Nothing else in the suite pins that —
+     * the other cases feed it LF and CRLF — so a future rewrite that mapped CR to anything else
+     * would stay green here and break every git and AI menu item, on every platform rather than
+     * just Windows.
+     */
+    @Test
+    fun `normalizing an already-submitted command is a no-op`() {
+        assertEquals("ls\r", normalizeSubmitNewlines("ls\r"))
+        assertEquals(submitLine("git status"), normalizeSubmitNewlines(submitLine("git status")))
+        assertEquals("cd /tmp\rls\r", normalizeSubmitNewlines(submitLine("cd /tmp\nls")))
+    }
+
     private fun String.debug() = replace("\r", "\\r").replace("\n", "\\n")
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/TerminalSubmitTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/util/TerminalSubmitTest.kt
@@ -1,0 +1,65 @@
+package ai.rever.bossterm.compose.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The submit character is CR, and there must be exactly one of it.
+ *
+ * Pinned because the wrong answer is invisible on macOS and Linux — the pty line discipline's
+ * `ICRNL` maps CR to NL on input, so LF, CR and CRLF all appear to work there and a regression would
+ * only ever be reported by a Windows user. Measured on Windows PowerShell 5.1 over ConPTY: a bare LF
+ * is Ctrl+J and leaves the command unrun at a `>>` continuation prompt, and CRLF runs the command
+ * but leaves the FOLLOWING prompt in continuation mode.
+ */
+class TerminalSubmitTest {
+
+    @Test
+    fun `a plain command gets exactly one carriage return`() {
+        assertEquals("claude --dangerously-skip-permissions\r", submitLine("claude --dangerously-skip-permissions"))
+    }
+
+    /** Callers are handed command strings from all over; none of them should have to check first. */
+    @Test
+    fun `every trailing separator collapses to one carriage return`() {
+        for (input in listOf("ls", "ls\n", "ls\r", "ls\r\n", "ls\n\n", "ls\r\r", "ls\r\n\r\n")) {
+            assertEquals("ls\r", submitLine(input), "input was ${input.debug()}")
+        }
+    }
+
+    /** The CRLF trap: one Enter, never a trailing LF that lands on the next prompt. */
+    @Test
+    fun `never emits a line feed`() {
+        val out = submitLine("git status\r\n")
+        assertFalse(out.contains('\n'), "a trailing LF poisons the next prompt: ${out.debug()}")
+        assertEquals(1, out.count { it == '\r' }, "exactly one Enter: ${out.debug()}")
+    }
+
+    /** A multi-line script is a sequence of commands, so each of its newlines is an Enter too. */
+    @Test
+    fun `interior newlines become carriage returns`() {
+        assertEquals("cd /tmp\rls\r", submitLine("cd /tmp\nls"))
+        assertEquals("cd /tmp\rls\r", submitLine("cd /tmp\r\nls\r\n"))
+    }
+
+    @Test
+    fun `an empty command is a bare Enter`() {
+        assertEquals("\r", submitLine(""))
+        assertEquals("\r", submitLine("\n"))
+    }
+
+    /**
+     * The normalize-only helper must NOT add a submit — it backs paste-like writes where trailing
+     * text is still being typed.
+     */
+    @Test
+    fun `normalize does not append a submit of its own`() {
+        assertEquals("git checkout -b ", normalizeSubmitNewlines("git checkout -b "))
+        assertEquals("a\rb", normalizeSubmitNewlines("a\nb"))
+        assertTrue(normalizeSubmitNewlines("echo hi\n").endsWith("\r"))
+    }
+
+    private fun String.debug() = replace("\r", "\\r").replace("\n", "\\n")
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/vcs/GitUtilsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/vcs/GitUtilsTest.kt
@@ -24,10 +24,13 @@ class GitUtilsTest {
 
     @Test
     fun `git command quotes cwd before worktree command`() {
+        // No trailing separator: the builder returns command text, and whoever runs it adds the
+        // Enter via submitLine. The Add Worktree… caller depends on that — it prefills the prompt
+        // for the user to finish typing, and used to have to strip the newline back off.
         val expected = if (ShellCustomizationUtils.isWindows()) {
-            "git -C \"/tmp/a b\" worktree add \n"
+            "git -C \"/tmp/a b\" worktree add "
         } else {
-            "git -C '/tmp/a b' worktree add \n"
+            "git -C '/tmp/a b' worktree add "
         }
         assertEquals(expected, GitUtils.gitCommand("worktree add ", "/tmp/a b"))
     }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceCrossLanguageContractTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceCrossLanguageContractTest.kt
@@ -139,7 +139,12 @@ class VoiceCrossLanguageContractTest {
         // clip(replace(…), 40), so clipping first would diverge on a CRLF straddling index 40 (one
         // surface counting two characters where the other counts one). Asserted as ordering rather
         // than as `a.text.slice(0, 40)`, because the replace has to come between them.
-        val typed = describe.substringAfter("""name === "send_input"""").substringBefore("if (name ===")
+        // Anchored on the block's closing brace, not the next `if (name ===`: if send_input ever
+        // becomes the last branch in voiceDescribeTool, that slice swallows the rest of the function
+        // and the ordering assertion below could pass against some other branch's .slice(0, 40).
+        val typed = describe
+            .substringAfter("""name === "send_input"""")
+            .substringBefore("\n      }")
         assertTrue(typed.contains(".slice(0, 40)"), "viewer.js must clip typed text at 40: $typed")
         assertTrue(
             typed.indexOf("""replace(/\r\n?|\n/g, "⏎")""") < typed.indexOf(".slice(0, 40)"),

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceCrossLanguageContractTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceCrossLanguageContractTest.kt
@@ -122,6 +122,28 @@ class VoiceCrossLanguageContractTest {
     }
 
     /**
+     * The viewer's Paste must convert newlines to CR before sending, like every other paste path.
+     *
+     * It hand-rolls the paste — `clipboard.readText()` straight into `sendInput` — so it gets
+     * neither xterm's own paste normalization nor `TerminalTab.pasteText`'s. The Input lane it lands
+     * on is verbatim by design (it carries xterm's `onData` keystrokes), so nothing downstream will
+     * fix it: a remote viewer pasting `git status\n` at a Windows host lands at a `>>` prompt.
+     *
+     * Asserted here because `SubmitCharacterCoverageTest` structurally cannot reach it — this is JS,
+     * on the far side of a socket — and this class already reads `viewer.js` for exactly that reason.
+     */
+    @Test
+    fun `the viewer normalizes newlines when pasting`() {
+        val paste = viewerJs.substringAfter("""ctxItem("Paste"""").substringBefore("ctxItem(")
+        assertTrue(paste.contains("readText"), "expected the Paste handler, got: $paste")
+        assertTrue(
+            paste.contains("""replace(/\r\n?|\n/g, "\r")"""),
+            "Paste must convert newlines to CR before sendInput - the Input lane is verbatim " +
+                "and will not do it downstream:\n$paste",
+        )
+    }
+
+    /**
      * Not just "both mention the tool" — the CLIP LENGTHS too. They had drifted: the viewer previewed
      * a command to 60 chars and the typed text to 40, while the host truncated at 48 and said a bare
      * "Typing…". Same call, same product, two different captions depending which surface you were on.

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceCrossLanguageContractTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceCrossLanguageContractTest.kt
@@ -122,24 +122,25 @@ class VoiceCrossLanguageContractTest {
     }
 
     /**
-     * The viewer's Paste must convert newlines to CR before sending, like every other paste path.
+     * The viewer's Paste must go through `term.paste`, not straight to `sendInput`.
      *
-     * It hand-rolls the paste — `clipboard.readText()` straight into `sendInput` — so it gets
-     * neither xterm's own paste normalization nor `TerminalTab.pasteText`'s. The Input lane it lands
-     * on is verbatim by design (it carries xterm's `onData` keystrokes), so nothing downstream will
-     * fix it: a remote viewer pasting `git status\n` at a Windows host lands at a `>>` prompt.
+     * `term.paste` is the only call that does both halves of what `TerminalTab.pasteText` does
+     * in-app: newlines to CR, *and* the ESC[200~ / ESC[201~ wrapper when the pane has bracketed
+     * paste on. Sending the text directly skips both, and the Input lane it lands on is verbatim by
+     * design (it carries `onData` keystrokes), so nothing downstream can make up the difference —
+     * a pasted `git status\n` reaches a Windows host as Ctrl+J, and a multi-line snippet runs line
+     * by line in an editor that asked not to have that happen.
      *
      * Asserted here because `SubmitCharacterCoverageTest` structurally cannot reach it — this is JS,
      * on the far side of a socket — and this class already reads `viewer.js` for exactly that reason.
      */
     @Test
-    fun `the viewer normalizes newlines when pasting`() {
-        val paste = viewerJs.substringAfter("""ctxItem("Paste"""").substringBefore("ctxItem(")
+    fun `the viewer pastes through xterm rather than raw input`() {
+        val paste = viewerJs.substringAfter("""ctxItem("Paste"""").substringBefore("""ctxItem("Select all"""")
         assertTrue(paste.contains("readText"), "expected the Paste handler, got: $paste")
         assertTrue(
-            paste.contains("""replace(/\r\n?|\n/g, "\r")"""),
-            "Paste must convert newlines to CR before sendInput - the Input lane is verbatim " +
-                "and will not do it downstream:\n$paste",
+            paste.contains("term.paste("),
+            "Paste must use term.paste, which applies CR conversion AND bracketed paste:\n$paste",
         )
     }
 

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceCrossLanguageContractTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceCrossLanguageContractTest.kt
@@ -129,12 +129,22 @@ class VoiceCrossLanguageContractTest {
     @Test
     fun `the two surfaces clip their captions to the same lengths`() {
         val describe = viewerJs.substringAfter("function voiceDescribeTool").substringBefore("\n  }")
-        for ((label, len) in listOf("script" to 60, "pattern" to 40, "text" to 40)) {
+        for ((label, len) in listOf("script" to 60, "pattern" to 40)) {
             assertTrue(
                 describe.contains("a.$label.slice(0, $len)"),
                 "viewer.js must clip $label at $len to match HostVoiceCallController.describeTool",
             )
         }
+        // send_input clips at 40 like the others, but only AFTER newlines become ⏎ — the host does
+        // clip(replace(…), 40), so clipping first would diverge on a CRLF straddling index 40 (one
+        // surface counting two characters where the other counts one). Asserted as ordering rather
+        // than as `a.text.slice(0, 40)`, because the replace has to come between them.
+        val typed = describe.substringAfter("""name === "send_input"""").substringBefore("if (name ===")
+        assertTrue(typed.contains(".slice(0, 40)"), "viewer.js must clip typed text at 40: $typed")
+        assertTrue(
+            typed.indexOf("""replace(/\r\n?|\n/g, "⏎")""") < typed.indexOf(".slice(0, 40)"),
+            "the ⏎ substitution must precede the clip, as it does in describeTool: $typed",
+        )
     }
 
     /**

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceInstructionsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceInstructionsTest.kt
@@ -65,13 +65,19 @@ class VoiceInstructionsTest {
      * available, not only in the fallback branch that first mentioned it.
      */
     @Test
-    fun `the agent is told that send_input needs a newline to submit`() {
+    fun `the agent is told that send_input needs a carriage return to submit`() {
         for (surface in listOf(fullToolset, fullToolset - "run_command")) {
             val rules = voiceAgentRules(surface, confirmationWording = "verbal")
             assertTrue(rules.contains("does not press Enter"), rules)
-            // Both characters, together: a bare \n submits in most shells but not every interactive
-            // program, and CRLF is what a terminal actually sends for Enter.
-            assertTrue(rules.contains("""\r\n"""), "the exact sequence must be named: $rules")
+            // CR, and only CR. This assertion used to demand \r\n on the theory that CRLF is what a
+            // terminal sends for Enter; it isn't. Enter is CR, and the trailing LF is delivered to
+            // the next prompt as Ctrl+J, leaving the shell in continuation mode after every command
+            // the agent runs. Measured on Windows PowerShell over ConPTY.
+            assertTrue(rules.contains("""\r"""), "the exact character must be named: $rules")
+            assertFalse(
+                rules.contains("""\r\n"""),
+                "CRLF poisons the following prompt - the rule must ask for a bare CR: $rules",
+            )
         }
     }
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1119,3 +1119,37 @@ EmbeddableTerminal(
     }
 )
 ```
+
+## Sending input: `write()` vs `writeVerbatim()`
+
+`write()` — and `TabbedTerminalState.write(text, tabId)` / `writeToFocusedPane()` — normalize
+newlines to CR before sending, so `write("ls\n")` presses Enter on every platform.
+
+CR is what the Enter key sends, and what a terminal's line editor accepts. LF is a different
+keystroke (Ctrl+J, "insert a newline without submitting"). On Linux and macOS the pty's `ICRNL`
+maps CR to NL on input, so both appear to work; ConPTY does no such translation, and a bare LF
+leaves the command sitting at a `>>` continuation prompt. See the CR note in `AGENTS.md`.
+
+Use `writeVerbatim()` when you mean keystrokes rather than a command — typing a newline into an
+AI CLI's multi-line prompt, for instance:
+
+```kotlin
+state.write("claude\n")            // runs it
+state.writeVerbatim("line 1\n")    // types a newline into the prompt, submits nothing
+```
+
+### Migration (behaviour changed, source unchanged)
+
+These compile exactly as before, so nothing flags at the call site — the difference only shows at
+runtime, and only on Windows.
+
+| API | Was | Now | If you relied on the old behaviour |
+|---|---|---|---|
+| `EmbeddableTerminalState.write`, `TabbedTerminalState.write`, `writeToFocusedPane` | bytes passed through | newlines normalized to CR, **including interior ones** | `writeVerbatim(text)` |
+| `GitUtils.gitCommand` / `ghCommand` | returned the command with a trailing `\n` | return the command text only | `submitLine(gitCommand(…))` to run it; as-is to prefill |
+| `writeToFocusedPane` | returned `false` for an unsplit tab that had never been activated | writes to that tab's single pane | nothing — the old `false` was a bug |
+
+The concrete case: on Windows, `write("line1\nline2")` used to *insert* a newline into an AI CLI's
+prompt and now submits each line. Unix is unchanged, so this closes a platform gap rather than
+opening one — but it is a change for any embedder using `write()` to feed multi-line text rather
+than to type a command.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -304,8 +304,22 @@ collection is enabled for the tab. Supports incremental polling via
 
 ### `send_input` (write tool)
 
-Write text to a tab's shell stdin. Append `\n` to the text yourself if you
-want the shell to execute it.
+Write text to a tab's shell stdin, verbatim — this tool presses no keys of its
+own. Append `\r` yourself if you want the shell to execute the text.
+
+`\r`, not `\n`. Enter is a carriage return: it is what `TerminalKeyEncoder`
+sends for the key, and what `pasteText` converts pasted newlines into. A bare
+`\n` is Ctrl+J, which inserts a newline into the line editor without submitting
+— on a Unix pty `ICRNL` hides the difference, but under Windows ConPTY there is
+no such translation and the text sits at a `>>` continuation prompt while
+`read_scrollback` shows no result. Don't send `\r\n` either: the `\r` submits and
+the orphan `\n` is then typed into the *next* prompt.
+
+`send_input` is deliberately the one write tool that does not normalize this for
+you, because `\n` is a keystroke a caller may genuinely want — a newline inside a
+multi-line prompt to an AI CLI, for instance. Every other write path
+(`run_command`, `run_in_panel`, the AI/git menus) submits with `\r` on your
+behalf via `submitLine`.
 
 - Required: `tab_id` (string), `text` (string).
 - Optional: `pane_id` (string).
@@ -329,8 +343,9 @@ with shell startup.
 
 - Required:
   - `panel`: `"new_tab"`, `"horizontal_split"`, or `"vertical_split"`.
-  - `script`: text to write to the new panel's shell. Include `\n` to submit
-    as a command.
+  - `script`: the command to run in the new panel. Submitted for you with a
+    carriage return, so a trailing newline is optional (it is stripped rather
+    than pressing Enter twice). Empty means "just open the panel".
 - Optional:
   - `tab_id` (string) - source tab id. Required for splits; defaults to the
     primary window's active tab.
@@ -378,8 +393,8 @@ Requires OSC 133 shell integration on the user's shell. See
 [`.claude/rules/shell-integration.md`](../.claude/rules/shell-integration.md).
 
 - Required:
-  - `script` (string) - shell command. A trailing newline is added if
-    absent. **Avoid embedded `\n`** for multi-statement scripts (the shell
+  - `script` (string) - shell command. Submitted for you with a carriage
+    return; a trailing newline is optional. **Avoid embedded `\n`** for multi-statement scripts (the shell
     fires multiple OSC 133;B/D cycles; the response carries the FIRST D's
     exit code and the slice covers from the first B onward). Use
     `bash -lc '…'` or `sh -c '…'` to bundle compound logic into a single

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -396,7 +396,8 @@ Requires OSC 133 shell integration on the user's shell. See
 - Required:
   - `script` (string) - shell command. Submitted for you with a carriage
     return; trailing newlines are optional and collapse into that one Enter, so
-    a script ending in a deliberate blank line needs `send_input` instead. **Avoid embedded `\n`** for multi-statement scripts (the shell
+    a script ending in a deliberate blank line needs `send_input` instead.
+    **Avoid embedded `\n`** for multi-statement scripts (the shell
     fires multiple OSC 133;B/D cycles; the response carries the FIRST D's
     exit code and the slice covers from the first B onward). Use
     `bash -lc '…'` or `sh -c '…'` to bundle compound logic into a single

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -344,8 +344,9 @@ with shell startup.
 - Required:
   - `panel`: `"new_tab"`, `"horizontal_split"`, or `"vertical_split"`.
   - `script`: the command to run in the new panel. Submitted for you with a
-    carriage return, so a trailing newline is optional (it is stripped rather
-    than pressing Enter twice). Empty means "just open the panel".
+    carriage return, so trailing newlines are optional — however many you send,
+    they collapse into the one Enter. A script that is empty, or only newlines,
+    means "just open the panel".
 - Optional:
   - `tab_id` (string) - source tab id. Required for splits; defaults to the
     primary window's active tab.
@@ -394,7 +395,8 @@ Requires OSC 133 shell integration on the user's shell. See
 
 - Required:
   - `script` (string) - shell command. Submitted for you with a carriage
-    return; a trailing newline is optional. **Avoid embedded `\n`** for multi-statement scripts (the shell
+    return; trailing newlines are optional and collapse into that one Enter, so
+    a script ending in a deliberate blank line needs `send_input` instead. **Avoid embedded `\n`** for multi-statement scripts (the shell
     fires multiple OSC 133;B/D cycles; the response carries the FIRST D's
     exit code and the slice covers from the first B onward). Use
     `bash -lc '…'` or `sh -c '…'` to bundle compound logic into a single

--- a/docs/wiki/MCP-Server.md
+++ b/docs/wiki/MCP-Server.md
@@ -277,8 +277,9 @@ with shell startup.
 - Required:
   - `panel`: `"new_tab"`, `"horizontal_split"`, or `"vertical_split"`.
   - `script`: the command to run in the new panel. Submitted for you with a
-    carriage return, so a trailing newline is optional. Empty means "just open
-    the panel".
+    carriage return, so trailing newlines are optional and collapse into that
+    one Enter. A script that is empty, or only newlines, means "just open the
+    panel".
 - Optional:
   - `tab_id` (string) - source tab id. Required for splits; defaults to the
     primary window's active tab.

--- a/docs/wiki/MCP-Server.md
+++ b/docs/wiki/MCP-Server.md
@@ -246,8 +246,13 @@ collection is enabled for the tab. Supports incremental polling via
 
 ### `send_input` (write tool)
 
-Write text to a tab's shell stdin. Append `\n` to the text yourself if you
-want the shell to execute it.
+Write text to a tab's shell stdin, verbatim — this tool presses no keys of its
+own. Append `\r` (carriage return, what Enter sends) if you want the shell to
+execute the text. A bare `\n` is Ctrl+J: it inserts a newline without
+submitting, which under Windows ConPTY leaves the text at a `>>` continuation
+prompt. Don't send `\r\n` — the `\r` submits and the leftover `\n` is typed into
+the next prompt. This is the one write tool that does not normalize for you, so
+that sending a real newline stays possible.
 
 - Required: `tab_id` (string), `text` (string).
 - Optional: `pane_id` (string).
@@ -271,8 +276,9 @@ with shell startup.
 
 - Required:
   - `panel`: `"new_tab"`, `"horizontal_split"`, or `"vertical_split"`.
-  - `script`: text to write to the new panel's shell. Include `\n` to submit
-    as a command.
+  - `script`: the command to run in the new panel. Submitted for you with a
+    carriage return, so a trailing newline is optional. Empty means "just open
+    the panel".
 - Optional:
   - `tab_id` (string) - source tab id. Required for splits; defaults to the
     primary window's active tab.


### PR DESCRIPTION
## The bug

Selecting **Claude Code** (or any AI CLI, or any git/gh item) from the context menu on Windows typed the command into the prompt and left it there, unsubmitted, in PSReadLine continuation mode.

Every programmatic write to a PTY ended its command with a bare `\n`. On a Unix pty that works only because the line discipline's `ICRNL` maps CR to NL on input — which is why it survived this long. ConPTY does no such translation: a bare LF is Ctrl+J, so PSReadLine inserts a newline into its edit buffer instead of accepting the line.

## Measurement

Each form written to a real pane over ConPTY (Windows PowerShell 5.1), reading the scrollback back:

| sent | runs? | after |
|---|---|---|
| `\n` (what we shipped) | **no** | stranded at a `>>` continuation prompt |
| `\r` | yes | clean prompt |
| `\r\n` | yes | **the NEXT prompt is `>>`** — the orphan LF is typed into it |
| `\n\r` | yes | runs, but the command echoes on a continuation line |

```
PS C:\...>
>> echo TEST-LF               <- LF alone: continuation, no output
TEST-LF                       <- then a bare CR submitted it
PS C:\...> echo TEST-CRLF
TEST-CRLF                     <- CRLF ran cleanly...
PS C:\...>
>> ^C                         <- ...but left THIS prompt in continuation
```

So **CR alone**. That is already what `TerminalKeyEncoder` sends for Enter and what `pasteText` normalizes pasted newlines to — the writers were the odd ones out. CRLF is the trap worth naming: it looks correct because the command works, and the damage lands on the user's following keystrokes.

## The change

New `util/TerminalSubmit.kt` is the single place that knows this — `submitLine()` (exactly one trailing CR, idempotent over whatever separator it was handed) and `normalizeSubmitNewlines()` (CRLF/LF → CR, no submit added).

Routed through it:

| site | covers |
|---|---|
| `ToolCommandProvider.getLaunchCommand` | context menu, AI menu, share viewer `LaunchAI` |
| `TabController` / `EmbeddableTerminal` `initialCommand` | MCP `run_in_panel`, tab restore, install-wizard `commandToRunAfter` |
| `BossTermMcpServer` `run_command` | was `if (endsWith("\n")) … else … + "\n"` |
| `CommandBlockActions` | Shift+R re-run |
| `TabbedTerminal.writeToTerminal` | ~20 git / gh / zshrc / starship / omz / prezto menu items, fixed at the helper so none get missed |

`run_in_panel` now trims CR as well as LF from the caller's script; `removeSuffix("\n")` alone left the CR of a CRLF-terminated script behind and submitted twice.

## Deliberate exception

**MCP `send_input` stays byte-verbatim.** A bare LF is a keystroke a caller may genuinely want — a newline inside a multi-line prompt to an AI CLI — and normalizing would remove the only way to send one. Its description (and the daemon's) now spells out `\r` vs `\n` instead.

## Also corrected

`VoiceInstructions` told the voice agent to end every `send_input` with `\r\n`, with a test asserting it on the reasoning that "CRLF is what a terminal actually sends for Enter". It isn't, and the measurement shows the cost: the prompt after every command the agent ran was left in continuation mode. Now `\r`, and the test asserts the *absence* of `\r\n`.

## Verification

- `compose-ui:desktopTest` — **1057 tests, 0 failures** (115 suites), including a new `TerminalSubmitTest` pinning the finding, since the wrong answer is invisible on macOS/Linux and would only ever be reported by a Windows user.
- Pre-existing and unrelated: `KittyGraphicsProtocolTest` fails 2 `/dev/*` denylist tests on Windows, identically on clean `master` (verified by stash).
- `AGENTS.md` gains the pattern entry with the table above.


## Behaviour changes for embedders

Source-compatible, behaviour-incompatible — they don't show up in a diff of the caller, only at runtime, and only on Windows. BossConsole embeds this surface.

| Change | Before | After | If you relied on the old behaviour |
|---|---|---|---|
| `EmbeddableTerminalState.write`, `TabbedTerminalState.write` (all 3 overloads), `writeToFocusedPane` | passed bytes through | normalize newlines to CR, **including interior ones** | `writeVerbatim(text)` — added on both APIs for exactly this |
| `GitUtils.gitCommand` / `ghCommand` | returned the command with a trailing `\n` | return the command text only | wrap in `submitLine(…)` to run it; use as-is to prefill |
| `writeToFocusedPane` resolver | `getFocusedSplitSession` — returned `false` for an unsplit tab never activated | `findSession` — writes to that tab's single pane, returns `true` | nothing; the old `false` was a bug |
| MCP `run_command` / `run_in_panel` script | a trailing newline was added if absent | trailing newlines collapse into the one Enter | `send_input` for a deliberate blank line or a double Enter |

The concrete case worth naming: on Windows, `write("line1\nline2")` used to *insert* a newline into an AI CLI's multi-line prompt (LF is Ctrl+J) and now submits each line. Unix is unchanged — `ICRNL` always submitted them — so this closes a platform gap rather than opening one, but it is a change for any embedder that used `write()` to feed multi-line text rather than to type a command.

## Known divergence left in place

`ProperTerminal.kt` workflow prefill with `workflowsAutoRun = false` stays verbatim, so a multi-line workflow prefills on Windows and submits line-by-line on Unix. Pre-existing, documented in a comment at the site, and the real fix is bracketed paste rather than newline conversion — worth a follow-up issue rather than widening this PR.
