### PR TITLE
Light themes for BossTerm: BOSS Blueprint Light and BOSS Daylight

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
@@ -2240,7 +2241,7 @@ fun TabbedTerminal(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(Color.White.copy(alpha = 0.15f))
+                    .background(BossUiTheme.current.chalk.copy(alpha = 0.15f))
             )
         }
 
@@ -2412,12 +2413,12 @@ fun TabbedTerminal(
                     Box(
                         modifier = Modifier
                             .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
-                            .background(Color(0xE6252526))
-                            .border(1.dp, Color(0xFF404040), androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                            .background(BossUiTheme.current.panel.copy(alpha = 0.90f))
+                            .border(1.dp, BossUiTheme.current.line, androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
                     ) {
                         androidx.compose.material3.Text(
                             "Signed in as $email",
-                            color = Color(0xFF81C784),
+                            color = BossUiTheme.current.ok,
                             fontSize = 11.sp,
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
                         )
@@ -2437,13 +2438,13 @@ fun TabbedTerminal(
                     Box(
                         modifier = Modifier
                             .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
-                            .background(Color(0xE6252526))
-                            .border(1.dp, Color(0xFF404040), androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                            .background(BossUiTheme.current.panel.copy(alpha = 0.90f))
+                            .border(1.dp, BossUiTheme.current.line, androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
                             .clickable { session.requestControl() }
                     ) {
                         androidx.compose.material3.Text(
                             "View only - click to request control",
-                            color = Color(0xFFB0B0B0),
+                            color = BossUiTheme.current.mist,
                             fontSize = 11.sp,
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
                         )
@@ -2456,15 +2457,15 @@ fun TabbedTerminal(
                     Box(
                         modifier = Modifier
                             .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
-                            .background(Color(0xE6252526))
-                            .border(1.dp, Color(0xFF404040), androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
+                            .background(BossUiTheme.current.panel.copy(alpha = 0.90f))
+                            .border(1.dp, BossUiTheme.current.line, androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
                             .clickable {
                                 tabController.activeTab?.id?.let { id -> activeRemoteSession?.requestControlFor(id) }
                             }
                     ) {
                         androidx.compose.material3.Text(
                             "View only - click to request control of ${up.name ?: "the origin"}",
-                            color = Color(0xFFB0B0B0),
+                            color = BossUiTheme.current.mist,
                             fontSize = 11.sp,
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
                         )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -2418,7 +2418,9 @@ fun TabbedTerminal(
                     ) {
                         androidx.compose.material3.Text(
                             "Signed in as $email",
-                            color = BossUiTheme.current.ok,
+                            // `chalk`, not `ok` - see the note in TabBar on the ⎇
+                            // label. The toast frame carries the "something happened".
+                            color = BossUiTheme.current.chalk,
                             fontSize = 11.sp,
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
                         )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/history/HistorySearchOverlay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/history/HistorySearchOverlay.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.history
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -94,6 +95,9 @@ fun HistorySearchOverlay(
     Box(
         modifier = modifier
             .fillMaxSize()
+            // The modal scrim stays literal black. A scrim's job is to dim whatever is
+            // behind it, and it is black under a light theme too - that is what every
+            // light-mode design system does. Allowlisted in ChromeTokenCoverageTest.
             .background(Color(0x88000000))
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
@@ -110,7 +114,7 @@ fun HistorySearchOverlay(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                 ) { },
-            color = Color(0xFF2A2A2A),
+            color = BossUiTheme.current.panel,
             shape = RoundedCornerShape(8.dp),
             shadowElevation = 8.dp,
         ) {
@@ -119,8 +123,8 @@ fun HistorySearchOverlay(
                     value = query,
                     onValueChange = { query = it; selected = 0 },
                     singleLine = true,
-                    textStyle = TextStyle(color = Color.White, fontSize = 14.sp),
-                    cursorBrush = SolidColor(Color.White),
+                    textStyle = TextStyle(color = BossUiTheme.current.chalk, fontSize = 14.sp),
+                    cursorBrush = SolidColor(BossUiTheme.current.chalk),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(12.dp)
@@ -143,13 +147,13 @@ fun HistorySearchOverlay(
                         },
                     decorationBox = { inner ->
                         if (query.isEmpty()) {
-                            Text("Search history…", color = Color(0xFF808080), fontSize = 14.sp)
+                            Text("Search history…", color = BossUiTheme.current.muted, fontSize = 14.sp)
                         }
                         inner()
                     },
                 )
 
-                Box(Modifier.fillMaxWidth().height(1.dp).background(Color(0xFF3A3A3A)))
+                Box(Modifier.fillMaxWidth().height(1.dp).background(BossUiTheme.current.line))
 
                 if (aiRowVisible) {
                     Row(
@@ -159,9 +163,9 @@ fun HistorySearchOverlay(
                             .padding(horizontal = 12.dp, vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text("✨ Ask AI:  $query", color = Color(0xFF66D9EF), fontSize = 13.sp, maxLines = 1)
+                        Text("✨ Ask AI:  $query", color = BossUiTheme.current.data, fontSize = 13.sp, maxLines = 1)
                     }
-                    Box(Modifier.fillMaxWidth().height(1.dp).background(Color(0xFF3A3A3A)))
+                    Box(Modifier.fillMaxWidth().height(1.dp).background(BossUiTheme.current.line))
                 }
 
                 LazyColumn(Modifier.heightIn(max = 360.dp)) {
@@ -169,12 +173,12 @@ fun HistorySearchOverlay(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .background(if (i == selected) Color(0xFF094771) else Color.Transparent)
+                                .background(if (i == selected) BossUiTheme.current.signalWash else Color.Transparent)
                                 .clickable { onDismiss(); onSelect(cmd) }
                                 .padding(horizontal = 12.dp, vertical = 8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Text(cmd, color = Color.White, fontSize = 13.sp, maxLines = 1)
+                            Text(cmd, color = BossUiTheme.current.chalk, fontSize = 13.sp, maxLines = 1)
                         }
                     }
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.mcp
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.TooltipPlacement
@@ -33,17 +34,26 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ai.rever.bossterm.compose.features.ContextMenuController
 
-private val McpOnColor = Color(0xFF4CAF50) // green
-private val McpOnGlow = Color(0x33_4C_AF_50) // 20% green halo
-private val McpOnLabelColor = Color(0xFFCFEFD4)
-private val McpOffColor = Color(0xFFE57373) // red
-private val McpOffGlow = Color(0x33_E5_73_73) // 20% red halo
-private val McpOffLabelColor = Color(0xFFF2C9C9)
-private val McpOffBorderColor = Color(0xFFB71C1C)
-private val McpToastBg = Color(0xCC_1E_1E_1E)
-private val McpToastTextColor = Color(0xFFE0E0E0)
-private val McpToastSuccessColor = Color(0xFF4CAF50)
-private val McpToastWarnColor = Color(0xFFFFC107)
+// All getters, never `val`: a file-scope val is initialised at class-init and
+// would pin these to whichever theme was active then, so they could not follow a
+// theme switch even between two dark themes. Same rule as SettingsTheme.
+//
+// The two LABEL colours become plain text tokens rather than tinted greens/reds.
+// The pale #CFEFD4 and #F2C9C9 were legible only on a dark floor, and there is no
+// "ok held to the text floor" token to reach for the way `signalText` is for the
+// accent. The dot, its halo and the border still carry the status, so nothing is
+// lost but the tint.
+private val McpOnColor: Color get() = BossUiTheme.current.ok
+private val McpOnGlow: Color get() = BossUiTheme.current.ok.copy(alpha = 0.20f)
+private val McpOnLabelColor: Color get() = BossUiTheme.current.chalk
+private val McpOffColor: Color get() = BossUiTheme.current.alert
+private val McpOffGlow: Color get() = BossUiTheme.current.alert.copy(alpha = 0.20f)
+private val McpOffLabelColor: Color get() = BossUiTheme.current.alert
+private val McpOffBorderColor: Color get() = BossUiTheme.current.alert
+private val McpToastBg: Color get() = BossUiTheme.current.panel.copy(alpha = 0.80f)
+private val McpToastTextColor: Color get() = BossUiTheme.current.chalk
+private val McpToastSuccessColor: Color get() = BossUiTheme.current.ok
+private val McpToastWarnColor: Color get() = BossUiTheme.current.warn
 
 /**
  * Lifecycle state of a one-click attach attempt, used by [AttachToast] to
@@ -133,7 +143,7 @@ fun McpStatusIndicator(
         ) {
             val dotColor = if (isRunning) McpOnColor else McpOffColor
             val haloColor = if (isRunning) McpOnGlow else McpOffGlow
-            val borderColor = if (isRunning) Color(0xFF388E3C) else McpOffBorderColor
+            val borderColor = if (isRunning) BossUiTheme.current.ok else McpOffBorderColor
             val labelColor = if (isRunning) McpOnLabelColor else McpOffLabelColor
             Box(
                 modifier = Modifier.size(16.dp),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/McpStatusIndicator.kt
@@ -38,18 +38,23 @@ import ai.rever.bossterm.compose.features.ContextMenuController
 // would pin these to whichever theme was active then, so they could not follow a
 // theme switch even between two dark themes. Same rule as SettingsTheme.
 //
-// The two LABEL colours become plain text tokens rather than tinted greens/reds.
-// The pale #CFEFD4 and #F2C9C9 were legible only on a dark floor, and there is no
-// "ok held to the text floor" token to reach for the way `signalText` is for the
-// accent. The dot, its halo and the border still carry the status, so nothing is
-// lost but the tint.
+// BOTH label colours become `chalk`, not tinted greens/reds. The pale #CFEFD4 and
+// #F2C9C9 were legible only on a dark floor, and `ok`/`alert` are FILL tokens held to
+// the 3:1 component floor - `alert` as 11.sp text is 4.2:1 on daylight's panel, under
+// the text floor this file's neighbours are strict about. There is no "ok held to the
+// text floor" token to reach for the way `signalText` is for the accent. The dot, its
+// halo and its ring carry the status, so only the tint is lost.
+//
+// The ring is `line2` in both states rather than a darker shade of the dot. Its job is
+// to define a 10.dp dot against the panel behind it, and a ring in the dot's own colour
+// does not do that at all - which is what an earlier revision shipped.
 private val McpOnColor: Color get() = BossUiTheme.current.ok
 private val McpOnGlow: Color get() = BossUiTheme.current.ok.copy(alpha = 0.20f)
 private val McpOnLabelColor: Color get() = BossUiTheme.current.chalk
 private val McpOffColor: Color get() = BossUiTheme.current.alert
 private val McpOffGlow: Color get() = BossUiTheme.current.alert.copy(alpha = 0.20f)
-private val McpOffLabelColor: Color get() = BossUiTheme.current.alert
-private val McpOffBorderColor: Color get() = BossUiTheme.current.alert
+private val McpOffLabelColor: Color get() = BossUiTheme.current.chalk
+private val McpDotRing: Color get() = BossUiTheme.current.line2
 private val McpToastBg: Color get() = BossUiTheme.current.panel.copy(alpha = 0.80f)
 private val McpToastTextColor: Color get() = BossUiTheme.current.chalk
 private val McpToastSuccessColor: Color get() = BossUiTheme.current.ok
@@ -143,7 +148,7 @@ fun McpStatusIndicator(
         ) {
             val dotColor = if (isRunning) McpOnColor else McpOffColor
             val haloColor = if (isRunning) McpOnGlow else McpOffGlow
-            val borderColor = if (isRunning) BossUiTheme.current.ok else McpOffBorderColor
+            val borderColor = McpDotRing
             val labelColor = if (isRunning) McpOnLabelColor else McpOffLabelColor
             Box(
                 modifier = Modifier.size(16.dp),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/CommandPalette.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/CommandPalette.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.palette
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -81,6 +82,9 @@ fun CommandPalette(
     Box(
         modifier = modifier
             .fillMaxSize()
+            // The modal scrim stays literal black. A scrim's job is to dim whatever is
+            // behind it, and it is black under a light theme too - that is what every
+            // light-mode design system does. Allowlisted in ChromeTokenCoverageTest.
             .background(Color(0x88000000))
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
@@ -97,7 +101,7 @@ fun CommandPalette(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                 ) { },
-            color = Color(0xFF2A2A2A),
+            color = BossUiTheme.current.panel,
             shape = RoundedCornerShape(8.dp),
             shadowElevation = 8.dp,
         ) {
@@ -106,8 +110,8 @@ fun CommandPalette(
                     value = query,
                     onValueChange = { query = it; selected = 0 },
                     singleLine = true,
-                    textStyle = TextStyle(color = Color.White, fontSize = 14.sp),
-                    cursorBrush = SolidColor(Color.White),
+                    textStyle = TextStyle(color = BossUiTheme.current.chalk, fontSize = 14.sp),
+                    cursorBrush = SolidColor(BossUiTheme.current.chalk),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(12.dp)
@@ -130,34 +134,34 @@ fun CommandPalette(
                         },
                     decorationBox = { inner ->
                         if (query.isEmpty()) {
-                            Text("Run a command…", color = Color(0xFF808080), fontSize = 14.sp)
+                            Text("Run a command…", color = BossUiTheme.current.muted, fontSize = 14.sp)
                         }
                         inner()
                     },
                 )
 
-                Box(Modifier.fillMaxWidth().height(1.dp).background(Color(0xFF3A3A3A)))
+                Box(Modifier.fillMaxWidth().height(1.dp).background(BossUiTheme.current.line))
 
                 LazyColumn(Modifier.heightIn(max = 360.dp)) {
                     itemsIndexed(filtered) { i, c ->
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .background(if (i == selected) Color(0xFF094771) else Color.Transparent)
+                                .background(if (i == selected) BossUiTheme.current.signalWash else Color.Transparent)
                                 .clickable { onDismiss(); c.run() }
                                 .padding(horizontal = 12.dp, vertical = 8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Text(
                                 c.group,
-                                color = Color(0xFF888888),
+                                color = BossUiTheme.current.muted,
                                 fontSize = 11.sp,
                                 modifier = Modifier.width(64.dp),
                             )
                             Column(Modifier.weight(1f)) {
-                                Text(c.title, color = Color.White, fontSize = 13.sp, maxLines = 1)
+                                Text(c.title, color = BossUiTheme.current.chalk, fontSize = 13.sp, maxLines = 1)
                                 c.subtitle?.let {
-                                    Text(it, color = Color(0xFFAAAAAA), fontSize = 11.sp, maxLines = 1)
+                                    Text(it, color = BossUiTheme.current.mist, fontSize = 11.sp, maxLines = 1)
                                 }
                             }
                         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/scrollbar/AlwaysVisibleScrollbar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/scrollbar/AlwaysVisibleScrollbar.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.scrollbar
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
@@ -252,12 +253,16 @@ fun AlwaysVisibleScrollbar(
                 // search markers; colored per block exit state).
                 if (blockMarkerPositions.isNotEmpty()) {
                     val density = LocalDensity.current
+                    // Hoisted out of the draw lambda on purpose: a token read inside
+                    // Canvas runs in the draw phase and does not subscribe the
+                    // composition to theme changes.
+                    val unknownBlockMarker = BossUiTheme.current.muted
                     Canvas(modifier = Modifier.fillMaxSize()) {
                         val markerHeightPx = with(density) { 2.dp.toPx() }
                         blockMarkerPositions.forEachIndexed { index, position ->
                             val y = position * size.height
                             drawRect(
-                                color = blockMarkerColors.getOrElse(index) { Color(0xFF9E9E9E) },
+                                color = blockMarkerColors.getOrElse(index) { unknownBlockMarker },
                                 topLeft = Offset(0f, y - markerHeightPx / 2),
                                 size = Size(size.width, markerHeightPx)
                             )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/scrollbar/AlwaysVisibleScrollbar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/scrollbar/AlwaysVisibleScrollbar.kt
@@ -253,9 +253,10 @@ fun AlwaysVisibleScrollbar(
                 // search markers; colored per block exit state).
                 if (blockMarkerPositions.isNotEmpty()) {
                     val density = LocalDensity.current
-                    // Hoisted out of the draw lambda on purpose: a token read inside
-                    // Canvas runs in the draw phase and does not subscribe the
-                    // composition to theme changes.
+                    // Hoisted out of the draw lambda for cost, not correctness: Compose
+                    // observes snapshot reads in the draw phase too, so reading the token
+                    // inside Canvas would still repaint on a theme change - it would just
+                    // do it once per marker per frame instead of once per composition.
                     val unknownBlockMarker = BossUiTheme.current.muted
                     Canvas(modifier = Modifier.fillMaxSize()) {
                         val markerHeightPx = with(density) { 2.dp.toPx() }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/search/SearchBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/search/SearchBar.kt
@@ -1,5 +1,7 @@
 package ai.rever.bossterm.compose.search
 
+import androidx.compose.foundation.border
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,7 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.*
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -90,7 +91,7 @@ fun SearchBar(
                         }
                     }
                 },
-            color = Color(0xFF252526),
+            color = BossUiTheme.current.panel,
             shape = RoundedCornerShape(4.dp),
             shadowElevation = 8.dp
         ) {
@@ -104,7 +105,8 @@ fun SearchBar(
                 modifier = Modifier
                     .weight(1f)
                     .height(28.dp)
-                    .background(Color(0xFF3C3C3C), RoundedCornerShape(2.dp))
+                    .background(BossUiTheme.current.raised, RoundedCornerShape(2.dp))
+                    .border(1.dp, BossUiTheme.current.line, RoundedCornerShape(2.dp))
                     .padding(horizontal = 8.dp),
                 contentAlignment = Alignment.CenterStart
             ) {
@@ -135,15 +137,15 @@ fun SearchBar(
                         },
                     singleLine = true,
                     textStyle = TextStyle(
-                        color = Color.White,
+                        color = BossUiTheme.current.chalk,
                         fontSize = 13.sp
                     ),
-                    cursorBrush = SolidColor(Color.White),
+                    cursorBrush = SolidColor(BossUiTheme.current.chalk),
                     decorationBox = { innerTextField ->
                         if (searchQuery.isEmpty()) {
                             Text(
                                 "Find",
-                                color = Color(0xFF808080),
+                                color = BossUiTheme.current.muted,
                                 fontSize = 13.sp
                             )
                         }
@@ -156,7 +158,7 @@ fun SearchBar(
             if (searchQuery.isNotEmpty()) {
                 Text(
                     text = if (totalMatches > 0) "$currentMatch/$totalMatches" else "0/0",
-                    color = if (totalMatches > 0) Color(0xFFCCCCCC) else Color(0xFFFF6B6B),
+                    color = if (totalMatches > 0) BossUiTheme.current.chalk else BossUiTheme.current.alert,
                     fontSize = 11.sp,
                     modifier = Modifier.padding(horizontal = 4.dp)
                 )
@@ -175,7 +177,7 @@ fun SearchBar(
                     Icon(
                         imageVector = Icons.Default.KeyboardArrowUp,
                         contentDescription = "Previous",
-                        tint = if (totalMatches > 0) Color(0xFFCCCCCC) else Color(0xFF606060),
+                        tint = if (totalMatches > 0) BossUiTheme.current.mist else BossUiTheme.current.muted,
                         modifier = Modifier.size(18.dp)
                     )
                 }
@@ -189,7 +191,7 @@ fun SearchBar(
                     Icon(
                         imageVector = Icons.Default.KeyboardArrowDown,
                         contentDescription = "Next",
-                        tint = if (totalMatches > 0) Color(0xFFCCCCCC) else Color(0xFF606060),
+                        tint = if (totalMatches > 0) BossUiTheme.current.mist else BossUiTheme.current.muted,
                         modifier = Modifier.size(18.dp)
                     )
                 }
@@ -201,7 +203,7 @@ fun SearchBar(
                 ) {
                     Text(
                         "Aa",
-                        color = if (caseSensitive) Color(0xFF4A90E2) else Color(0xFF808080),
+                        color = if (caseSensitive) BossUiTheme.current.signalText else BossUiTheme.current.muted,
                         fontSize = 12.sp,
                         fontWeight = if (caseSensitive) FontWeight.Bold else FontWeight.Normal
                     )
@@ -215,7 +217,7 @@ fun SearchBar(
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = "Close",
-                        tint = Color(0xFFCCCCCC),
+                        tint = BossUiTheme.current.mist,
                         modifier = Modifier.size(16.dp)
                     )
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/search/SearchBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/search/SearchBar.kt
@@ -158,7 +158,9 @@ fun SearchBar(
             if (searchQuery.isNotEmpty()) {
                 Text(
                     text = if (totalMatches > 0) "$currentMatch/$totalMatches" else "0/0",
-                    color = if (totalMatches > 0) BossUiTheme.current.chalk else BossUiTheme.current.alert,
+                    // `mist` to match the arrows beside it - the count and the two nav
+                    // buttons are one visual group and were one colour before.
+                    color = if (totalMatches > 0) BossUiTheme.current.mist else BossUiTheme.current.alert,
                     fontSize = 11.sp,
                     modifier = Modifier.padding(horizontal = 4.dp)
                 )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinColorPalettes.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinColorPalettes.kt
@@ -405,11 +405,36 @@ object BuiltinColorPalettes {
     )
 
     /**
+     * BOSS Blueprint Light - the ANSI 16 of the paper half of the same identity.
+     * Mix over any light theme to carry the BOSS palette onto paper.
+     */
+    // Derived from the theme, like the two above, so palette and theme cannot drift.
+    val BOSS_BLUEPRINT_LIGHT = ColorPalette.fromTheme(BuiltinThemes.BOSS_BLUEPRINT_LIGHT).copy(
+        id = "boss-blueprint-light",
+        name = "BOSS Blueprint Light",
+    )
+
+    /**
+     * BOSS Daylight - the ANSI 16 of the paper half of the Operator identity.
+     * Mix over any light theme to carry the amber palette onto paper.
+     */
+    // Derived from the theme, like the three above, so palette and theme cannot drift.
+    val BOSS_DAYLIGHT = ColorPalette.fromTheme(BuiltinThemes.BOSS_DAYLIGHT).copy(
+        id = "boss-daylight",
+        name = "BOSS Daylight",
+    )
+
+    /**
      * All built-in color palettes.
+     *
+     * BOSS_BLUEPRINT stays first: `ThemeDefaultsTest` asserts the default identity
+     * leads both builtin lists. Each light palette sits next to its dark sibling.
      */
     val ALL = listOf(
         BOSS_BLUEPRINT,
+        BOSS_BLUEPRINT_LIGHT,
         BOSS_OPERATOR,
+        BOSS_DAYLIGHT,
         XTERM,
         TANGO,
         UBUNTU,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinThemes.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinThemes.kt
@@ -435,11 +435,138 @@ object BuiltinThemes {
     )
 
     /**
+     * BOSS Blueprint Light - the paper half of the bossconsole.ai identity.
+     *
+     * Mirrors the host's `BossBlueprintLightColorScheme` (the site's `--paper`
+     * sections), so the terminal and the chrome around it read as one surface on
+     * a light host theme exactly as they do on a dark one.
+     *
+     * Three rules govern a light ANSI palette, and all three are the opposite of
+     * the dark case (`LightThemeContrastTest` enforces them):
+     *
+     * 1. Every `bright*` slot is DARKER than its base, not lighter. Bold text is
+     *    ANSI 8-15; brighten those on paper and every bold line disappears.
+     * 2. `white` (ANSI 7) is a mid grey, never near-white. This is the bug fixed
+     *    in `terminal-tab` PR #72: a near-white ANSI 7 is 1.27:1 on paper, and no
+     *    render-time guard reaches it because the palette IS the source.
+     * 3. The cursor is an opaque block, so it needs contrast against the FLOOR,
+     *    not against the text. `--blue` gives 4.90:1 here, which is why it can be
+     *    the cursor on paper while `boss-daylight` has to darken its amber.
+     */
+    val BOSS_BLUEPRINT_LIGHT = Theme(
+        id = "boss-blueprint-light",
+        name = "BOSS Blueprint Light",
+        // Softened off pure ink, the same way dark Blueprint's foreground sits a
+        // shade under its `chalk`: body copy, not headline weight. 14.6:1.
+        foreground = "0xFF141A24",
+        background = "0xFFF5F7FB",   // host `ink` / site `--paper`
+        cursor = "0xFF0F5BFF",       // host `signal` (--blue), 4.90:1 on paper
+        cursorText = "0xFFFFFFFF",   // host `onSignal`, 5.26:1 on the cursor fill
+        // Deepened from the host's `signalWash` #DCE7FF (1.16:1 on paper). That
+        // wash sits BEHIND a 2.dp indicator on a selected sidebar row; a terminal
+        // selection has no indicator, so the fill carries the whole signal alone.
+        // 1.30:1, and ink text still reads on it at 12.5:1.
+        selection = "0xFFC9DBFF",
+        selectionText = "0xFF05070B",// host `textPrimary`
+        // A warm fill has to do two jobs at once: separate from paper (3.1:1) and
+        // still carry ink-coloured text (11.9:1). The dark theme's pale #F1DF9E
+        // does neither on paper.
+        searchMatch = "0xFFFFC93B",
+        hyperlink = "0xFF0C3FBF",    // host `data` - deeper than signal, so links stay distinct
+        // ANSI 16 - warm-neutral hues re-grounded for paper
+        black = "0xFF1B2330",
+        red = "0xFFD33B4A",          // host `alert`
+        // Darkened off the host's `ok` #1E9E63, which is only 3.20:1 on paper.
+        // Green on white is the classic light-palette trap. 4.24:1.
+        green = "0xFF178750",
+        yellow = "0xFFA8710A",       // host `warn`
+        blue = "0xFF0F5BFF",         // host `signal`
+        magenta = "0xFF8B2FBF",
+        cyan = "0xFF0E7490",
+        white = "0xFF687081",        // host `textSecondary` - see rule 2 above
+        // ANSI 8 is the dim companion of ANSI 0, and on paper ANSI 0 is the ink,
+        // so 8 is necessarily LIGHTER than its base - the one slot exempt from
+        // rule 1. It still has to clear the 3:1 UI floor, which the host's
+        // `textMuted` #9AA3B2 does not (2.37:1). Dimmer than ANSI 7, readable. 3.38:1.
+        brightBlack = "0xFF7E8797",
+        brightRed = "0xFFB02A38",
+        brightGreen = "0xFF106340",
+        brightYellow = "0xFF87590A",
+        brightBlue = "0xFF0C3FBF",
+        brightMagenta = "0xFF6E1F99",
+        brightCyan = "0xFF0B5B73",
+        brightWhite = "0xFF05070B",  // host `textPrimary` - the strongest text
+        isBuiltin = true
+    )
+
+    /**
+     * BOSS Daylight - the paper half of the Operator identity.
+     *
+     * Mirrors the host's `BossLightColorScheme`. Same three light-palette rules as
+     * [BOSS_BLUEPRINT_LIGHT], plus one identity compromise that is deliberate:
+     *
+     * **The cursor is the darkened amber #95580A, not the identity's #D9871A.**
+     * The host scheme's own note records why - the amber signal is 2.6:1 on this
+     * floor, which is exactly why the host carries a separate `signalText` of
+     * #95580A for amber glyphs. An opaque block cursor at 2.6:1 is a smear, so the
+     * terminal takes the darker amber (5.29:1) and ANSI 3 follows it. The chrome
+     * still FILLS with #D9871A, so the signature survives where a fill can carry
+     * it. Amber on paper is a hard combination; this is the trade, not an oversight.
+     */
+    val BOSS_DAYLIGHT = Theme(
+        id = "boss-daylight",
+        name = "BOSS Daylight",
+        foreground = "0xFF1D242E",   // softened off the host's `textPrimary` #131820
+        background = "0xFFF5F7FA",   // host `ink`
+        cursor = "0xFF95580A",       // host `signalText`, 5.29:1 - see the note above
+        cursorText = "0xFFFFFFFF",   // 5.68:1 on the cursor fill
+        // Deepened from the host's `signalWash` #FBEFD8, which is 1.06:1 here and
+        // effectively invisible as a standalone selection. Same reasoning as
+        // BOSS_BLUEPRINT_LIGHT's selection. 1.41:1, text on it 10.3:1.
+        selection = "0xFFEFCE8C",
+        selectionText = "0xFF131820",// host `textPrimary`
+        searchMatch = "0xFFFFC44D",
+        // Darkened off the host's `data` #1E7FA8: that value is 4.20:1 on this
+        // floor, which clears the 3:1 UI-component floor but not the 4.5:1 text
+        // floor - and a hyperlink is text. 5.60:1.
+        hyperlink = "0xFF186A8E",
+        // ANSI 16 - the Operator hues re-grounded for paper
+        black = "0xFF20262E",
+        red = "0xFFD2453B",          // host `alert`
+        // Darkened off the host's `ok` #2F9E54 (3.19:1 here), as in
+        // BOSS_BLUEPRINT_LIGHT. 4.66:1.
+        green = "0xFF257F44",
+        // The darker amber again, not the host's `warn` #B87D0A: warn is 3.3:1 on
+        // this floor, which passes as a fill but not as a glyph, and ANSI 3 is text.
+        yellow = "0xFF95580A",
+        blue = "0xFF186A8E",         // the same darkened `data` as `hyperlink`
+        magenta = "0xFF9B2C8F",
+        cyan = "0xFF127C86",
+        white = "0xFF5A6675",        // host `textSecondary`
+        // The dim slot, exempt from rule 1 for the reason recorded on
+        // BOSS_BLUEPRINT_LIGHT. 3.06:1; the host's `textMuted` is 2.48:1.
+        brightBlack = "0xFF848F9E",
+        brightRed = "0xFFA8342C",
+        brightGreen = "0xFF1C6B39",
+        brightYellow = "0xFF7A4708",
+        brightBlue = "0xFF175F7E",
+        brightMagenta = "0xFF77206D",
+        brightCyan = "0xFF0D5C64",
+        brightWhite = "0xFF131820",  // host `textPrimary`
+        isBuiltin = true
+    )
+
+    /**
      * All built-in themes.
+     *
+     * BOSS_BLUEPRINT stays first: `ThemeDefaultsTest` asserts the default leads
+     * both builtin lists. Each light identity sits next to its dark sibling.
      */
     val ALL = listOf(
         BOSS_BLUEPRINT,
+        BOSS_BLUEPRINT_LIGHT,
         BOSS_OPERATOR,
+        BOSS_DAYLIGHT,
         DEFAULT,
         DRACULA,
         NORD,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinThemes.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/BuiltinThemes.kt
@@ -452,6 +452,14 @@ object BuiltinThemes {
      * 3. The cursor is an opaque block, so it needs contrast against the FLOOR,
      *    not against the text. `--blue` gives 4.90:1 here, which is why it can be
      *    the cursor on paper while `boss-daylight` has to darken its amber.
+     * 4. Every slot must clear `TerminalSettings.lightBackgroundMinContrast`, not
+     *    merely the 3:1 UI floor. `TerminalCanvasRenderer` runs EVERY glyph colour
+     *    through `ColorUtils.legibleOnLightBackground`, and indexed colours are
+     *    resolved from the palette BEFORE that call - so a slot below the setting
+     *    (4.5 by default) is silently mirrored-and-clamped at paint time and the
+     *    shipped colour is not the authored one. That is not a theoretical risk: it
+     *    ate the dim slot in the first draft, and `LightThemeContrastTest` now
+     *    asserts the guard is a no-op for every slot of these themes.
      */
     val BOSS_BLUEPRINT_LIGHT = Theme(
         id = "boss-blueprint-light",
@@ -475,20 +483,25 @@ object BuiltinThemes {
         hyperlink = "0xFF0C3FBF",    // host `data` - deeper than signal, so links stay distinct
         // ANSI 16 - warm-neutral hues re-grounded for paper
         black = "0xFF1B2330",
-        red = "0xFFD33B4A",          // host `alert`
+        red = "0xFFC63746",          // host `alert` #D33B4A, darkened to clear the guard
         // Darkened off the host's `ok` #1E9E63, which is only 3.20:1 on paper.
         // Green on white is the classic light-palette trap. 4.24:1.
-        green = "0xFF178750",
-        yellow = "0xFFA8710A",       // host `warn`
+        green = "0xFF157C4A",
+        yellow = "0xFF946309",       // host `warn` #A8710A, darkened to clear the guard
         blue = "0xFF0F5BFF",         // host `signal`
         magenta = "0xFF8B2FBF",
         cyan = "0xFF0E7490",
-        white = "0xFF687081",        // host `textSecondary` - see rule 2 above
+        // Darker than the host's `textSecondary` #687081 (4.64:1). Two reasons, both
+        // from rule 4: it has to clear the guard floor with margin, and ANSI 8 has to
+        // fit ABOVE it and still clear the floor itself. 7.22:1.
+        white = "0xFF4A5364",
         // ANSI 8 is the dim companion of ANSI 0, and on paper ANSI 0 is the ink,
         // so 8 is necessarily LIGHTER than its base - the one slot exempt from
-        // rule 1. It still has to clear the 3:1 UI floor, which the host's
-        // `textMuted` #9AA3B2 does not (2.37:1). Dimmer than ANSI 7, readable. 3.38:1.
-        brightBlack = "0xFF7E8797",
+        // rule 1. It still has to clear the guard floor (rule 4), which neither the
+        // host's `textMuted` #9AA3B2 (2.37:1) nor a mid-grey #7E8797 (3.38:1) does:
+        // the guard rewrote #7E8797 to #687181, one green-channel step off ANSI 7,
+        // collapsing the dim slot into it. 4.79:1, a clear 2.4 points lighter than 7.
+        brightBlack = "0xFF656E7E",
         brightRed = "0xFFB02A38",
         brightGreen = "0xFF106340",
         brightYellow = "0xFF87590A",
@@ -532,7 +545,7 @@ object BuiltinThemes {
         hyperlink = "0xFF186A8E",
         // ANSI 16 - the Operator hues re-grounded for paper
         black = "0xFF20262E",
-        red = "0xFFD2453B",          // host `alert`
+        red = "0xFFC13F36",          // host `alert` #D2453B, darkened to clear the guard
         // Darkened off the host's `ok` #2F9E54 (3.19:1 here), as in
         // BOSS_BLUEPRINT_LIGHT. 4.66:1.
         green = "0xFF257F44",
@@ -542,10 +555,13 @@ object BuiltinThemes {
         blue = "0xFF186A8E",         // the same darkened `data` as `hyperlink`
         magenta = "0xFF9B2C8F",
         cyan = "0xFF127C86",
-        white = "0xFF5A6675",        // host `textSecondary`
+        // Darker than the host's `textSecondary` #5A6675, to leave ANSI 8 room above it
+        // while both clear the guard floor. Same reasoning as BOSS_BLUEPRINT_LIGHT. 7.37:1.
+        white = "0xFF49525F",
         // The dim slot, exempt from rule 1 for the reason recorded on
-        // BOSS_BLUEPRINT_LIGHT. 3.06:1; the host's `textMuted` is 2.48:1.
-        brightBlack = "0xFF848F9E",
+        // BOSS_BLUEPRINT_LIGHT - but not from rule 4. 4.82:1; #848F9E (3.06:1) was
+        // rewritten to #616C7B by the guard, which erased the gap to ANSI 7.
+        brightBlack = "0xFF646E7C",
         brightRed = "0xFFA8342C",
         brightGreen = "0xFF1C6B39",
         brightYellow = "0xFF7A4708",

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/UiTheme.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/UiTheme.kt
@@ -10,9 +10,9 @@ import androidx.compose.ui.graphics.luminance
  * properties in docs/design-system.html.
  *
  * Tokens are derived from the active terminal [Theme] so the chrome follows
- * whatever theme the user picks. The two BOSS identities — BOSS Blueprint (the
- * default) and BOSS Operator — skip the derivation and map to their exact
- * design-system values; see [EXACT_TOKENS].
+ * whatever theme the user picks. The four BOSS identities - BOSS Blueprint (the
+ * default), BOSS Blueprint Light, BOSS Operator and BOSS Daylight - skip the
+ * derivation and map to their exact design-system values; see [EXACT_TOKENS].
  */
 data class UiTheme(
     // Surfaces
@@ -93,6 +93,87 @@ data class UiTheme(
         )
 
         /**
+         * Exact tokens for the paper half of the bossconsole.ai identity,
+         * mirroring the host's `BossBlueprintLightColorScheme`.
+         *
+         * **Deliberate divergence from the host:** the host sets `panel` and
+         * `raised` to the SAME pure white. That cannot be copied here. `raised` is
+         * `SettingsTheme.SurfaceColor`, which is the background of every row and
+         * card inside the settings panel, and `panel` is the panel window behind
+         * them - and those rows carry no border of their own (only the input fields
+         * nested inside them do). White on white would erase every one of them. So
+         * the ladder runs paper -> near-white -> white: the same direction a light
+         * design system elevates in, just with the step the host omits.
+         *
+         * The direction is the mirror image of the dark identities, where the ladder
+         * climbs from ink toward the text. `UiThemeTest` asserts monotonicity rather
+         * than a fixed direction for exactly this reason.
+         *
+         * `signalText` equals `signal` because `--blue` clears 4.9:1 against paper,
+         * so unlike the dark identity there is no separate glyph blue to author.
+         */
+        val BOSS_BLUEPRINT_LIGHT = UiTheme(
+            ink = Color(0xFFF5F7FB),      // host `ink` / site `--paper`
+            panel = Color(0xFFFAFBFD),    // the step the host omits - see above
+            raised = Color(0xFFFFFFFF),   // host `panel` / `raised`
+            line = Color(0xFFDCE2EB),
+            // Softened from the site's full-ink card border: a hard black edge is a
+            // signature on one landing-page card and a wall of noise on every text
+            // field in an app. The host softens it the same way.
+            line2 = Color(0xFFA8B2C2),
+            chalk = Color(0xFF05070B),
+            mist = Color(0xFF687081),
+            muted = Color(0xFF9AA3B2),
+            signal = Color(0xFF0F5BFF),
+            signalDim = Color(0xFF0A45C4),
+            signalWash = Color(0xFFDCE7FF),
+            signalText = Color(0xFF0F5BFF),
+            onSignal = Color(0xFFFFFFFF),
+            // Deeper than `signal` so a link stays distinct from the action blue,
+            // which on paper are otherwise the same colour doing two jobs.
+            data = Color(0xFF0C3FBF),
+            ok = Color(0xFF1E9E63),
+            warn = Color(0xFFA8710A),
+            alert = Color(0xFFD33B4A),
+        )
+
+        /**
+         * Exact tokens for the paper half of the Operator identity, mirroring the
+         * host's `BossLightColorScheme`.
+         *
+         * Same paper -> near-white -> white ladder as [BOSS_BLUEPRINT_LIGHT], and for
+         * the same reason: the host's identical `panel`/`raised` would erase every
+         * settings row.
+         *
+         * `signalText` is a much darker amber than `signal`: #D9871A is 2.6:1 on
+         * this floor, fine as a fill and unreadable as a glyph. That split is the
+         * whole reason both tokens exist, and it is also why
+         * [BuiltinThemes.BOSS_DAYLIGHT] gives its cursor and its ANSI 3 the darker
+         * value rather than the signature one.
+         */
+        val BOSS_DAYLIGHT = UiTheme(
+            ink = Color(0xFFF5F7FA),      // host `ink`
+            panel = Color(0xFFFAFBFC),    // the step the host omits - see above
+            raised = Color(0xFFFFFFFF),   // host `panel` / `raised`
+            line = Color(0xFFE2E7EE),
+            line2 = Color(0xFFC9D2DC),
+            chalk = Color(0xFF131820),
+            mist = Color(0xFF5A6675),
+            muted = Color(0xFF94A0AE),
+            signal = Color(0xFFD9871A),
+            signalDim = Color(0xFFB36F12),
+            signalWash = Color(0xFFFBEFD8),
+            signalText = Color(0xFF95580A),
+            onSignal = Color(0xFF2A1B05),
+            data = Color(0xFF1E7FA8),
+            ok = Color(0xFF2F9E54),
+            // Darkened from #C5860C, which was 2.88:1 on this near-white floor and
+            // so under the 3:1 UI-component floor. The host carries the same value.
+            warn = Color(0xFFB87D0A),
+            alert = Color(0xFFD2453B),
+        )
+
+        /**
          * The BOSS identities, whose chrome tokens are hand-authored rather than
          * derived.
          *
@@ -104,7 +185,9 @@ data class UiTheme(
         private val EXACT_TOKENS: Map<String, UiTheme> =
             mapOf(
                 BuiltinThemes.BOSS_BLUEPRINT.id to BOSS_BLUEPRINT,
+                BuiltinThemes.BOSS_BLUEPRINT_LIGHT.id to BOSS_BLUEPRINT_LIGHT,
                 BuiltinThemes.BOSS_OPERATOR.id to BOSS_OPERATOR,
+                BuiltinThemes.BOSS_DAYLIGHT.id to BOSS_DAYLIGHT,
             )
 
         /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/StatusStrip.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/share/StatusStrip.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.share
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.TooltipArea
@@ -31,10 +32,12 @@ import androidx.compose.ui.unit.sp
  *
  * The call segment's wording is the embedder's — see `TabbedTerminal`'s `callLabel` parameter.
  */
-private val ON = Color(0xFF4CAF50)
-private val OFF = Color(0xFF6B6B6B)
-private val BUSY = Color(0xFFE5A54B)
-private val LIVE_TALK = Color(0xFF4A90E2)
+// Getters, not vals: a file-scope val freezes at class-init and cannot follow a
+// theme switch. These four are status dot/pill fills, so the fill tokens apply.
+private val ON: Color get() = BossUiTheme.current.ok
+private val OFF: Color get() = BossUiTheme.current.muted
+private val BUSY: Color get() = BossUiTheme.current.warn
+private val LIVE_TALK: Color get() = BossUiTheme.current.data
 
 /**
  * What the in-app call button says when the embedder has not renamed it — i.e. always, in plain
@@ -112,9 +115,9 @@ fun StatusStrip(
     if (!showMcp && !showSharing && !showCall) return
     Surface(
         modifier = modifier,
-        color = Color(0xFF2B2B2B),
+        color = BossUiTheme.current.panel,
         shape = RoundedCornerShape(12.dp),
-        border = BorderStroke(1.dp, Color(0xFF404040))
+        border = BorderStroke(1.dp, BossUiTheme.current.line)
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
@@ -125,7 +128,7 @@ fun StatusStrip(
                 Segment(dot = if (mcpOn) ON else OFF, label = "MCP", onClick = onMcpClick)
             }
             if (showMcp && (showSharing || remoteCalls > 0)) {
-                Text("|", color = Color(0xFF555555), fontSize = 12.sp)
+                Text("|", color = BossUiTheme.current.line2, fontSize = 12.sp)
             }
             // A live remote call forces the segment on. Rendering it only inside `showSharing`
             // restored exactly the no-signal state RemoteVoiceCalls exists to close: a cosmetic
@@ -164,7 +167,7 @@ fun StatusStrip(
                 )
             }
             if ((showMcp || showSharing || remoteCalls > 0) && showCall) {
-                Text("|", color = Color(0xFF555555), fontSize = 12.sp)
+                Text("|", color = BossUiTheme.current.line2, fontSize = 12.sp)
             }
             if (showCall) {
                 Segment(
@@ -172,7 +175,7 @@ fun StatusStrip(
                         CallSegmentState.Connecting, CallSegmentState.Working -> BUSY
                         CallSegmentState.Speaking -> LIVE_TALK
                         CallSegmentState.Live -> ON
-                        CallSegmentState.Failed -> Color(0xFFD9534F)
+                        CallSegmentState.Failed -> BossUiTheme.current.alert
                         else -> OFF
                     },
                     label = callSegmentLabel(call, callLabel),
@@ -193,7 +196,7 @@ private fun Segment(dot: Color, label: String, onClick: () -> Unit, tooltip: Str
             horizontalArrangement = Arrangement.spacedBy(5.dp)
         ) {
             Box(Modifier.size(7.dp).background(dot, CircleShape))
-            Text(label, color = Color(0xFFCCCCCC), fontSize = 11.sp)
+            Text(label, color = BossUiTheme.current.chalk, fontSize = 11.sp)
         }
     }
     if (tooltip == null) {
@@ -204,12 +207,12 @@ private fun Segment(dot: Color, label: String, onClick: () -> Unit, tooltip: Str
         tooltip = {
             Text(
                 text = tooltip,
-                color = Color(0xFFDDDDDD),
+                color = BossUiTheme.current.chalk,
                 fontSize = 11.sp,
                 modifier = Modifier
                     .widthIn(max = 320.dp)
-                    .background(Color(0xFF2B2B2B), RoundedCornerShape(6.dp))
-                    .border(1.dp, Color(0xFF505050), RoundedCornerShape(6.dp))
+                    .background(BossUiTheme.current.raised, RoundedCornerShape(6.dp))
+                    .border(1.dp, BossUiTheme.current.line2, RoundedCornerShape(6.dp))
                     .padding(horizontal = 10.dp, vertical = 7.dp),
             )
         },

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.splits
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import ai.rever.bossterm.compose.ContextMenuElement
 import ai.rever.bossterm.compose.TerminalSession
 import ai.rever.bossterm.compose.hyperlinks.HyperlinkDetector
@@ -304,7 +305,7 @@ private fun RenderPane(
         if (isFocusedPane && !splitState.isSinglePane) {
             Modifier.border(2.dp, splitFocusBorderColor)
         } else {
-            Modifier.border(1.dp, Color(0xFF404040))
+            Modifier.border(1.dp, BossUiTheme.current.line2)
         }
     } else {
         Modifier

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitDivider.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitDivider.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.splits
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
@@ -12,7 +13,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
@@ -63,7 +63,7 @@ fun SplitDividerLine(
                     SplitOrientation.VERTICAL -> Modifier.fillMaxHeight().width(DIVIDER_THICKNESS)
                 }
             )
-            .background(Color(0xFF2D2D2D))
+            .background(BossUiTheme.current.line2)
     )
 }
 
@@ -178,7 +178,7 @@ fun SplitDivider(
                     SplitOrientation.VERTICAL -> Modifier.fillMaxHeight().width(DIVIDER_THICKNESS)
                 }
             )
-            .background(Color(0xFF2D2D2D))
+            .background(BossUiTheme.current.line2)
             .then(cursorModifier)
             .pointerInput(orientation) {
                 detectDragGestures { change, dragAmount ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.tabs
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import ai.rever.bossterm.compose.ai.AIAssistants
 import ai.rever.bossterm.compose.features.ContextMenuController
 import ai.rever.bossterm.compose.settings.theme.Theme
@@ -41,7 +42,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -86,8 +86,14 @@ enum class TabBarOrientation { TOP, LEFT }
 /** Gap between tab-groups (each group = one tab's panes). Larger than within a group. */
 private val TabGroupGap: Dp = 18.dp
 
-/** Accent for remote (mirrored) sessions — the box border + tab-chip color. */
-private val RemoteAccent: Color = Color(0xFF4FC3F7)
+/**
+ * Accent for remote (mirrored) sessions - the box border + tab-chip color.
+ *
+ * A `get()` and not a `val`: a file-scope val is initialised once at class-init and
+ * would pin the colour to whatever theme happened to be active then. Same reason
+ * every member of `SettingsTheme` is a getter.
+ */
+private val RemoteAccent: Color get() = BossUiTheme.current.data
 
 /** Gap between pane chips within the same tab-group. Tight, so they read as one cluster. */
 private val TabChipGap: Dp = 3.dp
@@ -863,7 +869,7 @@ fun TabBar(
                                     )
                                 } else {
                                     Text(
-                                        rg.header, color = Color(0xFFB0B0B0), fontSize = 11.sp,
+                                        rg.header, color = BossUiTheme.current.mist, fontSize = 11.sp,
                                         maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
                                     )
                                 }
@@ -872,7 +878,7 @@ fun TabBar(
                                     // it may heal, red when it gave up.
                                     Text(
                                         "· $label",
-                                        color = if (rg.statusError) Color(0xFFE57373) else Color(0xFFE0A030),
+                                        color = if (rg.statusError) BossUiTheme.current.alert else BossUiTheme.current.warn,
                                         fontSize = 10.sp, maxLines = 1
                                     )
                                 }
@@ -886,10 +892,10 @@ fun TabBar(
                                         horizontalArrangement = Arrangement.spacedBy(3.dp)
                                     ) {
                                         Box(Modifier.size(6.dp).background(
-                                            if (rg.mcpRunning) Color(0xFF4CAF50) else Color(0xFF6B6B6B),
+                                            if (rg.mcpRunning) BossUiTheme.current.ok else BossUiTheme.current.muted,
                                             androidx.compose.foundation.shape.CircleShape
                                         ))
-                                        Text("MCP", color = Color(0xFFB0B0B0), fontSize = 10.sp, maxLines = 1)
+                                        Text("MCP", color = BossUiTheme.current.mist, fontSize = 10.sp, maxLines = 1)
                                     }
                                 }
                                 if (!rg.canControl) {
@@ -897,13 +903,13 @@ fun TabBar(
                                     Icon(
                                         Icons.Default.Visibility,
                                         contentDescription = "View only - right-click to request control",
-                                        tint = Color(0xFF808080),
+                                        tint = BossUiTheme.current.muted,
                                         modifier = Modifier.size(12.dp)
                                     )
                                 }
                                 Box(
                                     modifier = Modifier.clip(RoundedCornerShape(4.dp)).clickable(onClick = rg.onDisconnect).padding(2.dp)
-                                ) { Icon(Icons.Default.Close, contentDescription = "Disconnect remote", tint = Color(0xFF808080), modifier = Modifier.size(13.dp)) }
+                                ) { Icon(Icons.Default.Close, contentDescription = "Disconnect remote", tint = BossUiTheme.current.muted, modifier = Modifier.size(13.dp)) }
                             }
                             // Match the local bar: split panes of one tab hug together
                             // (TabChipGap), separate tabs are spaced further apart (TabGroupGap).
@@ -925,11 +931,11 @@ fun TabBar(
                                                 horizontalArrangement = Arrangement.spacedBy(4.dp)
                                             ) {
                                                 Text(
-                                                    sec.label, color = Color(0xFF8A8A8A), fontSize = 10.sp,
+                                                    sec.label, color = BossUiTheme.current.muted, fontSize = 10.sp,
                                                     maxLines = 1, overflow = TextOverflow.Ellipsis
                                                 )
                                                 // Hairline ties the sub-title to its section.
-                                                Box(Modifier.weight(1f).height(1.dp).background(Color(0xFF3A3A3A)))
+                                                Box(Modifier.weight(1f).height(1.dp).background(BossUiTheme.current.line))
                                             }
                                             Column(verticalArrangement = Arrangement.spacedBy(TabGroupGap)) {
                                                 sec.groups.forEach { group ->
@@ -990,24 +996,24 @@ fun TabBar(
                                 ) {
                                     Icon(Icons.Default.Cloud, contentDescription = null, tint = groupAccent, modifier = Modifier.size(13.dp))
                                     Text(
-                                        "${nest.label} · via ${rg.header}", color = Color(0xFFB0B0B0), fontSize = 11.sp,
+                                        "${nest.label} · via ${rg.header}", color = BossUiTheme.current.mist, fontSize = 11.sp,
                                         maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f)
                                     )
                                     if (nest.offline) {
                                         // The host lost its upstream — these tabs are frozen.
-                                        Text("· offline", color = Color(0xFFE57373), fontSize = 10.sp, maxLines = 1)
+                                        Text("· offline", color = BossUiTheme.current.alert, fontSize = 10.sp, maxLines = 1)
                                     }
                                     if (nest.readOnly) {
                                         Icon(
                                             Icons.Default.Visibility,
                                             contentDescription = "Read-only via this host",
-                                            tint = Color(0xFF808080),
+                                            tint = BossUiTheme.current.muted,
                                             modifier = Modifier.size(12.dp)
                                         )
                                     }
                                     Box(
                                         modifier = Modifier.clip(RoundedCornerShape(4.dp)).clickable(onClick = nest.onClose).padding(2.dp)
-                                    ) { Icon(Icons.Default.Close, contentDescription = "Ask host to disconnect this upstream", tint = Color(0xFF808080), modifier = Modifier.size(13.dp)) }
+                                    ) { Icon(Icons.Default.Close, contentDescription = "Ask host to disconnect this upstream", tint = BossUiTheme.current.muted, modifier = Modifier.size(13.dp)) }
                                 }
                                 // The origin may share ALL its windows — section its tabs per
                                 // origin window (sub-title + targeted actions), like the host box.
@@ -1027,10 +1033,10 @@ fun TabBar(
                                                     horizontalArrangement = Arrangement.spacedBy(4.dp)
                                                 ) {
                                                     Text(
-                                                        sec.label, color = Color(0xFF8A8A8A), fontSize = 10.sp,
+                                                        sec.label, color = BossUiTheme.current.muted, fontSize = 10.sp,
                                                         maxLines = 1, overflow = TextOverflow.Ellipsis
                                                     )
-                                                    Box(Modifier.weight(1f).height(1.dp).background(Color(0xFF3A3A3A)))
+                                                    Box(Modifier.weight(1f).height(1.dp).background(BossUiTheme.current.line))
                                                 }
                                                 Column(verticalArrangement = Arrangement.spacedBy(TabGroupGap)) {
                                                     sec.groups.forEach { group ->
@@ -1092,10 +1098,10 @@ fun TabBar(
                         Icon(
                             imageVector = Icons.Default.Cloud,
                             contentDescription = "Add remote session",
-                            tint = Color(0xFFB0B0B0),
+                            tint = BossUiTheme.current.mist,
                             modifier = Modifier.size(16.dp)
                         )
-                        Text("Add remote", color = Color(0xFFB0B0B0), fontSize = 12.sp)
+                        Text("Add remote", color = BossUiTheme.current.mist, fontSize = 12.sp)
                     }
                     // A hover reveal pins itself open; the real bar collapses. Same slot, so
                     // the icon is the state: pin = "this will go away", chevron = "it's mine".
@@ -1171,7 +1177,13 @@ private fun TabItem(
     // passed in (one subscriber for the whole bar, not one per tab).
     val itemBg = tabTheme.backgroundColorValue
     val itemFg = tabTheme.foregroundColor
-    val itemRaised = lerp(itemBg, itemFg, 0.12f)    // active chip surface
+    // The `raised` token rather than an interpolation. Compose's Color lerp
+    // interpolates in Oklab, where a small step off a near-black floor rounds back
+    // to the floor - so on BOSS Blueprint (#05070B) the active chip had barely any
+    // surface at all. `raised` is the same idea (the floor stepped toward the text)
+    // computed in gamma sRGB by UiTheme's own mix, and on the light identities it is
+    // the white card the active chip should be.
+    val itemRaised = BossUiTheme.current.raised     // active chip surface
     val itemAccent = tabTheme.cursorColor           // active chip border
     val itemMuted = itemFg.copy(alpha = 0.62f)      // inactive text / active close-icon
     val itemSubtle = itemFg.copy(alpha = 0.22f)     // inactive border (hairline)
@@ -1268,7 +1280,7 @@ private fun TabItem(
                     if (!subtitle.isNullOrBlank() && subtitle != title) {
                         Text(
                             text = subtitle,
-                            color = Color(0xFF808080),
+                            color = itemMuted,
                             fontSize = 11.sp,
                             fontFamily = FontFamily.Monospace,
                             maxLines = 1,
@@ -1279,7 +1291,7 @@ private fun TabItem(
                     if (!branch.isNullOrBlank()) {
                         Text(
                             text = "⎇ $branch",
-                            color = Color(0xFF6A9955),
+                            color = BossUiTheme.current.ok,
                             fontSize = 11.sp,
                             fontFamily = FontFamily.Monospace,
                             maxLines = 1,
@@ -1327,11 +1339,11 @@ private fun TabRenameField(
         onValueChange = { text = it },
         singleLine = true,
         textStyle = TextStyle(
-            color = Color.White,
+            color = BossUiTheme.current.chalk,
             fontSize = 13.sp,
             fontFamily = FontFamily.Monospace
         ),
-        cursorBrush = SolidColor(Color.White),
+        cursorBrush = SolidColor(BossUiTheme.current.chalk),
         modifier = modifier
             .focusRequester(focusRequester)
             .onPreviewKeyEvent { event ->

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -1291,7 +1291,10 @@ private fun TabItem(
                     if (!branch.isNullOrBlank()) {
                         Text(
                             text = "⎇ $branch",
-                            color = BossUiTheme.current.ok,
+                            // `mist`, not `ok`: `ok` is a FILL token at the 3:1
+                            // component floor and is 3.2:1 on the light identities.
+                            // The ⎇ glyph already says "branch"; the green did not.
+                            color = itemMuted,
                             fontSize = 11.sp,
                             fontFamily = FontFamily.Monospace,
                             maxLines = 1,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateUI.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateUI.kt
@@ -194,7 +194,10 @@ private fun ReadyToInstallBanner(onInstall: () -> Unit) {
 
             TextButton(
                 onClick = onInstall,
-                colors = ButtonDefaults.textButtonColors(contentColor = AccentOrange),
+                // The banner's primary action, so it takes the accent held to the text
+                // floor - `warn` is a fill token and 3.3:1 on daylight. The Info icon
+                // above keeps AccentOrange: an icon is held to the 3:1 component floor.
+                colors = ButtonDefaults.textButtonColors(contentColor = AccentBlue),
                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
                 modifier = Modifier.height(28.dp)
             ) {

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateUI.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateUI.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.update
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
@@ -56,11 +57,15 @@ fun UpdateBanner(
 }
 
 // Colors matching TabBar
-private val BannerBackground = Color(0xFF1E1E1E)
-private val AccentBlue = Color(0xFF4A90E2)
-private val AccentGreen = Color(0xFF4CAF50)
-private val AccentOrange = Color(0xFFFF9800)
-private val AccentRed = Color(0xFFF44336)
+// Getters, not vals: a file-scope val is initialised at class-init and cannot
+// follow a theme switch. AccentBlue is used for text and icons as well as fills, so
+// it takes `signalText` - the accent held to the 4.5:1 text floor - rather than
+// `signal`, which is only held to the 3:1 component floor.
+private val BannerBackground: Color get() = BossUiTheme.current.panel
+private val AccentBlue: Color get() = BossUiTheme.current.signalText
+private val AccentGreen: Color get() = BossUiTheme.current.ok
+private val AccentOrange: Color get() = BossUiTheme.current.warn
+private val AccentRed: Color get() = BossUiTheme.current.alert
 
 @Composable
 private fun UpdateAvailableBanner(
@@ -92,12 +97,12 @@ private fun UpdateAvailableBanner(
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(
                     "Update v${updateInfo.latestVersion} available",
-                    color = Color.White,
+                    color = BossUiTheme.current.chalk,
                     fontSize = 12.sp
                 )
                 Text(
                     " (current: v${updateInfo.currentVersion})",
-                    color = Color(0xFF808080),
+                    color = BossUiTheme.current.muted,
                     fontSize = 12.sp
                 )
             }
@@ -113,7 +118,7 @@ private fun UpdateAvailableBanner(
                 }
                 TextButton(
                     onClick = onDismiss,
-                    colors = ButtonDefaults.textButtonColors(contentColor = Color(0xFF808080)),
+                    colors = ButtonDefaults.textButtonColors(contentColor = BossUiTheme.current.muted),
                     contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
                     modifier = Modifier.height(28.dp)
                 ) {
@@ -145,7 +150,7 @@ private fun DownloadProgressBanner(progress: Float) {
             Spacer(modifier = Modifier.width(6.dp))
             Text(
                 "Downloading... ${(progress * 100).toInt()}%",
-                color = Color.White,
+                color = BossUiTheme.current.chalk,
                 fontSize = 12.sp
             )
             Spacer(modifier = Modifier.width(12.dp))
@@ -153,7 +158,7 @@ private fun DownloadProgressBanner(progress: Float) {
                 progress = progress,
                 modifier = Modifier.weight(1f).height(4.dp),
                 color = AccentGreen,
-                backgroundColor = Color(0xFF404040)
+                backgroundColor = BossUiTheme.current.line
             )
         }
     }
@@ -182,7 +187,7 @@ private fun ReadyToInstallBanner(onInstall: () -> Unit) {
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(
                     "Update ready to install - password prompt will appear",
-                    color = Color.White,
+                    color = BossUiTheme.current.chalk,
                     fontSize = 12.sp
                 )
             }
@@ -220,7 +225,7 @@ private fun RestartRequiredBanner() {
             Spacer(modifier = Modifier.width(6.dp))
             Text(
                 "Installing update... App will relaunch automatically. Check /tmp/bossterm-updater/ for logs if needed.",
-                color = Color.White,
+                color = BossUiTheme.current.chalk,
                 fontSize = 12.sp
             )
         }
@@ -260,7 +265,7 @@ private fun ErrorBanner(
                     Spacer(modifier = Modifier.width(6.dp))
                     Text(
                         "Update error: $message",
-                        color = Color.White,
+                        color = BossUiTheme.current.chalk,
                         fontSize = 12.sp,
                         maxLines = 2
                     )
@@ -277,7 +282,7 @@ private fun ErrorBanner(
                     }
                     TextButton(
                         onClick = onDismiss,
-                        colors = ButtonDefaults.textButtonColors(contentColor = Color(0xFF808080)),
+                        colors = ButtonDefaults.textButtonColors(contentColor = BossUiTheme.current.muted),
                         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
                         modifier = Modifier.height(28.dp)
                     ) {
@@ -287,7 +292,7 @@ private fun ErrorBanner(
             }
             Text(
                 "Check logs: /tmp/bossterm-updater/update-*.log or /tmp/bossterm-update-debug-*.log",
-                color = Color(0xFF808080),
+                color = BossUiTheme.current.muted,
                 fontSize = 10.sp,
                 modifier = Modifier.padding(top = 2.dp, start = 22.dp)
             )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/HostCallBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/HostCallBar.kt
@@ -27,6 +27,9 @@ import androidx.compose.ui.unit.sp
 // status DOT fills here, so the fill tokens are the right ones; `Danger` is also
 // used as label text and as a button tint, which `alert` covers in both roles.
 private val Bg: Color get() = BossUiTheme.current.panel
+// The button sits ON the bar, so it needs the rung above `Bg`. It was #1E1E1E on a
+// #2B2B2B bar - recessed; pointing both at `panel` left it with only its border.
+private val ButtonBg: Color get() = BossUiTheme.current.raised
 private val Line: Color get() = BossUiTheme.current.line
 private val Label: Color get() = BossUiTheme.current.chalk
 private val Muted: Color get() = BossUiTheme.current.muted
@@ -126,7 +129,7 @@ private fun LevelMeter(muted: Boolean, color: Color) {
 @Composable
 private fun BarButton(label: String, onClick: () -> Unit, tint: Color = Label) {
     Surface(
-        color = BossUiTheme.current.panel,
+        color = ButtonBg,
         shape = RoundedCornerShape(10.dp),
         border = BorderStroke(1.dp, if (tint == Label) Line else tint),
         modifier = Modifier.clickable(onClick = onClick),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/HostCallBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/voice/HostCallBar.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.voice
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import ai.rever.bossterm.compose.share.CallSegmentState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -22,14 +23,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
-private val Bg = Color(0xFF2B2B2B)
-private val Line = Color(0xFF404040)
-private val Label = Color(0xFFCCCCCC)
-private val Muted = Color(0xFF999999)
-private val Green = Color(0xFF4CAF50)
-private val Blue = Color(0xFF4A90E2)
-private val Amber = Color(0xFFE5A54B)
-private val Danger = Color(0xFFD9534F)
+// Getters, not vals - see the note in McpStatusIndicator. `Blue` and `Green` are
+// status DOT fills here, so the fill tokens are the right ones; `Danger` is also
+// used as label text and as a button tint, which `alert` covers in both roles.
+private val Bg: Color get() = BossUiTheme.current.panel
+private val Line: Color get() = BossUiTheme.current.line
+private val Label: Color get() = BossUiTheme.current.chalk
+private val Muted: Color get() = BossUiTheme.current.muted
+private val Green: Color get() = BossUiTheme.current.ok
+private val Blue: Color get() = BossUiTheme.current.data
+private val Amber: Color get() = BossUiTheme.current.warn
+private val Danger: Color get() = BossUiTheme.current.alert
 
 /**
  * The in-app call strip, shown under the status pills while a call is up: a live microphone level
@@ -122,7 +126,7 @@ private fun LevelMeter(muted: Boolean, color: Color) {
 @Composable
 private fun BarButton(label: String, onClick: () -> Unit, tint: Color = Label) {
     Surface(
-        color = Color(0xFF1E1E1E),
+        color = BossUiTheme.current.panel,
         shape = RoundedCornerShape(10.dp),
         border = BorderStroke(1.dp, if (tint == Label) Line else tint),
         modifier = Modifier.clickable(onClick = onClick),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/window/TransparentWindowTitleBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/window/TransparentWindowTitleBar.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.window
 
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -95,7 +96,7 @@ fun WindowScope.CustomTitleBar(
             ) {
                 Text(
                     text = title,
-                    color = Color.White.copy(alpha = 0.9f),
+                    color = BossUiTheme.current.chalk.copy(alpha = 0.9f),
                     fontSize = 13.sp,
                     fontWeight = FontWeight.Medium
                 )
@@ -109,7 +110,7 @@ fun WindowScope.CustomTitleBar(
                 if (globalHotkeyHint != null) {
                     Text(
                         text = globalHotkeyHint,
-                        color = Color.White.copy(alpha = 0.5f),
+                        color = BossUiTheme.current.mist,
                         fontSize = 11.sp,
                         fontWeight = FontWeight.Normal
                     )
@@ -119,7 +120,16 @@ fun WindowScope.CustomTitleBar(
     }
 }
 
-// macOS traffic light colors (from official specs)
+/**
+ * macOS traffic light colors, from Apple's specs.
+ *
+ * Deliberately NOT themed, and the one set of literals in this file that should
+ * stay literal. These are the operating system's window controls: macOS paints the
+ * same red/yellow/green in light and dark appearance, so a user identifies them by
+ * colour before reading anything else in the window. Recolouring them per terminal
+ * theme would make BossTerm the only app on the machine whose close button is not
+ * red. `ChromeTokenCoverageTest` allowlists this object for that reason.
+ */
 private object TrafficLightColors {
     // Close button (red) - with transparency for glass effect
     val closeDefault = Color(0xFFFF6159)

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ChromeTokenCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ChromeTokenCoverageTest.kt
@@ -1,0 +1,185 @@
+package ai.rever.bossterm.compose.theme
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The chrome around the terminal must take its colours from the theme, not from
+ * literals.
+ *
+ * Every file in [converted] used to hold hardcoded VS-Code-ish greys and read
+ * zero theme tokens. Settings and dialogs had followed the theme for a long time via
+ * `SettingsTheme`, but the frame did not, so picking a light theme gave a light
+ * terminal inside a dark window - with `Color.White` text in the tab-rename field and
+ * on the search bar, on paper.
+ *
+ * This is a source scan for the same reason
+ * [ai.rever.bossterm.compose.util.SubmitCharacterCoverageTest] is: the failure is a
+ * literal in an argument list, and there is no seam to observe it through without
+ * rendering each surface under two themes and reading pixels back. Its reach is the
+ * limit of what it can promise - a colour arriving through a parameter has no literal
+ * to match - so it catches the shape that actually accumulated here, not every
+ * possible one.
+ *
+ * The list is the load-bearing part. 185 literals built up across 16 files precisely
+ * because nothing failed when one more was added; a new hardcoded colour in converted
+ * chrome now breaks the build instead of surfacing as a screenshot in review.
+ */
+class ChromeTokenCoverageTest {
+
+    /**
+     * Chrome converted to tokens, relative to `compose-ui/src/desktopMain/kotlin/`.
+     *
+     * `debug/DebugPanel*.kt` and `PreConnectScreen.kt` are deliberately absent: a
+     * dev-only panel and the SSH pre-connect screen, still literal, still to do. They
+     * are named here rather than left unmentioned so the gap is a known one.
+     */
+    private val converted = listOf(
+        // Always on screen.
+        "tabs/TabBar.kt",
+        "window/TransparentWindowTitleBar.kt",
+        "TabbedTerminal.kt",
+        "scrollbar/AlwaysVisibleScrollbar.kt",
+        "splits/SplitDivider.kt",
+        "splits/SplitContainer.kt",
+        // Frequently on screen.
+        "search/SearchBar.kt",
+        "palette/CommandPalette.kt",
+        "history/HistorySearchOverlay.kt",
+        "mcp/McpStatusIndicator.kt",
+        "share/StatusStrip.kt",
+        "update/UpdateUI.kt",
+        "voice/HostCallBar.kt",
+    )
+
+    /**
+     * Literals that are correct as literals, each with the reason it is not a token.
+     *
+     * Keyed by file so an allowlisted value cannot leak into a different file and be
+     * silently accepted there.
+     */
+    private val allowed: Map<String, List<String>> = mapOf(
+        // macOS paints the same red/yellow/green window controls in light and dark
+        // appearance. A user finds the close button by colour before reading anything
+        // else, so recolouring these per terminal theme would make BossTerm the only
+        // app on the machine whose close button is not red.
+        "window/TransparentWindowTitleBar.kt" to listOf(
+            "0xFFFF6159", "0xFFBF4942", "0xFF4D0000", "0x33000000",
+            "0xFFFFBD2E", "0xFFBF8E22", "0xFF995700",
+            "0xFF28C941", "0xFF1D9730", "0xFF006500",
+        ),
+        // A modal scrim dims whatever is behind it. It is black under a light theme
+        // too, exactly as in every light-mode design system.
+        "palette/CommandPalette.kt" to listOf("0x88000000"),
+        "history/HistorySearchOverlay.kt" to listOf("0x88000000"),
+        // These are @Composable PARAMETER DEFAULTS for values the user owns, not
+        // chrome. Every real call site passes the setting instead
+        // (`ProperTerminal` -> scrollbarThumbColor / scrollbarColor /
+        // searchMarkerColor, `TabbedTerminal` -> splitFocusBorderColor), and
+        // `ThemeDefaultsTest.scrollbar search markers stay independent of the theme`
+        // pins the markers as deliberately theme-independent. Pointing these at a
+        // token would let the active theme silently override a colour the user set in
+        // Settings, which is a worse bug than the one this test exists to catch.
+        "scrollbar/AlwaysVisibleScrollbar.kt" to listOf(
+            "Color.White", "0xFFFFFF00", "0xFFFF6600",
+        ),
+        "splits/SplitContainer.kt" to listOf("0xFF4A90E2"),
+    )
+
+    /** `Color(0xAARRGGBB)` / `Color(0xRRGGBB)`, plus the two named extremes. */
+    private val literalPattern = Regex("""Color\((0x[0-9A-Fa-f_]{6,11})\)|Color\.(White|Black)""")
+
+    @Test
+    fun `converted chrome holds no colour literals outside the allowlist`() {
+        val offenders = mutableListOf<String>()
+        for (rel in converted) {
+            val file = sourceFile(rel)
+            val ok = allowed[rel].orEmpty()
+            file.readLines().forEachIndexed { index, line ->
+                // Comments quote literals when explaining why a token replaced one.
+                if (line.trimStart().startsWith("//")) return@forEachIndexed
+                for (match in literalPattern.findAll(line)) {
+                    val literal = match.groupValues[1].ifEmpty { "Color.${match.groupValues[2]}" }
+                    if (literal !in ok) {
+                        offenders += "$rel:${index + 1}  $literal   (${line.trim().take(80)})"
+                    }
+                }
+            }
+        }
+        assertTrue(
+            offenders.isEmpty(),
+            "hardcoded colours in converted chrome - use a BossUiTheme token, or add the " +
+                "value to this test's allowlist WITH the reason it must stay literal:\n" +
+                offenders.joinToString("\n"),
+        )
+    }
+
+    /**
+     * Every converted file must actually read a token.
+     *
+     * The scan above passes vacuously on a file that has no colours at all, which is
+     * also what a botched merge that deleted the styling would look like.
+     */
+    @Test
+    fun `every converted file reads a theme token`() {
+        val silent = converted.filterNot { rel ->
+            val text = sourceFile(rel).readText()
+            "BossUiTheme" in text || "SettingsTheme" in text ||
+                // TabBar collects the active terminal theme directly, which is the
+                // same subscription by a different route.
+                "ThemeManager.instance.currentTheme" in text
+        }
+        assertEquals(emptyList(), silent, "converted chrome that reads no theme token at all")
+    }
+
+    /**
+     * The allowlist may not name a file that is not being scanned, or a literal that
+     * is no longer in it.
+     *
+     * Without this, deleting the traffic lights or the scrim would leave an entry that
+     * quietly excuses that value if it ever came back somewhere else in the file.
+     */
+    @Test
+    fun `the allowlist has no stale entries`() {
+        val stale = mutableListOf<String>()
+        for ((rel, literals) in allowed) {
+            if (rel !in converted) {
+                stale += "$rel is allowlisted but not scanned"
+                continue
+            }
+            val text = sourceFile(rel).readText()
+            for (literal in literals) {
+                if (literal !in text) stale += "$rel no longer contains $literal"
+            }
+        }
+        assertEquals(emptyList(), stale, "stale allowlist entries")
+    }
+
+    private fun sourceFile(rel: String): File {
+        val file = File(desktopMain, rel)
+        // A path typo would otherwise scan nothing and pass - the same vacuous-green
+        // failure SubmitCharacterCoverageTest's repoRoot note warns about.
+        assertTrue(file.isFile, "not found: $file")
+        return file
+    }
+
+    private companion object {
+        /**
+         * Injected by the build (`bossterm.repoRoot`), falling back to sniffing upward
+         * for `settings.gradle.kts` so the class also works outside Gradle. Same
+         * resolution as `SubmitCharacterCoverageTest`.
+         */
+        val repoRoot: File = System.getProperty("bossterm.repoRoot")?.let(::File)
+            ?: generateSequence(File(".").absoluteFile) { it.parentFile }
+                .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error(
+                "repo root not found: pass -Dbossterm.repoRoot, or run from inside the repo " +
+                    "(cwd was ${File(".").absolutePath})"
+            )
+
+        val desktopMain: File =
+            File(repoRoot, "compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose")
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ChromeTokenCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ChromeTokenCoverageTest.kt
@@ -88,8 +88,27 @@ class ChromeTokenCoverageTest {
         "splits/SplitContainer.kt" to listOf("0xFF4A90E2"),
     )
 
-    /** `Color(0xAARRGGBB)` / `Color(0xRRGGBB)`, plus the two named extremes. */
-    private val literalPattern = Regex("""Color\((0x[0-9A-Fa-f_]{6,11})\)|Color\.(White|Black)""")
+    /**
+     * `Color(0x…)`, `Color(r, g, b…)`, and any named `Color.Foo`.
+     *
+     * The named branch is a negated set rather than a list of the ones seen so far:
+     * an earlier version matched only `White` and `Black`, so `Color.Red`,
+     * `Color.Gray` and `Color.Cyan` would all have walked straight through the guard
+     * that exists to stop exactly them. `Transparent` and `Unspecified` are excluded
+     * because they carry no colour - both are legitimately used here for an unfilled
+     * row background.
+     *
+     * The component constructor is included for the same reason: `Color(0.1f, 0.2f,
+     * 0.3f)` is as hardcoded as any hex, and the hex-only pattern could not see it.
+     *
+     * Still out of reach: a literal split across lines, and a colour arriving through
+     * a parameter. Named so the limit is known rather than assumed.
+     */
+    private val literalPattern = Regex(
+        """Color\((0x[0-9A-Fa-f_]{6,11})\)""" +
+            """|Color\(\s*(?:red\s*=|[0-9.]+f\s*[,)])""" +
+            """|Color\.(?!Transparent\b|Unspecified\b)([A-Z]\w+)""",
+    )
 
     @Test
     fun `converted chrome holds no colour literals outside the allowlist`() {
@@ -98,10 +117,10 @@ class ChromeTokenCoverageTest {
             val file = sourceFile(rel)
             val ok = allowed[rel].orEmpty()
             file.readLines().forEachIndexed { index, line ->
-                // Comments quote literals when explaining why a token replaced one.
-                if (line.trimStart().startsWith("//")) return@forEachIndexed
-                for (match in literalPattern.findAll(line)) {
-                    val literal = match.groupValues[1].ifEmpty { "Color.${match.groupValues[2]}" }
+                for (match in literalPattern.findAll(codeOf(line))) {
+                    val literal = match.groupValues.drop(1).firstOrNull { it.isNotEmpty() }
+                        ?.let { if (it.startsWith("0x")) it else "Color.$it" }
+                        ?: "Color(components)"
                     if (literal !in ok) {
                         offenders += "$rel:${index + 1}  $literal   (${line.trim().take(80)})"
                     }
@@ -114,6 +133,51 @@ class ChromeTokenCoverageTest {
                 "value to this test's allowlist WITH the reason it must stay literal:\n" +
                 offenders.joinToString("\n"),
         )
+    }
+
+    /**
+     * The detector's own unit test.
+     *
+     * This regex is what holds the line for 13 files, so its reach is worth pinning
+     * directly rather than inferring from "the tree is clean". An earlier version
+     * matched only `Color.White` and `Color.Black`, so every other named colour walked
+     * through it, and the comment skip was start-of-line only, so a KDoc line quoting a
+     * literal would have failed the build pointing at prose.
+     *
+     * Both halves are exercised here because they compose: `codeOf` decides what the
+     * pattern even sees.
+     */
+    @Test
+    fun `the literal detector catches hardcoded colours and ignores prose`() {
+        val shouldFlag = listOf(
+            "            .background(Color(0xFF404040))",
+            "    private val X = Color(0x88000000)",
+            "        val c = Color.Red",
+            "        val c = Color.Gray",
+            "        val c = Color.Cyan",
+            "        val c = Color(0.1f, 0.2f, 0.3f)",
+            "        val c = Color(red = 0.1f, green = 0.2f, blue = 0.3f)",
+            "        Text(\"x\", color = Color.White)",
+        )
+        val shouldIgnore = listOf(
+            // Carry no colour, and both are used for an unfilled row background.
+            "        val c = Color.Transparent",
+            "        val c = Color.Unspecified",
+            // Prose, in each of the three shapes these files actually use.
+            "        // was Color(0xFF404040) before the sweep",
+            "     * Replaced Color(0xFF2D2D2D) with the line2 token.",
+            "        /* Color.White here was 1.07:1 on paper */",
+            "            .background(BossUiTheme.current.line2) // was Color(0xFF2D2D2D)",
+            // Tokens, which is the whole point.
+            "            .background(BossUiTheme.current.panel.copy(alpha = 0.90f))",
+            "        cursorBrush = SolidColor(BossUiTheme.current.chalk),",
+        )
+
+        val missed = shouldFlag.filter { !literalPattern.containsMatchIn(codeOf(it)) }
+        assertEquals(emptyList(), missed, "hardcoded colours the detector does not see")
+
+        val falsePositives = shouldIgnore.filter { literalPattern.containsMatchIn(codeOf(it)) }
+        assertEquals(emptyList(), falsePositives, "lines the detector flags but should not")
     }
 
     /**
@@ -155,6 +219,27 @@ class ChromeTokenCoverageTest {
             }
         }
         assertEquals(emptyList(), stale, "stale allowlist entries")
+    }
+
+    /**
+     * The code part of a line, with comments removed.
+     *
+     * These files explain in prose why a token replaced a literal, and several of
+     * those explanations quote the literal. Matching the whole line would fail the
+     * build with a message pointing at a comment - and the previous
+     * `trimStart().startsWith("//")` check only covered a comment that owns its whole
+     * line, so a KDoc `*` line or a trailing `// was Color(0xFF404040)` still counted.
+     * Nothing in the tree trips that today, which is exactly why it would have been a
+     * surprise later.
+     *
+     * Deliberately naive about `//` inside a string literal: no colour literal in
+     * these files lives inside a string, and a cheap over-strip only ever loses
+     * coverage on a line that has none.
+     */
+    private fun codeOf(line: String): String {
+        val trimmed = line.trimStart()
+        if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) return ""
+        return line.substringBefore("//")
     }
 
     private fun sourceFile(rel: String): File {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/LightThemeContrastTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/LightThemeContrastTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose.theme
 
+import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.settings.theme.BuiltinThemes
 import ai.rever.bossterm.compose.settings.theme.Theme
 import ai.rever.bossterm.compose.util.ColorUtils
@@ -31,6 +32,16 @@ import kotlin.test.assertTrue
  *  3. **The cursor is an opaque block, so it is measured against the FLOOR.** This is
  *     what forces `boss-daylight` to give its cursor and its ANSI 3 the darker amber
  *     #95580A instead of the identity's #D9871A, which is 2.6:1 on paper.
+ *  4. **The authored palette must BE the shipped palette.** `TerminalCanvasRenderer`
+ *     runs every glyph colour through [ColorUtils.legibleOnLightBackground], and
+ *     indexed colours resolve from the palette before that call, so any slot below
+ *     `TerminalSettings.lightBackgroundMinContrast` is rewritten at paint time. In the
+ *     first draft that quietly undid rule 1's whole argument: ANSI 8 `#7E8797` became
+ *     `#687181`, one green-channel step from ANSI 7's `#687081`, so the dim slot the
+ *     KDoc reasons out so carefully collapsed into the slot it is supposed to be
+ *     dimmer than. Asserting the raw values would have passed. The floors below are
+ *     therefore the SETTING, not a restated 4.5, and one test asserts the guard is a
+ *     no-op for every slot.
  *
  * Scoped to the BOSS light themes on purpose. `solarized-light` is a faithful port of
  * a published palette that deliberately inverts (its `brightBlack` IS its background,
@@ -43,6 +54,15 @@ class LightThemeContrastTest {
 
     /** UI-component floor: fills, block cursors, hairlines. WCAG 1.4.11. */
     private val uiFloor = 3.0f
+
+    /**
+     * The floor an ANSI slot has to clear to survive the render guard untouched.
+     *
+     * Read from the setting rather than restated, so the palettes track the guard if
+     * its default ever moves. See rule 4 above: below this, the shipped colour is not
+     * the authored one.
+     */
+    private val guardFloor = TerminalSettings().lightBackgroundMinContrast
 
     /** Text floor for anything painted as a glyph. WCAG 1.4.3 AA. */
     private val textFloor = 4.5f
@@ -125,7 +145,7 @@ class LightThemeContrastTest {
     }
 
     @Test
-    fun `every ANSI slot clears the UI floor on paper`() {
+    fun `every ANSI slot clears the render guard's floor on paper`() {
         for (t in lightIdentities) {
             val bg = t.backgroundColorValue
             for (i in 0..15) {
@@ -133,9 +153,41 @@ class LightThemeContrastTest {
                     t,
                     "ANSI $i (${Theme.ANSI_COLOR_NAMES[i]})",
                     ratio(t.getAnsiColor(i), bg),
-                    uiFloor,
+                    guardFloor,
                 )
             }
+        }
+    }
+
+    /**
+     * The teeth behind rule 4, and the assertion the first draft needed.
+     *
+     * Stated as "the guard changes nothing" rather than as a contrast number, because
+     * that is the actual property: whatever the guard would do to a slot, the user
+     * sees, and the only way the authored palette is the shipped palette is if the
+     * guard is a no-op on all sixteen.
+     */
+    @Test
+    fun `the render guard leaves every authored slot untouched`() {
+        for (t in lightIdentities) {
+            val bg = t.backgroundColorValue
+            for (i in 0..15) {
+                val raw = t.getAnsiColor(i)
+                val painted = ColorUtils.legibleOnLightBackground(raw, bg, guardFloor)
+                assertEquals(
+                    raw,
+                    painted,
+                    "${t.id}: ANSI $i (${Theme.ANSI_COLOR_NAMES[i]}) is rewritten at paint " +
+                        "time, so the authored value is not what ships - darken the slot until " +
+                        "it clears $guardFloor:1 on ${t.background}",
+                )
+            }
+            // The same for the plain foreground, which is painted through the guard too.
+            assertEquals(
+                t.foregroundColor,
+                ColorUtils.legibleOnLightBackground(t.foregroundColor, bg, guardFloor),
+                "${t.id}: foreground is rewritten at paint time",
+            )
         }
     }
 
@@ -145,17 +197,27 @@ class LightThemeContrastTest {
             for (i in 9..15) {
                 val base = t.getAnsiColor(i - 8)
                 val bright = t.getAnsiColor(i)
+                // Strictly darker: `<=` would admit bright == base, which erases the
+                // bold distinction just as thoroughly as inverting it, and is the same
+                // collapsed-rung failure the UiTheme ladder test guards against.
                 assertTrue(
-                    bright.luminance() <= base.luminance(),
-                    "${t.id}: ANSI $i (${Theme.ANSI_COLOR_NAMES[i]}) is LIGHTER than ANSI ${i - 8} " +
-                        "(${Theme.ANSI_COLOR_NAMES[i - 8]}) - on paper that makes bold text fade out",
+                    bright.luminance() < base.luminance(),
+                    "${t.id}: ANSI $i (${Theme.ANSI_COLOR_NAMES[i]}) is not darker than ANSI " +
+                        "${i - 8} (${Theme.ANSI_COLOR_NAMES[i - 8]}) - on paper that makes bold " +
+                        "text fade out",
                 )
             }
             // ANSI 8's exemption comes with its own obligation: it must still be the
-            // dimmer of the two greys, or the palette has no dim slot at all.
+            // dimmer of the two greys, or the palette has no dim slot at all. Held to a
+            // real margin rather than mere inequality - the first draft satisfied `>` by
+            // 0.002 luminance once the guard had finished with it, which is a dim slot
+            // on paper only.
+            val dim = t.getAnsiColor(8).luminance()
+            val normal = t.getAnsiColor(7).luminance()
             assertTrue(
-                t.getAnsiColor(8).luminance() > t.getAnsiColor(7).luminance(),
-                "${t.id}: ANSI 8 must be dimmer than ANSI 7 to serve as the dim slot",
+                dim > normal * 1.5f,
+                "${t.id}: ANSI 8 (lum $dim) must be visibly dimmer than ANSI 7 (lum $normal) " +
+                    "to serve as the dim slot, not merely a shade off it",
             )
         }
     }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/LightThemeContrastTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/LightThemeContrastTest.kt
@@ -1,0 +1,196 @@
+package ai.rever.bossterm.compose.theme
+
+import ai.rever.bossterm.compose.settings.theme.BuiltinThemes
+import ai.rever.bossterm.compose.settings.theme.Theme
+import ai.rever.bossterm.compose.util.ColorUtils
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The light-palette guard for the BOSS light identities.
+ *
+ * A light terminal palette is not a dark one with the floor swapped, and the three
+ * rules it has to follow are all counter-intuitive enough that each was violated in
+ * the first draft of these two themes. This test is what turned them from comments
+ * into constraints:
+ *
+ *  1. **Every `bright*` slot must be DARKER than its base.** Bold text renders in
+ *     ANSI 8-15. On a dark theme "bright" means lighter; brighten those on paper and
+ *     every bold line goes pale and disappears. ANSI 8 is the single exemption, and
+ *     it is a structural one rather than an excuse: 8 is the dim companion of ANSI 0,
+ *     and on paper ANSI 0 is the ink, so 8 has nowhere to go but lighter. It is still
+ *     held to the UI floor, and still required to be dimmer than ANSI 7.
+ *  2. **No ANSI slot may sit near the floor.** This is the bug fixed in
+ *     `terminal-tab` PR #72 from the other end: a near-white ANSI 7 is 1.27:1 on
+ *     paper. Nothing downstream can rescue it, because
+ *     [ColorUtils.legibleOnLightBackground] guards colours a CLI hardcodes - when the
+ *     PALETTE is the source of the bad colour, the palette is the only place to fix it.
+ *  3. **The cursor is an opaque block, so it is measured against the FLOOR.** This is
+ *     what forces `boss-daylight` to give its cursor and its ANSI 3 the darker amber
+ *     #95580A instead of the identity's #D9871A, which is 2.6:1 on paper.
+ *
+ * Scoped to the BOSS light themes on purpose. `solarized-light` is a faithful port of
+ * a published palette that deliberately inverts (its `brightBlack` IS its background,
+ * because Solarized uses ANSI 8 as an alternate surface); restyling someone else's
+ * palette to pass our floors would misrepresent it. It is named as an exemption below
+ * rather than skipped silently, and the exemption is itself asserted so it cannot go
+ * stale.
+ */
+class LightThemeContrastTest {
+
+    /** UI-component floor: fills, block cursors, hairlines. WCAG 1.4.11. */
+    private val uiFloor = 3.0f
+
+    /** Text floor for anything painted as a glyph. WCAG 1.4.3 AA. */
+    private val textFloor = 4.5f
+
+    /**
+     * A wash (selection, search highlight) is a fill behind text, so it has no text
+     * floor of its own - but it does have to be *seen*. 1.25:1 is a deliberate step
+     * up from the reference point in this repo: Solarized Light's selection wash is
+     * 1.14:1 against its own background, and the host's `signalWash` composited onto
+     * paper is 1.06:1, because that value was authored to sit behind a 2.dp indicator
+     * on a selected sidebar row. A terminal selection has no indicator, so the fill
+     * carries the whole signal by itself.
+     */
+    private val washFloor = 1.25f
+
+    private val lightIdentities = listOf(
+        BuiltinThemes.BOSS_BLUEPRINT_LIGHT,
+        BuiltinThemes.BOSS_DAYLIGHT,
+    )
+
+    private fun ratio(a: Color, b: Color) = ColorUtils.contrastRatio(a, b)
+
+    @Test
+    fun `the BOSS light identities really are light`() {
+        // Precondition for everything below. If a floor were darkened past the pivot,
+        // every other assertion here would still pass while testing the wrong thing.
+        for (t in lightIdentities) {
+            assertTrue(
+                ColorUtils.isLightBackground(t.backgroundColorValue),
+                "${t.id}: background ${t.background} is not above the light pivot, so the " +
+                    "render-time guard would not engage for it either",
+            )
+        }
+    }
+
+    @Test
+    fun `text slots clear the text floor on the floor they are painted on`() {
+        for (t in lightIdentities) {
+            val bg = t.backgroundColorValue
+            assertFloor(t, "foreground", ratio(t.foregroundColor, bg), textFloor)
+            // A hyperlink is text, which is why boss-daylight cannot use the host's
+            // `data` #1E7FA8 verbatim: 4.20:1 clears the UI floor but not this one.
+            assertFloor(t, "hyperlink", ratio(t.hyperlinkColor, bg), textFloor)
+        }
+    }
+
+    @Test
+    fun `the block cursor is legible against the floor and carries its own glyph`() {
+        for (t in lightIdentities) {
+            // Against the FLOOR, not against the text: an opaque block covers the cell.
+            assertFloor(t, "cursor on background", ratio(t.cursorColor, t.backgroundColorValue), uiFloor)
+            // And the character it covers is repainted in cursorText, so that pair is
+            // a real glyph-on-fill and takes the text floor.
+            assertFloor(t, "cursorText on cursor", ratio(t.cursorTextColor, t.cursorColor), textFloor)
+        }
+    }
+
+    @Test
+    fun `washes are visible without swallowing the text on top of them`() {
+        for (t in lightIdentities) {
+            val bg = t.backgroundColorValue
+            for ((name, wash) in listOf(
+                "selection" to t.selectionColor,
+                "searchMatch" to t.searchMatchColor,
+            )) {
+                assertFloor(t, "$name vs background", ratio(wash, bg), washFloor)
+                assertFloor(t, "foreground on $name", ratio(t.foregroundColor, wash), textFloor)
+            }
+            // selectionText is the pair the theme editor advertises for a selection,
+            // even though the renderer does not read it yet (see ThemeDefaultsTest's
+            // dead-slot list). Authoring it wrong now means shipping the bug the day
+            // it gets wired.
+            assertFloor(
+                t,
+                "selectionText on selection",
+                ratio(t.selectionTextColor, t.selectionColor),
+                textFloor,
+            )
+        }
+    }
+
+    @Test
+    fun `every ANSI slot clears the UI floor on paper`() {
+        for (t in lightIdentities) {
+            val bg = t.backgroundColorValue
+            for (i in 0..15) {
+                assertFloor(
+                    t,
+                    "ANSI $i (${Theme.ANSI_COLOR_NAMES[i]})",
+                    ratio(t.getAnsiColor(i), bg),
+                    uiFloor,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `bright ANSI slots are darker than their base, except the dim slot`() {
+        for (t in lightIdentities) {
+            for (i in 9..15) {
+                val base = t.getAnsiColor(i - 8)
+                val bright = t.getAnsiColor(i)
+                assertTrue(
+                    bright.luminance() <= base.luminance(),
+                    "${t.id}: ANSI $i (${Theme.ANSI_COLOR_NAMES[i]}) is LIGHTER than ANSI ${i - 8} " +
+                        "(${Theme.ANSI_COLOR_NAMES[i - 8]}) - on paper that makes bold text fade out",
+                )
+            }
+            // ANSI 8's exemption comes with its own obligation: it must still be the
+            // dimmer of the two greys, or the palette has no dim slot at all.
+            assertTrue(
+                t.getAnsiColor(8).luminance() > t.getAnsiColor(7).luminance(),
+                "${t.id}: ANSI 8 must be dimmer than ANSI 7 to serve as the dim slot",
+            )
+        }
+    }
+
+    /**
+     * The exemption list cannot quietly grow, and cannot go stale either.
+     *
+     * Written as "which builtin light themes fail" rather than "solarized-light is
+     * exempt" so that adding a third light identity and forgetting this file fails
+     * here, instead of the new theme joining an unexamined exemption.
+     */
+    @Test
+    fun `solarized-light is the only light builtin below these floors`() {
+        val failing = BuiltinThemes.ALL
+            .filter { ColorUtils.isLightBackground(it.backgroundColorValue) }
+            .filter { t ->
+                val bg = t.backgroundColorValue
+                ratio(t.foregroundColor, bg) < textFloor ||
+                    (0..15).any { ratio(t.getAnsiColor(it), bg) < uiFloor }
+            }
+            .map { it.id }
+            .toSet()
+        assertEquals(
+            setOf("solarized-light"),
+            failing,
+            "light-palette exemptions changed: fix the theme, or record why it is a " +
+                "faithful port that must keep its published values",
+        )
+    }
+
+    private fun assertFloor(theme: Theme, what: String, actual: Float, floor: Float) {
+        assertTrue(
+            actual >= floor,
+            "${theme.id}: $what is ${"%.2f".format(actual)}:1, below the " +
+                "${"%.2f".format(floor)}:1 floor",
+        )
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ThemeDefaultsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ThemeDefaultsTest.kt
@@ -16,7 +16,8 @@ import kotlin.test.assertNotNull
  *     that would otherwise silently fall back at runtime), and PRODUCT_DEFAULT is
  *     the theme it names.
  *  2. Each BOSS palette's ANSI 16 stays identical to its theme's, so the
- *     "derive the palette from the theme" wiring can never drift.
+ *     "derive the palette from the theme" wiring can never drift - and every BOSS
+ *     theme HAS a palette, which the per-pair tests alone cannot promise.
  *  3. TerminalSettings' fresh-install colors equal the default theme's.
  */
 class ThemeDefaultsTest {
@@ -52,6 +53,49 @@ class ThemeDefaultsTest {
     @Test
     fun `boss-operator palette ANSI matches the theme`() {
         assertAnsiMatches(BuiltinThemes.BOSS_OPERATOR, BuiltinColorPalettes.BOSS_OPERATOR)
+    }
+
+    @Test
+    fun `boss-blueprint-light palette ANSI matches the theme`() {
+        assertAnsiMatches(
+            BuiltinThemes.BOSS_BLUEPRINT_LIGHT,
+            BuiltinColorPalettes.BOSS_BLUEPRINT_LIGHT,
+        )
+    }
+
+    @Test
+    fun `boss-daylight palette ANSI matches the theme`() {
+        assertAnsiMatches(BuiltinThemes.BOSS_DAYLIGHT, BuiltinColorPalettes.BOSS_DAYLIGHT)
+    }
+
+    /**
+     * Every BOSS theme needs a same-id palette, and vice versa.
+     *
+     * The per-theme tests above only check the pairs someone remembered to name. A
+     * new identity whose palette was never added to [BuiltinColorPalettes.ALL] still
+     * passes all of them, and the failure is invisible in the picker: selecting the
+     * theme recolors the terminal, but the Palette tab has no matching entry, so
+     * `ColorPaletteManager` keeps whatever palette was active and the ANSI 16 quietly
+     * stay from the previous theme.
+     */
+    @Test
+    fun `every BOSS theme has a palette with the same id`() {
+        val bossThemes = BuiltinThemes.ALL.filter { it.id.startsWith("boss-") }.map { it.id }.toSet()
+        val bossPalettes =
+            BuiltinColorPalettes.ALL.filter { it.id.startsWith("boss-") }.map { it.id }.toSet()
+        assertEquals(
+            bossThemes,
+            bossPalettes,
+            "BOSS themes and BOSS palettes must correspond one-to-one",
+        )
+        // And each pair must really carry the same ANSI 16, not just the same id.
+        for (id in bossThemes) {
+            val theme = BuiltinThemes.getById(id)
+            assertNotNull(theme, "no builtin theme for id '$id'")
+            val palette = BuiltinColorPalettes.getById(id)
+            assertNotNull(palette, "no builtin palette for id '$id'")
+            assertAnsiMatches(theme, palette)
+        }
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/UiThemeTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/UiThemeTest.kt
@@ -8,16 +8,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 /**
  * Locks the terminal-theme → UI-chrome bridge:
- *  1. BOTH BOSS identities map to their exact design-system tokens, not a lerp
- *     approximation. Two tests, because [UiTheme.EXACT_TOKENS] is keyed by theme
- *     id: when the default moved from boss-operator to boss-blueprint, keying off
- *     `DEFAULT_THEME_ID` would have silently dropped boss-operator into the
- *     derivation path.
+ *  1. ALL FOUR BOSS identities - the two dark and the two light - map to their
+ *     exact design-system tokens, not a lerp approximation. One test each plus a
+ *     sweep, because `UiTheme.EXACT_TOKENS` is keyed by theme id: when the default
+ *     moved from boss-operator to boss-blueprint, keying off `DEFAULT_THEME_ID`
+ *     would have silently dropped boss-operator into the derivation path, and a
+ *     mistyped key does the same thing to a light identity today.
  *  2. Derivation for arbitrary themes yields a readable surface ladder and a
  *     signal distinct from the floor (including light themes).
  *  3. SettingsTheme stays wired to BossUiTheme, and BossUiTheme's own seed is the
@@ -76,21 +78,41 @@ class UiThemeTest {
         assertTrue(ui.isDark)
     }
 
+    /**
+     * Asserts the ladder is STRICTLY MONOTONIC, not that it runs in a particular
+     * direction.
+     *
+     * The previous version required light themes to step *darker* than their floor.
+     * That was true of every theme it ever saw, because it was really asserting a
+     * property of [UiTheme.fromTheme]'s derivation (`mix(bg, fg, t)` moves toward
+     * the text, which on paper means darker) rather than a property of a good
+     * surface ladder. The hand-authored light identities elevate the way light
+     * design systems actually do - paper floor, white cards above it - and the old
+     * assertion called that a bug.
+     *
+     * Direction is the theme author's call; collapse is the bug. A collapsed rung
+     * is what erases every settings row, since `raised` is
+     * `SettingsTheme.SurfaceColor` and those rows have no border of their own.
+     */
     @Test
     fun `derived themes keep a readable surface ladder`() {
         for (theme in BuiltinThemes.ALL) {
             val ui = UiTheme.fromTheme(theme)
             val inkLum = ui.ink.luminance()
             val panelLum = ui.panel.luminance()
-            val chalkLum = ui.chalk.luminance()
-            // Surfaces step from the floor toward the text color.
-            if (chalkLum > inkLum) {
-                assertTrue(panelLum > inkLum, "${theme.id}: panel should be lighter than ink")
-                assertTrue(ui.raised.luminance() > panelLum, "${theme.id}: raised should be lighter than panel")
-            } else {
-                assertTrue(panelLum < inkLum, "${theme.id}: panel should be darker than ink (light theme)")
-                assertTrue(ui.raised.luminance() < panelLum, "${theme.id}: raised should be darker than panel (light theme)")
-            }
+            val raisedLum = ui.raised.luminance()
+            // Whichever way this theme's ladder runs, every rung must continue it.
+            assertNotEquals(
+                inkLum,
+                panelLum,
+                "${theme.id}: panel is indistinguishable from ink - the ladder collapsed",
+            )
+            val climbs = panelLum > inkLum
+            assertTrue(
+                if (climbs) raisedLum > panelLum else raisedLum < panelLum,
+                "${theme.id}: ink -> panel ${if (climbs) "climbs" else "descends"} but " +
+                    "panel -> raised does not follow (ink $inkLum, panel $panelLum, raised $raisedLum)",
+            )
             // The signal must never dissolve into the floor or the text color.
             assertNotEquals(ui.ink, ui.signal, "${theme.id}: signal must differ from ink")
             assertNotEquals(ui.chalk, ui.signal, "${theme.id}: signal must differ from chalk")
@@ -112,6 +134,116 @@ class UiThemeTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun `boss-blueprint-light maps to exact tokens and mirrors the host`() {
+        val ui = UiTheme.fromTheme(BuiltinThemes.BOSS_BLUEPRINT_LIGHT)
+        val t = BuiltinThemes.BOSS_BLUEPRINT_LIGHT
+        assertEquals(t.backgroundColorValue, ui.ink, "chrome floor must be the terminal floor")
+
+        // Values shared with the host's BossBlueprintLightColorScheme. plugin-ui-core
+        // has no dependency edge to here, so hand-transcription is the only link and
+        // this is where it breaks loudly.
+        assertEquals(Color(0xFFF5F7FB), ui.ink, "host ink / site --paper")
+        assertEquals(Color(0xFFDCE2EB), ui.line, "host line")
+        assertEquals(Color(0xFFA8B2C2), ui.line2, "host lineStrong")
+        assertEquals(Color(0xFF05070B), ui.chalk, "host textPrimary")
+        assertEquals(Color(0xFF687081), ui.mist, "host textSecondary")
+        assertEquals(Color(0xFF9AA3B2), ui.muted, "host textMuted")
+        assertEquals(Color(0xFF0F5BFF), ui.signal, "host signal / --blue")
+        assertEquals(Color(0xFF0A45C4), ui.signalDim, "host signalDim")
+        assertEquals(Color(0xFFDCE7FF), ui.signalWash, "host signalWash / --blue-soft")
+        assertEquals(Color(0xFF0F5BFF), ui.signalText, "--blue clears 4.9:1 on paper, so no separate glyph blue")
+        assertEquals(Color(0xFFFFFFFF), ui.onSignal, "host onSignal")
+        assertEquals(Color(0xFF0C3FBF), ui.data, "host data")
+        assertEquals(Color(0xFF1E9E63), ui.ok, "host ok")
+        assertEquals(Color(0xFFA8710A), ui.warn, "host warn")
+        assertEquals(Color(0xFFD33B4A), ui.alert, "host alert")
+
+        // The one deliberate divergence, asserted so it stays deliberate: the host
+        // uses pure white for BOTH panel and raised. `raised` is the settings ROW
+        // background and `panel` the window behind it, and those rows draw no border,
+        // so copying the host would erase every row on a light theme.
+        assertEquals(Color(0xFFFAFBFD), ui.panel, "the near-white rung the host omits")
+        assertEquals(Color(0xFFFFFFFF), ui.raised, "host panel / raised")
+        assertNotEquals(ui.panel, ui.raised, "the rung that makes settings rows visible")
+
+        assertFalse(ui.isDark, "paper floor must read as a light theme")
+    }
+
+    @Test
+    fun `boss-daylight maps to exact tokens and mirrors the host`() {
+        val ui = UiTheme.fromTheme(BuiltinThemes.BOSS_DAYLIGHT)
+        val t = BuiltinThemes.BOSS_DAYLIGHT
+        assertEquals(t.backgroundColorValue, ui.ink, "chrome floor must be the terminal floor")
+
+        // Shared with the host's BossLightColorScheme.
+        assertEquals(Color(0xFFF5F7FA), ui.ink, "host ink")
+        assertEquals(Color(0xFFE2E7EE), ui.line, "host line")
+        assertEquals(Color(0xFFC9D2DC), ui.line2, "host lineStrong")
+        assertEquals(Color(0xFF131820), ui.chalk, "host textPrimary")
+        assertEquals(Color(0xFF5A6675), ui.mist, "host textSecondary")
+        assertEquals(Color(0xFF94A0AE), ui.muted, "host textMuted")
+        assertEquals(Color(0xFFD9871A), ui.signal, "host signal - the amber FILL")
+        assertEquals(Color(0xFFB36F12), ui.signalDim, "host signalDim")
+        assertEquals(Color(0xFFFBEFD8), ui.signalWash, "host signalWash")
+        assertEquals(Color(0xFF2A1B05), ui.onSignal, "host onSignal")
+        assertEquals(Color(0xFF1E7FA8), ui.data, "host data")
+        assertEquals(Color(0xFF2F9E54), ui.ok, "host ok")
+        assertEquals(Color(0xFFB87D0A), ui.warn, "host warn")
+        assertEquals(Color(0xFFD2453B), ui.alert, "host alert")
+
+        assertEquals(Color(0xFFFAFBFC), ui.panel, "the near-white rung the host omits")
+        assertEquals(Color(0xFFFFFFFF), ui.raised, "host panel / raised")
+        assertNotEquals(ui.panel, ui.raised, "the rung that makes settings rows visible")
+
+        // The split that defines this identity on paper: the amber that works as a
+        // FILL is unreadable as a GLYPH, so signalText is a much darker amber. This
+        // is also why the terminal theme's cursor and ANSI 3 take the darker value
+        // (see LightThemeContrastTest).
+        assertEquals(Color(0xFF95580A), ui.signalText, "host signalText")
+        assertNotEquals(ui.signal, ui.signalText, "#D9871A is 2.6:1 on this floor")
+        assertTrue(
+            contrastRatio(ui.signal, ui.ink) < 4.5f,
+            "precondition for the split: the amber signal is below the text floor here",
+        )
+        assertTrue(
+            contrastRatio(ui.signalText, ui.ink) >= 4.5f,
+            "the darker amber is what clears it",
+        )
+
+        assertFalse(ui.isDark, "paper floor must read as a light theme")
+    }
+
+    /**
+     * All four hand-authored identities must actually be reached by
+     * [UiTheme.fromTheme]. `EXACT_TOKENS` is private and keyed by theme id, so a
+     * typo in a key is invisible: the theme silently falls through to derivation and
+     * produces plausible-looking values that are not the design-system ones.
+     */
+    @Test
+    fun `every BOSS identity is wired into the exact-token map`() {
+        val authored = mapOf(
+            BuiltinThemes.BOSS_BLUEPRINT to UiTheme.BOSS_BLUEPRINT,
+            BuiltinThemes.BOSS_BLUEPRINT_LIGHT to UiTheme.BOSS_BLUEPRINT_LIGHT,
+            BuiltinThemes.BOSS_OPERATOR to UiTheme.BOSS_OPERATOR,
+            BuiltinThemes.BOSS_DAYLIGHT to UiTheme.BOSS_DAYLIGHT,
+        )
+        for ((theme, tokens) in authored) {
+            assertEquals(
+                tokens,
+                UiTheme.fromTheme(theme),
+                "${theme.id} fell through to derivation instead of its authored tokens",
+            )
+        }
+        // And each identity is a distinct set of tokens, so a copy-paste that pointed
+        // two ids at one UiTheme would fail here rather than ship a duplicate.
+        assertEquals(
+            authored.size,
+            authored.values.toSet().size,
+            "two BOSS identities resolve to the same tokens",
+        )
     }
 
     @Test


### PR DESCRIPTION
BossTerm shipped eleven terminal themes and both BOSS identities - `boss-blueprint` and `boss-operator` - were dark. BossConsole has two light themes, so a user running the host on Blueprint Light next to the standalone app got two different products.

Two commits: the identities, then the reason picking one would have looked broken.

## The chrome was hardwired dark

Settings, dialogs and wizards have followed the active theme through `SettingsTheme` -> `BossUiTheme` for a long time (31 files). The frame around the terminal never did: **16 files held ~185 colour literals and read no theme token at all.** Picking Solarized Light today already gives a light terminal inside a dark window, with `Color.White` text in the tab-rename field and in the search bar, on paper.

This converts the 13 always-visible and frequently-visible surfaces - tab bar, title bar, toasts, split divider and border, scrollbar block markers, search bar, command palette, history overlay, MCP indicator, status strip, update banner, call bar.

## Three decisions worth reviewing

**The host's `panel` and `raised` could not be copied.** Both are pure white there. In BossTerm `raised` *is* `SettingsTheme.SurfaceColor` - the background of every row and card inside the settings panel - and `panel` is the window behind them, and those rows carry no border of their own. White on white erases all of them. The light identities run paper -> near-white -> white instead, elevating the way a light design system actually does, with the step the host omits.

**That meant relaxing an existing test.** `UiThemeTest`'s ladder test required light themes to step *darker* than their floor. It was really asserting a property of `fromTheme`'s `mix(bg, fg, t)` derivation, not a property of a good surface ladder, and it called the hand-authored direction a bug. It now asserts strict monotonicity in whichever direction the theme declares: a collapsed rung is the bug, direction is the author's call.

**Amber cannot be the cursor on paper.** BOSS Daylight's cursor is `#95580A`, not the identity's `#D9871A`. The host's own note in `BossThemes.kt` records why - the amber signal is 2.6:1 on that floor, which is exactly why the host carries a separate `signalText`. A block cursor at 2.6:1 is a smear, so the cursor and ANSI 3 take the darker amber (5.3:1) while the chrome still fills with the signature.

## A light ANSI palette inverts three rules

All three were wrong in the first draft, and `LightThemeContrastTest` now enforces them:

- **Every `bright*` slot must be DARKER than its base.** Bold text is ANSI 8-15; brighten those on paper and every bold line fades out. ANSI 8 is the one exemption, structurally: it is the dim companion of ANSI 0, and on paper ANSI 0 is the ink.
- **ANSI 7 must not be near-white.** This is terminal-tab#72 from the other end. A near-white ANSI 7 is 1.27:1 on paper, and `ColorUtils.legibleOnLightBackground` cannot rescue it, because there the palette *is* the source of the bad colour.
- **The cursor is an opaque block, so it is measured against the floor**, not against the text.

## Two latent bugs the sweep turned up

Neither was being looked for.

`StatusStrip`, `HostCallBar`, `McpStatusIndicator`, `UpdateUI` and `TabBar`'s `RemoteAccent` held their colours in file-scope `private val`s. Those initialise once at class-init, so they could never follow a theme switch - not even between two dark themes. All are now `get() =`.

`TabBar` derived its active-chip surface with Compose's `Color` `lerp`, which interpolates in Oklab: a small step off a near-black floor rounds back to the floor, so on BOSS Blueprint (`#05070B`) the active chip had almost no surface at all.

## Deliberately left literal

Both allowlisted with the reason recorded in place:

- **The macOS traffic lights.** macOS paints the same red/yellow/green in both appearances, and a user finds the close button by colour before reading anything else. Theming them would make BossTerm the only app on the machine whose close button is not red.
- **Scrollbar thumb/track, search markers, split focus border.** These only look like chrome. They are `TerminalSettings` values the user owns; the literals are `@Composable` parameter defaults and every real call site passes the setting. Pointing them at a token would let the active theme silently override a colour set in Settings, which is worse than the bug being fixed. `ThemeDefaultsTest` already pins the search markers as theme-independent.

## Tests

1100/1100 green. 12 new assertions:

| test | covers |
| --- | --- |
| `LightThemeContrastTest` (7) | the three palette rules, text/UI/wash floors, and that `solarized-light` is the only light builtin below them, so the exemption cannot grow or go stale |
| `ChromeTokenCoverageTest` (3) | no literals outside the allowlist, every converted file really reads a token, no stale allowlist entries |
| `UiThemeTest` (+4) | exact tokens, the host mirror, and that all four BOSS identities are actually reached by `EXACT_TOKENS` - a mistyped key otherwise falls through to derivation silently |
| `ThemeDefaultsTest` (+3) | the two new palette pairs, plus a sweep that every BOSS theme *has* a palette |

**Every new assertion was verified by mutation**: reverting each value fails exactly the intended test, and nothing else.

`ChromeTokenCoverageTest` scans source for the same reason `SubmitCharacterCoverageTest` does - the failure is a literal in an argument list, with no seam to observe it through short of rendering each surface twice and reading pixels back. 185 literals accumulated across these files precisely because nothing failed when one more was added.

## What the tests cannot prove

**Surface separation on light.** A missing border is a layout fact, not a colour fact. Worth switching to BOSS Blueprint Light and opening the search bar, command palette, history overlay and a toast to confirm each still reads as a distinct surface.

## Known gaps, not addressed here

- The `scrollbarColor` default `0x40FFFFFF` (25% white) is invisible on paper. The thumb is still visible so the scrollbar works; fixing it properly means theme-aware settings defaults, which is a design decision rather than a token swap.
- `debug/DebugPanelComponents.kt` (27 literals) and `PreConnectScreen.kt` (20) stay dark - a dev-only panel and the SSH pre-connect screen. Named in `ChromeTokenCoverageTest` so the gap is recorded.
- On macOS the **native** title bar follows the new theme only after a restart: `apple.awt.application.appearance` is read once before AWT boots. Everything else restyles live.
- `terminal-tab`'s `HostTerminalThemeBridge` synthesises a light theme per host theme and could now select these builtins by host theme id instead, deleting its duplicated ANSI tables. Separate repo, separate release chain.
- **Settings overrides and the frame diverge.** `applyTheme` copies a theme's colours into `TerminalSettings`, while `BossUiTheme` derives from `ThemeManager.currentTheme` - so editing the background colour in Settings without changing the theme moves the terminal and leaves the whole frame put. Pre-existing, but the hardcoded-dark frame masked it for dark overrides; now picking `boss-blueprint-light` and overriding the background to black gives a paper frame around a black terminal. Same class as the `scrollbarColor` default above.
- **No contrast guard on the chrome tokens.** `LightThemeContrastTest` guards the terminal palette; nothing guards `UiTheme`. The mirror of it would have caught the fill-as-glyph uses fixed in the third commit. It is not in this PR because the measurements say it cannot pass without a sizeable exemption list on themes this PR does not touch: worst ratio over `ink`/`panel`/`raised`, `alert` is already **2.14** on gruvbox-dark, 2.43 on nord, 2.88 on solarized-dark, 2.99 on monokai and 3.07 on the default theme - below the 3:1 component floor as a *fill*, before any text question. That is pre-existing debt worth its own pass, not something to fold in here.

`DEFAULT_THEME_ID` is unchanged.

