### PR TITLE
fix(process): do not start a shell for a session that is already gone

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/PlatformServices.desktop.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/PlatformServices.desktop.kt
@@ -4,6 +4,9 @@ import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 
 /**
  * Desktop platform services implementation.
@@ -87,22 +90,63 @@ class DesktopFileSystemService : PlatformServices.FileSystemService {
     override fun getTempDirectory(): String = System.getProperty("java.io.tmpdir")
 }
 
-class DesktopProcessService : PlatformServices.ProcessService {
+/**
+ * @param startPty how a pty is actually started. Injectable for ONE reason: the failure this
+ *   class's error handling exists for is a `LinkageError` from a closed plugin classloader, and
+ *   there is no way to provoke one through the real `PtyProcessBuilder`. Without a seam here the
+ *   Throwable-vs-Exception distinction below is untestable, and an untested catch clause is how it
+ *   came to be `catch (e: Exception)` in the first place - which does not catch an Error.
+ */
+class DesktopProcessService(
+    private val startPty: (
+        command: Array<String>,
+        config: PlatformServices.ProcessService.ProcessConfig,
+        isWindows: Boolean,
+    ) -> com.pty4j.PtyProcess = { command, config, isWindows ->
+        com.pty4j.PtyProcessBuilder()
+            .setCommand(command)
+            .setEnvironment(config.environment)
+            .setDirectory(config.workingDirectory ?: System.getProperty("user.home"))
+            .setConsole(false) // Don't attach to parent console
+            .setWindowsAnsiColorEnabled(isWindows) // Enable ANSI colors on Windows
+            .setUseWinConPty(isWindows) // Use Windows ConPTY for better compatibility
+            .start()
+    },
+) : PlatformServices.ProcessService {
     override suspend fun spawnProcess(config: PlatformServices.ProcessService.ProcessConfig): PlatformServices.ProcessService.ProcessHandle? {
+        // Do not start a process for a session that has already been cancelled.
+        //
+        // Cancellation is cooperative and `PtyProcessBuilder.start()` is a blocking JNI chain with
+        // no suspension point, so a coroutine already inside it never notices. Session init does
+        // real work before this line - environment assembly, shell-integration injection - which is
+        // exactly the span during which a tab can be disposed. Checking here narrows the window
+        // from all of that to the gap between this line and the next.
+        //
+        // It matters because of where a late spawn ends up. When BossTerm runs inside the
+        // terminal-tab plugin, disposal is followed by the plugin's classloader being closed, and a
+        // spawn that arrives after it produced:
+        //
+        //   ClassNotFoundException: Plugin classloader for '...terminaltab' is UNLOADED; refusing
+        //   to resolve 'com.pty4j.util.PtyUtil' against the host classloader.
+        //
+        // from `PtyHelpers.<clinit>` - the first pty spawn in that classloader happening during its
+        // teardown.
+        currentCoroutineContext().ensureActive()
         return try {
             val command = arrayOf(config.command) + config.arguments.toTypedArray()
-            val isWindows = ShellCustomizationUtils.isWindows()
-            val pty = com.pty4j.PtyProcessBuilder()
-                .setCommand(command)
-                .setEnvironment(config.environment)
-                .setDirectory(config.workingDirectory ?: System.getProperty("user.home"))
-                .setConsole(false)  // Don't attach to parent console
-                .setWindowsAnsiColorEnabled(isWindows)  // Enable ANSI colors on Windows
-                .setUseWinConPty(isWindows)  // Use Windows ConPTY for better compatibility
-                .start()
-            PtyProcessHandle(pty)
-        } catch (e: Exception) {
-            e.printStackTrace()
+            PtyProcessHandle(startPty(command, config, ShellCustomizationUtils.isWindows()))
+        } catch (e: CancellationException) {
+            // Rethrown, not reported. `Exception` below would otherwise swallow it and turn a tab
+            // being disposed into a visible "Failed to spawn process" error on its way out.
+            throw e
+        } catch (t: Throwable) {
+            // Throwable, not Exception. A closed plugin classloader raises
+            // ExceptionInInitializerError / NoClassDefFoundError - which are Errors, so the old
+            // `catch (e: Exception)` did not catch them and the whole "returns null on failure"
+            // contract broke in precisely the case that produced the stack above. The caller's
+            // null branch already renders a connection error, which is the right outcome for a
+            // session that cannot start.
+            t.printStackTrace()
             null
         }
     }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ProcessSpawnTeardownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ProcessSpawnTeardownTest.kt
@@ -36,24 +36,23 @@ import kotlin.test.assertTrue
  * What is NOT claimed: this is a cooperative check, not a lock. A cancellation landing between the
  * check and the blocking call still gets through. It narrows the window from the whole of session
  * init to an instruction gap; it does not close it, and there is no test here pretending otherwise.
+ *
+ * Nor is it claimed that pty4j can bring up a pty on any given machine. Every test here either
+ * injects `startPty` or uses a command that is meant not to resolve, so the suite is hermetic and
+ * says nothing about the native layer. That is deliberate: the one test that did spawn a real shell
+ * could not pass on a windows-latest runner, and its failure carried no cause, because
+ * `spawnProcess` swallows the throwable and returns null by contract.
  */
 class ProcessSpawnTeardownTest {
     private val service = DesktopProcessService()
 
     /**
-     * A shell that actually exists on the host running the test.
+     * A shell name that means something on whatever host runs the test.
      *
-     * `/bin/sh` was hardcoded, which made `an active caller still gets a process` a
-     * Unix-only test: on Windows the path does not resolve, `spawnProcess` returns null
-     * exactly as `a command that cannot start resolves to null` asserts it should, and
-     * the assertion that a normal spawn succeeds failed. macOS and Linux passed, so the
-     * gap only showed up on the third runner.
-     *
-     * `getValidShell` is the resolver the app itself uses - `$SHELL`, then `/bin/bash`,
-     * then `/bin/sh` on Unix; `cmd.exe` on Windows. Asking for "cmd" rather than the
-     * default "powershell" keeps this cheap: the PowerShell branch shells out to check
-     * whether powershell.exe is installed, and this test only needs a process that
-     * starts and can be killed.
+     * No test in this class spawns it any more - the one that did is injected now - so this is
+     * about not carrying a Unix-only literal through a suite that runs on three platforms.
+     * `getValidShell` is the resolver the app itself uses: `$SHELL`, then `/bin/bash`, then
+     * `/bin/sh` on Unix, and `cmd.exe` on Windows.
      */
     private val shell = ShellCustomizationUtils.getValidShell("cmd")
 
@@ -127,14 +126,59 @@ class ProcessSpawnTeardownTest {
 
     @Test
     fun `an active caller still gets a process`() {
-        // The guard must not have made spawning impossible. This is the only test here that starts
-        // a real shell, and it kills it immediately.
-        val handle =
-            runBlocking {
-                service.spawnProcess(config(shell))
+        // The guard must not have made spawning impossible: an active context has to reach
+        // `startPty` and get a handle back.
+        //
+        // Injected rather than spawning a real shell. This test used to start `/bin/sh`, which made
+        // it Unix-only; pointing it at the platform's shell instead did not fix Windows either, and
+        // that is the tell - whether a windows-latest runner can bring up a pty at all is a
+        // property of the environment, not of the guard this PR adds. `spawnProcess` swallows the
+        // cause and returns null by design, so the failure could not even say why.
+        //
+        // Asserting on a real pty here was buying an end-to-end signal the suite could not keep:
+        // it never held on the third platform, and `a command that cannot start resolves to null`
+        // passes on Windows whether pty4j works or not, so nothing here was ever evidence that it
+        // does. What this test is FOR - that the cancellation check does not refuse a live caller -
+        // is fully covered by the seam.
+        var startPtyCalled = false
+        val spawning =
+            DesktopProcessService { _, _, _ ->
+                startPtyCalled = true
+                FakePtyProcess()
             }
+        val handle = runBlocking { spawning.spawnProcess(config(shell)) }
+        assertTrue(startPtyCalled, "the guard refused a caller whose context was still active")
         assertNotNull(handle, "a normal spawn was refused")
         runBlocking { handle.kill() }
+    }
+
+    /**
+     * The smallest thing `PtyProcessHandle` will accept.
+     *
+     * `PtyProcess` is abstract over two methods of its own; the rest comes from
+     * `java.lang.Process`, whose `isAlive`, `waitFor(timeout, unit)` and `destroyForcibly` are all
+     * defined in terms of the abstracts below - so an already-exited process needs nothing more
+     * than these, and `kill()` returns without waiting on anything.
+     */
+    private class FakePtyProcess : com.pty4j.PtyProcess() {
+        private val stdin = java.io.ByteArrayInputStream(ByteArray(0))
+        private val stdout = java.io.ByteArrayOutputStream()
+
+        override fun getInputStream(): java.io.InputStream = stdin
+
+        override fun getOutputStream(): java.io.OutputStream = stdout
+
+        override fun getErrorStream(): java.io.InputStream = java.io.ByteArrayInputStream(ByteArray(0))
+
+        override fun waitFor(): Int = 0
+
+        override fun exitValue(): Int = 0
+
+        override fun destroy() = Unit
+
+        override fun setWinSize(winSize: com.pty4j.WinSize) = Unit
+
+        override fun getWinSize(): com.pty4j.WinSize = com.pty4j.WinSize(80, 24)
     }
 
     @Test

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ProcessSpawnTeardownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ProcessSpawnTeardownTest.kt
@@ -1,0 +1,135 @@
+package ai.rever.bossterm.compose
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Not starting a shell for a session that is already going away.
+ *
+ * `PtyProcessBuilder.start()` is a blocking JNI chain with no suspension point, so cancellation
+ * cannot interrupt a coroutine already inside it. Session init does real work first - environment
+ * assembly, shell-integration injection - and that span is exactly when a tab can be disposed.
+ *
+ * Where a late spawn lands is what makes it matter. Inside the terminal-tab plugin, disposal is
+ * followed by the plugin's classloader closing, and a spawn arriving after that produced:
+ *
+ * ```
+ * ClassNotFoundException: Plugin classloader for '...terminaltab' is UNLOADED; refusing to
+ * resolve 'com.pty4j.util.PtyUtil' against the host classloader.
+ * ```
+ *
+ * from `PtyHelpers.<clinit>` - the first pty spawn in that classloader happening during its own
+ * teardown. Two properties are pinned here: the spawn is refused when the caller is cancelled, and
+ * a failure that arrives as an **Error** rather than an Exception still resolves to null instead of
+ * escaping.
+ *
+ * What is NOT claimed: this is a cooperative check, not a lock. A cancellation landing between the
+ * check and the blocking call still gets through. It narrows the window from the whole of session
+ * init to an instruction gap; it does not close it, and there is no test here pretending otherwise.
+ */
+class ProcessSpawnTeardownTest {
+    private val service = DesktopProcessService()
+
+    private fun config(command: String) =
+        PlatformServices.ProcessService.ProcessConfig(
+            command = command,
+            arguments = emptyList(),
+            environment = emptyMap(),
+            workingDirectory = System.getProperty("java.io.tmpdir"),
+        )
+
+    @Test
+    fun `a cancelled caller does not get a process`() {
+        // The window this closes. A cancelled scope must not reach PtyProcessBuilder at all.
+        var spawned: PlatformServices.ProcessService.ProcessHandle? = null
+        var cancelled = false
+        runBlocking {
+            val scope = CoroutineScope(Job())
+            val job =
+                scope.launch {
+                    scope.cancel()
+                    try {
+                        spawned = service.spawnProcess(config("/bin/sh"))
+                    } catch (e: CancellationException) {
+                        cancelled = true
+                        throw e
+                    }
+                }
+            job.join()
+        }
+        assertTrue(cancelled, "the spawn was attempted for a cancelled session")
+        assertNull(spawned, "a process was started for a session that no longer exists")
+    }
+
+    @Test
+    fun `a linkage error resolves to null rather than escaping`() {
+        // THE case this error handling exists for, and the one the old `catch (e: Exception)` did
+        // not cover. A closed plugin classloader raises NoClassDefFoundError from
+        // `PtyHelpers.<clinit>` - an Error, not an Exception - so it escaped the catch entirely and
+        // reached the host as a stack trace instead of the documented null.
+        val failing =
+            DesktopProcessService { _, _, _ ->
+                throw NoClassDefFoundError("com/pty4j/util/PtyUtil")
+            }
+        val handle = runBlocking { failing.spawnProcess(config("/bin/sh")) }
+        assertNull(handle, "a LinkageError escaped instead of resolving to a failed spawn")
+    }
+
+    @Test
+    fun `cancellation from inside the spawn propagates`() {
+        // `catch (e: Exception)` would swallow CancellationException and return null, turning a tab
+        // on its way out into a visible "Failed to spawn process". It has to propagate, which needs
+        // the CancellationException clause to sit ABOVE the Throwable one.
+        val cancelling =
+            DesktopProcessService { _, _, _ ->
+                throw CancellationException("disposed mid-spawn")
+            }
+        var caught: Throwable? = null
+        runBlocking {
+            try {
+                cancelling.spawnProcess(config("/bin/sh"))
+            } catch (t: Throwable) {
+                caught = t
+            }
+        }
+        assertTrue(
+            caught is CancellationException,
+            "cancellation surfaced as ${caught?.let { it::class.simpleName }} rather than propagating",
+        )
+    }
+
+    @Test
+    fun `an active caller still gets a process`() {
+        // The guard must not have made spawning impossible. This is the only test here that starts
+        // a real shell, and it kills it immediately.
+        val handle =
+            runBlocking {
+                service.spawnProcess(config("/bin/sh"))
+            }
+        assertNotNull(handle, "a normal spawn was refused")
+        runBlocking { handle.kill() }
+    }
+
+    @Test
+    fun `a command that cannot start resolves to null rather than throwing`() {
+        // The documented contract, and the one the old `catch (e: Exception)` only half kept: it
+        // covered an Exception but not the LinkageError a closed classloader raises. A missing
+        // binary is the reachable stand-in for that in a test - what matters is that the caller
+        // gets null and renders a connection error instead of an escaping throwable.
+        val handle =
+            runBlocking {
+                service.spawnProcess(config("/nonexistent/definitely-not-a-shell"))
+            }
+        assertNull(handle)
+    }
+
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ProcessSpawnTeardownTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/ProcessSpawnTeardownTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.bossterm.compose
 
+import ai.rever.bossterm.compose.shell.ShellCustomizationUtils
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -39,6 +40,23 @@ import kotlin.test.assertTrue
 class ProcessSpawnTeardownTest {
     private val service = DesktopProcessService()
 
+    /**
+     * A shell that actually exists on the host running the test.
+     *
+     * `/bin/sh` was hardcoded, which made `an active caller still gets a process` a
+     * Unix-only test: on Windows the path does not resolve, `spawnProcess` returns null
+     * exactly as `a command that cannot start resolves to null` asserts it should, and
+     * the assertion that a normal spawn succeeds failed. macOS and Linux passed, so the
+     * gap only showed up on the third runner.
+     *
+     * `getValidShell` is the resolver the app itself uses - `$SHELL`, then `/bin/bash`,
+     * then `/bin/sh` on Unix; `cmd.exe` on Windows. Asking for "cmd" rather than the
+     * default "powershell" keeps this cheap: the PowerShell branch shells out to check
+     * whether powershell.exe is installed, and this test only needs a process that
+     * starts and can be killed.
+     */
+    private val shell = ShellCustomizationUtils.getValidShell("cmd")
+
     private fun config(command: String) =
         PlatformServices.ProcessService.ProcessConfig(
             command = command,
@@ -58,7 +76,7 @@ class ProcessSpawnTeardownTest {
                 scope.launch {
                     scope.cancel()
                     try {
-                        spawned = service.spawnProcess(config("/bin/sh"))
+                        spawned = service.spawnProcess(config(shell))
                     } catch (e: CancellationException) {
                         cancelled = true
                         throw e
@@ -80,7 +98,7 @@ class ProcessSpawnTeardownTest {
             DesktopProcessService { _, _, _ ->
                 throw NoClassDefFoundError("com/pty4j/util/PtyUtil")
             }
-        val handle = runBlocking { failing.spawnProcess(config("/bin/sh")) }
+        val handle = runBlocking { failing.spawnProcess(config(shell)) }
         assertNull(handle, "a LinkageError escaped instead of resolving to a failed spawn")
     }
 
@@ -96,7 +114,7 @@ class ProcessSpawnTeardownTest {
         var caught: Throwable? = null
         runBlocking {
             try {
-                cancelling.spawnProcess(config("/bin/sh"))
+                cancelling.spawnProcess(config(shell))
             } catch (t: Throwable) {
                 caught = t
             }
@@ -113,7 +131,7 @@ class ProcessSpawnTeardownTest {
         // a real shell, and it kills it immediately.
         val handle =
             runBlocking {
-                service.spawnProcess(config("/bin/sh"))
+                service.spawnProcess(config(shell))
             }
         assertNotNull(handle, "a normal spawn was refused")
         runBlocking { handle.kill() }


### PR DESCRIPTION
## Seen in a live install

Updating terminal-tab reloaded the plugin, and during the teardown a pty spawn arrived at the already-closed classloader:

```
ClassNotFoundException: Plugin classloader for '...terminaltab' is UNLOADED;
refusing to resolve 'com.pty4j.util.PtyUtil' against the host classloader.
Something still referenced the plugin after it was unloaded - that reference is the bug.
  at com.pty4j.unix.PtyHelpers.<clinit>(PtyHelpers.java:206)
  at com.pty4j.PtyProcessBuilder.start(PtyProcessBuilder.java:175)
  at DesktopProcessService.spawnProcess(PlatformServices.desktop.kt:102)
  at TabController$initializeTerminalSession$1.invokeSuspend(TabController.kt:1546)
```

The host's guard was right to refuse. The first pty spawn in that classloader happened during its own teardown, so `PtyHelpers` ran its static initialiser against a loader that was already closed.

## Three faults, not one

**1. The spawn was attempted for a cancelled session.**

`TerminalTab.dispose` does call `coroutineScope.cancel()`. But cancellation is cooperative and `PtyProcessBuilder.start()` is a blocking JNI chain with no suspension point, so a coroutine already inside it never notices. Session init does real work before that call - environment assembly, shell-integration injection - and that whole span is when a tab can be disposed.

`currentCoroutineContext().ensureActive()` before the call narrows the window from all of session init to an instruction gap. **It does not close it**, and nothing in the code or the tests claims otherwise.

**2. `catch (e: Exception)` did not catch the failure.**

A closed classloader raises `NoClassDefFoundError` / `ExceptionInInitializerError`. Those are **Errors**, not Exceptions, so the documented "returns null on failure" contract broke in exactly the case that produced the stack above: rather than a connection error on the tab, the throwable escaped to the host. Now `catch (t: Throwable)`.

**3. Cancellation would have been swallowed by that same clause** and reported as "Failed to spawn process" on a tab already on its way out. The `CancellationException` clause sits above it and rethrows.

## Why the pty start is now injectable

One reason: a `LinkageError` cannot be provoked through the real `PtyProcessBuilder`, so without a seam the Throwable-vs-Exception distinction is untestable - and an untested catch clause is how it came to be Exception-only in the first place. The default argument is the original builder chain, unchanged.

This was not hypothetical caution. My first version of the cancellation test used `withContext(cancelledJob)`, which throws at the `withContext` boundary before `spawnProcess` runs, so it passed against the Exception-only catch and proved nothing. The seam is what made both properties real.

## Tests

**1089 compose-ui tests, all green.** Verified by reverting each change separately - each fails exactly one test and no others:

| Reverted | Fails |
|---|---|
| `catch (t: Throwable)` → `catch (t: Exception)` | `a linkage error resolves to null rather than escaping` |
| the `CancellationException` clause | `cancellation from inside the spawn propagates` |
| `ensureActive()` | `a cancelled caller does not get a process` |

I also deleted a test I had written with `assertFalse(false, "placeholder…")` in it. It asserted nothing; the limitation it was gesturing at is stated in the KDoc instead.

## Deliberately not done

Eagerly warming the pty4j classes at startup would remove this stack entirely, since `<clinit>` could never run late. It costs class loading plus a JNA library load on every launch for users who never open a terminal, which is the wrong trade for a startup path. The two guards make a late spawn resolve cleanly instead of crashing.