### PR TITLE
Light-theme follow-up: stop the chrome using the disabled tier for text, and give the selected row its indicator

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -2418,8 +2418,9 @@ fun TabbedTerminal(
                     ) {
                         androidx.compose.material3.Text(
                             "Signed in as $email",
-                            // `chalk`, not `ok` - see the note in TabBar on the ⎇
-                            // label. The toast frame carries the "something happened".
+                            // `chalk`, not `ok`: `ok` is a fill token at the 3:1
+                            // component floor and is 3.2:1 on the light identities.
+                            // The toast frame carries the "something happened".
                             color = BossUiTheme.current.chalk,
                             fontSize = 11.sp,
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/history/HistorySearchOverlay.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/history/HistorySearchOverlay.kt
@@ -1,5 +1,7 @@
 package ai.rever.bossterm.compose.history
 
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.IntrinsicSize
 import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -147,7 +149,7 @@ fun HistorySearchOverlay(
                         },
                     decorationBox = { inner ->
                         if (query.isEmpty()) {
-                            Text("Search history…", color = BossUiTheme.current.muted, fontSize = 14.sp)
+                            Text("Search history…", color = BossUiTheme.current.mist, fontSize = 14.sp)
                         }
                         inner()
                     },
@@ -173,12 +175,31 @@ fun HistorySearchOverlay(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                // See the note in CommandPalette: IntrinsicSize.Min is what
+                                // lets the indicator's fillMaxHeight() resolve inside a
+                                // LazyColumn item.
+                                .height(IntrinsicSize.Min)
                                 .background(if (i == selected) BossUiTheme.current.signalWash else Color.Transparent)
-                                .clickable { onDismiss(); onSelect(cmd) }
-                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                                .clickable { onDismiss(); onSelect(cmd) },
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Text(cmd, color = BossUiTheme.current.chalk, fontSize = 13.sp, maxLines = 1)
+                            Box(
+                                Modifier
+                                    .width(2.dp)
+                                    .fillMaxHeight()
+                                    .background(
+                                        if (i == selected) BossUiTheme.current.signal
+                                        else Color.Transparent
+                                    )
+                            )
+                            Row(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(horizontal = 10.dp, vertical = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(cmd, color = BossUiTheme.current.chalk, fontSize = 13.sp, maxLines = 1)
+                            }
                         }
                     }
                 }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/CommandPalette.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/palette/CommandPalette.kt
@@ -1,5 +1,7 @@
 package ai.rever.bossterm.compose.palette
 
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.IntrinsicSize
 import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -134,7 +136,7 @@ fun CommandPalette(
                         },
                     decorationBox = { inner ->
                         if (query.isEmpty()) {
-                            Text("Run a command…", color = BossUiTheme.current.muted, fontSize = 14.sp)
+                            Text("Run a command…", color = BossUiTheme.current.mist, fontSize = 14.sp)
                         }
                         inner()
                     },
@@ -147,21 +149,45 @@ fun CommandPalette(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                // Bounds the height so the indicator's fillMaxHeight()
+                                // resolves; a LazyColumn item's incoming max height is
+                                // unbounded and would collapse it to nothing.
+                                .height(IntrinsicSize.Min)
                                 .background(if (i == selected) BossUiTheme.current.signalWash else Color.Transparent)
-                                .clickable { onDismiss(); c.run() }
-                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                                .clickable { onDismiss(); c.run() },
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Text(
-                                c.group,
-                                color = BossUiTheme.current.muted,
-                                fontSize = 11.sp,
-                                modifier = Modifier.width(64.dp),
+                            // The wash cannot carry the selection alone: it is 1.10:1 on
+                            // daylight and 1.20:1 on blueprint-light against `panel`. The
+                            // design system's answer is a wash PLUS a 2.dp indicator, which
+                            // is what UiTheme.BOSS_BLUEPRINT's KDoc prescribes and what this
+                            // row was missing.
+                            Box(
+                                Modifier
+                                    .width(2.dp)
+                                    .fillMaxHeight()
+                                    .background(
+                                        if (i == selected) BossUiTheme.current.signal
+                                        else Color.Transparent
+                                    )
                             )
-                            Column(Modifier.weight(1f)) {
-                                Text(c.title, color = BossUiTheme.current.chalk, fontSize = 13.sp, maxLines = 1)
-                                c.subtitle?.let {
-                                    Text(it, color = BossUiTheme.current.mist, fontSize = 11.sp, maxLines = 1)
+                            Row(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(horizontal = 10.dp, vertical = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    c.group,
+                                    color = BossUiTheme.current.mist,
+                                    fontSize = 11.sp,
+                                    modifier = Modifier.width(64.dp),
+                                )
+                                Column(Modifier.weight(1f)) {
+                                    Text(c.title, color = BossUiTheme.current.chalk, fontSize = 13.sp, maxLines = 1)
+                                    c.subtitle?.let {
+                                        Text(it, color = BossUiTheme.current.mist, fontSize = 11.sp, maxLines = 1)
+                                    }
                                 }
                             }
                         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/search/SearchBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/search/SearchBar.kt
@@ -145,7 +145,7 @@ fun SearchBar(
                         if (searchQuery.isEmpty()) {
                             Text(
                                 "Find",
-                                color = BossUiTheme.current.muted,
+                                color = BossUiTheme.current.mist,
                                 fontSize = 13.sp
                             )
                         }
@@ -205,7 +205,7 @@ fun SearchBar(
                 ) {
                     Text(
                         "Aa",
-                        color = if (caseSensitive) BossUiTheme.current.signalText else BossUiTheme.current.muted,
+                        color = if (caseSensitive) BossUiTheme.current.signalText else BossUiTheme.current.mist,
                         fontSize = 12.sp,
                         fontWeight = if (caseSensitive) FontWeight.Bold else FontWeight.Normal
                     )

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -588,6 +588,9 @@ fun TabBar(
     val barFg = tabBarTheme.foregroundColor
     val barMuted = barFg.copy(alpha = 0.62f)
     val barDivider = barFg.copy(alpha = 0.14f)
+    // Read here and passed down, not read inside TabItem: one subscriber for the whole
+    // bar rather than one per chip, which is what the note in TabItem promises.
+    val barRaised = BossUiTheme.current.raised
 
     val newTabButton: @Composable () -> Unit = {
         IconButton(onClick = onNewTab, modifier = Modifier.size(36.dp)) {
@@ -631,6 +634,7 @@ fun TabBar(
             branch = pane.branch,
             multiLine = vertical,
             tabTheme = tabBarTheme,
+            chipRaised = barRaised,
             isActive = group.tabIndex == activeTabIndex && pane.paneId == focusedPaneId,
             colorHex = pane.colorHex,
             isEditing = pane.paneId == editingPaneId,
@@ -903,13 +907,13 @@ fun TabBar(
                                     Icon(
                                         Icons.Default.Visibility,
                                         contentDescription = "View only - right-click to request control",
-                                        tint = BossUiTheme.current.muted,
+                                        tint = BossUiTheme.current.mist,
                                         modifier = Modifier.size(12.dp)
                                     )
                                 }
                                 Box(
                                     modifier = Modifier.clip(RoundedCornerShape(4.dp)).clickable(onClick = rg.onDisconnect).padding(2.dp)
-                                ) { Icon(Icons.Default.Close, contentDescription = "Disconnect remote", tint = BossUiTheme.current.muted, modifier = Modifier.size(13.dp)) }
+                                ) { Icon(Icons.Default.Close, contentDescription = "Disconnect remote", tint = BossUiTheme.current.mist, modifier = Modifier.size(13.dp)) }
                             }
                             // Match the local bar: split panes of one tab hug together
                             // (TabChipGap), separate tabs are spaced further apart (TabGroupGap).
@@ -931,7 +935,7 @@ fun TabBar(
                                                 horizontalArrangement = Arrangement.spacedBy(4.dp)
                                             ) {
                                                 Text(
-                                                    sec.label, color = BossUiTheme.current.muted, fontSize = 10.sp,
+                                                    sec.label, color = BossUiTheme.current.mist, fontSize = 10.sp,
                                                     maxLines = 1, overflow = TextOverflow.Ellipsis
                                                 )
                                                 // Hairline ties the sub-title to its section.
@@ -1007,13 +1011,13 @@ fun TabBar(
                                         Icon(
                                             Icons.Default.Visibility,
                                             contentDescription = "Read-only via this host",
-                                            tint = BossUiTheme.current.muted,
+                                            tint = BossUiTheme.current.mist,
                                             modifier = Modifier.size(12.dp)
                                         )
                                     }
                                     Box(
                                         modifier = Modifier.clip(RoundedCornerShape(4.dp)).clickable(onClick = nest.onClose).padding(2.dp)
-                                    ) { Icon(Icons.Default.Close, contentDescription = "Ask host to disconnect this upstream", tint = BossUiTheme.current.muted, modifier = Modifier.size(13.dp)) }
+                                    ) { Icon(Icons.Default.Close, contentDescription = "Ask host to disconnect this upstream", tint = BossUiTheme.current.mist, modifier = Modifier.size(13.dp)) }
                                 }
                                 // The origin may share ALL its windows — section its tabs per
                                 // origin window (sub-title + targeted actions), like the host box.
@@ -1033,7 +1037,7 @@ fun TabBar(
                                                     horizontalArrangement = Arrangement.spacedBy(4.dp)
                                                 ) {
                                                     Text(
-                                                        sec.label, color = BossUiTheme.current.muted, fontSize = 10.sp,
+                                                        sec.label, color = BossUiTheme.current.mist, fontSize = 10.sp,
                                                         maxLines = 1, overflow = TextOverflow.Ellipsis
                                                     )
                                                     Box(Modifier.weight(1f).height(1.dp).background(BossUiTheme.current.line))
@@ -1160,6 +1164,14 @@ private fun TabItem(
     title: String,
     isActive: Boolean,
     tabTheme: Theme,
+    /**
+     * `UiTheme.raised`, collected once by [TabBar].
+     *
+     * A parameter rather than a `BossUiTheme.current` read in here, so the claim below
+     * about one subscriber for the whole bar stays true - a token read inside this
+     * composable subscribes every chip independently.
+     */
+    chipRaised: Color,
     colorHex: String?,
     isEditing: Boolean,
     onSelected: () -> Unit,
@@ -1183,7 +1195,7 @@ private fun TabItem(
     // surface at all. `raised` is the same idea (the floor stepped toward the text)
     // computed in gamma sRGB by UiTheme's own mix, and on the light identities it is
     // the white card the active chip should be.
-    val itemRaised = BossUiTheme.current.raised     // active chip surface
+    val itemRaised = chipRaised                     // active chip surface
     val itemAccent = tabTheme.cursorColor           // active chip border
     val itemMuted = itemFg.copy(alpha = 0.62f)      // inactive text / active close-icon
     val itemSubtle = itemFg.copy(alpha = 0.22f)     // inactive border (hairline)
@@ -1291,8 +1303,8 @@ private fun TabItem(
                     if (!branch.isNullOrBlank()) {
                         Text(
                             text = "⎇ $branch",
-                            // `mist`, not `ok`: `ok` is a FILL token at the 3:1
-                            // component floor and is 3.2:1 on the light identities.
+                            // `itemMuted`, not `ok`: `ok` is a FILL token held to the
+                            // 3:1 component floor and is 3.2:1 on the light identities.
                             // The ⎇ glyph already says "branch"; the green did not.
                             color = itemMuted,
                             fontSize = 11.sp,

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateUI.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/update/UpdateUI.kt
@@ -102,7 +102,7 @@ private fun UpdateAvailableBanner(
                 )
                 Text(
                     " (current: v${updateInfo.currentVersion})",
-                    color = BossUiTheme.current.muted,
+                    color = BossUiTheme.current.mist,
                     fontSize = 12.sp
                 )
             }
@@ -118,7 +118,7 @@ private fun UpdateAvailableBanner(
                 }
                 TextButton(
                     onClick = onDismiss,
-                    colors = ButtonDefaults.textButtonColors(contentColor = BossUiTheme.current.muted),
+                    colors = ButtonDefaults.textButtonColors(contentColor = BossUiTheme.current.mist),
                     contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
                     modifier = Modifier.height(28.dp)
                 ) {
@@ -285,7 +285,7 @@ private fun ErrorBanner(
                     }
                     TextButton(
                         onClick = onDismiss,
-                        colors = ButtonDefaults.textButtonColors(contentColor = BossUiTheme.current.muted),
+                        colors = ButtonDefaults.textButtonColors(contentColor = BossUiTheme.current.mist),
                         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
                         modifier = Modifier.height(28.dp)
                     ) {
@@ -295,7 +295,7 @@ private fun ErrorBanner(
             }
             Text(
                 "Check logs: /tmp/bossterm-updater/update-*.log or /tmp/bossterm-update-debug-*.log",
-                color = BossUiTheme.current.muted,
+                color = BossUiTheme.current.mist,
                 fontSize = 10.sp,
                 modifier = Modifier.padding(top = 2.dp, start = 22.dp)
             )

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ChromeTokenCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ChromeTokenCoverageTest.kt
@@ -199,6 +199,42 @@ class ChromeTokenCoverageTest {
     }
 
     /**
+     * `muted` may not be a text colour in converted chrome.
+     *
+     * A literal scan cannot see this class of bug: swapping a hardcoded grey for a
+     * token that is *wrong for the role* passes every check above, and that is exactly
+     * what happened - the sweep routed section labels, placeholders, group labels and
+     * two button labels to `muted`, which is 2.4:1 on the light identities. See
+     * [UiThemeContrastTest], which pins `muted` as the deliberately sub-floor disabled
+     * tier.
+     *
+     * Scans the argument NAMES that put a colour on text (`color =`, `contentColor =`)
+     * rather than trying to understand the call. `tint =` is left out on purpose: an
+     * icon tint is sometimes a genuinely disabled control, which is what `muted` is
+     * for - `SearchBar`'s nav arrows with no matches are the case in point - so a blanket
+     * ban there would be wrong. That is a real hole in the coverage, and it is named
+     * here rather than papered over.
+     */
+    @Test
+    fun `muted is never used as a text colour in converted chrome`() {
+        val offenders = mutableListOf<String>()
+        for (rel in converted) {
+            sourceFile(rel).readLines().forEachIndexed { index, line ->
+                val code = codeOf(line)
+                val textRole = "color =" in code || "contentColor =" in code
+                val muted = "current.muted" in code || "TextMuted" in code
+                if (textRole && muted) offenders += "$rel:${index + 1}  ${line.trim().take(90)}"
+            }
+        }
+        assertEquals(
+            emptyList(),
+            offenders,
+            "`muted` is the disabled tier, not a text colour - it is 2.4:1 on the light " +
+                "identities. Use `mist` for secondary text:\n" + offenders.joinToString("\n"),
+        )
+    }
+
+    /**
      * The allowlist may not name a file that is not being scanned, or a literal that
      * is no longer in it.
      *

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/UiThemeContrastTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/UiThemeContrastTest.kt
@@ -1,0 +1,222 @@
+package ai.rever.bossterm.compose.theme
+
+import ai.rever.bossterm.compose.settings.theme.BuiltinThemes
+import ai.rever.bossterm.compose.settings.theme.Theme
+import ai.rever.bossterm.compose.settings.theme.UiTheme
+import ai.rever.bossterm.compose.util.ColorUtils
+import androidx.compose.ui.graphics.Color
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The chrome-token half of [LightThemeContrastTest].
+ *
+ * That test guards the terminal palette. Nothing guarded `UiTheme`, and the gap had a
+ * cost: the light identities shipped with `muted` at 2.4:1 carrying real 10-11 sp
+ * labels, while the same review round rejected `alert` at 4.2:1 and swapped out `warn`
+ * at 3.3:1 for exactly that reason. A 2.4:1 label is a bigger violation than either of
+ * the two that were fixed by hand. This is the test that would have said so.
+ *
+ * **Scoped to the two BOSS light identities**, deliberately, and not for convenience.
+ * A sweep over `BuiltinThemes.ALL` cannot pass and should not be written to look as
+ * though it does - measured worst-case over `ink`/`panel`/`raised`, `alert` is 2.14:1
+ * on gruvbox-dark, 2.43:1 on nord, 2.88:1 on solarized-dark and 2.99:1 on monokai, all
+ * below the 3:1 component floor as a *fill*, before any question of text. `mist` is
+ * under the TEXT floor on six themes for the same underlying reason: a derived theme's
+ * tokens are mixed off whatever foreground the ported palette happens to carry. That is
+ * pre-existing debt across ports of other people's palettes, it predates the light
+ * identities, and folding it in here would mean an exemption list longer than the test.
+ * [derivedThemesAreNotCoveredHere] records the measurement so the next pass starts from
+ * data rather than re-deriving it.
+ *
+ * The two identities in scope are ours, hand-authored, and mirror the host, so they can
+ * be held to the floors without exemption.
+ */
+class UiThemeContrastTest {
+
+    /** WCAG 1.4.3 AA for body text. */
+    private val textFloor = 4.5f
+
+    /**
+     * WCAG 1.4.11 for a UI component - a fill, a 2.dp indicator, a status dot.
+     *
+     * `signal` on `boss-daylight` sits just under this at 2.63:1 and is exempted by
+     * name below rather than by a lowered floor, because the reason is specific: amber
+     * on paper cannot reach 3:1 without ceasing to be the identity's amber, which is
+     * the same trade [BuiltinThemes.BOSS_DAYLIGHT] records for its cursor.
+     */
+    private val componentFloor = 3.0f
+
+    private val identities = listOf(
+        BuiltinThemes.BOSS_BLUEPRINT_LIGHT,
+        BuiltinThemes.BOSS_DAYLIGHT,
+    )
+
+    private fun surfaces(u: UiTheme) = listOf("ink" to u.ink, "panel" to u.panel, "raised" to u.raised)
+
+    private fun assertOnEverySurface(theme: Theme, name: String, color: Color, floor: Float) {
+        val u = UiTheme.fromTheme(theme)
+        for ((surfaceName, surface) in surfaces(u)) {
+            val ratio = ColorUtils.contrastRatio(color, surface)
+            assertTrue(
+                ratio >= floor,
+                "${theme.id}: $name is ${"%.2f".format(ratio)}:1 on $surfaceName, below the " +
+                    "${"%.1f".format(floor)}:1 floor",
+            )
+        }
+    }
+
+    @Test
+    fun `text tokens clear the text floor on every surface they can be painted on`() {
+        for (t in identities) {
+            val u = UiTheme.fromTheme(t)
+            assertOnEverySurface(t, "chalk", u.chalk, textFloor)
+            assertOnEverySurface(t, "mist", u.mist, textFloor)
+            // The accent's glyph variant. Held here as well as in UiThemeTest because
+            // this is where the text/fill split is the subject.
+            assertOnEverySurface(t, "signalText", u.signalText, textFloor)
+        }
+    }
+
+    /**
+     * `muted` is NOT a text colour, and this test exists to say so in a place that
+     * cannot rot.
+     *
+     * It is 2.37:1 and 2.48:1 on these two identities - under the component floor, let
+     * alone the text one - and that is faithful to the host, whose `textMuted` was
+     * authored for disabled state rather than for reading. `UiTheme`'s own comment
+     * calls it "tertiary / disabled".
+     *
+     * So the assertion is inverted on purpose: it pins `muted` as sub-floor, so anyone
+     * who reaches for it as a label colour finds a test that already decided this, and
+     * anyone who "fixes" it by darkening it toward `mist` has to delete an assertion
+     * that explains why the two tiers are not interchangeable.
+     */
+    @Test
+    fun `muted is deliberately below the text floor and must not carry text`() {
+        for (t in identities) {
+            val u = UiTheme.fromTheme(t)
+            val worst = surfaces(u).minOf { ColorUtils.contrastRatio(u.muted, it.second) }
+            assertTrue(
+                worst < textFloor,
+                "${t.id}: muted now clears the text floor at ${"%.2f".format(worst)}:1. If that " +
+                    "was deliberate, it is no longer the disabled tier and this test and " +
+                    "UiTheme's KDoc both need updating; use mist for secondary text.",
+            )
+        }
+    }
+
+    @Test
+    fun `fill tokens clear the component floor on every surface`() {
+        // boss-daylight's amber signal is the one exemption, by name and with a reason.
+        val exempt = setOf("boss-daylight" to "signal")
+        for (t in identities) {
+            val u = UiTheme.fromTheme(t)
+            val fills = listOf(
+                "signal" to u.signal,
+                "ok" to u.ok,
+                "warn" to u.warn,
+                "alert" to u.alert,
+                "data" to u.data,
+            )
+            for ((name, color) in fills) {
+                if (t.id to name in exempt) continue
+                assertOnEverySurface(t, name, color, componentFloor)
+            }
+        }
+    }
+
+    /**
+     * The exemption cannot quietly grow, and cannot go stale either.
+     *
+     * Written as "which fills fall short" rather than "daylight's signal is exempt", so
+     * that darkening the amber makes this fail and the exemption get deleted, instead
+     * of leaving a stale excuse behind.
+     */
+    @Test
+    fun `daylight's amber signal is the only fill below the component floor`() {
+        val short = mutableSetOf<String>()
+        for (t in identities) {
+            val u = UiTheme.fromTheme(t)
+            val fills = mapOf(
+                "signal" to u.signal, "ok" to u.ok, "warn" to u.warn,
+                "alert" to u.alert, "data" to u.data,
+            )
+            for ((name, color) in fills) {
+                val worst = surfaces(u).minOf { ColorUtils.contrastRatio(color, it.second) }
+                if (worst < componentFloor) short += "${t.id}:$name"
+            }
+        }
+        assertEquals(
+            setOf("boss-daylight:signal"),
+            short,
+            "the set of sub-floor fills changed: fix the token, or record why it cannot be fixed",
+        )
+    }
+
+    @Test
+    fun `content on a signal fill is legible against it`() {
+        for (t in identities) {
+            val u = UiTheme.fromTheme(t)
+            val ratio = ColorUtils.contrastRatio(u.onSignal, u.signal)
+            assertTrue(
+                ratio >= textFloor,
+                "${t.id}: onSignal is ${"%.2f".format(ratio)}:1 on signal - buttons filled with " +
+                    "the accent would be hard to read",
+            )
+        }
+    }
+
+    /**
+     * The surface ladder needs a real step, not just a direction.
+     *
+     * `UiThemeTest` asserts strict monotonicity across every builtin, which catches a
+     * fully collapsed rung. It cannot catch a rung that is technically distinct and
+     * visually identical - and that is not hypothetical: the render guard rewrote an
+     * ANSI slot to within one channel step of its neighbour, and an assertion of the
+     * same shape passed. Held only for the authored identities, since a derived theme's
+     * rungs come from `mix(bg, fg, 0.05f)` off whatever floor it has.
+     */
+    @Test
+    fun `the authored light ladder has a perceptible step between rungs`() {
+        for (t in identities) {
+            val u = UiTheme.fromTheme(t)
+            for ((from, to) in listOf("ink" to "panel", "panel" to "raised")) {
+                val a = if (from == "ink") u.ink else u.panel
+                val b = if (to == "panel") u.panel else u.raised
+                val ratio = ColorUtils.contrastRatio(a, b)
+                assertTrue(
+                    ratio >= 1.02f,
+                    "${t.id}: $from -> $to is only ${"%.4f".format(ratio)}:1 - distinct values, " +
+                        "but not a step anyone can see",
+                )
+            }
+        }
+    }
+
+    /**
+     * Records why the sweep stops at two themes, with the numbers.
+     *
+     * A prose note in a KDoc goes stale silently. This fails if the pre-existing debt
+     * is ever paid down, which is the moment the scope of this file should widen.
+     */
+    @Test
+    fun derivedThemesAreNotCoveredHere() {
+        val subFloorAlert = BuiltinThemes.ALL
+            .filter { it !in identities }
+            .filter { t ->
+                val u = UiTheme.fromTheme(t)
+                surfaces(u).minOf { ColorUtils.contrastRatio(u.alert, it.second) } < componentFloor
+            }
+            .map { it.id }
+            .toSet()
+        assertEquals(
+            setOf("nord", "solarized-dark", "gruvbox-dark", "monokai"),
+            subFloorAlert,
+            "the set of themes whose `alert` is below the component floor changed. If it " +
+                "shrank, the debt that keeps this test scoped to two identities is being paid " +
+                "down and the scope can widen.",
+        )
+    }
+}


### PR DESCRIPTION
Follow-up to #371, addressing the review round that landed ~80 minutes before it merged and was not acted on. Two of these ship in **v1.2.151**, so this is a real fix rather than tidying.

## `muted` was carrying real text

`muted` is **2.37:1** and **2.48:1** against `panel` on the two light identities — under the 4.5:1 text floor, and under the 3:1 component floor too. #371's sweep routed 15 genuine 10-11 sp labels and icon tints to it: the remote-group section labels, three placeholders, the command-palette group column, two body labels and two `TextButton` labels in the update banner, and four close-icon tints.

That is inconsistent with the standard #371 set for itself: it rejected `alert` at 4.2:1 for an 11 sp label and swapped `warn` out at 3.3:1. A 2.4:1 label is a bigger violation than either of those. Those 15 sites now take `mist` (4.64:1 / 5.45:1).

`muted` itself is unchanged and still mirrors the host's `textMuted`. It is the disabled tier — which is what `UiTheme`'s own comment calls it — and the uses that genuinely are disabled or decorative keep it: the OFF status dots, the scrollbar block-marker fallback, and `SearchBar`'s nav arrows when there are no matches.

## The selected row had a fill and no indicator

`signalWash` alone was the only thing marking which row Enter would run in the command palette and history overlay. Against the `panel` it actually sits on:

| theme | wash vs panel |
|---|---|
| boss-operator (dark) | 1.07:1 |
| boss-daylight | 1.10:1 |
| boss-blueprint (dark) | 1.15:1 |
| boss-blueprint-light | 1.20:1 |
| the literal it replaced | 1.47:1 |

All below the 1.25 floor `LightThemeContrastTest` asserts for a *terminal* selection, on an argument that applies verbatim: "no indicator, so the fill carries the whole signal." And `UiTheme.BOSS_BLUEPRINT`'s KDoc states the rule outright — a wash **plus** a 2.dp indicator, never one alone. Both rows have the indicator now. It was also a small regression on the two dark themes, not only a light-theme issue.

`IntrinsicSize.Min` on those rows is load-bearing rather than tidying: a `LazyColumn` item's incoming max height is unbounded, so a bare `fillMaxHeight()` indicator measures to zero and paints nothing. `TabBar` hit exactly this with its tab-colour stripe, and this is that fix.

## Two comments described code that had changed under them

- `itemRaised` read `BossUiTheme.current` inside `TabItem`, contradicting the note three lines above it promising "one subscriber for the whole bar, not one per tab". `raised` is now collected once in `TabBar` and passed down as `chipRaised`.
- The comment on the git-branch label said "`mist`, not `ok`" while the code assigned `itemMuted`. `TabbedTerminal` then cited that comment for its own choice, so the inaccuracy had already propagated one file over. Both now say what the code does.

In a PR that argued the comments are the spec, these are not cosmetic.

## Two new guards

Neither problem above was catchable by anything that existed. A literal scan cannot see a token used in the wrong **role**, and nothing guarded `UiTheme` at all.

- **`UiThemeContrastTest`** — the chrome-token mirror of `LightThemeContrastTest`: text tokens at 4.5:1 on all three surfaces, fills at 3:1, `onSignal` on `signal`, and a perceptible step between ladder rungs. `muted` gets an **inverted** assertion pinning it as deliberately sub-floor, so anyone reaching for it as a label colour finds a test that already decided this, and anyone "fixing" it by darkening it toward `mist` has to delete an assertion explaining why the tiers are not interchangeable.
- **`ChromeTokenCoverageTest`** gains a scan for `muted` in a `color =` / `contentColor =` position across the 13 converted files. `tint =` is deliberately excluded — a disabled icon is what the token is for — which is a real hole in the coverage, named rather than papered over.

**On scope:** both are limited to the two BOSS light identities, and that limit is measured, not convenient. Over `BuiltinThemes.ALL`, `alert` is already 2.14:1 on gruvbox-dark, 2.43:1 on nord, 2.88:1 on solarized-dark and 2.99:1 on monokai *as a fill*, and `mist` is under the text floor on six themes — because a derived theme's tokens are mixed off whatever foreground the ported palette happens to carry. A global sweep would need an exemption list longer than the test. One assertion records that set, so it fails when the debt is paid down and the scope can widen.

Both guards verified by mutation: reverting the palette group label to `muted` fails the scan with file and line; setting blueprint-light's `mist` to the old `muted` value fails the text floor at 2.37:1.

## Deliberately not in this PR

`SettingsTheme.TextMuted` points at `muted` across **149 call sites**, and `muted` is below the text floor on **all 14 builtins** — 1.47:1 to 4.01:1, including 4.01 on the default dark identity. So this is long-standing debt that the light themes made worse and more visible, not something they introduced. Repointing it is a visible change to the settings panel on every theme; it deserves its own PR and its own review rather than riding along here. Same for `ContextMenuController.menuMuted`.

## Verification

1110 tests green (up from 1102), CI's two commands clean, full build clean.

**What is not tested:** the indicator's *geometry*. Its colour is guarded, its measured height is not — there is no Compose UI-test dependency in this module, and adding one to a library's test classpath for a single layout assertion is out of proportion. It follows the pattern already proven in `TabBar`, and it belongs in the same manual pass as #371's surface-separation check: switch to BOSS Blueprint Light, open the command palette and the history overlay (Ctrl+R), and confirm the selected row is unmistakable.
