### PR TITLE
fix(theme): let the focused pane's border follow the active theme

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1881,7 +1881,11 @@ fun TabbedTerminal(
                 menuActions = menuActions,
                 // Split pane settings
                 splitFocusBorderEnabled = settings.splitFocusBorderEnabled,
-                splitFocusBorderColor = settings.splitFocusBorderColorValue,
+                // Theme unless the user picked a colour: the focus border is the one
+                // piece of pane chrome that used to sit at a hardcoded blue while
+                // everything around it followed the theme.
+                splitFocusBorderColor = settings.splitFocusBorderColorOverride
+                    ?: BossUiTheme.current.signal,
                 splitMinimumSize = settings.splitMinimumSize,
                 // Shared handler: SSH URLs open a new tab, everything else
                 // delegates to the caller's onLinkClick (see linkOpenHandler).

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1885,7 +1885,7 @@ fun TabbedTerminal(
                 // piece of pane chrome that used to sit at a hardcoded blue while
                 // everything around it followed the theme.
                 splitFocusBorderColor = settings.splitFocusBorderColorOverride
-                    ?: BossUiTheme.current.signal,
+                    ?: BossUiTheme.current.focusRing,
                 splitMinimumSize = settings.splitMinimumSize,
                 // Shared handler: SSH URLs open a new tab, everything else
                 // delegates to the caller's onLinkClick (see linkOpenHandler).

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/SettingsManager.kt
@@ -28,6 +28,33 @@ internal fun migrateCursorRenderingDefaults(
 }
 
 /**
+ * Clear the focus border's pre-theme default once, so an existing install picks the
+ * theme up.
+ *
+ * `0xFF4A90E2` was [TerminalSettings.splitFocusBorderColor]'s factory value and is
+ * serialized verbatim into every settings file written before the focus border
+ * became theme-derived. Nobody chose it, but nothing in the file says so - the same
+ * missing provenance [migrateCursorRenderingDefaults] records - so it is read as the
+ * old default and cleared once. Any other colour is a real choice and survives.
+ *
+ * Doing this here rather than in [TerminalSettings] is what keeps the blue a colour
+ * the picker can still select: after the migration a stored `0xFF4A90E2` means the
+ * user picked it, and the marker stops it being cleared a second time.
+ */
+internal fun migrateSplitFocusBorderDefault(
+    settings: TerminalSettings,
+    hasSplitFocusBorderVersion: Boolean,
+): TerminalSettings {
+    if (hasSplitFocusBorderVersion) return settings
+
+    return if (settings.splitFocusBorderColor.equals(TerminalSettings.LEGACY_FOCUS_BORDER_BLUE, ignoreCase = true)) {
+        settings.copy(splitFocusBorderColor = "", splitFocusBorderVersion = 2)
+    } else {
+        settings.copy(splitFocusBorderVersion = 2)
+    }
+}
+
+/**
  * Manager for terminal settings with persistence support.
  * Settings are saved to ~/.bossterm/settings.json by default,
  * or to a custom path if specified.
@@ -252,9 +279,12 @@ class SettingsManager(private val customSettingsPath: String? = null) {
                 wasFreshInstall = false
                 val jsonString = settingsFile.readText()
                 val rawSettings = json.parseToJsonElement(jsonString).jsonObject
-                val loadedSettings = migrateCursorRenderingDefaults(
-                    settings = json.decodeFromJsonElement(TerminalSettings.serializer(), rawSettings),
-                    hasCursorRenderingVersion = "cursorRenderingVersion" in rawSettings,
+                val loadedSettings = migrateSplitFocusBorderDefault(
+                    settings = migrateCursorRenderingDefaults(
+                        settings = json.decodeFromJsonElement(TerminalSettings.serializer(), rawSettings),
+                        hasCursorRenderingVersion = "cursorRenderingVersion" in rawSettings,
+                    ),
+                    hasSplitFocusBorderVersion = "splitFocusBorderVersion" in rawSettings,
                 )
                 publish(loadedSettings)
                 println("Settings loaded from: ${settingsFile.absolutePath}")

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -939,21 +939,28 @@ data class TerminalSettings(
 
     /**
      * Colour of the focus border (serialized as ARGB hex), or **blank to follow the
-     * active theme's `signal`**. Blank is the default, so a fresh install and every
-     * install that never opened this setting track the theme.
+     * active theme's focus ring**. Blank is the default, so a fresh install and
+     * every install that never opened this setting track the theme.
      *
-     * [LEGACY_FOCUS_BORDER_BLUE] counts as blank. It was the old default: a generic
-     * blue belonging to no BOSS identity, which passed unnoticed for as long as
-     * Blueprint was the default theme and reads as a foreign object on NVIDIA
-     * (green on pure black). Treating it as "never set" is what lets an existing
-     * settings file - which has the old default written into it verbatim - pick the
-     * theme up at all. The one case this gets wrong is a user who deliberately
-     * chose that exact blue; every other custom colour is preserved, which makes
-     * this the narrowest reinterpretation available.
+     * The old default was the literal [LEGACY_FOCUS_BORDER_BLUE], a generic blue
+     * belonging to no BOSS identity. It passed unnoticed for as long as Blueprint
+     * was the default theme and reads as a foreign object on NVIDIA (green on pure
+     * black). Existing installs carry it verbatim, so
+     * [ai.rever.bossterm.compose.settings.migrateSplitFocusBorderDefault] clears it
+     * once on load. That is a migration rather than a rule in this class on
+     * purpose: reading the blue as "unset" forever would make it the one colour the
+     * picker can never select.
      *
      * Only visible when [splitFocusBorderEnabled] is true.
      */
     val splitFocusBorderColor: String = "",
+
+    /**
+     * Schema marker for the one-time [splitFocusBorderColor] migration, persisted so
+     * that picking the old blue by hand after upgrading stays a stable preference.
+     * Mirrors [cursorRenderingVersion].
+     */
+    val splitFocusBorderVersion: Int = 2,
 
     /**
      * New split panes inherit working directory from parent.
@@ -1409,12 +1416,18 @@ data class TerminalSettings(
      * this one's default is blank, so a throw here would come out of the
      * constructor of *every* [TerminalSettings]. A garbage value falls back to the
      * theme instead.
+     *
+     * A fully transparent value is garbage too, and it is the one an ordinary
+     * mistake produces: a 6-digit `"0xFF0000"` parses fine and lands as alpha 0,
+     * which would otherwise read as "the user chose something" while painting an
+     * invisible border.
      */
     @Transient
     val splitFocusBorderColorOverride: Color? =
         splitFocusBorderColor
-            .takeIf { it.isNotBlank() && !it.equals(LEGACY_FOCUS_BORDER_BLUE, ignoreCase = true) }
+            .takeIf { it.isNotBlank() }
             ?.let { hex -> runCatching { Color(hex.removePrefix("0x").toULong(16).toLong()) }.getOrNull() }
+            ?.takeIf { it.alpha > 0f }
 
     @Transient
     val commandBlockSuccessColorValue: Color = Color(commandBlockSuccessColor.removePrefix("0x").toULong(16).toLong())
@@ -1432,9 +1445,9 @@ data class TerminalSettings(
         val DEFAULT = TerminalSettings()
 
         /**
-         * The pre-theme default for [splitFocusBorderColor], kept as a named
-         * constant because it is now a *value to ignore* rather than a value to
-         * use, and that only reads as deliberate with a name on it.
+         * The pre-theme default for [splitFocusBorderColor]. Named rather than
+         * inlined in the migration because it is a value with a history, not a
+         * colour anyone chose.
          */
         const val LEGACY_FOCUS_BORDER_BLUE = "0xFF4A90E2"
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -938,10 +938,22 @@ data class TerminalSettings(
     val splitFocusBorderEnabled: Boolean = true,
 
     /**
-     * Color of the focus border (serialized as ARGB hex).
-     * Only visible when splitFocusBorderEnabled is true.
+     * Colour of the focus border (serialized as ARGB hex), or **blank to follow the
+     * active theme's `signal`**. Blank is the default, so a fresh install and every
+     * install that never opened this setting track the theme.
+     *
+     * [LEGACY_FOCUS_BORDER_BLUE] counts as blank. It was the old default: a generic
+     * blue belonging to no BOSS identity, which passed unnoticed for as long as
+     * Blueprint was the default theme and reads as a foreign object on NVIDIA
+     * (green on pure black). Treating it as "never set" is what lets an existing
+     * settings file - which has the old default written into it verbatim - pick the
+     * theme up at all. The one case this gets wrong is a user who deliberately
+     * chose that exact blue; every other custom colour is preserved, which makes
+     * this the narrowest reinterpretation available.
+     *
+     * Only visible when [splitFocusBorderEnabled] is true.
      */
-    val splitFocusBorderColor: String = "0xFF4A90E2",
+    val splitFocusBorderColor: String = "",
 
     /**
      * New split panes inherit working directory from parent.
@@ -1384,8 +1396,25 @@ data class TerminalSettings(
     @Transient
     val currentSearchMarkerColorValue: Color = Color(currentSearchMarkerColor.removePrefix("0x").toULong(16).toLong())
 
+    /**
+     * The colour the user explicitly chose for the focus border, or null to follow
+     * the active theme.
+     *
+     * Nullable rather than resolved here on purpose: the theme lives in
+     * `BossUiTheme`, a Compose snapshot read that a plain serializable data class
+     * must not make. The composable call sites resolve the fallback.
+     *
+     * Parsed defensively, unlike its siblings above. Those carry a valid literal as
+     * their default, so a malformed value can only come from a hand-edited file;
+     * this one's default is blank, so a throw here would come out of the
+     * constructor of *every* [TerminalSettings]. A garbage value falls back to the
+     * theme instead.
+     */
     @Transient
-    val splitFocusBorderColorValue: Color = Color(splitFocusBorderColor.removePrefix("0x").toULong(16).toLong())
+    val splitFocusBorderColorOverride: Color? =
+        splitFocusBorderColor
+            .takeIf { it.isNotBlank() && !it.equals(LEGACY_FOCUS_BORDER_BLUE, ignoreCase = true) }
+            ?.let { hex -> runCatching { Color(hex.removePrefix("0x").toULong(16).toLong()) }.getOrNull() }
 
     @Transient
     val commandBlockSuccessColorValue: Color = Color(commandBlockSuccessColor.removePrefix("0x").toULong(16).toLong())
@@ -1401,6 +1430,13 @@ data class TerminalSettings(
          * Default settings instance
          */
         val DEFAULT = TerminalSettings()
+
+        /**
+         * The pre-theme default for [splitFocusBorderColor], kept as a named
+         * constant because it is now a *value to ignore* rather than a value to
+         * use, and that only reads as deliberate with a name on it.
+         */
+        const val LEGACY_FOCUS_BORDER_BLUE = "0xFF4A90E2"
 
         /**
          * Convert Color to hex string for serialization (0xAARRGGBB format)

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettingsOverride.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettingsOverride.kt
@@ -148,6 +148,10 @@ data class TerminalSettingsOverride(
     val splitDefaultRatio: Float? = null,
     val splitMinimumSize: Float? = null,
     val splitFocusBorderEnabled: Boolean? = null,
+    // Two levels of "unset": null does not override at all, and `""` overrides with
+    // "follow the active theme". An override never passes through
+    // `migrateSplitFocusBorderDefault`, so an embedder pinning the old 0xFF4A90E2
+    // still gets that blue - the migration only clears it from a user's own file.
     val splitFocusBorderColor: String? = null,
     val splitInheritWorkingDirectory: Boolean? = null,
 

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/SplitsSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/SplitsSettingsSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import ai.rever.bossterm.compose.settings.TerminalSettings
 import ai.rever.bossterm.compose.settings.components.*
+import ai.rever.bossterm.compose.settings.theme.BossUiTheme
 import ai.rever.bossterm.compose.settings.toSettingsHex
 
 /**
@@ -62,12 +63,32 @@ fun SplitsSettingsSection(
                 description = "Highlight the focused pane with a colored border"
             )
 
+            val themeSignal = BossUiTheme.current.signal
+            val followsTheme = settings.splitFocusBorderColorOverride == null
+
+            SettingsToggle(
+                label = "Match Theme",
+                checked = followsTheme,
+                // Turning this OFF writes the colour that is currently on screen
+                // rather than a stored one, so the picker below opens on what the
+                // user was just looking at instead of jumping to an old value.
+                onCheckedChange = { follow ->
+                    onSettingsChange(
+                        settings.copy(
+                            splitFocusBorderColor = if (follow) "" else themeSignal.toSettingsHex()
+                        )
+                    )
+                },
+                description = "Use the active theme's accent for the focus indicator",
+                enabled = settings.splitFocusBorderEnabled
+            )
+
             ColorSetting(
                 label = "Focus Border Color",
-                color = settings.splitFocusBorderColorValue,
+                color = settings.splitFocusBorderColorOverride ?: themeSignal,
                 onColorChange = { onSettingsChange(settings.copy(splitFocusBorderColor = it.toSettingsHex())) },
                 description = "Color of the focus indicator border",
-                enabled = settings.splitFocusBorderEnabled
+                enabled = settings.splitFocusBorderEnabled && !followsTheme
             )
         }
     }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/SplitsSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/SplitsSettingsSection.kt
@@ -4,6 +4,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import ai.rever.bossterm.compose.settings.TerminalSettings
@@ -63,19 +67,32 @@ fun SplitsSettingsSection(
                 description = "Highlight the focused pane with a colored border"
             )
 
-            val themeSignal = BossUiTheme.current.signal
-            val followsTheme = settings.splitFocusBorderColorOverride == null
+            val themeFocusRing = BossUiTheme.current.focusRing
+            val override = settings.splitFocusBorderColorOverride
+            val followsTheme = override == null
+
+            // Turning Match Theme off has to write *some* colour, and the stored one
+            // is gone by then. Holding the last explicit choice for as long as the
+            // window is open makes on -> off -> on lossless, which is the round trip
+            // someone actually performs (flip it on, look at it, flip it back).
+            // Deliberately not persisted: a colour nobody can see in the UI is worse
+            // than re-picking one.
+            var lastExplicit by remember { mutableStateOf(override) }
+            if (override != null && override != lastExplicit) lastExplicit = override
 
             SettingsToggle(
                 label = "Match Theme",
                 checked = followsTheme,
-                // Turning this OFF writes the colour that is currently on screen
-                // rather than a stored one, so the picker below opens on what the
-                // user was just looking at instead of jumping to an old value.
                 onCheckedChange = { follow ->
                     onSettingsChange(
                         settings.copy(
-                            splitFocusBorderColor = if (follow) "" else themeSignal.toSettingsHex()
+                            splitFocusBorderColor = when {
+                                follow -> ""
+                                // Falls back to what is on screen for someone who has
+                                // never picked a colour, so the picker opens on what
+                                // they were just looking at.
+                                else -> (lastExplicit ?: themeFocusRing).toSettingsHex()
+                            }
                         )
                     )
                 },
@@ -85,7 +102,7 @@ fun SplitsSettingsSection(
 
             ColorSetting(
                 label = "Focus Border Color",
-                color = settings.splitFocusBorderColorOverride ?: themeSignal,
+                color = override ?: themeFocusRing,
                 onColorChange = { onSettingsChange(settings.copy(splitFocusBorderColor = it.toSettingsHex())) },
                 description = "Color of the focus indicator border",
                 enabled = settings.splitFocusBorderEnabled && !followsTheme

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/UiTheme.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/theme/UiTheme.kt
@@ -38,7 +38,34 @@ data class UiTheme(
 ) {
     val isDark: Boolean get() = ink.luminance() < 0.5f
 
+    /**
+     * The colour for a focus ring - the border that says "this pane has keyboard
+     * focus". [signal] normally, [signalText] where signal cannot clear
+     * [FOCUS_RING_MIN_CONTRAST] against [ink].
+     *
+     * A focus ring is a hairline with nothing behind it, so unlike a `signalWash`
+     * fill it has only its own contrast to be seen by, and unlike [signal] as a
+     * fill it has no [onSignal] content riding on it. [signal] alone is not enough:
+     * it is the theme's cursor colour for every derived theme and is nudged for
+     * legibility nowhere, so an amber-on-paper identity lands under the floor -
+     * measured, `boss-daylight` is 2.63:1 and `solarized-light` 2.98:1, while their
+     * [signalText] is 5.32:1 and 5.34:1. Reaching for the token that IS held to a
+     * legibility floor is cheaper than nudging a second one, and on the twelve
+     * builtins already over the line it changes nothing.
+     *
+     * `SplitFocusBorderTest` holds every builtin to the floor through this property,
+     * which is why it needs no by-name exemption for the two above.
+     */
+    val focusRing: Color
+        get() = if (contrastRatio(signal, ink) >= FOCUS_RING_MIN_CONTRAST) signal else signalText
+
     companion object {
+        /**
+         * WCAG 1.4.11's floor for a non-text UI component, which is what a focus
+         * ring is. The same number `UiThemeContrastTest` already holds indicators to.
+         */
+        const val FOCUS_RING_MIN_CONTRAST = 3f
+
         /**
          * Exact tokens for the bossconsole.ai identity, mirroring the host's
          * `BossBlueprintColorScheme` (`line2` is the host's `lineStrong`).

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
@@ -62,7 +62,9 @@ fun SplitContainer(
     menuActions: MenuActions?,
     // Split pane settings
     splitFocusBorderEnabled: Boolean = true,
-    splitFocusBorderColor: Color = Color(0xFF4A90E2),
+    // The real call site passes the user's colour when they set one; this default is
+    // what an embedder gets, and it follows the theme like the unfocused border below.
+    splitFocusBorderColor: Color = BossUiTheme.current.signal,
     splitMinimumSize: Float = 0.1f,
     onLinkClick: ((HyperlinkInfo) -> Boolean)? = null,
     customContextMenuItems: List<ContextMenuElement> = emptyList(),

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/splits/SplitContainer.kt
@@ -64,7 +64,7 @@ fun SplitContainer(
     splitFocusBorderEnabled: Boolean = true,
     // The real call site passes the user's colour when they set one; this default is
     // what an embedder gets, and it follows the theme like the unfocused border below.
-    splitFocusBorderColor: Color = BossUiTheme.current.signal,
+    splitFocusBorderColor: Color = BossUiTheme.current.focusRing,
     splitMinimumSize: Float = 0.1f,
     onLinkClick: ((HyperlinkInfo) -> Boolean)? = null,
     customContextMenuItems: List<ContextMenuElement> = emptyList(),

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ChromeTokenCoverageTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/ChromeTokenCoverageTest.kt
@@ -75,17 +75,23 @@ class ChromeTokenCoverageTest {
         "palette/CommandPalette.kt" to listOf("0x88000000"),
         "history/HistorySearchOverlay.kt" to listOf("0x88000000"),
         // These are @Composable PARAMETER DEFAULTS for values the user owns, not
-        // chrome. Every real call site passes the setting instead
-        // (`ProperTerminal` -> scrollbarThumbColor / scrollbarColor /
-        // searchMarkerColor, `TabbedTerminal` -> splitFocusBorderColor), and
+        // chrome. Every real call site passes the setting instead (`ProperTerminal`
+        // -> scrollbarThumbColor / scrollbarColor / searchMarkerColor), and
         // `ThemeDefaultsTest.scrollbar search markers stay independent of the theme`
         // pins the markers as deliberately theme-independent. Pointing these at a
         // token would let the active theme silently override a colour the user set in
         // Settings, which is a worse bug than the one this test exists to catch.
+        //
+        // `splits/SplitContainer.kt` used to be on this list for the same reason and
+        // is no longer: "a colour the user set in Settings" was never true of its
+        // 0xFF4A90E2, which nobody had set - it was the factory default, and it
+        // outvoted the theme for everyone who never opened the Splits section. The
+        // user's ownership now lives one level up, in
+        // `TerminalSettings.splitFocusBorderColorOverride`, which is null until they
+        // pick something; only then does a colour beat the theme.
         "scrollbar/AlwaysVisibleScrollbar.kt" to listOf(
             "Color.White", "0xFFFFFF00", "0xFFFF6600",
         ),
-        "splits/SplitContainer.kt" to listOf("0xFF4A90E2"),
     )
 
     /**

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/SplitFocusBorderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/SplitFocusBorderTest.kt
@@ -1,0 +1,145 @@
+package ai.rever.bossterm.compose.theme
+
+import ai.rever.bossterm.compose.settings.TerminalSettings
+import ai.rever.bossterm.compose.settings.theme.BuiltinThemes
+import ai.rever.bossterm.compose.settings.theme.Theme
+import ai.rever.bossterm.compose.settings.theme.UiTheme
+import ai.rever.bossterm.compose.settings.toSettingsHex
+import androidx.compose.ui.graphics.Color
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+/**
+ * The focused pane's border follows the theme unless the user chose a colour.
+ *
+ * The bug: `splitFocusBorderColor` defaulted to the literal 0xFF4A90E2, a blue that
+ * belongs to no BOSS identity. Every other piece of pane chrome had been converted to
+ * tokens - the unfocused border is `UiTheme.line2`, the divider is `line`, the tab
+ * chips take the theme's cursor - so the focus rectangle was the last hardcoded colour
+ * on that surface. It went unseen for as long as Blueprint was the default theme,
+ * because a generic blue on a blue identity looks intentional. On NVIDIA (green on
+ * pure black) it is the only non-green thing on screen.
+ *
+ * Two halves worth pinning separately, because the second is the one that reaches a
+ * real user: the resolution rule, and the fact that an *existing* settings file - which
+ * has the old default serialized into it verbatim - resolves the same way as a fresh
+ * one. A fix that only changed the default would pass the first and leave every
+ * installed copy blue.
+ */
+class SplitFocusBorderTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * What the host bridge synthesizes for the NVIDIA identity: pure-black floor,
+     * near-white text, the brand green as the cursor.
+     *
+     * Built here rather than taken from [BuiltinThemes] because BossTerm has no NVIDIA
+     * builtin - the host theme reaches the terminal as a synthesized `boss-host-dark`,
+     * and it is that derived path, not a curated one, whose signal has to come out
+     * green.
+     */
+    private val nvidiaLike = Theme(
+        id = "boss-host-dark",
+        name = "BOSS Host (Dark)",
+        foreground = "0xFFEEEEEE",
+        background = "0xFF000000",
+        cursor = "0xFF76B900",
+        cursorText = "0xFF000000",
+        selection = "0x4D76B900",
+        selectionText = "0xFFEEEEEE",
+        searchMatch = "0xFFEF9100",
+        hyperlink = "0xFF10B1FB",
+        black = "0xFF15202B",
+        red = "0xFFFF8181",
+        green = "0xFF1DBBA4",
+        yellow = "0xFFEF9100",
+        blue = "0xFF5C9FE0",
+        magenta = "0xFFC792EA",
+        cyan = "0xFF10B1FB",
+        white = "0xFFC7D1DB",
+        brightBlack = "0xFF3A4B5C",
+        brightRed = "0xFFFF8A80",
+        brightGreen = "0xFF8FE0A6",
+        brightYellow = "0xFFFFC560",
+        brightBlue = "0xFF82B7F0",
+        brightMagenta = "0xFFDDB0F5",
+        brightCyan = "0xFF7FD9EE",
+        brightWhite = "0xFFE9EEF3",
+        isBuiltin = false,
+    )
+
+    @Test
+    fun `a fresh install follows the theme`() {
+        assertNull(
+            TerminalSettings.DEFAULT.splitFocusBorderColorOverride,
+            "the shipped default must be 'follow the theme', not a colour",
+        )
+    }
+
+    @Test
+    fun `an existing settings file carrying the old default follows the theme`() {
+        // Verbatim from a real ~/.boss/bossterm/settings.json written before this
+        // change. This is the case the whole design turns on: the value is not the
+        // user's choice, it is the factory default that was persisted on first save.
+        val stored = json.decodeFromString<TerminalSettings>(
+            """{"splitFocusBorderColor":"${TerminalSettings.LEGACY_FOCUS_BORDER_BLUE}"}""",
+        )
+        assertNull(
+            stored.splitFocusBorderColorOverride,
+            "an install still carrying the old default must pick the theme up",
+        )
+    }
+
+    @Test
+    fun `the legacy value is recognised whatever case it was written in`() {
+        // colorToHex uppercases, but a hand-edited file or an older writer need not.
+        val lower = TerminalSettings(splitFocusBorderColor = "0xff4a90e2")
+        assertNull(lower.splitFocusBorderColorOverride)
+    }
+
+    @Test
+    fun `a colour the user picked wins over the theme`() {
+        val chosen = Color(0xFFFF00FF)
+        val settings = TerminalSettings(splitFocusBorderColor = chosen.toSettingsHex())
+        assertEquals(chosen, settings.splitFocusBorderColorOverride)
+    }
+
+    @Test
+    fun `a malformed colour falls back to the theme instead of throwing`() {
+        // The other colour fields parse eagerly and would throw out of the
+        // constructor; this one's default is blank, so every TerminalSettings would
+        // be affected by a strict parse here.
+        assertNull(TerminalSettings(splitFocusBorderColor = "not-a-colour").splitFocusBorderColorOverride)
+        assertNull(TerminalSettings(splitFocusBorderColor = "0xZZZZZZZZ").splitFocusBorderColorOverride)
+    }
+
+    @Test
+    fun `the resolved border is the identity's accent, not the old blue`() {
+        // What TabbedTerminal computes: override ?: UiTheme.signal.
+        val legacyBlue = Color(0xFF4A90E2)
+
+        val nvidiaSignal = UiTheme.fromTheme(nvidiaLike).signal
+        assertEquals(Color(0xFF76B900), nvidiaSignal, "NVIDIA's focus border must be the brand green")
+        assertNotEquals(legacyBlue, nvidiaSignal)
+
+        // And the identity that used to hide the bug still gets a blue, so this is a
+        // recolour of one theme's chrome rather than a change everyone sees.
+        val blueprintSignal = UiTheme.fromTheme(BuiltinThemes.BOSS_BLUEPRINT).signal
+        assertEquals(UiTheme.BOSS_BLUEPRINT.signal, blueprintSignal)
+    }
+
+    @Test
+    fun `every builtin resolves a focus border distinct from its own floor`() {
+        // A focus indicator the same colour as the surface it sits on is not an
+        // indicator. Cheap to assert across the set, and it is the failure mode a
+        // future derived theme would hit.
+        for (theme in BuiltinThemes.ALL) {
+            val ui = UiTheme.fromTheme(theme)
+            assertNotEquals(ui.ink, ui.signal, "${theme.id}: focus border is invisible on its own floor")
+        }
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/SplitFocusBorderTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/theme/SplitFocusBorderTest.kt
@@ -1,16 +1,19 @@
 package ai.rever.bossterm.compose.theme
 
 import ai.rever.bossterm.compose.settings.TerminalSettings
+import ai.rever.bossterm.compose.settings.migrateSplitFocusBorderDefault
 import ai.rever.bossterm.compose.settings.theme.BuiltinThemes
 import ai.rever.bossterm.compose.settings.theme.Theme
 import ai.rever.bossterm.compose.settings.theme.UiTheme
 import ai.rever.bossterm.compose.settings.toSettingsHex
+import ai.rever.bossterm.compose.util.ColorUtils
 import androidx.compose.ui.graphics.Color
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * The focused pane's border follows the theme unless the user chose a colour.
@@ -23,28 +26,31 @@ import kotlin.test.assertNull
  * because a generic blue on a blue identity looks intentional. On NVIDIA (green on
  * pure black) it is the only non-green thing on screen.
  *
- * Two halves worth pinning separately, because the second is the one that reaches a
- * real user: the resolution rule, and the fact that an *existing* settings file - which
- * has the old default serialized into it verbatim - resolves the same way as a fresh
- * one. A fix that only changed the default would pass the first and leave every
- * installed copy blue.
+ * Three things worth pinning separately:
+ *  1. the resolution rule (blank means follow the theme);
+ *  2. the one-time migration, which is what reaches an *existing* user - a fix that
+ *     only changed the default would leave every installed copy blue, because the old
+ *     default is serialized into their file verbatim;
+ *  3. the contrast floor, which is the regression this change introduces rather than
+ *     one it inherits. A hardcoded blue was at least always visible; a theme-derived
+ *     colour is only as visible as the theme makes it.
  */
 class SplitFocusBorderTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
     /**
-     * What the host bridge synthesizes for the NVIDIA identity: pure-black floor,
-     * near-white text, the brand green as the cursor.
+     * A derived (non-builtin) theme shaped like the host's NVIDIA identity: pure-black
+     * floor, near-white text, the brand green as the cursor.
      *
      * Built here rather than taken from [BuiltinThemes] because BossTerm has no NVIDIA
-     * builtin - the host theme reaches the terminal as a synthesized `boss-host-dark`,
-     * and it is that derived path, not a curated one, whose signal has to come out
-     * green.
+     * builtin - the host theme reaches the terminal as a theme BossConsole synthesizes,
+     * so this fixture cannot drift-detect against the producing code and is not trying
+     * to. What it covers is the derived path, whose signal has to come out green.
      */
     private val nvidiaLike = Theme(
-        id = "boss-host-dark",
-        name = "BOSS Host (Dark)",
+        id = "host-derived-dark",
+        name = "Host derived (dark)",
         foreground = "0xFFEEEEEE",
         background = "0xFF000000",
         cursor = "0xFF76B900",
@@ -72,33 +78,14 @@ class SplitFocusBorderTest {
         isBuiltin = false,
     )
 
+    // ----- 1. the resolution rule -------------------------------------------------
+
     @Test
     fun `a fresh install follows the theme`() {
         assertNull(
             TerminalSettings.DEFAULT.splitFocusBorderColorOverride,
             "the shipped default must be 'follow the theme', not a colour",
         )
-    }
-
-    @Test
-    fun `an existing settings file carrying the old default follows the theme`() {
-        // Verbatim from a real ~/.boss/bossterm/settings.json written before this
-        // change. This is the case the whole design turns on: the value is not the
-        // user's choice, it is the factory default that was persisted on first save.
-        val stored = json.decodeFromString<TerminalSettings>(
-            """{"splitFocusBorderColor":"${TerminalSettings.LEGACY_FOCUS_BORDER_BLUE}"}""",
-        )
-        assertNull(
-            stored.splitFocusBorderColorOverride,
-            "an install still carrying the old default must pick the theme up",
-        )
-    }
-
-    @Test
-    fun `the legacy value is recognised whatever case it was written in`() {
-        // colorToHex uppercases, but a hand-edited file or an older writer need not.
-        val lower = TerminalSettings(splitFocusBorderColor = "0xff4a90e2")
-        assertNull(lower.splitFocusBorderColorOverride)
     }
 
     @Test
@@ -109,37 +96,136 @@ class SplitFocusBorderTest {
     }
 
     @Test
+    fun `the old blue is selectable again once the migration has run`() {
+        // The migration clears it from a legacy file; after that the value can only
+        // have come from the picker, and it must be honoured like any other choice.
+        // Reading it as "unset" forever would make it the one colour nobody can pick.
+        val settings = TerminalSettings(splitFocusBorderColor = TerminalSettings.LEGACY_FOCUS_BORDER_BLUE)
+        assertEquals(Color(0xFF4A90E2), settings.splitFocusBorderColorOverride)
+    }
+
+    @Test
     fun `a malformed colour falls back to the theme instead of throwing`() {
         // The other colour fields parse eagerly and would throw out of the
-        // constructor; this one's default is blank, so every TerminalSettings would
-        // be affected by a strict parse here.
+        // constructor; this one's default is blank, so a strict parse here would
+        // affect every TerminalSettings.
         assertNull(TerminalSettings(splitFocusBorderColor = "not-a-colour").splitFocusBorderColorOverride)
         assertNull(TerminalSettings(splitFocusBorderColor = "0xZZZZZZZZ").splitFocusBorderColorOverride)
     }
 
     @Test
-    fun `the resolved border is the identity's accent, not the old blue`() {
-        // What TabbedTerminal computes: override ?: UiTheme.signal.
-        val legacyBlue = Color(0xFF4A90E2)
+    fun `a hex that parses to full transparency is not an override`() {
+        // "0xFF0000" looks like red and is alpha 0 - the mistake a 6-digit hex makes.
+        // Without this it would read as a deliberate choice AND paint nothing, so the
+        // border would vanish with Match Theme showing off.
+        assertNull(TerminalSettings(splitFocusBorderColor = "0xFF0000").splitFocusBorderColorOverride)
+        assertNull(TerminalSettings(splitFocusBorderColor = "0x0076B900").splitFocusBorderColorOverride)
+    }
 
-        val nvidiaSignal = UiTheme.fromTheme(nvidiaLike).signal
-        assertEquals(Color(0xFF76B900), nvidiaSignal, "NVIDIA's focus border must be the brand green")
-        assertNotEquals(legacyBlue, nvidiaSignal)
+    // ----- 2. the migration -------------------------------------------------------
 
-        // And the identity that used to hide the bug still gets a blue, so this is a
-        // recolour of one theme's chrome rather than a change everyone sees.
-        val blueprintSignal = UiTheme.fromTheme(BuiltinThemes.BOSS_BLUEPRINT).signal
-        assertEquals(UiTheme.BOSS_BLUEPRINT.signal, blueprintSignal)
+    @Test
+    fun `an existing settings file carrying the old default is migrated to the theme`() {
+        // Verbatim from a real settings.json written before this change, with no
+        // version marker. This is the case the whole design turns on: the value is not
+        // the user's choice, it is the factory default that was persisted on first save.
+        val onDisk = json.decodeFromString<TerminalSettings>(
+            """{"splitFocusBorderColor":"${TerminalSettings.LEGACY_FOCUS_BORDER_BLUE}"}""",
+        )
+        val migrated = migrateSplitFocusBorderDefault(onDisk, hasSplitFocusBorderVersion = false)
+
+        assertEquals("", migrated.splitFocusBorderColor)
+        assertNull(migrated.splitFocusBorderColorOverride, "a legacy install must pick the theme up")
+        assertEquals(2, migrated.splitFocusBorderVersion, "the marker must stop this running twice")
     }
 
     @Test
-    fun `every builtin resolves a focus border distinct from its own floor`() {
-        // A focus indicator the same colour as the surface it sits on is not an
-        // indicator. Cheap to assert across the set, and it is the failure mode a
-        // future derived theme would hit.
-        for (theme in BuiltinThemes.ALL) {
+    fun `the legacy value is recognised whatever case it was written in`() {
+        // colorToHex uppercases, but a hand-edited file or an older writer need not.
+        val lower = TerminalSettings(splitFocusBorderColor = "0xff4a90e2")
+        assertEquals("", migrateSplitFocusBorderDefault(lower, hasSplitFocusBorderVersion = false).splitFocusBorderColor)
+    }
+
+    @Test
+    fun `the migration leaves a real choice alone`() {
+        val chosen = TerminalSettings(splitFocusBorderColor = "0xFFFF00FF")
+        val migrated = migrateSplitFocusBorderDefault(chosen, hasSplitFocusBorderVersion = false)
+
+        assertEquals("0xFFFF00FF", migrated.splitFocusBorderColor)
+        assertEquals(2, migrated.splitFocusBorderVersion)
+    }
+
+    @Test
+    fun `the migration does not run a second time`() {
+        // Post-migration, the blue is a deliberate pick and must survive every
+        // subsequent load. Without the marker check it would be cleared forever.
+        val deliberate = TerminalSettings(
+            splitFocusBorderColor = TerminalSettings.LEGACY_FOCUS_BORDER_BLUE,
+            splitFocusBorderVersion = 2,
+        )
+        assertEquals(
+            deliberate,
+            migrateSplitFocusBorderDefault(deliberate, hasSplitFocusBorderVersion = true),
+        )
+    }
+
+    // ----- 3. what the theme resolves to ------------------------------------------
+
+    @Test
+    fun `the resolved border is the identity's accent, not the old blue`() {
+        val nvidiaRing = UiTheme.fromTheme(nvidiaLike).focusRing
+        assertEquals(Color(0xFF76B900), nvidiaRing, "NVIDIA's focus border must be the brand green")
+        assertNotEquals(Color(0xFF4A90E2), nvidiaRing)
+
+        // Blueprint moves too - #4A90E2 to #0F5BFF. Less noticeable than the green,
+        // but this is not a no-op for the identity that used to hide the bug, and
+        // pinning the literal says which blue rather than re-checking a map lookup.
+        assertEquals(Color(0xFF0F5BFF), UiTheme.fromTheme(BuiltinThemes.BOSS_BLUEPRINT).focusRing)
+    }
+
+    @Test
+    fun `every builtin resolves a focus ring that clears the component contrast floor`() {
+        // The regression this change introduces. `signal` is the cursor colour for a
+        // derived theme and is nudged for legibility nowhere, so this is not free:
+        // boss-daylight's amber is 2.63:1 on its own paper and solarized-light's is
+        // 2.98:1. `focusRing` reaches for `signalText` in exactly those cases, which
+        // is why this needs no exemption list.
+        val under = BuiltinThemes.ALL.mapNotNull { theme ->
             val ui = UiTheme.fromTheme(theme)
-            assertNotEquals(ui.ink, ui.signal, "${theme.id}: focus border is invisible on its own floor")
+            val ratio = ColorUtils.contrastRatio(ui.focusRing, ui.ink)
+            if (ratio < UiTheme.FOCUS_RING_MIN_CONTRAST) "${theme.id}: %.2f:1".format(ratio) else null
         }
+        assertEquals(
+            emptyList(),
+            under,
+            "a focus border under ${UiTheme.FOCUS_RING_MIN_CONTRAST}:1 on its own floor is not an indicator",
+        )
+    }
+
+    @Test
+    fun `the focus ring only leaves signal behind when signal cannot carry it`() {
+        // The guard must be a last resort, not a blanket swap: on a theme whose signal
+        // already clears the floor, the accent the user recognises is the one that has
+        // to show up.
+        // Stated as the property rather than a list of names, so adding a theme does
+        // not fail this for the wrong reason. Today the two that swap are
+        // boss-daylight and solarized-light.
+        val wronglySwapped = BuiltinThemes.ALL.mapNotNull { theme ->
+            val ui = UiTheme.fromTheme(theme)
+            val ratio = ColorUtils.contrastRatio(ui.signal, ui.ink)
+            if (ui.focusRing != ui.signal && ratio >= UiTheme.FOCUS_RING_MIN_CONTRAST) {
+                "${theme.id}: signal is %.2f:1 and was swapped anyway".format(ratio)
+            } else {
+                null
+            }
+        }
+        assertEquals(emptyList(), wronglySwapped)
+
+        // And the guard fires where it must, or the test above would pass vacuously
+        // on a build where focusRing simply returned signalText everywhere.
+        assertTrue(
+            BuiltinThemes.ALL.any { UiTheme.fromTheme(it).let { ui -> ui.focusRing == ui.signal } },
+            "focusRing must be signal for the themes that can carry it",
+        )
     }
 }

--- a/docs/wiki/API-Reference.md
+++ b/docs/wiki/API-Reference.md
@@ -315,7 +315,7 @@ data class TerminalSettings(
     val splitDefaultRatio: Float = 0.5f,
     val splitMinimumSize: Float = 0.1f,
     val splitFocusBorderEnabled: Boolean = true,
-    val splitFocusBorderColor: String = "0xFF4A90E2",
+    val splitFocusBorderColor: String = "",  // blank follows the active theme
     val splitInheritWorkingDirectory: Boolean = true,
 
     // Tab Bar

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -109,7 +109,7 @@ Location: `~/.bossterm/settings.json`
 | `splitDefaultRatio` | Float | `0.5` | Default split ratio (0.0-1.0) |
 | `splitMinimumSize` | Float | `0.1` | Minimum pane size (0.0-0.5) |
 | `splitFocusBorderEnabled` | Boolean | `true` | Show border on focused pane |
-| `splitFocusBorderColor` | String | `"0xFF4A90E2"` | Focus border color |
+| `splitFocusBorderColor` | String | `""` | Focus border color; blank follows the active theme |
 | `splitInheritWorkingDirectory` | Boolean | `true` | New splits inherit CWD |
 
 ### Clipboard Settings (OSC 52)


### PR DESCRIPTION
## The bug

Pick **NVIDIA** as the BOSS theme and the terminal re-skins correctly - pure-black floor, green selection, green tab-chip accents - except for one thing: a blue rectangle around the focused pane.

I sampled it off a running app to be sure. The border is `#4A90E2`, `splitFocusBorderColor`'s default. Everything else on that surface had already been converted to tokens (the unfocused border is `UiTheme.line2`, the divider is `line`, the tab chip takes the theme's cursor), so the focus rectangle was the last hardcoded colour on the pane.

It passed unnoticed for as long as Blueprint was the default, because a generic blue on a blue identity looks intentional. On green-on-pure-black it is the only non-green thing on screen.

## Why the allowlist entry was wrong

`ChromeTokenCoverageTest` explicitly blessed this literal:

> These are @Composable PARAMETER DEFAULTS for values the user owns, not chrome. [...] Pointing these at a token would let the active theme silently override a colour the user set in Settings, which is a worse bug than the one this test exists to catch.

Right principle, wrong subject. That reasoning holds for the scrollbar markers, which stay allowlisted. It was never true of this one: nobody set `#4A90E2`. It was the factory default, and it outvoted the theme for every user who never opened the Splits section.

Ownership moves one level up. `TerminalSettings.splitFocusBorderColorOverride` is null until the user picks something, and only a non-null override beats the theme. The literal is gone from `SplitContainer`, so the allowlist entry goes with it (`the allowlist has no stale entries` would have failed otherwise).

## The migration half

Changing the default alone would fix nobody who already runs BossTerm. `0xFF4A90E2` is serialized verbatim into every existing `settings.json`, so those installs would stay blue forever.

So the old default reads as blank too. The one case this gets wrong is a user who deliberately chose that exact blue; every other custom colour survives, which makes it the narrowest reinterpretation available. It is named `LEGACY_FOCUS_BORDER_BLUE` so it reads as a value to ignore rather than one to use.

## Settings

A **Match Theme** toggle, on by default. Turning it off writes the colour currently on screen, so the picker opens on what the user was just looking at rather than jumping to a stored value.

## Tests

`SplitFocusBorderTest`, 7 cases: fresh install follows the theme, an existing file carrying the old default follows the theme (decoded from real JSON, since that is the case that reaches a user), case-insensitive legacy match, a chosen colour wins, a malformed colour falls back instead of throwing out of the constructor of every `TerminalSettings`, the NVIDIA-shaped derived theme resolves to `#76B900` while Blueprint still resolves to blue, and no builtin resolves a border equal to its own floor.

Verified against the bug by restoring the old semantics: 3 of the 7 fail, and they are the three that pin the new behaviour. Full `:compose-ui:desktopTest` is green.

## Ships as

BossTerm release -> `terminal-tab` bundle bump. Unrelated but worth noting for the same report: the active tab chip's surface collapsing to near-black on a pure-black floor was the Oklab-lerp bug already fixed in v1.2.152 (#373), so that half arrives once the plugin moves past its current 1.2.150.