### PR TITLE
Tab hover: show what the chip had to clip, plus a screen preview

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -1279,11 +1279,50 @@ fun TabbedTerminal(
                 }
             }
 
+            // The same path with the home prefix folded to "~" but nothing elided — the
+            // hover tooltip's job is to show what abbreviateCwd() had to drop.
+            fun fullCwd(path: String?): String? {
+                if (path.isNullOrBlank()) return null
+                val home = System.getProperty("user.home")?.trimEnd('/')
+                val clean = path.trimEnd('/').ifEmpty { "/" }
+                return if (!home.isNullOrEmpty() && (clean == home || clean.startsWith("$home/")))
+                    "~" + clean.removePrefix(home) else clean
+            }
+
+            // Tooltip-only: which remote a mirrored chip belongs to. Same label precedence as
+            // the remote box header, so the box and the chip name the host identically.
+            fun hostLabelFor(session: TerminalSession): String? {
+                val remote = rm?.sessionForMirror(session) ?: return null
+                return remote.customName.value
+                    ?: remote.hostName.value
+                    ?: runCatching { java.net.URI(remote.link).host ?: remote.link }.getOrDefault(remote.link)
+            }
+
+            // Tooltip-only: state worth calling out. Connected is the norm and says nothing;
+            // the rest is why a chip looks idle or empty.
+            fun statusLabelFor(session: TerminalSession): String? =
+                when (val st = session.connectionState.value) {
+                    is ConnectionState.Initializing, is ConnectionState.Connecting -> "starting…"
+                    is ConnectionState.Error -> "error: ${st.message}"
+                    else -> null
+                }
+
             // Resolve the session a chip refers to: a split pane by id, or the tab
             // itself for the synthetic tab-level chip (summary mode / not-yet-split).
             fun sessionFor(tabIndex: Int, paneId: String): TerminalSession? {
                 val tab = tabController.tabs.getOrNull(tabIndex) ?: return null
                 return splitStates[tab.id]?.getAllPanes()?.firstOrNull { it.id == paneId }?.session ?: tab
+            }
+
+            // Raw screen text behind the tooltip's scrollback preview. Called only while a
+            // tooltip is on screen, so the buffer lock is taken on hover and nowhere else.
+            //
+            // The visible screen, not the history: its bottom rows ARE the most recent output,
+            // and the history-inclusive read (createSnapshot, what read_scrollback uses) copies
+            // every scrollback line — thousands of them — which is not a hover's price to pay.
+            fun screenTextFor(tabIndex: Int, paneId: String): String? {
+                val session = sessionFor(tabIndex, paneId) ?: return null
+                return runCatching { session.textBuffer.getScreenLines() }.getOrNull()
             }
 
             // Each tab contributes a group of pane-chips (one chip per split pane).
@@ -1298,7 +1337,10 @@ fun TabbedTerminal(
                             p.id, p.session.title.value, colorHexFor(p.session),
                             subtitle = abbreviateCwd(p.session.workingDirectory.value),
                             branch = terminalPane?.gitBranch?.value,
-                            isGitRepo = if (terminalPane == null) false else terminalPane.isGitRepo.value
+                            isGitRepo = if (terminalPane == null) false else terminalPane.isGitRepo.value,
+                            fullPath = fullCwd(p.session.workingDirectory.value),
+                            hostLabel = hostLabelFor(p.session),
+                            statusLabel = statusLabelFor(p.session)
                         )
                     }
                 } else {
@@ -1306,7 +1348,10 @@ fun TabbedTerminal(
                         tab.id, tab.title.value, colorHexFor(tab),
                         subtitle = abbreviateCwd(tab.workingDirectory.value),
                         branch = tab.gitBranch.value,
-                        isGitRepo = tab.isGitRepo.value
+                        isGitRepo = tab.isGitRepo.value,
+                        fullPath = fullCwd(tab.workingDirectory.value),
+                        hostLabel = hostLabelFor(tab),
+                        statusLabel = statusLabelFor(tab)
                     ))
                 }
                 tab to ai.rever.bossterm.compose.tabs.TabBarGroup(index, panes)
@@ -1620,7 +1665,8 @@ fun TabbedTerminal(
                 collapsed = collapsed,
                 onToggleCollapse = if (tabBarOnLeft) onToggleCollapse else null,
                 onPin = if (tabBarOnLeft) drawer?.onPin else null,
-                onTransientInteraction = drawer?.onBusyChange
+                onTransientInteraction = drawer?.onBusyChange,
+                scrollbackPreview = { tabIndex, paneId -> screenTextFor(tabIndex, paneId) }
             )
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/TabbedTerminal.kt
@@ -105,6 +105,9 @@ import ai.rever.bossterm.compose.voice.VoiceToolSource
 import ai.rever.bossterm.compose.voice.segmentState
 import ai.rever.bossterm.compose.ui.ProperTerminal
 
+/** Tab-bar diagnostics that must never surface as UI (a hover cannot show an error). */
+private val tabBarLog = org.slf4j.LoggerFactory.getLogger("ai.rever.bossterm.compose.TabBar")
+
 /**
  * Terminal composable with multi-tab support.
  *
@@ -1239,14 +1242,26 @@ fun TabbedTerminal(
             val rm = state?.remoteSessions
             val tabBarClipboard = androidx.compose.ui.platform.LocalClipboardManager.current
 
+            // Read once per bar composition, not once per chip.
+            val userHome = remember { System.getProperty("user.home")?.trimEnd('/') }
+            // link → display host, for the one label branch that has to parse a URI.
+            val remoteLinkHosts = remember { mutableMapOf<String, String>() }
+
             // Resolve the per-tab accent color: a manual color (Color ▸ menu) always
             // wins; otherwise, when color-by-directory is on, derive a stable accent
             // from the session's cwd. Reads MutableState so the bar recomposes live.
-            fun colorHexFor(session: TerminalSession): String? {
+            //
+            // [remote] is passed in rather than looked up: it is an O(sessions) scan over
+            // `ownsMirror`, this runs for every chip on every recomposition of the bar, and the
+            // tooltip's host label needs the same answer.
+            fun colorHexFor(
+                session: TerminalSession,
+                remote: ai.rever.bossterm.compose.remote.RemoteSession?
+            ): String? {
                 if (session.isRemote) {
                     // Group accent (set via the remote box header's right-click) wins; the
                     // default cyan marks mirrored remote tabs.
-                    return rm?.sessionForMirror(session)?.accent?.value ?: "0xFF4FC3F7"
+                    return remote?.accent?.value ?: "0xFF4FC3F7"
                 }
                 session.tabColor.value?.let { return it }
                 if (settings.tabColorByDirectory) {
@@ -1265,10 +1280,8 @@ fun TabbedTerminal(
             // full home path there, matching the web viewer (its second line is never blank/"~").
             fun abbreviateCwd(path: String?): String? {
                 if (path.isNullOrBlank()) return null
-                val home = System.getProperty("user.home")?.trimEnd('/')
                 val clean = path.trimEnd('/').ifEmpty { "/" }
-                val withTilde = if (!home.isNullOrEmpty() && (clean == home || clean.startsWith("$home/")))
-                    "~" + clean.removePrefix(home) else clean
+                val withTilde = ai.rever.bossterm.compose.tabs.tildePath(path, userHome) ?: return null
                 val parts = withTilde.split('/').filter { it.isNotEmpty() }
                 return when {
                     withTilde == "~" -> clean // home: show the real path (the "~" title carries the tilde)
@@ -1280,22 +1293,23 @@ fun TabbedTerminal(
             }
 
             // The same path with the home prefix folded to "~" but nothing elided — the
-            // hover tooltip's job is to show what abbreviateCwd() had to drop.
-            fun fullCwd(path: String?): String? {
-                if (path.isNullOrBlank()) return null
-                val home = System.getProperty("user.home")?.trimEnd('/')
-                val clean = path.trimEnd('/').ifEmpty { "/" }
-                return if (!home.isNullOrEmpty() && (clean == home || clean.startsWith("$home/")))
-                    "~" + clean.removePrefix(home) else clean
-            }
+            // hover tooltip's job is to show what abbreviateCwd() had to drop. A mirrored
+            // pane's cwd is the HOST's, so the local home is not folded into it.
+            fun fullCwd(path: String?, remote: ai.rever.bossterm.compose.remote.RemoteSession?): String? =
+                ai.rever.bossterm.compose.tabs.tildePath(path, if (remote != null) null else userHome)
 
             // Tooltip-only: which remote a mirrored chip belongs to. Same label precedence as
             // the remote box header, so the box and the chip name the host identically.
-            fun hostLabelFor(session: TerminalSession): String? {
-                val remote = rm?.sessionForMirror(session) ?: return null
+            fun hostLabelFor(remote: ai.rever.bossterm.compose.remote.RemoteSession?): String? {
+                if (remote == null) return null
                 return remote.customName.value
                     ?: remote.hostName.value
-                    ?: runCatching { java.net.URI(remote.link).host ?: remote.link }.getOrDefault(remote.link)
+                    // Last resort, and the only expensive branch — memoised, since a live
+                    // session's link never changes but this is read on every recomposition.
+                    ?: remoteLinkHosts.getOrPut(remote.link) {
+                        runCatching { java.net.URI(remote.link).host ?: remote.link }
+                            .getOrDefault(remote.link)
+                    }
             }
 
             // Tooltip-only: state worth calling out. Connected is the norm and says nothing;
@@ -1322,7 +1336,16 @@ fun TabbedTerminal(
             // every scrollback line — thousands of them — which is not a hover's price to pay.
             fun screenTextFor(tabIndex: Int, paneId: String): String? {
                 val session = sessionFor(tabIndex, paneId) ?: return null
-                return runCatching { session.textBuffer.getScreenLines() }.getOrNull()
+                return try {
+                    session.textBuffer.getScreenLines()
+                } catch (e: IndexOutOfBoundsException) {
+                    // The plausible throw: line-storage index churn against a concurrent
+                    // resize. Caught (a hover must not take the app down) but not swallowed —
+                    // if it ever becomes systematic, a silently preview-less tooltip would be
+                    // the only symptom.
+                    tabBarLog.debug("Tooltip preview read failed for pane {}: {}", paneId, e.toString())
+                    null
+                }
             }
 
             // Each tab contributes a group of pane-chips (one chip per split pane).
@@ -1333,24 +1356,26 @@ fun TabbedTerminal(
                 val panes = if (st != null && !summaryMode) {
                     st.getAllPanes().map { p ->
                         val terminalPane = p.session as? ai.rever.bossterm.compose.tabs.TerminalTab
+                        val paneRemote = if (p.session.isRemote) rm?.sessionForMirror(p.session) else null
                         ai.rever.bossterm.compose.tabs.TabBarPane(
-                            p.id, p.session.title.value, colorHexFor(p.session),
+                            p.id, p.session.title.value, colorHexFor(p.session, paneRemote),
                             subtitle = abbreviateCwd(p.session.workingDirectory.value),
                             branch = terminalPane?.gitBranch?.value,
                             isGitRepo = if (terminalPane == null) false else terminalPane.isGitRepo.value,
-                            fullPath = fullCwd(p.session.workingDirectory.value),
-                            hostLabel = hostLabelFor(p.session),
+                            fullPath = fullCwd(p.session.workingDirectory.value, paneRemote),
+                            hostLabel = hostLabelFor(paneRemote),
                             statusLabel = statusLabelFor(p.session)
                         )
                     }
                 } else {
+                    val tabRemote = if (tab.isRemote) rm?.sessionForMirror(tab) else null
                     listOf(ai.rever.bossterm.compose.tabs.TabBarPane(
-                        tab.id, tab.title.value, colorHexFor(tab),
+                        tab.id, tab.title.value, colorHexFor(tab, tabRemote),
                         subtitle = abbreviateCwd(tab.workingDirectory.value),
                         branch = tab.gitBranch.value,
                         isGitRepo = tab.isGitRepo.value,
-                        fullPath = fullCwd(tab.workingDirectory.value),
-                        hostLabel = hostLabelFor(tab),
+                        fullPath = fullCwd(tab.workingDirectory.value, tabRemote),
+                        hostLabel = hostLabelFor(tabRemote),
                         statusLabel = statusLabelFor(tab)
                     ))
                 }
@@ -1666,7 +1691,13 @@ fun TabbedTerminal(
                 onToggleCollapse = if (tabBarOnLeft) onToggleCollapse else null,
                 onPin = if (tabBarOnLeft) drawer?.onPin else null,
                 onTransientInteraction = drawer?.onBusyChange,
-                scrollbackPreview = { tabIndex, paneId -> screenTextFor(tabIndex, paneId) }
+                // Null, not an empty-string provider: the tooltip drops the whole preview
+                // section (and its rule) when the setting is off.
+                scrollbackPreview = if (settings.tabHoverPreview) {
+                    { tabIndex, paneId -> screenTextFor(tabIndex, paneId) }
+                } else {
+                    null
+                }
             )
             }
         }

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/TerminalSettings.kt
@@ -524,6 +524,15 @@ data class TerminalSettings(
      */
     val tabColorByDirectory: Boolean = false,
 
+    /**
+     * Include a few rows of a pane's screen in its tab hover tooltip. On by default.
+     *
+     * Off leaves the rest of the tooltip (title, path, branch) alone — it exists because the
+     * preview draws a BACKGROUND pane's output into a popup, which during a screen share or a
+     * recording is content that was not on screen a moment ago.
+     */
+    val tabHoverPreview: Boolean = true,
+
     // ===== Session restore (Phase 6) =====
 
     /** Reopen tabs / split layout / cwds on launch. */

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/BehaviorSettingsSection.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/settings/sections/BehaviorSettingsSection.kt
@@ -122,6 +122,13 @@ fun BehaviorSettingsSection(
                 onCheckedChange = { onSettingsChange(settings.copy(tabColorByDirectory = it)) },
                 description = "Auto-assign a stable accent color per working directory (a manual color always wins)"
             )
+            SettingsToggle(
+                label = "Preview Output on Tab Hover",
+                checked = settings.tabHoverPreview,
+                onCheckedChange = { onSettingsChange(settings.copy(tabHoverPreview = it)) },
+                description = "Include the last few rows of a tab's screen in its hover tooltip. " +
+                    "Off still shows the title, path and branch"
+            )
         }
 
         Spacer(modifier = Modifier.height(24.dp))

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -7,6 +7,7 @@ import ai.rever.bossterm.compose.settings.theme.Theme
 import ai.rever.bossterm.compose.settings.theme.ThemeManager
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.TooltipPlacement
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -60,6 +61,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
@@ -97,6 +99,22 @@ private val RemoteAccent: Color get() = BossUiTheme.current.data
 
 /** Gap between pane chips within the same tab-group. Tight, so they read as one cluster. */
 private val TabChipGap: Dp = 3.dp
+
+/**
+ * Hover dwell before a chip's tooltip appears. Deliberately slower than the MCP pill's
+ * 350ms: the bar is a row of adjacent hover targets, and the pointer crosses several of
+ * them on any trip to the terminal.
+ */
+private const val TabTooltipDelayMillis: Int = 500
+
+/** Preview rows kept from the tail of a pane's screen. Enough to recognise, not to read. */
+private const val TabTooltipPreviewLines: Int = 6
+
+/**
+ * Per-row character clip for the preview. Rows arrive padded to the terminal's full width and
+ * a wide pane is 200+ columns; laying all of that out to then ellipsise it is wasted work.
+ */
+private const val TabTooltipPreviewChars: Int = 96
 
 /**
  * Consume secondary presses before click gestures can treat them as primary actions.
@@ -137,6 +155,10 @@ internal fun parseTabColor(hex: String?): Color? {
  * the second and third lines shown on the vertical (left) bar's Warp-style chips;
  * both are ignored by the single-line top bar. [isGitRepo] gates repository-only
  * actions in the local chip menu; null means repository detection is pending.
+ *
+ * [fullPath], [hostLabel] and [statusLabel] are tooltip-only: neither bar has the
+ * room for them, but a chip clipped to 200dp of monospace hides exactly the detail
+ * needed to tell two same-named tabs apart, and hover is where that belongs.
  */
 data class TabBarPane(
     val paneId: String,
@@ -144,8 +166,54 @@ data class TabBarPane(
     val colorHex: String? = null,
     val subtitle: String? = null,
     val branch: String? = null,
-    val isGitRepo: Boolean? = null
+    val isGitRepo: Boolean? = null,
+    /** Untruncated working directory (home as "~"), not the elided [subtitle]. */
+    val fullPath: String? = null,
+    /** For a mirrored chip, the remote session it belongs to (shown as "via <host>"). */
+    val hostLabel: String? = null,
+    /** Session state worth calling out while it is not simply connected ("starting…", an error). */
+    val statusLabel: String? = null
 )
+
+/**
+ * Detail lines of a chip's hover tooltip, in render order. The title is rendered
+ * separately (emphasized), so it never appears here, and a line that would only
+ * restate the title is dropped — a tooltip that says "BossTerm" twice is noise.
+ */
+internal fun tabTooltipDetails(pane: TabBarPane): List<String> {
+    val details = mutableListOf<String>()
+    // The untruncated path when the caller has it; the chip's elided subtitle is the
+    // fallback so remote chips (no local cwd) still say where they are.
+    val path = pane.fullPath?.takeIf { it.isNotBlank() } ?: pane.subtitle?.takeIf { it.isNotBlank() }
+    if (path != null && path != pane.title) details += path
+    pane.branch?.takeIf { it.isNotBlank() }?.let { details += "⎇ $it" }
+    pane.hostLabel?.takeIf { it.isNotBlank() }?.let { details += "via $it" }
+    pane.statusLabel?.takeIf { it.isNotBlank() }?.let { details += it }
+    return details
+}
+
+/**
+ * Shape a raw screen dump (see `TerminalTextBuffer.getScreenLines`, whose rows are padded to
+ * the terminal width) into the tooltip's preview: trailing padding stripped, blank rows
+ * dropped, the last [maxLines] kept, each clipped to [maxChars].
+ *
+ * Blank rows are dropped rather than kept, so an idle shell previews its last real output
+ * instead of six empty rows below the prompt.
+ */
+internal fun tabTooltipPreview(
+    screenText: String?,
+    maxLines: Int = TabTooltipPreviewLines,
+    maxChars: Int = TabTooltipPreviewChars
+): List<String> {
+    if (screenText.isNullOrBlank()) return emptyList()
+    val rows = screenText.lineSequence()
+        .map { it.trimEnd() }
+        .filter { it.isNotBlank() }
+        .toList()
+    return rows.takeLast(maxLines).map { row ->
+        if (row.length > maxChars) row.take(maxChars) + "…" else row
+    }
+}
 
 /** Keep worktree creation optimistic while repository detection is still pending. */
 internal fun canCreateWorktree(isGitRepo: Boolean?): Boolean = isGitRepo != false
@@ -340,6 +408,12 @@ fun TabBar(
      * "Rename…" silently does nothing and a drag past the edge is dropped.
      */
     onTransientInteraction: ((Boolean) -> Unit)? = null,
+    /**
+     * Raw screen text for one pane (the caller's `TerminalTextBuffer.getScreenLines()`), read
+     * ONLY while that pane's hover tooltip is on screen — never per composition, since it
+     * locks the buffer. Null omits the tooltip's preview section entirely.
+     */
+    scrollbackPreview: ((tabIndex: Int, paneId: String) -> String?)? = null,
     modifier: Modifier = Modifier
 ) {
     // Context menu controller for chip right-click menu
@@ -628,26 +702,43 @@ fun TabBar(
     // separate tabs are spaced further apart (TabGroupGap). The focused pane of the
     // active tab is highlighted.
     val chip: @Composable (TabBarGroup, TabBarPane, Modifier) -> Unit = { group, pane, chipModifier ->
-        TabItem(
-            title = pane.title,
-            subtitle = pane.subtitle,
-            branch = pane.branch,
-            multiLine = vertical,
-            tabTheme = tabBarTheme,
-            chipRaised = barRaised,
-            isActive = group.tabIndex == activeTabIndex && pane.paneId == focusedPaneId,
-            colorHex = pane.colorHex,
-            isEditing = pane.paneId == editingPaneId,
-            onSelected = { onPaneSelected(group.tabIndex, pane.paneId) },
-            onCommitRename = { newTitle ->
-                editingPaneId = null
-                onRename(group.tabIndex, pane.paneId, newTitle)
-            },
-            onCancelRename = { editingPaneId = null },
-            onClose = { onPaneClosed(group.tabIndex, pane.paneId) },
-            onContextMenu = { showMenuFor(group.tabIndex, pane.paneId) },
+        // Hover reveals what the chip had to clip: the full title, the untruncated path,
+        // the branch, and the remote it mirrors. Suppressed while renaming — the tooltip
+        // would sit over the field being typed into, describing its stale title.
+        TabHoverTooltip(
+            pane = pane,
+            enabled = pane.paneId != editingPaneId,
+            beside = vertical,
+            bg = barBg,
+            fg = barFg,
+            muted = barMuted,
+            divider = barDivider,
+            preview = scrollbackPreview?.let { read -> { read(group.tabIndex, pane.paneId) } },
             modifier = chipModifier
-        )
+        ) {
+            TabItem(
+                title = pane.title,
+                subtitle = pane.subtitle,
+                branch = pane.branch,
+                multiLine = vertical,
+                tabTheme = tabBarTheme,
+                chipRaised = barRaised,
+                isActive = group.tabIndex == activeTabIndex && pane.paneId == focusedPaneId,
+                colorHex = pane.colorHex,
+                isEditing = pane.paneId == editingPaneId,
+                onSelected = { onPaneSelected(group.tabIndex, pane.paneId) },
+                onCommitRename = { newTitle ->
+                    editingPaneId = null
+                    onRename(group.tabIndex, pane.paneId, newTitle)
+                },
+                onCancelRename = { editingPaneId = null },
+                onClose = { onPaneClosed(group.tabIndex, pane.paneId) },
+                onContextMenu = { showMenuFor(group.tabIndex, pane.paneId) },
+                // fillMaxWidth again inside the tooltip's wrapper Box: `chipModifier` sized
+                // that Box, and the chip would otherwise shrink to its text inside it.
+                modifier = if (vertical) Modifier.fillMaxWidth() else Modifier
+            )
+        }
     }
 
     // Right-clicking empty sidebar chrome targets the active pane. Child controls consume
@@ -721,14 +812,20 @@ fun TabBar(
                             group.panes.forEach { pane ->
                                 val active = group.tabIndex == activeTabIndex && pane.paneId == focusedPaneId
                                 val accent = parseTabColor(pane.colorHex) ?: barMuted
-                                TooltipArea(tooltip = {
-                                    Surface(color = barBg, shadowElevation = 4.dp, shape = RoundedCornerShape(4.dp)) {
-                                        Text(
-                                            pane.title, color = barFg, fontSize = 11.sp,
-                                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
-                                        )
+                                // The rail is nothing but coloured dots, so its tooltip is the
+                                // only label there is — the same card the chips get.
+                                TabHoverTooltip(
+                                    pane = pane,
+                                    enabled = true,
+                                    beside = true,
+                                    bg = barBg,
+                                    fg = barFg,
+                                    muted = barMuted,
+                                    divider = barDivider,
+                                    preview = scrollbackPreview?.let { read ->
+                                        { read(group.tabIndex, pane.paneId) }
                                     }
-                                }) {
+                                ) {
                                     Box(
                                         modifier = Modifier.size(24.dp).clip(RoundedCornerShape(6.dp))
                                             .consumeSecondaryPress {
@@ -1153,6 +1250,123 @@ fun TabBar(
             }
         }
     }
+}
+
+/**
+ * Hover tooltip for one chip: the full title, [tabTooltipDetails], and — under a rule — the
+ * tail of the pane's own screen from [preview] (see [tabTooltipPreview]), so a tab can be
+ * identified by what it is *showing* and not just by what it is called.
+ *
+ * Rendered as a small raised card in the bar's own theme colors, matching the
+ * status-pill tooltip rather than the Material default (which paints a surface the
+ * terminal palette never asked for).
+ */
+@Composable
+private fun TabTooltipCard(
+    pane: TabBarPane,
+    bg: Color,
+    fg: Color,
+    muted: Color,
+    divider: Color,
+    preview: (() -> String?)? = null
+) {
+    // Read once, when the card appears — NOT on every recomposition. The provider locks the
+    // terminal buffer, and a preview that re-read itself under a live `tail -f` would both
+    // churn the lock and reflow the card under the pointer. The popup subtree is disposed on
+    // hide, so this re-reads on the next hover; keyed on the pane alone, since `preview` is a
+    // fresh closure every composition and would otherwise invalidate on each one.
+    val previewLines = remember(pane.paneId) { tabTooltipPreview(preview?.invoke()) }
+    Surface(
+        color = bg,
+        shadowElevation = 4.dp,
+        shape = RoundedCornerShape(4.dp),
+        border = androidx.compose.foundation.BorderStroke(1.dp, fg.copy(alpha = 0.14f))
+    ) {
+        Column(
+            // Wide enough for a real project path, and wrapping (no maxLines) past that:
+            // a tooltip that ellipsises the path it exists to reveal would be pointless.
+            modifier = Modifier.widthIn(max = 360.dp).padding(horizontal = 10.dp, vertical = 6.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Text(
+                text = pane.title,
+                color = fg,
+                fontSize = 12.sp,
+                fontFamily = FontFamily.Monospace
+            )
+            tabTooltipDetails(pane).forEach { line ->
+                Text(
+                    text = line,
+                    color = muted,
+                    fontSize = 11.sp,
+                    fontFamily = FontFamily.Monospace
+                )
+            }
+            if (previewLines.isNotEmpty()) {
+                // A rule, not a gap: without it the terminal's own text reads as more tooltip
+                // metadata — and the pane's last line can be anything, including a path.
+                Box(Modifier.fillMaxWidth().padding(vertical = 3.dp).height(1.dp).background(divider))
+                previewLines.forEach { line ->
+                    Text(
+                        text = line,
+                        // Dimmer than the detail lines: this is quoted terminal output, and it
+                        // must not out-shout the title it is attached to.
+                        color = muted.copy(alpha = 0.72f),
+                        fontSize = 10.sp,
+                        fontFamily = FontFamily.Monospace,
+                        // Clipped rather than wrapped — one screen row stays one preview row,
+                        // so the shape of the output survives (a wrapped row reads as two).
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Wraps a chip in its hover tooltip. [enabled] false renders [content] bare, so a
+ * chip being renamed is left alone — the popup would otherwise sit over the field
+ * being typed into, describing the title it is replacing.
+ *
+ * Cursor-placed, like the MCP pill's tooltip, and not `ComponentRect` anchored to the
+ * chip: only the cursor provider flips and clamps against the window, and a full path
+ * on the last chip of a narrow window is exactly where an anchored card gets clipped
+ * off the edge. [beside] (the left bar and its rail) nudges it clear to the right
+ * instead of straight down, where it would cover the next chip.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun TabHoverTooltip(
+    pane: TabBarPane,
+    enabled: Boolean,
+    beside: Boolean,
+    bg: Color,
+    fg: Color,
+    muted: Color,
+    divider: Color,
+    preview: (() -> String?)? = null,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    if (!enabled) {
+        Box(modifier) { content() }
+        return
+    }
+    TooltipArea(
+        tooltip = {
+            TabTooltipCard(
+                pane = pane, bg = bg, fg = fg, muted = muted, divider = divider, preview = preview
+            )
+        },
+        modifier = modifier,
+        delayMillis = TabTooltipDelayMillis,
+        tooltipPlacement = TooltipPlacement.CursorPoint(
+            offset = if (beside) DpOffset(14.dp, 10.dp) else DpOffset(0.dp, 20.dp)
+        ),
+        content = content
+    )
 }
 
 /**

--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/tabs/TabBar.kt
@@ -112,9 +112,26 @@ private const val TabTooltipPreviewLines: Int = 6
 
 /**
  * Per-row character clip for the preview. Rows arrive padded to the terminal's full width and
- * a wide pane is 200+ columns; laying all of that out to then ellipsise it is wasted work.
+ * a wide pane is 200+ columns; laying all of that out is wasted work.
+ *
+ * NOT the visible boundary — at 10sp monospace the card's 360dp fits roughly 55 characters, so
+ * the row's own `maxLines = 1` ellipsis always lands first (and eats the "…" this clip appends).
+ * It exists to bound layout work, so tuning it changes nothing you can see.
  */
 private const val TabTooltipPreviewChars: Int = 96
+
+/**
+ * Character clip for the title and detail rows.
+ *
+ * Every one of them is terminal-controlled: the title is whatever OSC 1/2 said, the path
+ * whatever OSC 7 said, the status an exception's message. The chip caps its own title at one
+ * line, so without this the tooltip would be the one surface where a program that emits a
+ * multi-kilobyte title paints a card taller than the window.
+ */
+private const val TabTooltipTextChars: Int = 200
+
+/** Rows a title or detail line may wrap to before it is ellipsised. */
+private const val TabTooltipTextLines: Int = 2
 
 /**
  * Consume secondary presses before click gestures can treat them as primary actions.
@@ -176,20 +193,54 @@ data class TabBarPane(
 )
 
 /**
+ * Fold a leading [home] in [path] to "~", trimming a trailing slash. Nothing is elided — this
+ * is the whole path, which is what the tooltip promises and what the chip's abbreviation drops.
+ *
+ * [home] is a parameter, not a `user.home` read, for two reasons: it is testable, and a
+ * MIRRORED pane's cwd belongs to the remote host, where the local home means nothing (fold
+ * `/home/alice` there and a same-named remote user turns `/home/alice/proj` into `~/proj`).
+ * Callers pass null for those.
+ *
+ * The "$home/" guard is what keeps a sibling directory intact: `/Users/alice-backup` must stay
+ * itself and not become `~-backup`.
+ */
+internal fun tildePath(path: String?, home: String?): String? {
+    if (path.isNullOrBlank()) return null
+    val cleanHome = home?.trimEnd('/')
+    val clean = path.trimEnd('/').ifEmpty { "/" }
+    return if (!cleanHome.isNullOrEmpty() && (clean == cleanHome || clean.startsWith("$cleanHome/"))) {
+        "~" + clean.removePrefix(cleanHome)
+    } else {
+        clean
+    }
+}
+
+/** Clip one terminal-controlled tooltip line to [TabTooltipTextChars]. */
+private fun clipTooltipText(text: String): String =
+    if (text.length > TabTooltipTextChars) text.take(TabTooltipTextChars) + "…" else text
+
+/** The tooltip's title line: the chip's title, bounded (see [TabTooltipTextChars]). */
+internal fun tabTooltipTitle(title: String): String = clipTooltipText(title)
+
+/**
  * Detail lines of a chip's hover tooltip, in render order. The title is rendered
  * separately (emphasized), so it never appears here, and a line that would only
  * restate the title is dropped — a tooltip that says "BossTerm" twice is noise.
  */
 internal fun tabTooltipDetails(pane: TabBarPane): List<String> {
     val details = mutableListOf<String>()
-    // The untruncated path when the caller has it; the chip's elided subtitle is the
-    // fallback so remote chips (no local cwd) still say where they are.
-    val path = pane.fullPath?.takeIf { it.isNotBlank() } ?: pane.subtitle?.takeIf { it.isNotBlank() }
-    if (path != null && path != pane.title) details += path
+    // Prefer the untruncated path, but fall THROUGH to the chip's elided subtitle when the
+    // full one only restates the title, rather than emitting no path at all. That case is
+    // real: at $HOME the title is "~" and so is the folded path, while the subtitle
+    // deliberately carries the expanded "/Users/you" — the one thing worth showing there.
+    // (The subtitle is also the only path a remote chip has.)
+    val path = listOfNotNull(pane.fullPath, pane.subtitle)
+        .firstOrNull { it.isNotBlank() && it != pane.title }
+    if (path != null) details += path
     pane.branch?.takeIf { it.isNotBlank() }?.let { details += "⎇ $it" }
     pane.hostLabel?.takeIf { it.isNotBlank() }?.let { details += "via $it" }
     pane.statusLabel?.takeIf { it.isNotBlank() }?.let { details += it }
-    return details
+    return details.map(::clipTooltipText)
 }
 
 /**
@@ -704,10 +755,13 @@ fun TabBar(
     val chip: @Composable (TabBarGroup, TabBarPane, Modifier) -> Unit = { group, pane, chipModifier ->
         // Hover reveals what the chip had to clip: the full title, the untruncated path,
         // the branch, and the remote it mirrors. Suppressed while renaming — the tooltip
-        // would sit over the field being typed into, describing its stale title.
+        // would sit over the field being typed into, describing its stale title — and while
+        // a sidebar drag is in flight: reordering slides chips under a held pointer, so each
+        // one entered starts a fresh dwell that a slow drag outlasts, and the card would land
+        // on the bar being rearranged.
         TabHoverTooltip(
             pane = pane,
-            enabled = pane.paneId != editingPaneId,
+            enabled = pane.paneId != editingPaneId && draggedTabIndex == null,
             beside = vertical,
             bg = barBg,
             fg = barFg,
@@ -1283,23 +1337,30 @@ private fun TabTooltipCard(
         border = androidx.compose.foundation.BorderStroke(1.dp, fg.copy(alpha = 0.14f))
     ) {
         Column(
-            // Wide enough for a real project path, and wrapping (no maxLines) past that:
-            // a tooltip that ellipsises the path it exists to reveal would be pointless.
+            // Wide enough for a real project path, wrapping past that rather than ellipsising
+            // it away. A card carrying a preview always measures to the full width anyway —
+            // preview rows are single-line with unbounded intrinsic width.
             modifier = Modifier.widthIn(max = 360.dp).padding(horizontal = 10.dp, vertical = 6.dp),
             verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
+            // maxLines on both, not just the clip: 200 characters of a narrow path still wrap
+            // to four rows, and the card must stay a tooltip.
             Text(
-                text = pane.title,
+                text = tabTooltipTitle(pane.title),
                 color = fg,
                 fontSize = 12.sp,
-                fontFamily = FontFamily.Monospace
+                fontFamily = FontFamily.Monospace,
+                maxLines = TabTooltipTextLines,
+                overflow = TextOverflow.Ellipsis
             )
             tabTooltipDetails(pane).forEach { line ->
                 Text(
                     text = line,
                     color = muted,
                     fontSize = 11.sp,
-                    fontFamily = FontFamily.Monospace
+                    fontFamily = FontFamily.Monospace,
+                    maxLines = TabTooltipTextLines,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
             if (previewLines.isNotEmpty()) {

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabTooltipDetailsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabTooltipDetailsTest.kt
@@ -2,6 +2,7 @@ package ai.rever.bossterm.compose.tabs
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class TabTooltipDetailsTest {
 
@@ -67,5 +68,57 @@ class TabTooltipDetailsTest {
     @Test
     fun `a bare chip contributes no detail lines`() {
         assertEquals(emptyList(), tabTooltipDetails(pane()))
+    }
+}
+
+class TabTooltipBoundsTest {
+
+    private fun pane(
+        title: String = "BossTerm",
+        subtitle: String? = null,
+        fullPath: String? = null,
+        statusLabel: String? = null
+    ) = TabBarPane(
+        paneId = "p1",
+        title = title,
+        subtitle = subtitle,
+        fullPath = fullPath,
+        statusLabel = statusLabel
+    )
+
+    @Test
+    fun `at home the tooltip falls through to the expanded subtitle`() {
+        // abbreviateCwd deliberately expands $HOME ("the ~ title carries the tilde"), so the
+        // folded fullPath only restates the title. Emitting nothing would leave the tooltip
+        // hiding the very path the chip shows.
+        val details = tabTooltipDetails(pane(title = "~", fullPath = "~", subtitle = "/Users/alice"))
+        assertEquals(listOf("/Users/alice"), details)
+    }
+
+    @Test
+    fun `a terminal-controlled title cannot grow the card without bound`() {
+        // OSC 1/2 sets this, so it is as long as a program cares to make it.
+        val huge = "A".repeat(20_000)
+        val clipped = tabTooltipTitle(huge)
+        assertTrue(clipped.length < 250, "title still $clipped.length chars")
+        assertTrue(clipped.endsWith("…"))
+    }
+
+    @Test
+    fun `a detail line is clipped too - path and error message alike`() {
+        val deepPath = "/" + (1..500).joinToString("/") { "dir$it" }
+        val message = "error: " + "x".repeat(5_000)
+        val details = tabTooltipDetails(pane(fullPath = deepPath, statusLabel = message))
+        assertEquals(2, details.size)
+        details.forEach { line ->
+            assertTrue(line.length < 250, "detail line still ${line.length} chars")
+            assertTrue(line.endsWith("…"))
+        }
+    }
+
+    @Test
+    fun `a title at the clip boundary keeps its exact text`() {
+        val exact = "B".repeat(200)
+        assertEquals(exact, tabTooltipTitle(exact))
     }
 }

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabTooltipDetailsTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabTooltipDetailsTest.kt
@@ -1,0 +1,71 @@
+package ai.rever.bossterm.compose.tabs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TabTooltipDetailsTest {
+
+    private fun pane(
+        title: String = "BossTerm",
+        subtitle: String? = null,
+        branch: String? = null,
+        fullPath: String? = null,
+        hostLabel: String? = null,
+        statusLabel: String? = null
+    ) = TabBarPane(
+        paneId = "p1",
+        title = title,
+        subtitle = subtitle,
+        branch = branch,
+        fullPath = fullPath,
+        hostLabel = hostLabel,
+        statusLabel = statusLabel
+    )
+
+    @Test
+    fun `the untruncated path wins over the chip's elided subtitle`() {
+        val details = tabTooltipDetails(
+            pane(subtitle = "~/…/Boss/BossTerm", fullPath = "~/Development/Boss/BossTerm")
+        )
+        assertEquals(listOf("~/Development/Boss/BossTerm"), details)
+    }
+
+    @Test
+    fun `a remote chip with no local cwd still falls back to the subtitle`() {
+        // Mirrored chips carry the host's abbreviated path and nothing else — dropping the
+        // fallback would leave the tooltip with only a title the chip already showed.
+        val details = tabTooltipDetails(pane(subtitle = "~/src", hostLabel = "mac-mini"))
+        assertEquals(listOf("~/src", "via mac-mini"), details)
+    }
+
+    @Test
+    fun `every line renders in order`() {
+        val details = tabTooltipDetails(
+            pane(
+                fullPath = "~/Development/Boss",
+                branch = "master",
+                hostLabel = "mac-mini",
+                statusLabel = "starting…"
+            )
+        )
+        assertEquals(listOf("~/Development/Boss", "⎇ master", "via mac-mini", "starting…"), details)
+    }
+
+    @Test
+    fun `a path identical to the title is dropped rather than said twice`() {
+        assertEquals(emptyList(), tabTooltipDetails(pane(title = "~", fullPath = "~")))
+    }
+
+    @Test
+    fun `blank fields never become empty lines`() {
+        val details = tabTooltipDetails(
+            pane(fullPath = "  ", subtitle = "", branch = "", hostLabel = " ", statusLabel = "")
+        )
+        assertEquals(emptyList(), details)
+    }
+
+    @Test
+    fun `a bare chip contributes no detail lines`() {
+        assertEquals(emptyList(), tabTooltipDetails(pane()))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabTooltipPreviewTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TabTooltipPreviewTest.kt
@@ -1,0 +1,52 @@
+package ai.rever.bossterm.compose.tabs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TabTooltipPreviewTest {
+
+    @Test
+    fun `the tail of the screen is what a hover shows`() {
+        val screen = (1..20).joinToString("\n") { "line $it" }
+        assertEquals(
+            listOf("line 15", "line 16", "line 17", "line 18", "line 19", "line 20"),
+            tabTooltipPreview(screen)
+        )
+    }
+
+    @Test
+    fun `an idle shell previews its last output, not the blank rows under the prompt`() {
+        // getScreenLines() pads every row to the terminal width and emits the whole screen,
+        // so an idle pane is mostly padding — the naive tail would be six empty lines.
+        val screen = "$ ./gradlew build      \nBUILD SUCCESSFUL       \n$                      " +
+            "\n                       ".repeat(30)
+        assertEquals(listOf("$ ./gradlew build", "BUILD SUCCESSFUL", "$"), tabTooltipPreview(screen))
+    }
+
+    @Test
+    fun `a long row is clipped with an ellipsis rather than laid out in full`() {
+        val row = "x".repeat(400)
+        val previewed = tabTooltipPreview(row, maxChars = 20).single()
+        assertEquals("x".repeat(20) + "…", previewed)
+        assertTrue(previewed.length < row.length)
+    }
+
+    @Test
+    fun `a row exactly at the clip is left alone`() {
+        assertEquals(listOf("x".repeat(20)), tabTooltipPreview("x".repeat(20), maxChars = 20))
+    }
+
+    @Test
+    fun `a pane with nothing on screen contributes no preview`() {
+        assertEquals(emptyList(), tabTooltipPreview(null))
+        assertEquals(emptyList(), tabTooltipPreview(""))
+        assertEquals(emptyList(), tabTooltipPreview("   \n   \n\n  "))
+    }
+
+    @Test
+    fun `blank rows between output are dropped so the tail stays dense`() {
+        val screen = "first\n\n\nsecond\n\nthird\n"
+        assertEquals(listOf("first", "second", "third"), tabTooltipPreview(screen, maxLines = 3))
+    }
+}

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TildePathTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/tabs/TildePathTest.kt
@@ -1,0 +1,54 @@
+package ai.rever.bossterm.compose.tabs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TildePathTest {
+
+    private val home = "/Users/alice"
+
+    @Test
+    fun `a path under home folds to a tilde`() {
+        assertEquals("~/Development/Boss", tildePath("/Users/alice/Development/Boss", home))
+    }
+
+    @Test
+    fun `home itself folds to a bare tilde`() {
+        assertEquals("~", tildePath("/Users/alice", home))
+        assertEquals("~", tildePath("/Users/alice/", home))
+    }
+
+    @Test
+    fun `a sibling that merely starts with home is left intact`() {
+        // The "$home/" guard, not a bare prefix test: this must not become "~-backup".
+        assertEquals("/Users/alice-backup", tildePath("/Users/alice-backup", home))
+        assertEquals("/Users/alice-backup/src", tildePath("/Users/alice-backup/src", home))
+    }
+
+    @Test
+    fun `a trailing slash is trimmed but the root survives it`() {
+        assertEquals("/etc/nginx", tildePath("/etc/nginx/", home))
+        assertEquals("/", tildePath("/", home))
+    }
+
+    @Test
+    fun `a null or empty home folds nothing`() {
+        // What a mirrored pane passes: the cwd belongs to the remote host, so folding the
+        // LOCAL home would turn a same-named remote user's /Users/alice/proj into ~/proj.
+        assertEquals("/Users/alice/proj", tildePath("/Users/alice/proj", null))
+        assertEquals("/Users/alice/proj", tildePath("/Users/alice/proj", ""))
+    }
+
+    @Test
+    fun `home is matched with its own trailing slash trimmed`() {
+        assertEquals("~/proj", tildePath("/Users/alice/proj", "/Users/alice/"))
+    }
+
+    @Test
+    fun `nothing in, nothing out`() {
+        assertNull(tildePath(null, home))
+        assertNull(tildePath("", home))
+        assertNull(tildePath("   ", home))
+    }
+}


### PR DESCRIPTION
## Why

Hovering a tab chip in the tab bar showed nothing. That made the one thing a chip cannot fit the same thing you could not get at: which of two same-named tabs is which, and what a background tab is actually doing.

## What hover shows now

A small card in the bar's own theme colours:

- **Full title** - chips ellipsise at 200dp of monospace
- **Untruncated working directory** - the chip's second line is elided to `~/.../Boss/BossTerm`; the card shows `~/Development/Boss/BossTerm`
- **Git branch** (`⎇ master`)
- **`via <host>`** for a mirrored remote chip, using the same label precedence as the remote box header
- **Status** while a session is not simply connected (`starting…`, `error: …`)
- **The last 6 non-blank rows of that pane's screen**, under a hairline rule

One shared `chip` lambda feeds the top bar, the expanded left sidebar and the remote group boxes, so all three gain it at once. The collapsed rail's old title-only tooltip now renders the same card - its dots have no other label.

## The preview, and what it costs

`TerminalTextBuffer.getScreenLines()` called from inside the popup, so the buffer lock is taken on hover and nowhere else, and `remember`ed per pane so a live `tail -f` cannot reflow the card under the pointer (the popup subtree is disposed on hide, so the next hover re-reads).

The visible screen, not the history: its bottom rows *are* the recent output, while the history-inclusive read - `createSnapshot()`, what the `read_scrollback` MCP tool uses - deep-copies every scrollback line. Rows arrive padded to the terminal width, so blank rows are dropped (an idle shell would otherwise preview six empty rows below its prompt) and each row is clipped at 96 chars before layout rather than laid out at 200+ columns to then ellipsise.

## Placement

`TooltipPlacement.CursorPoint`, matching the MCP status pill. I started with `ComponentRect` anchored under the chip, then read the provider: `rememberComponentRectPositionProvider` does no window clamping, so a full path on the last chip of a narrow window would be clipped off the edge. `PopupPositionProviderAtPosition` (the cursor provider) flips and clamps. In the left bar the offset nudges right so the card does not cover the next chip down.

The card is suppressed while a chip is being renamed - it would otherwise sit over the field being typed into, describing the title being replaced.

## Tests

`tabTooltipDetails` and `tabTooltipPreview` are pure and covered by 12 cases across `TabTooltipDetailsTest` and `TabTooltipPreviewTest` (path-beats-elided-subtitle, the remote fallback, no-line-said-twice, the padded idle screen, the clip boundary, blank handling).

Full `:compose-ui:desktopTest` suite green: **1139 tests, 0 failures**.

Also run in a real app (`:bossterm-app:run`) off this branch, not just compiled.