### PR TITLE
feat(mcp): run_in_panel reuses its pane instead of splitting every call

### DIFF
--- a/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
+++ b/compose-ui/src/desktopMain/kotlin/ai/rever/bossterm/compose/mcp/BossTermMcpServer.kt
@@ -1050,13 +1050,29 @@ class BossTermMcpServer(
                         "(or only newlines) just opens the panel. " +
                         "All three modes wait for the shell's OSC 133;A prompt-ready signal " +
                         "(or the configured fallback delay) before sending the script, so the " +
-                        "command runs cleanly rather than racing with shell startup."
+                        "command runs cleanly rather than racing with shell startup. " +
+                        "A split mode REUSES the pane this tool already owns in the target tab " +
+                        "when there is one, rather than splitting again - so calling this " +
+                        "repeatedly gives you one panel with a scrollback, not a tab sliced into " +
+                        "N unreadable strips. Pass force_new to opt out."
             ),
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("panel") {
                         put("type", "string")
                         put("description", "One of: new_tab, horizontal_split, vertical_split.")
+                    }
+                    putJsonObject("force_new") {
+                        put("type", "boolean")
+                        put(
+                            "description",
+                            "Split even when this tool already has a live pane in the target " +
+                                "tab. Default false: a split mode reuses that pane and runs the " +
+                                "script there, so repeated calls stack output in ONE panel " +
+                                "instead of carving the tab into ever-smaller slices. Pass true " +
+                                "only when panels genuinely need to sit side by side, such as " +
+                                "watching two logs at once."
+                        )
                     }
                     putJsonObject("script") {
                         put("type", "string")
@@ -1092,6 +1108,7 @@ class BossTermMcpServer(
                 ?: return@addTool errorResult("Missing required argument: script")
             val requestedTabId = args.requireString("tab_id")
             val workingDir = args.requireString("working_dir")
+            val forceNew = args.optionalBoolean("force_new") ?: false
 
             // Resolve the target state. If tab_id given, find the state that
             // owns it. Otherwise prefer the window the calling client lives
@@ -1132,16 +1149,49 @@ class BossTermMcpServer(
                     // path submits it, matching the new_tab branch. An empty script means
                     // "just split, don't run anything".
                     val normalizedScript = stripTrailingSubmit(script).ifEmpty { null }
+                    // The pane this tool already owns in this tab, if it is still alive.
+                    // Verified through findSession rather than trusted: the user may have
+                    // closed it, in which case the cache entry is a stale hint.
+                    val existing = registry.getScratchPane(targetTabId)
+                        ?.takeIf { state.findSession(targetTabId, it) != null }
+
+                    // Reuse by default. Every call used to split, so an agent running six
+                    // commands left six panes and a tab too narrow to read - the cost of
+                    // that is silent and lands on the user, while the cost of reuse is a
+                    // caller occasionally passing force_new. Anchor stacking below is kept
+                    // for the force_new path, so opting out still lays panes out sanely
+                    // instead of carving up whatever happens to be focused.
+                    if (existing != null && !forceNew) {
+                        val reuseSession = state.findSession(targetTabId, existing)
+                            ?: return@addTool errorResult(
+                                "Pane $existing vanished while resolving it"
+                            )
+                        val reuseScript = stripTrailingSubmit(script)
+                        if (reuseScript.isNotEmpty()) {
+                            // Same per-pane mutex run_command takes: two overlapping calls
+                            // on one pane would otherwise interleave in the shell's stdin.
+                            registry.paneMutex(existing).withLock {
+                                reuseSession.writeUserInput(reuseScript + "\r")
+                            }
+                        }
+                        val payload = RunInPanelResult(
+                            ok = true,
+                            tabId = targetTabId,
+                            paneId = existing,
+                            reused = true
+                        )
+                        return@addTool successJson(
+                            json.encodeToString(RunInPanelResult.serializer(), payload)
+                        )
+                    }
+
                     // Anchor stacking: if there's already an MCP scratch pane for
                     // this tab and the caller asked for horizontal_split, stack
                     // the new pane to the RIGHT of that existing pane instead of
                     // splitting whatever's focused — keeps consecutive MCP panes
                     // in a horizontal strip along the bottom rather than fighting
                     // for the focused pane's real estate.
-                    val anchor = if (panel == "horizontal_split") {
-                        registry.getScratchPane(targetTabId)
-                            ?.takeIf { state.findSession(targetTabId, it) != null }
-                    } else null
+                    val anchor = if (panel == "horizontal_split") existing else null
                     val paneId = when {
                         anchor != null -> state.splitVerticalFromPane(
                             tabId = targetTabId,
@@ -2540,7 +2590,13 @@ class BossTermMcpServer(
         val ok: Boolean,
         val tabId: String,
         /** Non-null only for split modes — the new pane's session id. */
-        val paneId: String?
+        val paneId: String?,
+        /**
+         * True when the script went into a pane that already existed rather than a
+         * freshly created split. Lets a caller tell "your panel is the one already on
+         * screen" from "a new one appeared" without diffing list_panes.
+         */
+        val reused: Boolean = false
     )
 
     @Serializable

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/RunInPanelReuseTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/mcp/RunInPanelReuseTest.kt
@@ -1,0 +1,91 @@
+package ai.rever.bossterm.compose.mcp
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `run_in_panel` reuses the pane it already owns instead of splitting again.
+ *
+ * The behaviour itself needs a live `TabbedTerminalState` (a real window, a real PTY), so what
+ * is pinned here is everything that decides whether the norm can take effect at all: the
+ * opt-out argument has to exist or a caller passing `force_new` is silently ignored, the
+ * description has to say so because that text is what actually steers a model, and the
+ * scratch-pane bookkeeping the reuse path reads has to round-trip.
+ */
+class RunInPanelReuseTest {
+
+    @BeforeTest
+    fun setUp() = McpTerminalRegistry.setMcpConfig(BossTermMcpConfig())
+
+    @AfterTest
+    fun tearDown() {
+        McpTerminalRegistry.clearScratchPane(TAB)
+        McpTerminalRegistry.setMcpConfig(BossTermMcpConfig())
+    }
+
+    private fun schema() = BossTermMcpServer(McpTerminalRegistry).createServer()
+        .tools["run_in_panel"]
+        ?: error("run_in_panel is not registered")
+
+    @Test
+    fun forceNewIsDeclaredSoCallersCanOptOut() {
+        val props = schema().tool.inputSchema.properties.orEmpty()
+        assertTrue("force_new" in props, "force_new missing: an opt-out nobody can pass is not one")
+    }
+
+    @Test
+    fun forceNewIsOptional() {
+        // Required would invert the norm: every caller would have to think about panes.
+        val required = schema().tool.inputSchema.required.orEmpty()
+        assertTrue("force_new" !in required, "force_new must default, not be demanded")
+    }
+
+    @Test
+    fun theDescriptionStatesTheNorm() {
+        // The tool description is the only thing steering a model's choice here, so an
+        // implementation that reuses while the text still promises a fresh split every call
+        // would keep producing the pane sprawl this exists to stop.
+        val description = schema().tool.description.orEmpty().lowercase()
+        assertTrue("reuse" in description, "description does not mention reuse: $description")
+        assertTrue("force_new" in description, "description does not mention the opt-out")
+    }
+
+    @Test
+    fun scratchPaneRoundTripsSoTheReusePathCanFindIt() {
+        assertNull(McpTerminalRegistry.getScratchPane(TAB))
+        McpTerminalRegistry.setScratchPane(TAB, PANE)
+        assertEquals(PANE, McpTerminalRegistry.getScratchPane(TAB))
+        McpTerminalRegistry.clearScratchPane(TAB, PANE)
+        assertNull(McpTerminalRegistry.getScratchPane(TAB))
+    }
+
+    @Test
+    fun resultCarriesWhetherAPaneWasReused() {
+        // A caller that cannot tell reuse from creation has to diff list_panes to find out.
+        val json = Json { encodeDefaults = true }
+        val reused = json.encodeToString(
+            BossTermMcpServer.RunInPanelResult.serializer(),
+            BossTermMcpServer.RunInPanelResult(ok = true, tabId = TAB, paneId = PANE, reused = true)
+        )
+        assertTrue("\"reused\":true" in reused.replace(" ", ""), reused)
+
+        val fresh = json.parseToJsonElement(
+            json.encodeToString(
+                BossTermMcpServer.RunInPanelResult.serializer(),
+                BossTermMcpServer.RunInPanelResult(ok = true, tabId = TAB, paneId = PANE)
+            )
+        ).jsonObject
+        assertEquals("false", fresh["reused"].toString(), "a fresh split must not claim reuse")
+    }
+
+    private companion object {
+        const val TAB = "reuse-test-tab"
+        const val PANE = "reuse-test-pane"
+    }
+}


### PR DESCRIPTION
## Problem

`run_in_panel` created a new split on **every** call. Six commands left six panes and a tab too narrow to read anything in. That cost is silent and lands on the user.

## What was already there

`McpTerminalRegistry` has kept a per-tab scratch pane since `run_command` started reusing one, with lazy staleness checks through `findSession` and a GC sweep for closed panes.

`run_command` consults that cache *before* honouring `panel` at all, so it has been compliant with this norm all along - `panel` only decides what to create on a cache **miss**. `run_in_panel` read the same cache but used it purely as a stacking anchor, never as a reason to skip the split. That asymmetry is the whole bug.

## Change

A split mode now runs the script in the existing pane when one is alive, guarded by the same per-pane mutex `run_command` takes - two overlapping calls on one pane would otherwise interleave in the shell's stdin.

- `force_new: true` restores the old behaviour, for the genuine side-by-side case such as watching two logs.
- Anchor stacking is kept on the `force_new` path, so opting out still lays panes out in a strip rather than carving up whatever happens to be focused.
- `RunInPanelResult` gains `reused`, so a caller can tell "your panel is the one already on screen" from "a new one appeared" without diffing `list_panes`.
- The tool description states the norm, since that text is what actually steers a model.

Recommendation rather than restriction, as asked: the easy path reuses, the deliberate path still splits.

`show_image` is deliberately untouched. Its own comment explains that an image is a one-shot display rather than a reused command pane, so consecutive calls are meant to produce independent panes.

## Tested

Full `:compose-ui:desktopTest` green.

The reuse path itself needs a live `TabbedTerminalState` - a real window and a real PTY - so it is **not** covered here, and that gap is worth knowing about. What is pinned is everything that decides whether the norm can take effect: that the opt-out exists and is optional (an argument nobody can pass is not an opt-out), that the scratch cache round-trips, that `reused` serialises and a fresh split does not claim it, and that the description states the norm.

That last test is load-bearing rather than cosmetic - an implementation that reuses while the description still promises a fresh split every call would keep producing the sprawl this removes. Dropping the norm from the description fails it.