### PR TITLE
test: stop the voice budget test racing the CI scheduler

### DIFF
--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceToolSafetyTest.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceToolSafetyTest.kt
@@ -728,17 +728,40 @@ class VoiceToolSafetyTest {
      */
     @Test
     fun `approval spends the tool's budget rather than adding to it`() {
+        // Budget spent by the modal is SCRIPTED through the injected clock, not slept away.
+        //
+        // The original version slept `delay(250)` inside the approver against an approval
+        // slice of min(APPROVAL_MS, 400) = 400 ms, leaving ~150 ms of headroom for two
+        // `Dispatchers.IO` hops and the runner's scheduler. On a loaded macOS CI box that
+        // headroom ran out: the approval itself timed out, `confirmationRefusal` returned
+        // the refusal payload instead of the call ever running, no exception was thrown,
+        // and `assertFailsWith` failed. It went red twice in four days on macOS only, and
+        // passed everywhere else - a test asserting on the scheduler, not on the executor.
+        //
+        // With the clock scripted, the approver returns immediately while REPORTING that it
+        // spent 250 ms, which is precisely the input the property is about.
+        var clockMs = 0L
         val source = FakeToolSource(
             list = listOf(externalTool("git_discard")),
-            policy = VoiceToolPolicy(approve = { _, _ -> kotlinx.coroutines.delay(250); true }),
+            policy = VoiceToolPolicy(approve = { _, _ -> clockMs += 250L; true }),
             onCall = { _, _ -> kotlinx.coroutines.delay(250); """{"ok":true}""" },
         )
-        val exec = composite(FakeBaseExecutor(emptyList()), source, callTimeoutMs = 400L)
+        val exec = composite(
+            FakeBaseExecutor(emptyList()),
+            source,
+            callTimeoutMs = 400L,
+            nowMs = { clockMs },
+        )
 
         val failure = assertFailsWith<VoiceToolException> {
             runBlocking { exec.execute("git_discard", noArgs, null) }
         }
         assertTrue(failure.message!!.contains("timed out"), failure.message!!)
+        // Why this is now deterministic in the direction that matters: the approval reports
+        // 250 ms of a 400 ms budget, so the call runs under `withTimeoutOrNull(150)` while
+        // sleeping 250 ms. `delay` can overshoot but never finish early, so the timeout
+        // always wins. Reintroduce the bug - hand the call a fresh 400 ms instead of the
+        // remaining 150 - and the 250 ms call completes, nothing throws, and this fails.
     }
 
     /**

--- a/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceToolSourceFixtures.kt
+++ b/compose-ui/src/desktopTest/kotlin/ai/rever/bossterm/compose/voice/VoiceToolSourceFixtures.kt
@@ -100,10 +100,17 @@ internal fun composite(
     gate: VoiceConfirmationGate = VoiceConfirmationGate(),
     enumerateTimeoutMs: Long = 1_000L,
     callTimeoutMs: Long = 1_000L,
+    /**
+     * The executor's clock. Pass a scripted one to make a budget test deterministic: a test
+     * that spends budget with a real `delay` is asserting on the CI runner's scheduler, not
+     * on the executor.
+     */
+    nowMs: () -> Long = { System.currentTimeMillis() },
 ) = CompositeVoiceToolExecutor(
     base = base,
     source = source,
     confirmations = gate,
     enumerateTimeoutMs = enumerateTimeoutMs,
     callTimeoutMs = { callTimeoutMs },
+    nowMs = nowMs,
 )


### PR DESCRIPTION
## The flake

`VoiceToolSafetyTest > approval spends the tool's budget rather than adding to it`, macOS only, never Ubuntu or Windows:

| commit | Build & Test |
|---|---|
| `47b61bc4` (Aug 24, before the latency work) | ❌ this test |
| `cacaba54` | ✅ |
| `ae378765` (#376 merge) | ❌ this test |
| `ea28e085` (#377 merge, current master) | ✅ |

Pre-existing and unrelated to either merge - it predates both. It fails at the `assertFailsWith` line, meaning **no exception at all**, not the wrong one.

## Cause

The test sleeps `delay(250)` inside the approver, against an approval slice of `min(APPROVAL_MS, 400) = 400 ms`. That leaves ~150 ms of headroom to cover two `withContext(Dispatchers.IO)` hops plus whatever the runner is doing.

When the headroom runs out on a loaded box, `withTimeoutOrNull` around the approval returns null, `confirmationRefusal` answers with the refusal payload, the tool call never runs, nothing throws, and `assertFailsWith` fails. The test was asserting on the scheduler rather than on the executor.

## Fix

`CompositeVoiceToolExecutor` already takes an injectable clock - added with the comment *"Injected so a slow approval can be exercised without one"*. The test simply never used it.

The approver now returns immediately while **reporting** that it spent 250 ms, which is exactly the input the property is about. The fixture gains a `nowMs` parameter to pass it through.

Deterministic in the direction that matters: the approval reports 250 ms of a 400 ms budget, so the call runs under `withTimeoutOrNull(150)` while sleeping 250 ms. `delay` can overshoot but never finish early, so the timeout always wins. The remaining sleep is 250-vs-150, where overshoot only strengthens the assertion - rather than 250-vs-400, where overshoot inverted the outcome.

## Still catches the bug it exists for

Mutating `remainingMs = budgetMs - (nowMs() - startedAtMs)` to `= budgetMs` (a fresh budget for the call - the exact bug the test was written for) makes it fail. Verified.

## Swept for the same shape

The other delays in these tests are all `delay(60_000)` against small budgets, where overshoot can only make the timeout *more* certain. No other instance of a sleep sized close to the budget it races.

## What I did not do

I did not try to prove this with local load testing. The flake is macOS-CI-specific, and a green loop on a developer machine is exactly what let it look fine while it was failing in CI. **This PR's own CI run is the evidence**, and re-running it a few times is the honest way to build confidence.

Test-only change: 2 files, +32/-2.
